### PR TITLE
Fix various miscellaneous Darwin API issues.

### DIFF
--- a/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
@@ -55,23 +55,23 @@ public:
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
         MTRReadParams * params = [[MTRReadParams alloc] init];
         params.fabricFiltered = mFabricFiltered.HasValue() ? [NSNumber numberWithBool:mFabricFiltered.Value()] : nil;
-        [device
-            readAttributeWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
-                              clusterID:[NSNumber numberWithUnsignedInteger:mClusterId]
-                            attributeID:[NSNumber numberWithUnsignedInteger:mAttributeId]
-                                 params:params
-                                  queue:callbackQueue
-                             completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
-                                 if (error != nil) {
-                                     LogNSError("Error reading attribute", error);
-                                 }
-                                 if (values) {
-                                     for (id item in values) {
-                                         NSLog(@"Response Item: %@", [item description]);
-                                     }
-                                 }
-                                 SetCommandExitStatus(error);
-                             }];
+        [device readAttributePathWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
+                                      clusterID:[NSNumber numberWithUnsignedInteger:mClusterId]
+                                    attributeID:[NSNumber numberWithUnsignedInteger:mAttributeId]
+                                         params:params
+                                          queue:callbackQueue
+                                     completion:^(
+                                         NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                                         if (error != nil) {
+                                             LogNSError("Error reading attribute", error);
+                                         }
+                                         if (values) {
+                                             for (id item in values) {
+                                                 NSLog(@"Response Item: %@", [item description]);
+                                             }
+                                         }
+                                         SetCommandExitStatus(error);
+                                     }];
         return CHIP_NO_ERROR;
     }
 
@@ -129,7 +129,7 @@ public:
             = mKeepSubscriptions.HasValue() ? [NSNumber numberWithBool:mKeepSubscriptions.Value()] : nil;
         params.autoResubscribe = mAutoResubscribe.HasValue() ? [NSNumber numberWithBool:mAutoResubscribe.Value()] : nil;
 
-        [device subscribeAttributeWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
+        [device subscribeAttributePathWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
             clusterID:[NSNumber numberWithUnsignedInteger:mClusterId]
             attributeID:[NSNumber numberWithUnsignedInteger:mAttributeId]
             minInterval:[NSNumber numberWithUnsignedInteger:mMinInterval]

--- a/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
@@ -55,23 +55,23 @@ public:
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
         MTRReadParams * params = [[MTRReadParams alloc] init];
         params.fabricFiltered = mFabricFiltered.HasValue() ? [NSNumber numberWithBool:mFabricFiltered.Value()] : nil;
-        [device readAttributePathWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
-                                      clusterID:[NSNumber numberWithUnsignedInteger:mClusterId]
-                                    attributeID:[NSNumber numberWithUnsignedInteger:mAttributeId]
-                                         params:params
-                                          queue:callbackQueue
-                                     completion:^(
-                                         NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
-                                         if (error != nil) {
-                                             LogNSError("Error reading attribute", error);
-                                         }
-                                         if (values) {
-                                             for (id item in values) {
-                                                 NSLog(@"Response Item: %@", [item description]);
-                                             }
-                                         }
-                                         SetCommandExitStatus(error);
-                                     }];
+        [device
+            readAttributesWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
+                               clusterID:[NSNumber numberWithUnsignedInteger:mClusterId]
+                             attributeID:[NSNumber numberWithUnsignedInteger:mAttributeId]
+                                  params:params
+                                   queue:callbackQueue
+                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                                  if (error != nil) {
+                                      LogNSError("Error reading attribute", error);
+                                  }
+                                  if (values) {
+                                      for (id item in values) {
+                                          NSLog(@"Response Item: %@", [item description]);
+                                      }
+                                  }
+                                  SetCommandExitStatus(error);
+                              }];
         return CHIP_NO_ERROR;
     }
 
@@ -129,7 +129,7 @@ public:
             = mKeepSubscriptions.HasValue() ? [NSNumber numberWithBool:mKeepSubscriptions.Value()] : nil;
         params.autoResubscribe = mAutoResubscribe.HasValue() ? [NSNumber numberWithBool:mAutoResubscribe.Value()] : nil;
 
-        [device subscribeAttributePathWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
+        [device subscribeToAttributesWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
             clusterID:[NSNumber numberWithUnsignedInteger:mClusterId]
             attributeID:[NSNumber numberWithUnsignedInteger:mAttributeId]
             minInterval:[NSNumber numberWithUnsignedInteger:mMinInterval]

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -176,14 +176,21 @@ extern NSString * const MTRArrayValueType;
     resubscriptionScheduled:(MTRDeviceResubscriptionScheduledHandler _Nullable)resubscriptionScheduled MTR_NEWLY_AVAILABLE;
 
 /**
- * Read attribute in a designated attribute path
+ * Reads the given attribute path from the device.
+ *
+ * nil values for endpointID, clusterID, attributeID indicate wildcards
+ * (e.g. nil attributeID means "read all the attributes from the endpoint(s) and
+ * cluster(s) that match endpointID/clusterID").
+ *
+ * A non-nil attributeID along with a nil clusterID will only succeed if the
+ * attribute ID is for a global attribute that applies to all clusters.
  */
-- (void)readAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
-                          clusterID:(NSNumber * _Nullable)clusterID
-                        attributeID:(NSNumber * _Nullable)attributeID
-                             params:(MTRReadParams * _Nullable)params
-                              queue:(dispatch_queue_t)queue
-                         completion:(MTRDeviceResponseHandler)completion MTR_NEWLY_AVAILABLE;
+- (void)readAttributePathWithEndpointID:(NSNumber * _Nullable)endpointID
+                              clusterID:(NSNumber * _Nullable)clusterID
+                            attributeID:(NSNumber * _Nullable)attributeID
+                                 params:(MTRReadParams * _Nullable)params
+                                  queue:(dispatch_queue_t)queue
+                             completion:(MTRDeviceResponseHandler)completion MTR_NEWLY_AVAILABLE;
 
 /**
  * Write to attribute in a designated attribute path
@@ -195,8 +202,8 @@ extern NSString * const MTRArrayValueType;
  *
  * @param completion  response handler will receive either values or error.
  *
- *                    Received values are an NSArray object with response-value element as described in
- *                    readAttributeWithEndpointID:clusterID:attributeID:queue:completion:.
+ *                    Received values are documented in the definition of
+ *                    MTRDeviceResponseHandler.
  */
 - (void)writeAttributeWithEndpointID:(NSNumber *)endpointID
                            clusterID:(NSNumber *)clusterID
@@ -227,17 +234,25 @@ extern NSString * const MTRArrayValueType;
                          completion:(MTRDeviceResponseHandler)completion MTR_NEWLY_AVAILABLE;
 
 /**
- * Subscribe an attribute in a designated attribute path
+ * Subscribes to the given attribute path on the device.
+ *
+ * nil values for endpointID, clusterID, attributeID indicate wildcards
+ * (e.g. nil attributeID means "read all the attributes from the endpoint(s) and
+ * cluster(s) that match endpointID/clusterID").
+ *
+ * A non-nil attributeID along with a nil clusterID will only succeed if the
+ * attribute ID is for a global attribute that applies to all clusters.
  */
-- (void)subscribeAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
-                               clusterID:(NSNumber * _Nullable)clusterID
-                             attributeID:(NSNumber * _Nullable)attributeID
-                             minInterval:(NSNumber *)minInterval
-                             maxInterval:(NSNumber *)maxInterval
-                                  params:(MTRSubscribeParams * _Nullable)params
-                                   queue:(dispatch_queue_t)queue
-                           reportHandler:(MTRDeviceResponseHandler)reportHandler
-                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished MTR_NEWLY_AVAILABLE;
+- (void)subscribeAttributePathWithEndpointID:(NSNumber * _Nullable)endpointID
+                                   clusterID:(NSNumber * _Nullable)clusterID
+                                 attributeID:(NSNumber * _Nullable)attributeID
+                                 minInterval:(NSNumber *)minInterval
+                                 maxInterval:(NSNumber *)maxInterval
+                                      params:(MTRSubscribeParams * _Nullable)params
+                                       queue:(dispatch_queue_t)queue
+                               reportHandler:(MTRDeviceResponseHandler)reportHandler
+                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
+    MTR_NEWLY_AVAILABLE;
 
 /**
  * Deregister all local report handlers for a remote device
@@ -272,9 +287,9 @@ extern NSString * const MTRArrayValueType;
 @end
 
 @interface MTRAttributePath : NSObject <NSCopying>
-@property (nonatomic, readonly, strong, nonnull) NSNumber * endpoint;
-@property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
-@property (nonatomic, readonly, strong, nonnull) NSNumber * attribute;
+@property (nonatomic, readonly, copy) NSNumber * endpoint;
+@property (nonatomic, readonly, copy) NSNumber * cluster;
+@property (nonatomic, readonly, copy) NSNumber * attribute;
 
 + (instancetype)attributePathWithEndpointID:(NSNumber *)endpointID
                                   clusterID:(NSNumber *)clusterID
@@ -285,9 +300,9 @@ extern NSString * const MTRArrayValueType;
 @end
 
 @interface MTREventPath : NSObject
-@property (nonatomic, readonly, strong, nonnull) NSNumber * endpoint;
-@property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
-@property (nonatomic, readonly, strong, nonnull) NSNumber * event;
+@property (nonatomic, readonly, copy) NSNumber * endpoint;
+@property (nonatomic, readonly, copy) NSNumber * cluster;
+@property (nonatomic, readonly, copy) NSNumber * event;
 
 + (instancetype)eventPathWithEndpointID:(NSNumber *)endpointID
                               clusterID:(NSNumber *)clusterID
@@ -298,9 +313,9 @@ extern NSString * const MTRArrayValueType;
 @end
 
 @interface MTRCommandPath : NSObject
-@property (nonatomic, readonly, strong, nonnull) NSNumber * endpoint;
-@property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
-@property (nonatomic, readonly, strong, nonnull) NSNumber * command;
+@property (nonatomic, readonly, copy) NSNumber * endpoint;
+@property (nonatomic, readonly, copy) NSNumber * cluster;
+@property (nonatomic, readonly, copy) NSNumber * command;
 
 + (instancetype)commandPathWithEndpointID:(NSNumber *)endpointID
                                 clusterID:(NSNumber *)clusterID
@@ -311,25 +326,27 @@ extern NSString * const MTRArrayValueType;
 @end
 
 @interface MTRAttributeReport : NSObject
-@property (nonatomic, readonly, strong, nonnull) MTRAttributePath * path;
+@property (nonatomic, readonly, copy) MTRAttributePath * path;
 // value is nullable because nullable attributes can have nil as value.
-@property (nonatomic, readonly, strong, nullable) id value;
+@property (nonatomic, readonly, copy, nullable) id value;
 // If this specific path resulted in an error, the error (in the
 // MTRInteractionErrorDomain or MTRErrorDomain) that corresponds to this
 // path.
-@property (nonatomic, readonly, strong, nullable) NSError * error;
+@property (nonatomic, readonly, copy, nullable) NSError * error;
 @end
 
 @interface MTREventReport : NSObject
-@property (nonatomic, readonly, strong, nonnull) MTREventPath * path;
-@property (nonatomic, readonly, strong, nonnull) NSNumber * eventNumber; // chip::EventNumber type (uint64_t)
-@property (nonatomic, readonly, strong, nonnull) NSNumber * priority; // chip::app::PriorityLevel type (uint8_t)
-@property (nonatomic, readonly, strong, nonnull) NSNumber * timestamp; // chip::app::Timestamp.mValue type (uint64_t)
-@property (nonatomic, readonly, strong, nullable) id value;
+@property (nonatomic, readonly, copy) MTREventPath * path;
+@property (nonatomic, readonly, copy) NSNumber * eventNumber; // EventNumber type (uint64_t)
+@property (nonatomic, readonly, copy) NSNumber * priority; // PriorityLevel type (uint8_t)
+@property (nonatomic, readonly, copy) NSNumber * timestamp; // Timestamp type (uint64_t)
+// An instance of one of the event payload interfaces.
+@property (nonatomic, readonly, copy) id value;
+
 // If this specific path resulted in an error, the error (in the
 // MTRInteractionErrorDomain or MTRErrorDomain) that corresponds to this
 // path.
-@property (nonatomic, readonly, strong, nullable) NSError * error;
+@property (nonatomic, readonly, copy, nullable) NSError * error;
 @end
 
 @interface MTRBaseDevice (Deprecated)
@@ -357,7 +374,7 @@ extern NSString * const MTRArrayValueType;
                              params:(MTRReadParams * _Nullable)params
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(MTRDeviceResponseHandler)completion
-    MTR_NEWLY_DEPRECATED("Please use readAttributeWithEndpointID:clusterID:attributeID:params:queue:completion:");
+    MTR_NEWLY_DEPRECATED("Please use readAttributePathWithEndpointID:clusterID:attributeID:params:queue:completion:");
 
 - (void)writeAttributeWithEndpointId:(NSNumber *)endpointId
                            clusterId:(NSNumber *)clusterId
@@ -387,9 +404,9 @@ extern NSString * const MTRArrayValueType;
                              clientQueue:(dispatch_queue_t)clientQueue
                            reportHandler:(MTRDeviceResponseHandler)reportHandler
                  subscriptionEstablished:(dispatch_block_t _Nullable)subscriptionEstablishedHandler
-    MTR_NEWLY_DEPRECATED(
-        "Please use "
-        "subscribeAttributeWithEndpointID:clusterID:attributeID:params:minInterval:maxInterval:queue:reportHandler:");
+    MTR_NEWLY_DEPRECATED("Please use "
+                         "subscribeAttributePathWithEndpointID:clusterID:attributeID:params:minInterval:maxInterval:queue:"
+                         "reportHandler:subscriptionEstablished:");
 
 - (void)deregisterReportHandlersWithClientQueue:(dispatch_queue_t)queue
                                      completion:(dispatch_block_t)completion

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -176,21 +176,27 @@ extern NSString * const MTRArrayValueType;
     resubscriptionScheduled:(MTRDeviceResubscriptionScheduledHandler _Nullable)resubscriptionScheduled MTR_NEWLY_AVAILABLE;
 
 /**
- * Reads the given attribute path from the device.
+ * Reads attributes from the device.
  *
- * nil values for endpointID, clusterID, attributeID indicate wildcards
+ * Nil values for endpointID, clusterID, attributeID indicate wildcards
  * (e.g. nil attributeID means "read all the attributes from the endpoint(s) and
  * cluster(s) that match endpointID/clusterID").
+ *
+ * If all of endpointID, clusterID, attributeID are non-nil, a single
+ * attribute will be read.
+ *
+ * If all of endpointID, clusterID, attributeID are nil, all attributes on the
+ * device will be read.
  *
  * A non-nil attributeID along with a nil clusterID will only succeed if the
  * attribute ID is for a global attribute that applies to all clusters.
  */
-- (void)readAttributePathWithEndpointID:(NSNumber * _Nullable)endpointID
-                              clusterID:(NSNumber * _Nullable)clusterID
-                            attributeID:(NSNumber * _Nullable)attributeID
-                                 params:(MTRReadParams * _Nullable)params
-                                  queue:(dispatch_queue_t)queue
-                             completion:(MTRDeviceResponseHandler)completion MTR_NEWLY_AVAILABLE;
+- (void)readAttributesWithEndpointID:(NSNumber * _Nullable)endpointID
+                           clusterID:(NSNumber * _Nullable)clusterID
+                         attributeID:(NSNumber * _Nullable)attributeID
+                              params:(MTRReadParams * _Nullable)params
+                               queue:(dispatch_queue_t)queue
+                          completion:(MTRDeviceResponseHandler)completion MTR_NEWLY_AVAILABLE;
 
 /**
  * Write to attribute in a designated attribute path
@@ -234,24 +240,30 @@ extern NSString * const MTRArrayValueType;
                          completion:(MTRDeviceResponseHandler)completion MTR_NEWLY_AVAILABLE;
 
 /**
- * Subscribes to the given attribute path on the device.
+ * Subscribes to the specified attributes on the device.
  *
- * nil values for endpointID, clusterID, attributeID indicate wildcards
- * (e.g. nil attributeID means "read all the attributes from the endpoint(s) and
- * cluster(s) that match endpointID/clusterID").
+ * Nil values for endpointID, clusterID, attributeID indicate wildcards
+ * (e.g. nil attributeID means "subscribe to all the attributes from the
+ * endpoint(s) and cluster(s) that match endpointID/clusterID").
+ *
+ * If all of endpointID, clusterID, attributeID are non-nil, a single attribute
+ * will be subscribed to.
+ *
+ * If all of endpointID, clusterID, attributeID are nil, all attributes on the
+ * device will be subscribed to.
  *
  * A non-nil attributeID along with a nil clusterID will only succeed if the
  * attribute ID is for a global attribute that applies to all clusters.
  */
-- (void)subscribeAttributePathWithEndpointID:(NSNumber * _Nullable)endpointID
-                                   clusterID:(NSNumber * _Nullable)clusterID
-                                 attributeID:(NSNumber * _Nullable)attributeID
-                                 minInterval:(NSNumber *)minInterval
-                                 maxInterval:(NSNumber *)maxInterval
-                                      params:(MTRSubscribeParams * _Nullable)params
-                                       queue:(dispatch_queue_t)queue
-                               reportHandler:(MTRDeviceResponseHandler)reportHandler
-                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
+- (void)subscribeToAttributesWithEndpointID:(NSNumber * _Nullable)endpointID
+                                  clusterID:(NSNumber * _Nullable)clusterID
+                                attributeID:(NSNumber * _Nullable)attributeID
+                                minInterval:(NSNumber *)minInterval
+                                maxInterval:(NSNumber *)maxInterval
+                                     params:(MTRSubscribeParams * _Nullable)params
+                                      queue:(dispatch_queue_t)queue
+                              reportHandler:(MTRDeviceResponseHandler)reportHandler
+                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
     MTR_NEWLY_AVAILABLE;
 
 /**
@@ -374,7 +386,7 @@ extern NSString * const MTRArrayValueType;
                              params:(MTRReadParams * _Nullable)params
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(MTRDeviceResponseHandler)completion
-    MTR_NEWLY_DEPRECATED("Please use readAttributePathWithEndpointID:clusterID:attributeID:params:queue:completion:");
+    MTR_NEWLY_DEPRECATED("Please use readAttributesWithEndpointID:clusterID:attributeID:params:queue:completion:");
 
 - (void)writeAttributeWithEndpointId:(NSNumber *)endpointId
                            clusterId:(NSNumber *)clusterId
@@ -405,7 +417,7 @@ extern NSString * const MTRArrayValueType;
                            reportHandler:(MTRDeviceResponseHandler)reportHandler
                  subscriptionEstablished:(dispatch_block_t _Nullable)subscriptionEstablishedHandler
     MTR_NEWLY_DEPRECATED("Please use "
-                         "subscribeAttributePathWithEndpointID:clusterID:attributeID:params:minInterval:maxInterval:queue:"
+                         "subscribeToAttributesWithEndpointID:clusterID:attributeID:params:minInterval:maxInterval:queue:"
                          "reportHandler:subscriptionEstablished:");
 
 - (void)deregisterReportHandlersWithClientQueue:(dispatch_queue_t)queue

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -774,12 +774,12 @@ private:
     Platform::UniquePtr<app::ReadClient> mReadClient;
 };
 
-- (void)readAttributePathWithEndpointID:(NSNumber * _Nullable)endpointID
-                              clusterID:(NSNumber * _Nullable)clusterID
-                            attributeID:(NSNumber * _Nullable)attributeID
-                                 params:(MTRReadParams * _Nullable)params
-                                  queue:(dispatch_queue_t)queue
-                             completion:(MTRDeviceResponseHandler)completion
+- (void)readAttributesWithEndpointID:(NSNumber * _Nullable)endpointID
+                           clusterID:(NSNumber * _Nullable)clusterID
+                         attributeID:(NSNumber * _Nullable)attributeID
+                              params:(MTRReadParams * _Nullable)params
+                               queue:(dispatch_queue_t)queue
+                          completion:(MTRDeviceResponseHandler)completion
 {
     endpointID = (endpointID == nil) ? nil : [endpointID copy];
     clusterID = (clusterID == nil) ? nil : [clusterID copy];
@@ -1117,15 +1117,15 @@ exit:
         });
 }
 
-- (void)subscribeAttributePathWithEndpointID:(NSNumber * _Nullable)endpointID
-                                   clusterID:(NSNumber * _Nullable)clusterID
-                                 attributeID:(NSNumber * _Nullable)attributeID
-                                 minInterval:(NSNumber *)minInterval
-                                 maxInterval:(NSNumber *)maxInterval
-                                      params:(MTRSubscribeParams * _Nullable)params
-                                       queue:(dispatch_queue_t)queue
-                               reportHandler:(MTRDeviceResponseHandler)reportHandler
-                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler)subscriptionEstablished
+- (void)subscribeToAttributesWithEndpointID:(NSNumber * _Nullable)endpointID
+                                  clusterID:(NSNumber * _Nullable)clusterID
+                                attributeID:(NSNumber * _Nullable)attributeID
+                                minInterval:(NSNumber *)minInterval
+                                maxInterval:(NSNumber *)maxInterval
+                                     params:(MTRSubscribeParams * _Nullable)params
+                                      queue:(dispatch_queue_t)queue
+                              reportHandler:(MTRDeviceResponseHandler)reportHandler
+                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler)subscriptionEstablished
 {
     if (self.isPASEDevice) {
         // We don't support subscriptions over PASE.
@@ -1488,12 +1488,12 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(MTRDeviceResponseHandler)completion
 {
-    [self readAttributePathWithEndpointID:endpointId
-                                clusterID:clusterId
-                              attributeID:attributeId
-                                   params:params
-                                    queue:clientQueue
-                               completion:completion];
+    [self readAttributesWithEndpointID:endpointId
+                             clusterID:clusterId
+                           attributeID:attributeId
+                                params:params
+                                 queue:clientQueue
+                            completion:completion];
 }
 
 - (void)writeAttributeWithEndpointId:(NSNumber *)endpointId
@@ -1540,15 +1540,15 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
                            reportHandler:(MTRDeviceResponseHandler)reportHandler
                  subscriptionEstablished:(dispatch_block_t _Nullable)subscriptionEstablishedHandler
 {
-    [self subscribeAttributePathWithEndpointID:endpointId
-                                     clusterID:clusterId
-                                   attributeID:attributeId
-                                   minInterval:minInterval
-                                   maxInterval:maxInterval
-                                        params:params
-                                         queue:clientQueue
-                                 reportHandler:reportHandler
-                       subscriptionEstablished:subscriptionEstablishedHandler];
+    [self subscribeToAttributesWithEndpointID:endpointId
+                                    clusterID:clusterId
+                                  attributeID:attributeId
+                                  minInterval:minInterval
+                                  maxInterval:maxInterval
+                                       params:params
+                                        queue:clientQueue
+                                reportHandler:reportHandler
+                      subscriptionEstablished:subscriptionEstablishedHandler];
 }
 
 - (void)deregisterReportHandlersWithClientQueue:(dispatch_queue_t)queue completion:(dispatch_block_t)completion

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -262,7 +262,7 @@ public:
 - (void)subscribeWithQueue:(dispatch_queue_t)queue
                 minInterval:(NSNumber *)minInterval
                 maxInterval:(NSNumber *)maxInterval
-                     params:(nullable MTRSubscribeParams *)params
+                     params:(MTRSubscribeParams * _Nullable)params
     attributeCacheContainer:(MTRAttributeCacheContainer * _Nullable)attributeCacheContainer
      attributeReportHandler:(MTRDeviceReportHandler _Nullable)attributeReportHandler
          eventReportHandler:(MTRDeviceReportHandler _Nullable)eventReportHandler
@@ -774,12 +774,12 @@ private:
     Platform::UniquePtr<app::ReadClient> mReadClient;
 };
 
-- (void)readAttributeWithEndpointID:(NSNumber *)endpointID
-                          clusterID:(NSNumber *)clusterID
-                        attributeID:(NSNumber *)attributeID
-                             params:(MTRReadParams * _Nullable)params
-                              queue:(dispatch_queue_t)queue
-                         completion:(MTRDeviceResponseHandler)completion
+- (void)readAttributePathWithEndpointID:(NSNumber * _Nullable)endpointID
+                              clusterID:(NSNumber * _Nullable)clusterID
+                            attributeID:(NSNumber * _Nullable)attributeID
+                                 params:(MTRReadParams * _Nullable)params
+                                  queue:(dispatch_queue_t)queue
+                             completion:(MTRDeviceResponseHandler)completion
 {
     endpointID = (endpointID == nil) ? nil : [endpointID copy];
     clusterID = (clusterID == nil) ? nil : [clusterID copy];
@@ -1117,15 +1117,15 @@ exit:
         });
 }
 
-- (void)subscribeAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
-                               clusterID:(NSNumber * _Nullable)clusterID
-                             attributeID:(NSNumber * _Nullable)attributeID
-                             minInterval:(NSNumber *)minInterval
-                             maxInterval:(NSNumber *)maxInterval
-                                  params:(MTRSubscribeParams * _Nullable)params
-                                   queue:(dispatch_queue_t)queue
-                           reportHandler:(MTRDeviceResponseHandler)reportHandler
-                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler)subscriptionEstablished
+- (void)subscribeAttributePathWithEndpointID:(NSNumber * _Nullable)endpointID
+                                   clusterID:(NSNumber * _Nullable)clusterID
+                                 attributeID:(NSNumber * _Nullable)attributeID
+                                 minInterval:(NSNumber *)minInterval
+                                 maxInterval:(NSNumber *)maxInterval
+                                      params:(MTRSubscribeParams * _Nullable)params
+                                       queue:(dispatch_queue_t)queue
+                               reportHandler:(MTRDeviceResponseHandler)reportHandler
+                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler)subscriptionEstablished
 {
     if (self.isPASEDevice) {
         // We don't support subscriptions over PASE.
@@ -1488,12 +1488,12 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(MTRDeviceResponseHandler)completion
 {
-    [self readAttributeWithEndpointID:endpointId
-                            clusterID:clusterId
-                          attributeID:attributeId
-                               params:params
-                                queue:clientQueue
-                           completion:completion];
+    [self readAttributePathWithEndpointID:endpointId
+                                clusterID:clusterId
+                              attributeID:attributeId
+                                   params:params
+                                    queue:clientQueue
+                               completion:completion];
 }
 
 - (void)writeAttributeWithEndpointId:(NSNumber *)endpointId
@@ -1540,15 +1540,15 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
                            reportHandler:(MTRDeviceResponseHandler)reportHandler
                  subscriptionEstablished:(dispatch_block_t _Nullable)subscriptionEstablishedHandler
 {
-    [self subscribeAttributeWithEndpointID:endpointId
-                                 clusterID:clusterId
-                               attributeID:attributeId
-                               minInterval:minInterval
-                               maxInterval:maxInterval
-                                    params:params
-                                     queue:clientQueue
-                             reportHandler:reportHandler
-                   subscriptionEstablished:subscriptionEstablishedHandler];
+    [self subscribeAttributePathWithEndpointID:endpointId
+                                     clusterID:clusterId
+                                   attributeID:attributeId
+                                   minInterval:minInterval
+                                   maxInterval:maxInterval
+                                        params:params
+                                         queue:clientQueue
+                                 reportHandler:reportHandler
+                       subscriptionEstablished:subscriptionEstablishedHandler];
 }
 
 - (void)deregisterReportHandlersWithClientQueue:(dispatch_queue_t)queue completion:(dispatch_block_t)completion
@@ -1639,6 +1639,11 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
 
     return [[MTREventPath alloc] initWithPath:path];
 }
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    return [MTREventPath eventPathWithEndpointID:_endpoint clusterID:_cluster eventID:_event];
+}
 @end
 
 @implementation MTREventPath (Deprecated)
@@ -1666,6 +1671,11 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
 
     return [[MTRCommandPath alloc] initWithPath:path];
 }
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    return [MTRCommandPath commandPathWithEndpointID:_endpoint clusterID:_cluster commandID:_command];
+}
 @end
 
 @implementation MTRCommandPath (Deprecated)
@@ -1676,7 +1686,7 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
 @end
 
 @implementation MTRAttributeReport
-- (instancetype)initWithPath:(const ConcreteDataAttributePath &)path value:(nullable id)value error:(nullable NSError *)error
+- (instancetype)initWithPath:(const ConcreteDataAttributePath &)path value:(id _Nullable)value error:(NSError * _Nullable)error
 {
     if (self = [super init]) {
         _path = [[MTRAttributePath alloc] initWithPath:path];
@@ -1692,8 +1702,8 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
                  eventNumber:(NSNumber *)eventNumber
                     priority:(NSNumber *)priority
                    timestamp:(NSNumber *)timestamp
-                       value:(nullable id)value
-                       error:(nullable NSError *)error
+                       value:(id _Nullable)value
+                       error:(NSError * _Nullable)error
 {
     if (self = [super init]) {
         _path = [[MTREventPath alloc] initWithPath:path];

--- a/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
@@ -85,8 +85,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRAttributeReport ()
 - (instancetype)initWithPath:(const chip::app::ConcreteDataAttributePath &)path
-                       value:(nullable id)value
-                       error:(nullable NSError *)error;
+                       value:(id _Nullable)value
+                       error:(NSError * _Nullable)error;
 @end
 
 @interface MTREventReport ()
@@ -94,8 +94,8 @@ NS_ASSUME_NONNULL_BEGIN
                  eventNumber:(NSNumber *)eventNumber
                     priority:(NSNumber *)priority
                    timestamp:(NSNumber *)timestamp
-                       value:(nullable id)value
-                       error:(nullable NSError *)error;
+                       value:(id _Nullable)value
+                       error:(NSError * _Nullable)error;
 @end
 
 // Exported utility function

--- a/src/darwin/Framework/CHIP/MTRCertificates.h
+++ b/src/darwin/Framework/CHIP/MTRCertificates.h
@@ -20,6 +20,9 @@
 
 #import <Foundation/Foundation.h>
 
+typedef NSData MTRCertificateDERBytes;
+typedef NSData MTRCertificateTLVBytes;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol MTRKeypair;
@@ -27,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRCertificates : NSObject
 
 /**
- * Generate a root (self-signed) X.509 DER encoded certificate that has the
+ * Create a root (self-signed) X.509 DER encoded certificate that has the
  * right fields to be a valid Matter root certificate.
  *
  * If issuerID is nil, a random issuer id is generated.  Otherwise the provided
@@ -39,13 +42,14 @@ NS_ASSUME_NONNULL_BEGIN
  * On failure returns nil and if "error" is not null sets *error to the relevant
  * error.
  */
-+ (nullable NSData *)generateRootCertificate:(id<MTRKeypair>)keypair
-                                    issuerID:(nullable NSNumber *)issuerID
-                                    fabricID:(nullable NSNumber *)fabricID
-                                       error:(NSError * __autoreleasing _Nullable * _Nullable)error MTR_NEWLY_AVAILABLE;
++ (MTRCertificateDERBytes * _Nullable)createRootCertificate:(id<MTRKeypair>)keypair
+                                                   issuerID:(NSNumber * _Nullable)issuerID
+                                                   fabricID:(NSNumber * _Nullable)fabricID
+                                                      error:(NSError * __autoreleasing _Nullable * _Nullable)error
+    MTR_NEWLY_AVAILABLE;
 
 /**
- * Generate an intermediate X.509 DER encoded certificate that has the
+ * Create an intermediate X.509 DER encoded certificate that has the
  * right fields to be a valid Matter intermediate certificate.
  *
  * If issuerID is nil, a random issuer id is generated.  Otherwise the provided
@@ -57,15 +61,16 @@ NS_ASSUME_NONNULL_BEGIN
  * On failure returns nil and if "error" is not null sets *error to the relevant
  * error.
  */
-+ (nullable NSData *)generateIntermediateCertificate:(id<MTRKeypair>)rootKeypair
-                                     rootCertificate:(NSData *)rootCertificate
-                               intermediatePublicKey:(SecKeyRef)intermediatePublicKey
-                                            issuerID:(nullable NSNumber *)issuerID
-                                            fabricID:(nullable NSNumber *)fabricID
-                                               error:(NSError * __autoreleasing _Nullable * _Nullable)error MTR_NEWLY_AVAILABLE;
++ (MTRCertificateDERBytes * _Nullable)createIntermediateCertificate:(id<MTRKeypair>)rootKeypair
+                                                    rootCertificate:(MTRCertificateDERBytes *)rootCertificate
+                                              intermediatePublicKey:(SecKeyRef)intermediatePublicKey
+                                                           issuerID:(NSNumber * _Nullable)issuerID
+                                                           fabricID:(NSNumber * _Nullable)fabricID
+                                                              error:(NSError * __autoreleasing _Nullable * _Nullable)error
+    MTR_NEWLY_AVAILABLE;
 
 /**
- * Generate an X.509 DER encoded certificate that has the
+ * Create an X.509 DER encoded certificate that has the
  * right fields to be a valid Matter operational certificate.
  *
  * signingKeypair and signingCertificate are the root or intermediate that is
@@ -85,13 +90,14 @@ NS_ASSUME_NONNULL_BEGIN
  * On failure returns nil and if "error" is not null sets *error to the relevant
  * error.
  */
-+ (nullable NSData *)generateOperationalCertificate:(id<MTRKeypair>)signingKeypair
-                                 signingCertificate:(NSData *)signingCertificate
-                               operationalPublicKey:(SecKeyRef)operationalPublicKey
-                                           fabricID:(NSNumber *)fabricID
-                                             nodeID:(NSNumber *)nodeID
-                              caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
-                                              error:(NSError * __autoreleasing _Nullable * _Nullable)error MTR_NEWLY_AVAILABLE;
++ (MTRCertificateDERBytes * _Nullable)createOperationalCertificate:(id<MTRKeypair>)signingKeypair
+                                                signingCertificate:(MTRCertificateDERBytes *)signingCertificate
+                                              operationalPublicKey:(SecKeyRef)operationalPublicKey
+                                                          fabricID:(NSNumber *)fabricID
+                                                            nodeID:(NSNumber *)nodeID
+                                             caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
+                                                             error:(NSError * __autoreleasing _Nullable * _Nullable)error
+    MTR_NEWLY_AVAILABLE;
 
 /**
  * Check whether the given keypair's public key matches the given certificate's
@@ -107,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
  * of having the same public key and the same subject DN.  Returns NO if public
  * keys or subject DNs cannot be extracted from the certificates.
  */
-+ (BOOL)isCertificate:(NSData *)certificate1 equalTo:(NSData *)certificate2;
++ (BOOL)isCertificate:(MTRCertificateDERBytes *)certificate1 equalTo:(MTRCertificateDERBytes *)certificate2;
 
 /**
  * Generate a PKCS#10 certificate signing request from a MTRKeypair.  This can
@@ -122,8 +128,8 @@ NS_ASSUME_NONNULL_BEGIN
  * On failure returns nil and if "error" is not null sets *error to the relevant
  * error.
  */
-+ (nullable NSData *)generateCertificateSigningRequest:(id<MTRKeypair>)keypair
-                                                 error:(NSError * __autoreleasing _Nullable * _Nullable)error;
++ (NSData * _Nullable)createCertificateSigningRequest:(id<MTRKeypair>)keypair
+                                                error:(NSError * __autoreleasing _Nullable * _Nullable)error;
 
 /**
  * Convert the given X.509v3 DER encoded certificate to the Matter certificate
@@ -133,7 +139,7 @@ NS_ASSUME_NONNULL_BEGIN
  * as a DER encoded X.509 certificate, or if the certificate cannot be
  * represented in the Matter certificate format).
  */
-+ (nullable NSData *)convertX509Certificate:(NSData *)x509Certificate;
++ (MTRCertificateTLVBytes * _Nullable)convertX509Certificate:(MTRCertificateDERBytes *)x509Certificate;
 
 @end
 
@@ -143,7 +149,7 @@ NS_ASSUME_NONNULL_BEGIN
                                     issuerId:(nullable NSNumber *)issuerId
                                     fabricId:(nullable NSNumber *)fabricId
                                        error:(NSError * __autoreleasing _Nullable * _Nullable)error
-    MTR_NEWLY_DEPRECATED("Please use generateRootCertificate:issuerId:fabricId:error:");
+    MTR_NEWLY_DEPRECATED("Please use createRootCertificate:issuerID:fabricID:error:");
 
 + (nullable NSData *)generateIntermediateCertificate:(id<MTRKeypair>)rootKeypair
                                      rootCertificate:(NSData *)rootCertificate
@@ -151,8 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
                                             issuerId:(nullable NSNumber *)issuerId
                                             fabricId:(nullable NSNumber *)fabricId
                                                error:(NSError * __autoreleasing _Nullable * _Nullable)error
-    MTR_NEWLY_DEPRECATED(
-        "Please use generateIntermediateCertificate:rootCertificate:intermediatePublicKey:issuerID:fabricID:error:");
+    MTR_NEWLY_DEPRECATED("Please use createIntermediateCertificate:rootCertificate:intermediatePublicKey:issuerID:fabricID:error:");
 
 + (nullable NSData *)generateOperationalCertificate:(id<MTRKeypair>)signingKeypair
                                  signingCertificate:(NSData *)signingCertificate
@@ -163,7 +168,11 @@ NS_ASSUME_NONNULL_BEGIN
                                               error:(NSError * __autoreleasing _Nullable * _Nullable)error
     MTR_NEWLY_DEPRECATED(
         "Plase use "
-        "generateOperationalCertificate:signingCertificate:operationalPublicKey:fabricID:nodeID:caseAuthenticatedTags:error:");
+        "createOperationalCertificate:signingCertificate:operationalPublicKey:fabricID:nodeID:caseAuthenticatedTags:error:");
+
++ (nullable NSData *)generateCertificateSigningRequest:(id<MTRKeypair>)keypair
+                                                 error:(NSError * __autoreleasing _Nullable * _Nullable)error
+    MTR_NEWLY_DEPRECATED("Please use createCertificateSigningRequest:error:");
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCertificates.h
+++ b/src/darwin/Framework/CHIP/MTRCertificates.h
@@ -20,8 +20,8 @@
 
 #import <Foundation/Foundation.h>
 
-typedef NSData MTRCertificateDERBytes;
-typedef NSData MTRCertificateTLVBytes;
+typedef NSData * MTRCertificateDERBytes;
+typedef NSData * MTRCertificateTLVBytes;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -42,10 +42,10 @@ NS_ASSUME_NONNULL_BEGIN
  * On failure returns nil and if "error" is not null sets *error to the relevant
  * error.
  */
-+ (MTRCertificateDERBytes * _Nullable)createRootCertificate:(id<MTRKeypair>)keypair
-                                                   issuerID:(NSNumber * _Nullable)issuerID
-                                                   fabricID:(NSNumber * _Nullable)fabricID
-                                                      error:(NSError * __autoreleasing _Nullable * _Nullable)error
++ (MTRCertificateDERBytes _Nullable)createRootCertificate:(id<MTRKeypair>)keypair
+                                                 issuerID:(NSNumber * _Nullable)issuerID
+                                                 fabricID:(NSNumber * _Nullable)fabricID
+                                                    error:(NSError * __autoreleasing _Nullable * _Nullable)error
     MTR_NEWLY_AVAILABLE;
 
 /**
@@ -61,12 +61,12 @@ NS_ASSUME_NONNULL_BEGIN
  * On failure returns nil and if "error" is not null sets *error to the relevant
  * error.
  */
-+ (MTRCertificateDERBytes * _Nullable)createIntermediateCertificate:(id<MTRKeypair>)rootKeypair
-                                                    rootCertificate:(MTRCertificateDERBytes *)rootCertificate
-                                              intermediatePublicKey:(SecKeyRef)intermediatePublicKey
-                                                           issuerID:(NSNumber * _Nullable)issuerID
-                                                           fabricID:(NSNumber * _Nullable)fabricID
-                                                              error:(NSError * __autoreleasing _Nullable * _Nullable)error
++ (MTRCertificateDERBytes _Nullable)createIntermediateCertificate:(id<MTRKeypair>)rootKeypair
+                                                  rootCertificate:(MTRCertificateDERBytes)rootCertificate
+                                            intermediatePublicKey:(SecKeyRef)intermediatePublicKey
+                                                         issuerID:(NSNumber * _Nullable)issuerID
+                                                         fabricID:(NSNumber * _Nullable)fabricID
+                                                            error:(NSError * __autoreleasing _Nullable * _Nullable)error
     MTR_NEWLY_AVAILABLE;
 
 /**
@@ -90,13 +90,13 @@ NS_ASSUME_NONNULL_BEGIN
  * On failure returns nil and if "error" is not null sets *error to the relevant
  * error.
  */
-+ (MTRCertificateDERBytes * _Nullable)createOperationalCertificate:(id<MTRKeypair>)signingKeypair
-                                                signingCertificate:(MTRCertificateDERBytes *)signingCertificate
-                                              operationalPublicKey:(SecKeyRef)operationalPublicKey
-                                                          fabricID:(NSNumber *)fabricID
-                                                            nodeID:(NSNumber *)nodeID
-                                             caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
-                                                             error:(NSError * __autoreleasing _Nullable * _Nullable)error
++ (MTRCertificateDERBytes _Nullable)createOperationalCertificate:(id<MTRKeypair>)signingKeypair
+                                              signingCertificate:(MTRCertificateDERBytes)signingCertificate
+                                            operationalPublicKey:(SecKeyRef)operationalPublicKey
+                                                        fabricID:(NSNumber *)fabricID
+                                                          nodeID:(NSNumber *)nodeID
+                                           caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
+                                                           error:(NSError * __autoreleasing _Nullable * _Nullable)error
     MTR_NEWLY_AVAILABLE;
 
 /**
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
  * of having the same public key and the same subject DN.  Returns NO if public
  * keys or subject DNs cannot be extracted from the certificates.
  */
-+ (BOOL)isCertificate:(MTRCertificateDERBytes *)certificate1 equalTo:(MTRCertificateDERBytes *)certificate2;
++ (BOOL)isCertificate:(MTRCertificateDERBytes)certificate1 equalTo:(MTRCertificateDERBytes)certificate2;
 
 /**
  * Generate a PKCS#10 certificate signing request from a MTRKeypair.  This can
@@ -139,7 +139,7 @@ NS_ASSUME_NONNULL_BEGIN
  * as a DER encoded X.509 certificate, or if the certificate cannot be
  * represented in the Matter certificate format).
  */
-+ (MTRCertificateTLVBytes * _Nullable)convertX509Certificate:(MTRCertificateDERBytes *)x509Certificate;
++ (MTRCertificateTLVBytes _Nullable)convertX509Certificate:(MTRCertificateDERBytes)x509Certificate;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCertificates.mm
+++ b/src/darwin/Framework/CHIP/MTRCertificates.mm
@@ -31,10 +31,10 @@ using namespace chip::Credentials;
 
 @implementation MTRCertificates
 
-+ (MTRCertificateDERBytes * _Nullable)createRootCertificate:(id<MTRKeypair>)keypair
-                                                   issuerID:(NSNumber * _Nullable)issuerID
-                                                   fabricID:(NSNumber * _Nullable)fabricID
-                                                      error:(NSError * __autoreleasing *)error
++ (MTRCertificateDERBytes _Nullable)createRootCertificate:(id<MTRKeypair>)keypair
+                                                 issuerID:(NSNumber * _Nullable)issuerID
+                                                 fabricID:(NSNumber * _Nullable)fabricID
+                                                    error:(NSError * __autoreleasing *)error
 {
     NSLog(@"Generating root certificate");
 
@@ -53,12 +53,12 @@ using namespace chip::Credentials;
     return rootCert;
 }
 
-+ (MTRCertificateDERBytes * _Nullable)createIntermediateCertificate:(id<MTRKeypair>)rootKeypair
-                                                    rootCertificate:(MTRCertificateDERBytes *)rootCertificate
-                                              intermediatePublicKey:(SecKeyRef)intermediatePublicKey
-                                                           issuerID:(NSNumber * _Nullable)issuerID
-                                                           fabricID:(NSNumber * _Nullable)fabricID
-                                                              error:(NSError * __autoreleasing *)error
++ (MTRCertificateDERBytes _Nullable)createIntermediateCertificate:(id<MTRKeypair>)rootKeypair
+                                                  rootCertificate:(MTRCertificateDERBytes)rootCertificate
+                                            intermediatePublicKey:(SecKeyRef)intermediatePublicKey
+                                                         issuerID:(NSNumber * _Nullable)issuerID
+                                                         fabricID:(NSNumber * _Nullable)fabricID
+                                                            error:(NSError * __autoreleasing *)error
 {
     NSLog(@"Generating intermediate certificate");
 
@@ -78,13 +78,13 @@ using namespace chip::Credentials;
     return intermediate;
 }
 
-+ (MTRCertificateDERBytes * _Nullable)createOperationalCertificate:(id<MTRKeypair>)signingKeypair
-                                                signingCertificate:(MTRCertificateDERBytes *)signingCertificate
-                                              operationalPublicKey:(SecKeyRef)operationalPublicKey
-                                                          fabricID:(NSNumber *)fabricID
-                                                            nodeID:(NSNumber *)nodeID
-                                             caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
-                                                             error:(NSError * __autoreleasing _Nullable * _Nullable)error
++ (MTRCertificateDERBytes _Nullable)createOperationalCertificate:(id<MTRKeypair>)signingKeypair
+                                              signingCertificate:(MTRCertificateDERBytes)signingCertificate
+                                            operationalPublicKey:(SecKeyRef)operationalPublicKey
+                                                        fabricID:(NSNumber *)fabricID
+                                                          nodeID:(NSNumber *)nodeID
+                                           caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
+                                                           error:(NSError * __autoreleasing _Nullable * _Nullable)error
 {
     NSLog(@"Generating operational certificate");
 
@@ -127,7 +127,7 @@ using namespace chip::Credentials;
     return certKeySpan.data_equal(keypairKeySpan);
 }
 
-+ (BOOL)isCertificate:(MTRCertificateDERBytes *)certificate1 equalTo:(MTRCertificateDERBytes *)certificate2
++ (BOOL)isCertificate:(MTRCertificateDERBytes)certificate1 equalTo:(MTRCertificateDERBytes)certificate2
 {
     [MTRMemory ensureInit];
 
@@ -197,7 +197,7 @@ using namespace chip::Credentials;
     return nil;
 }
 
-+ (MTRCertificateTLVBytes * _Nullable)convertX509Certificate:(MTRCertificateDERBytes *)x509Certificate
++ (MTRCertificateTLVBytes _Nullable)convertX509Certificate:(MTRCertificateDERBytes)x509Certificate
 {
 
     chip::ByteSpan x509CertBytes = AsByteSpan(x509Certificate);

--- a/src/darwin/Framework/CHIP/MTRCertificates.mm
+++ b/src/darwin/Framework/CHIP/MTRCertificates.mm
@@ -31,10 +31,10 @@ using namespace chip::Credentials;
 
 @implementation MTRCertificates
 
-+ (nullable NSData *)generateRootCertificate:(id<MTRKeypair>)keypair
-                                    issuerID:(nullable NSNumber *)issuerID
-                                    fabricID:(nullable NSNumber *)fabricID
-                                       error:(NSError * __autoreleasing *)error
++ (MTRCertificateDERBytes * _Nullable)createRootCertificate:(id<MTRKeypair>)keypair
+                                                   issuerID:(NSNumber * _Nullable)issuerID
+                                                   fabricID:(NSNumber * _Nullable)fabricID
+                                                      error:(NSError * __autoreleasing *)error
 {
     NSLog(@"Generating root certificate");
 
@@ -53,12 +53,12 @@ using namespace chip::Credentials;
     return rootCert;
 }
 
-+ (nullable NSData *)generateIntermediateCertificate:(id<MTRKeypair>)rootKeypair
-                                     rootCertificate:(NSData *)rootCertificate
-                               intermediatePublicKey:(SecKeyRef)intermediatePublicKey
-                                            issuerID:(nullable NSNumber *)issuerID
-                                            fabricID:(nullable NSNumber *)fabricID
-                                               error:(NSError * __autoreleasing *)error
++ (MTRCertificateDERBytes * _Nullable)createIntermediateCertificate:(id<MTRKeypair>)rootKeypair
+                                                    rootCertificate:(MTRCertificateDERBytes *)rootCertificate
+                                              intermediatePublicKey:(SecKeyRef)intermediatePublicKey
+                                                           issuerID:(NSNumber * _Nullable)issuerID
+                                                           fabricID:(NSNumber * _Nullable)fabricID
+                                                              error:(NSError * __autoreleasing *)error
 {
     NSLog(@"Generating intermediate certificate");
 
@@ -78,13 +78,13 @@ using namespace chip::Credentials;
     return intermediate;
 }
 
-+ (nullable NSData *)generateOperationalCertificate:(id<MTRKeypair>)signingKeypair
-                                 signingCertificate:(NSData *)signingCertificate
-                               operationalPublicKey:(SecKeyRef)operationalPublicKey
-                                           fabricID:(NSNumber *)fabricID
-                                             nodeID:(NSNumber *)nodeID
-                              caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
-                                              error:(NSError * __autoreleasing _Nullable * _Nullable)error
++ (MTRCertificateDERBytes * _Nullable)createOperationalCertificate:(id<MTRKeypair>)signingKeypair
+                                                signingCertificate:(MTRCertificateDERBytes *)signingCertificate
+                                              operationalPublicKey:(SecKeyRef)operationalPublicKey
+                                                          fabricID:(NSNumber *)fabricID
+                                                            nodeID:(NSNumber *)nodeID
+                                             caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
+                                                             error:(NSError * __autoreleasing _Nullable * _Nullable)error
 {
     NSLog(@"Generating operational certificate");
 
@@ -127,7 +127,7 @@ using namespace chip::Credentials;
     return certKeySpan.data_equal(keypairKeySpan);
 }
 
-+ (BOOL)isCertificate:(NSData *)certificate1 equalTo:(NSData *)certificate2
++ (BOOL)isCertificate:(MTRCertificateDERBytes *)certificate1 equalTo:(MTRCertificateDERBytes *)certificate2
 {
     [MTRMemory ensureInit];
 
@@ -168,8 +168,8 @@ using namespace chip::Credentials;
     return subject1.IsEqual(subject2);
 }
 
-+ (nullable NSData *)generateCertificateSigningRequest:(id<MTRKeypair>)keypair
-                                                 error:(NSError * __autoreleasing _Nullable * _Nullable)error
++ (NSData * _Nullable)createCertificateSigningRequest:(id<MTRKeypair>)keypair
+                                                error:(NSError * __autoreleasing _Nullable * _Nullable)error
 {
     [MTRMemory ensureInit];
 
@@ -197,7 +197,7 @@ using namespace chip::Credentials;
     return nil;
 }
 
-+ (nullable NSData *)convertX509Certificate:(NSData *)x509Certificate
++ (MTRCertificateTLVBytes * _Nullable)convertX509Certificate:(MTRCertificateDERBytes *)x509Certificate
 {
 
     chip::ByteSpan x509CertBytes = AsByteSpan(x509Certificate);
@@ -223,7 +223,7 @@ using namespace chip::Credentials;
                                     fabricId:(nullable NSNumber *)fabricId
                                        error:(NSError * __autoreleasing _Nullable * _Nullable)error
 {
-    return [MTRCertificates generateRootCertificate:keypair issuerID:issuerId fabricID:fabricId error:error];
+    return [MTRCertificates createRootCertificate:keypair issuerID:issuerId fabricID:fabricId error:error];
 }
 
 + (nullable NSData *)generateIntermediateCertificate:(id<MTRKeypair>)rootKeypair
@@ -233,12 +233,12 @@ using namespace chip::Credentials;
                                             fabricId:(nullable NSNumber *)fabricId
                                                error:(NSError * __autoreleasing _Nullable * _Nullable)error
 {
-    return [MTRCertificates generateIntermediateCertificate:rootKeypair
-                                            rootCertificate:rootCertificate
-                                      intermediatePublicKey:intermediatePublicKey
-                                                   issuerID:issuerId
-                                                   fabricID:fabricId
-                                                      error:error];
+    return [MTRCertificates createIntermediateCertificate:rootKeypair
+                                          rootCertificate:rootCertificate
+                                    intermediatePublicKey:intermediatePublicKey
+                                                 issuerID:issuerId
+                                                 fabricID:fabricId
+                                                    error:error];
 }
 
 + (nullable NSData *)generateOperationalCertificate:(id<MTRKeypair>)signingKeypair
@@ -249,13 +249,19 @@ using namespace chip::Credentials;
                               caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
                                               error:(NSError * __autoreleasing _Nullable * _Nullable)error
 {
-    return [MTRCertificates generateOperationalCertificate:signingKeypair
-                                        signingCertificate:signingCertificate
-                                      operationalPublicKey:operationalPublicKey
-                                                  fabricID:fabricId
-                                                    nodeID:nodeId
-                                     caseAuthenticatedTags:caseAuthenticatedTags
-                                                     error:error];
+    return [MTRCertificates createOperationalCertificate:signingKeypair
+                                      signingCertificate:signingCertificate
+                                    operationalPublicKey:operationalPublicKey
+                                                fabricID:fabricId
+                                                  nodeID:nodeId
+                                   caseAuthenticatedTags:caseAuthenticatedTags
+                                                   error:error];
+}
+
++ (nullable NSData *)generateCertificateSigningRequest:(id<MTRKeypair>)keypair
+                                                 error:(NSError * __autoreleasing _Nullable * _Nullable)error
+{
+    return [MTRCertificates createCertificateSigningRequest:keypair error:error];
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRCluster.h
+++ b/src/darwin/Framework/CHIP/MTRCluster.h
@@ -61,8 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  * from the sever to the client (for the status response and actual write
  * request) within the timeout window.
  *
- * This value is specified in milliseconds
- *
+ * This value is specified in milliseconds.
  */
 @property (nonatomic, copy, nullable) NSNumber * timedWriteTimeout;
 
@@ -73,9 +72,6 @@ NS_ASSUME_NONNULL_BEGIN
  * the cluster matches the provided data version.
  */
 @property (nonatomic, copy, nullable) NSNumber * dataVersion;
-
-- (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
 
 @end
 
@@ -98,9 +94,6 @@ NS_ASSUME_NONNULL_BEGIN
  * non-fabric-sensitive data for the given attribute path.
  */
 @property (nonatomic, copy, nullable) NSNumber * fabricFiltered;
-
-- (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
 
 @end
 
@@ -138,7 +131,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * autoResubscribe;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCluster.mm
+++ b/src/darwin/Framework/CHIP/MTRCluster.mm
@@ -51,7 +51,7 @@ using namespace ::chip;
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRWriteParams alloc] init];
     other.timedWriteTimeout = self.timedWriteTimeout;
@@ -70,7 +70,7 @@ using namespace ::chip;
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRReadParams alloc] init];
     other.fabricFiltered = self.fabricFiltered;
@@ -89,7 +89,7 @@ using namespace ::chip;
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRSubscribeParams alloc] init];
     other.fabricFiltered = self.fabricFiltered;

--- a/src/darwin/Framework/CHIP/MTRCluster_internal.h
+++ b/src/darwin/Framework/CHIP/MTRCluster_internal.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRCluster ()
 @property (readonly, nonatomic) dispatch_queue_t callbackQueue;
-- (nullable instancetype)initWithQueue:(dispatch_queue_t)queue;
+- (instancetype _Nullable)initWithQueue:(dispatch_queue_t)queue;
 - (chip::ByteSpan)asByteSpan:(NSData *)value;
 - (chip::CharSpan)asCharSpan:(NSString *)value;
 @end

--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
@@ -22,26 +22,34 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol MTRDeviceAttestationDelegate;
 
 /**
- * The class definition for the CHIPCommissioningParameters
- *
+ * Information that can be provided to commissionWithNodeID to commision devices.
  */
 @interface MTRCommissioningParameters : NSObject
 
 /**
- *  The CSRNonce
+ * The nonce to use when requesting a CSR for the node's operational
+ * certificate.
+ *
+ * If nil, a random nonce will be generated automatically.
+ *
+ * If not nil, must be 32 bytes of data.
  */
-@property (nonatomic, copy, nullable) NSData * CSRNonce;
+@property (nonatomic, copy, nullable) NSData * csrNonce MTR_NEWLY_AVAILABLE;
 /**
- *  The AttestationNonce
+ * The nonce to use when requesting attestation information from the device.
+ *
+ * If nil, a random nonce will be generated automatically.
+ *
+ * If not nil, must be 32 bytes of data.
  */
 @property (nonatomic, copy, nullable) NSData * attestationNonce;
 /**
- *  The Wi-Fi SSID, if available.
+ * The Wi-Fi SSID, if available.
  */
 @property (nonatomic, copy, nullable) NSData * wifiSSID;
 /**
- *  The Wi-Fi Credentials.  Allowed to be nil or 0-length data for an open
- *  network, as long as wifiSSID is not nil.
+ * The Wi-Fi Credentials.  Allowed to be nil or 0-length data for an open
+ * network, as long as wifiSSID is not nil.
  */
 @property (nonatomic, copy, nullable) NSData * wifiCredentials;
 /**
@@ -49,13 +57,27 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy, nullable) NSData * threadOperationalDataset;
 /**
- *  The Device Attestation status delegate
+ * An optional delegate that can be notified upon completion of device
+ * attestation.  See documentation for MTRDeviceAttestationDelegate for
+ * details.
  */
 @property (nonatomic, strong, nullable) id<MTRDeviceAttestationDelegate> deviceAttestationDelegate;
 /**
- *  The timeout in secs to set for fail-safe when attestation fails
+ * The timeout, in seconds, to set for the fail-safe when calling into the
+ * deviceAttestationDelegate and waiting for it to respond.
+ *
+ * If nil, the fail-safe will not be extended before calling into the
+ * deviceAttestationDelegate.
+
  */
-@property (nonatomic, copy, nullable) NSNumber * failSafeExpiryTimeoutSecs;
+@property (nonatomic, copy, nullable) NSNumber * failSafeExpiryTimeout MTR_NEWLY_AVAILABLE;
+
+@end
+
+@interface MTRCommissioningParameters (Deprecated)
+
+@property (nonatomic, copy, nullable) NSData * CSRNonce MTR_NEWLY_DEPRECATED("Please use csrNonce");
+@property (nonatomic, copy, nullable) NSNumber * failSafeExpiryTimeoutSecs MTR_NEWLY_DEPRECATED("Plase use failSafeExpiryTimeout");
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.m
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.m
@@ -23,4 +23,28 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@implementation MTRCommissioningParameters (Deprecated)
+
+- (NSData * _Nullable)CSRNonce
+{
+    return self.csrNonce;
+}
+
+- (void)setCSRNonce:(NSData * _Nullable)CSRNonce
+{
+    self.csrNonce = CSRNonce;
+}
+
+- (NSNumber * _Nullable)failSafeExpiryTimeoutSecs
+{
+    return self.failSafeExpiryTimeout;
+}
+
+- (void)setFailSafeExpiryTimeoutSecs:(NSNumber * _Nullable)failSafeExpiryTimeoutSecs
+{
+    self.failSafeExpiryTimeout = failSafeExpiryTimeoutSecs;
+}
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -418,7 +418,7 @@ private:
                                              }
 
                                              // TODO: better retry logic
-                                             if (retryCount < 2) {
+                                             if (error && (retryCount < 2)) {
                                                  [workItem retryWork];
                                              } else {
                                                  [workItem endWork];

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -404,26 +404,26 @@ private:
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [self newBaseDevice];
 
-        [baseDevice readAttributePathWithEndpointID:endpointID
-                                          clusterID:clusterID
-                                        attributeID:attributeID
-                                             params:params
-                                              queue:self.queue
-                                         completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values,
-                                             NSError * _Nullable error) {
-                                             if (values) {
-                                                 // Since the format is the same data-value dictionary, this looks like an attribute
-                                                 // report
-                                                 [self _handleAttributeReport:values];
-                                             }
+        [baseDevice
+            readAttributesWithEndpointID:endpointID
+                               clusterID:clusterID
+                             attributeID:attributeID
+                                  params:params
+                                   queue:self.queue
+                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                                  if (values) {
+                                      // Since the format is the same data-value dictionary, this looks like an attribute
+                                      // report
+                                      [self _handleAttributeReport:values];
+                                  }
 
-                                             // TODO: better retry logic
-                                             if (error && (retryCount < 2)) {
-                                                 [workItem retryWork];
-                                             } else {
-                                                 [workItem endWork];
-                                             }
-                                         }];
+                                  // TODO: better retry logic
+                                  if (error && (retryCount < 2)) {
+                                      [workItem retryWork];
+                                  } else {
+                                      [workItem endWork];
+                                  }
+                              }];
     };
     workItem.readyHandler = readyHandler;
     [_asyncCallbackWorkQueue enqueueWorkItem:workItem];

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -404,26 +404,26 @@ private:
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [self newBaseDevice];
 
-        [baseDevice
-            readAttributeWithEndpointID:endpointID
-                              clusterID:clusterID
-                            attributeID:attributeID
-                                 params:params
-                                  queue:self.queue
-                             completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
-                                 if (values) {
-                                     // Since the format is the same data-value dictionary, this looks like an attribute
-                                     // report
-                                     [self _handleAttributeReport:values];
-                                 }
+        [baseDevice readAttributePathWithEndpointID:endpointID
+                                          clusterID:clusterID
+                                        attributeID:attributeID
+                                             params:params
+                                              queue:self.queue
+                                         completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values,
+                                             NSError * _Nullable error) {
+                                             if (values) {
+                                                 // Since the format is the same data-value dictionary, this looks like an attribute
+                                                 // report
+                                                 [self _handleAttributeReport:values];
+                                             }
 
-                                 // TODO: better retry logic
-                                 if (error && (retryCount < 2)) {
-                                     [workItem retryWork];
-                                 } else {
-                                     [workItem endWork];
-                                 }
-                             }];
+                                             // TODO: better retry logic
+                                             if (retryCount < 2) {
+                                                 [workItem retryWork];
+                                             } else {
+                                                 [workItem endWork];
+                                             }
+                                         }];
     };
     workItem.readyHandler = readyHandler;
     [_asyncCallbackWorkQueue enqueueWorkItem:workItem];

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -173,7 +173,7 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
  * Attempts to retrieve the attestation challenge for a commissionee with the given Device ID.
  * Returns nil if given Device ID does not match an active commissionee, or if a Secure Session is not availale.
  */
-- (nullable NSData *)fetchAttestationChallengeForDeviceID:(uint64_t)deviceID MTR_NEWLY_AVAILABLE;
+- (NSData * _Nullable)fetchAttestationChallengeForDeviceID:(NSNumber *)deviceID MTR_NEWLY_AVAILABLE;
 
 /**
  * Compute a PASE verifier and passcode ID for the desired setup pincode.

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -173,7 +173,7 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
  * Attempts to retrieve the attestation challenge for a commissionee with the given Device ID.
  * Returns nil if given Device ID does not match an active commissionee, or if a Secure Session is not availale.
  */
-- (NSData * _Nullable)fetchAttestationChallengeForDeviceID:(NSNumber *)deviceID MTR_NEWLY_AVAILABLE;
+- (NSData * _Nullable)attestationChallengeForDeviceID:(NSNumber *)deviceID MTR_NEWLY_AVAILABLE;
 
 /**
  * Compute a PASE verifier and passcode ID for the desired setup pincode.
@@ -199,7 +199,7 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
 @property (readonly, nonatomic, nullable) NSNumber * controllerNodeId MTR_NEWLY_DEPRECATED("Please use controllerNodeID");
 
 - (nullable NSData *)fetchAttestationChallengeForDeviceId:(uint64_t)deviceId
-    MTR_NEWLY_DEPRECATED("Please use fetchAttestationChallengeForDeviceID");
+    MTR_NEWLY_DEPRECATED("Please use attestationChallengeForDeviceID");
 
 - (BOOL)getBaseDevice:(uint64_t)deviceID
                 queue:(dispatch_queue_t)queue

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -472,8 +472,8 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
         VerifyOrReturn([self checkIsRunning:error]);
 
         chip::Controller::CommissioningParameters params;
-        if (commissioningParams.CSRNonce) {
-            params.SetCSRNonce(AsByteSpan(commissioningParams.CSRNonce));
+        if (commissioningParams.csrNonce) {
+            params.SetCSRNonce(AsByteSpan(commissioningParams.csrNonce));
         }
         if (commissioningParams.attestationNonce) {
             params.SetAttestationNonce(AsByteSpan(commissioningParams.attestationNonce));
@@ -494,9 +494,9 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
             [self clearDeviceAttestationDelegateBridge];
 
             chip::Optional<uint16_t> timeoutSecs;
-            if (commissioningParams.failSafeExpiryTimeoutSecs) {
+            if (commissioningParams.failSafeExpiryTimeout) {
                 timeoutSecs
-                    = chip::MakeOptional(static_cast<uint16_t>([commissioningParams.failSafeExpiryTimeoutSecs unsignedIntValue]));
+                    = chip::MakeOptional(static_cast<uint16_t>([commissioningParams.failSafeExpiryTimeout unsignedIntValue]));
             }
             BOOL shouldWaitAfterDeviceAttestation = NO;
             if ([commissioningParams.deviceAttestationDelegate
@@ -734,7 +734,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
     return AsData(serializedBytes);
 }
 
-- (nullable NSData *)fetchAttestationChallengeForDeviceID:(uint64_t)deviceID
+- (NSData * _Nullable)fetchAttestationChallengeForDeviceID:(NSNumber *)deviceID
 {
     VerifyOrReturnValue([self checkIsRunning], nil);
 
@@ -743,7 +743,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
         VerifyOrReturn([self checkIsRunning]);
 
         chip::CommissioneeDeviceProxy * deviceProxy;
-        auto errorCode = self.cppCommissioner->GetDeviceBeingCommissioned(deviceID, &deviceProxy);
+        auto errorCode = self.cppCommissioner->GetDeviceBeingCommissioned([deviceID unsignedLongLongValue], &deviceProxy);
         auto success = ![self checkForError:errorCode logMsg:kErrorGetCommissionee error:nil];
         VerifyOrReturn(success);
 
@@ -983,7 +983,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
 
 - (nullable NSData *)fetchAttestationChallengeForDeviceId:(uint64_t)deviceId
 {
-    return [self fetchAttestationChallengeForDeviceID:deviceId];
+    return [self fetchAttestationChallengeForDeviceID:@(deviceId)];
 }
 
 - (BOOL)getBaseDevice:(uint64_t)deviceID queue:(dispatch_queue_t)queue completionHandler:(MTRDeviceConnectionCallback)completion

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -734,7 +734,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
     return AsData(serializedBytes);
 }
 
-- (NSData * _Nullable)fetchAttestationChallengeForDeviceID:(NSNumber *)deviceID
+- (NSData * _Nullable)attestationChallengeForDeviceID:(NSNumber *)deviceID
 {
     VerifyOrReturnValue([self checkIsRunning], nil);
 
@@ -983,7 +983,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
 
 - (nullable NSData *)fetchAttestationChallengeForDeviceId:(uint64_t)deviceId
 {
-    return [self fetchAttestationChallengeForDeviceID:@(deviceId)];
+    return [self attestationChallengeForDeviceID:@(deviceId)];
 }
 
 - (BOOL)getBaseDevice:(uint64_t)deviceID queue:(dispatch_queue_t)queue completionHandler:(MTRDeviceConnectionCallback)completion

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+typedef NSData MTRCertificateDERBytes;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol MTRKeypair;
@@ -130,7 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
  *   2) The subject DN must match the subject DN of the existing root
  *      certificate.
  */
-@property (nonatomic, copy, nullable) NSData * rootCertificate;
+@property (nonatomic, copy, nullable) MTRCertificateDERBytes * rootCertificate;
 
 /**
  * Intermediate certificate, in X.509 DER form, to use.
@@ -162,7 +164,7 @@ NS_ASSUME_NONNULL_BEGIN
  *     allows switching from using an intermediate CA to not using one.
  *
  */
-@property (nonatomic, copy, nullable) NSData * intermediateCertificate;
+@property (nonatomic, copy, nullable) MTRCertificateDERBytes * intermediateCertificate;
 
 /**
  * Operational certificate, in X.509 DER form, to use.
@@ -173,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
  * If nil, an operational certificate will be determined as described in the
  * documentation for nodeID.
  */
-@property (nonatomic, copy, readonly, nullable) NSData * operationalCertificate;
+@property (nonatomic, copy, readonly, nullable) MTRCertificateDERBytes * operationalCertificate;
 
 /**
  * Operational keypair to use.  If operationalCertificate is not nil, the public
@@ -214,9 +216,9 @@ NS_ASSUME_NONNULL_BEGIN
  * ipk must be 16 bytes in length.
  */
 - (instancetype)initWithOperationalKeypair:(id<MTRKeypair>)operationalKeypair
-                    operationalCertificate:(NSData *)operationalCertificate
-                   intermediateCertificate:(nullable NSData *)intermediateCertificate
-                           rootCertificate:(NSData *)rootCertificate
+                    operationalCertificate:(MTRCertificateDERBytes *)operationalCertificate
+                   intermediateCertificate:(MTRCertificateDERBytes * _Nullable)intermediateCertificate
+                           rootCertificate:(MTRCertificateDERBytes *)rootCertificate
                                        ipk:(NSData *)ipk;
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-typedef NSData MTRCertificateDERBytes;
+typedef NSData * MTRCertificateDERBytes;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -132,7 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
  *   2) The subject DN must match the subject DN of the existing root
  *      certificate.
  */
-@property (nonatomic, copy, nullable) MTRCertificateDERBytes * rootCertificate;
+@property (nonatomic, copy, nullable) MTRCertificateDERBytes rootCertificate;
 
 /**
  * Intermediate certificate, in X.509 DER form, to use.
@@ -164,7 +164,7 @@ NS_ASSUME_NONNULL_BEGIN
  *     allows switching from using an intermediate CA to not using one.
  *
  */
-@property (nonatomic, copy, nullable) MTRCertificateDERBytes * intermediateCertificate;
+@property (nonatomic, copy, nullable) MTRCertificateDERBytes intermediateCertificate;
 
 /**
  * Operational certificate, in X.509 DER form, to use.
@@ -175,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
  * If nil, an operational certificate will be determined as described in the
  * documentation for nodeID.
  */
-@property (nonatomic, copy, readonly, nullable) MTRCertificateDERBytes * operationalCertificate;
+@property (nonatomic, copy, readonly, nullable) MTRCertificateDERBytes operationalCertificate;
 
 /**
  * Operational keypair to use.  If operationalCertificate is not nil, the public
@@ -216,9 +216,9 @@ NS_ASSUME_NONNULL_BEGIN
  * ipk must be 16 bytes in length.
  */
 - (instancetype)initWithOperationalKeypair:(id<MTRKeypair>)operationalKeypair
-                    operationalCertificate:(MTRCertificateDERBytes *)operationalCertificate
-                   intermediateCertificate:(MTRCertificateDERBytes * _Nullable)intermediateCertificate
-                           rootCertificate:(MTRCertificateDERBytes *)rootCertificate
+                    operationalCertificate:(MTRCertificateDERBytes)operationalCertificate
+                   intermediateCertificate:(MTRCertificateDERBytes _Nullable)intermediateCertificate
+                           rootCertificate:(MTRCertificateDERBytes)rootCertificate
                                        ipk:(NSData *)ipk;
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -49,9 +49,9 @@ using namespace chip;
 }
 
 - (instancetype)initWithOperationalKeypair:(id<MTRKeypair>)operationalKeypair
-                    operationalCertificate:(MTRCertificateDERBytes *)operationalCertificate
-                   intermediateCertificate:(MTRCertificateDERBytes * _Nullable)intermediateCertificate
-                           rootCertificate:(MTRCertificateDERBytes *)rootCertificate
+                    operationalCertificate:(MTRCertificateDERBytes)operationalCertificate
+                   intermediateCertificate:(MTRCertificateDERBytes _Nullable)intermediateCertificate
+                           rootCertificate:(MTRCertificateDERBytes)rootCertificate
                                        ipk:(NSData *)ipk
 {
     if (!(self = [super init])) {

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -49,9 +49,9 @@ using namespace chip;
 }
 
 - (instancetype)initWithOperationalKeypair:(id<MTRKeypair>)operationalKeypair
-                    operationalCertificate:(NSData *)operationalCertificate
-                   intermediateCertificate:(nullable NSData *)intermediateCertificate
-                           rootCertificate:(NSData *)rootCertificate
+                    operationalCertificate:(MTRCertificateDERBytes *)operationalCertificate
+                   intermediateCertificate:(MTRCertificateDERBytes * _Nullable)intermediateCertificate
+                           rootCertificate:(MTRCertificateDERBytes *)rootCertificate
                                        ipk:(NSData *)ipk
 {
     if (!(self = [super init])) {
@@ -213,10 +213,10 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
 
     if (self.rootCertificate == nil) {
         NSError * error;
-        self.rootCertificate = [MTRCertificates generateRootCertificate:self.nocSigner
-                                                               issuerID:nil
-                                                               fabricID:self.fabricID
-                                                                  error:&error];
+        self.rootCertificate = [MTRCertificates createRootCertificate:self.nocSigner
+                                                             issuerID:nil
+                                                             fabricID:self.fabricID
+                                                                error:&error];
         if (error != nil || self.rootCertificate == nil) {
             MTR_LOG_ERROR("Failed to generate root certificate: %@", error);
             return nil;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRDeviceControllerStartupParams ()
 // We want to be able to write to operationalCertificate in
 // MTRDeviceControllerStartupParamsInternal.
-@property (nonatomic, copy, nullable) NSData * operationalCertificate;
+@property (nonatomic, copy, nullable) MTRCertificateDERBytes * operationalCertificate;
 
 // Init method that just copies the values of all our ivars.
 - (instancetype)initWithParams:(MTRDeviceControllerStartupParams *)params;
@@ -85,9 +85,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithSigningKeypair:(id<MTRKeypair>)nocSigner fabricID:(NSNumber *)fabricID ipk:(NSData *)ipk NS_UNAVAILABLE;
 - (instancetype)initWithOperationalKeypair:(id<MTRKeypair>)operationalKeypair
-                    operationalCertificate:(NSData *)operationalCertificate
-                   intermediateCertificate:(nullable NSData *)intermediateCertificate
-                           rootCertificate:(NSData *)rootCertificate
+                    operationalCertificate:(MTRCertificateDERBytes *)operationalCertificate
+                   intermediateCertificate:(MTRCertificateDERBytes * _Nullable)intermediateCertificate
+                           rootCertificate:(MTRCertificateDERBytes *)rootCertificate
                                        ipk:(NSData *)ipk NS_UNAVAILABLE;
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRDeviceControllerStartupParams ()
 // We want to be able to write to operationalCertificate in
 // MTRDeviceControllerStartupParamsInternal.
-@property (nonatomic, copy, nullable) MTRCertificateDERBytes * operationalCertificate;
+@property (nonatomic, copy, nullable) MTRCertificateDERBytes operationalCertificate;
 
 // Init method that just copies the values of all our ivars.
 - (instancetype)initWithParams:(MTRDeviceControllerStartupParams *)params;
@@ -85,9 +85,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithSigningKeypair:(id<MTRKeypair>)nocSigner fabricID:(NSNumber *)fabricID ipk:(NSData *)ipk NS_UNAVAILABLE;
 - (instancetype)initWithOperationalKeypair:(id<MTRKeypair>)operationalKeypair
-                    operationalCertificate:(MTRCertificateDERBytes *)operationalCertificate
-                   intermediateCertificate:(MTRCertificateDERBytes * _Nullable)intermediateCertificate
-                           rootCertificate:(MTRCertificateDERBytes *)rootCertificate
+                    operationalCertificate:(MTRCertificateDERBytes)operationalCertificate
+                   intermediateCertificate:(MTRCertificateDERBytes _Nullable)intermediateCertificate
+                           rootCertificate:(MTRCertificateDERBytes)rootCertificate
                                        ipk:(NSData *)ipk NS_UNAVAILABLE;
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.m
@@ -49,12 +49,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)subscribeWithQueue:(dispatch_queue_t)queue
                 minInterval:(NSNumber *)minInterval
                 maxInterval:(NSNumber *)maxInterval
-                     params:(nullable MTRSubscribeParams *)params
+                     params:(MTRSubscribeParams * _Nullable)params
     attributeCacheContainer:(MTRAttributeCacheContainer * _Nullable)attributeCacheContainer
-     attributeReportHandler:(nullable void (^)(NSArray * value))attributeReportHandler
-         eventReportHandler:(nullable void (^)(NSArray * value))eventReportHandler
+     attributeReportHandler:(void (^_Nullable)(NSArray * value))attributeReportHandler
+         eventReportHandler:(void (^_Nullable)(NSArray * value))eventReportHandler
                errorHandler:(void (^)(NSError * error))errorHandler
-    subscriptionEstablished:(nullable void (^)(void))subscriptionEstablishedHandler
+    subscriptionEstablished:(void (^_Nullable)(void))subscriptionEstablishedHandler
     resubscriptionScheduled:(MTRDeviceResubscriptionScheduledHandler _Nullable)resubscriptionScheduledHandler
 {
     MTR_LOG_DEBUG("Subscribing all attributes... Note that attributeReportHandler, eventReportHandler, and resubscriptionScheduled "
@@ -91,12 +91,12 @@ NS_ASSUME_NONNULL_BEGIN
         }];
 }
 
-- (void)readAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
-                          clusterID:(NSNumber * _Nullable)clusterID
-                        attributeID:(NSNumber * _Nullable)attributeID
-                             params:(MTRReadParams * _Nullable)params
-                              queue:(dispatch_queue_t)queue
-                         completion:(MTRDeviceResponseHandler)completion
+- (void)readAttributePathWithEndpointID:(NSNumber * _Nullable)endpointID
+                              clusterID:(NSNumber * _Nullable)clusterID
+                            attributeID:(NSNumber * _Nullable)attributeID
+                                 params:(MTRReadParams * _Nullable)params
+                                  queue:(dispatch_queue_t)queue
+                             completion:(MTRDeviceResponseHandler)completion
 {
     MTR_LOG_DEBUG("Reading attribute ...");
     [_xpcConnection
@@ -203,15 +203,15 @@ NS_ASSUME_NONNULL_BEGIN
         }];
 }
 
-- (void)subscribeAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
-                               clusterID:(NSNumber * _Nullable)clusterID
-                             attributeID:(NSNumber * _Nullable)attributeID
-                             minInterval:(NSNumber *)minInterval
-                             maxInterval:(NSNumber *)maxInterval
-                                  params:(MTRSubscribeParams * _Nullable)params
-                                   queue:(dispatch_queue_t)queue
-                           reportHandler:(MTRDeviceResponseHandler)reportHandler
-                 subscriptionEstablished:(void (^_Nullable)(void))subscriptionEstablishedHandler
+- (void)subscribeAttributePathWithEndpointID:(NSNumber * _Nullable)endpointID
+                                   clusterID:(NSNumber * _Nullable)clusterID
+                                 attributeID:(NSNumber * _Nullable)attributeID
+                                 minInterval:(NSNumber *)minInterval
+                                 maxInterval:(NSNumber *)maxInterval
+                                      params:(MTRSubscribeParams * _Nullable)params
+                                       queue:(dispatch_queue_t)queue
+                               reportHandler:(MTRDeviceResponseHandler)reportHandler
+                     subscriptionEstablished:(void (^_Nullable)(void))subscriptionEstablishedHandler
 {
     MTR_LOG_DEBUG("Subscribing attribute ...");
     [_xpcConnection getProxyHandleWithCompletion:^(

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.m
@@ -91,12 +91,12 @@ NS_ASSUME_NONNULL_BEGIN
         }];
 }
 
-- (void)readAttributePathWithEndpointID:(NSNumber * _Nullable)endpointID
-                              clusterID:(NSNumber * _Nullable)clusterID
-                            attributeID:(NSNumber * _Nullable)attributeID
-                                 params:(MTRReadParams * _Nullable)params
-                                  queue:(dispatch_queue_t)queue
-                             completion:(MTRDeviceResponseHandler)completion
+- (void)readAttributesWithEndpointID:(NSNumber * _Nullable)endpointID
+                           clusterID:(NSNumber * _Nullable)clusterID
+                         attributeID:(NSNumber * _Nullable)attributeID
+                              params:(MTRReadParams * _Nullable)params
+                               queue:(dispatch_queue_t)queue
+                          completion:(MTRDeviceResponseHandler)completion
 {
     MTR_LOG_DEBUG("Reading attribute ...");
     [_xpcConnection
@@ -203,15 +203,15 @@ NS_ASSUME_NONNULL_BEGIN
         }];
 }
 
-- (void)subscribeAttributePathWithEndpointID:(NSNumber * _Nullable)endpointID
-                                   clusterID:(NSNumber * _Nullable)clusterID
-                                 attributeID:(NSNumber * _Nullable)attributeID
-                                 minInterval:(NSNumber *)minInterval
-                                 maxInterval:(NSNumber *)maxInterval
-                                      params:(MTRSubscribeParams * _Nullable)params
-                                       queue:(dispatch_queue_t)queue
-                               reportHandler:(MTRDeviceResponseHandler)reportHandler
-                     subscriptionEstablished:(void (^_Nullable)(void))subscriptionEstablishedHandler
+- (void)subscribeToAttributesWithEndpointID:(NSNumber * _Nullable)endpointID
+                                  clusterID:(NSNumber * _Nullable)clusterID
+                                attributeID:(NSNumber * _Nullable)attributeID
+                                minInterval:(NSNumber *)minInterval
+                                maxInterval:(NSNumber *)maxInterval
+                                     params:(MTRSubscribeParams * _Nullable)params
+                                      queue:(dispatch_queue_t)queue
+                              reportHandler:(MTRDeviceResponseHandler)reportHandler
+                    subscriptionEstablished:(void (^_Nullable)(void))subscriptionEstablishedHandler
 {
     MTR_LOG_DEBUG("Subscribing attribute ...");
     [_xpcConnection getProxyHandleWithCompletion:^(

--- a/src/darwin/Framework/CHIP/MTRDevicePairingDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRDevicePairingDelegate.h
@@ -43,19 +43,19 @@ typedef NS_ENUM(NSUInteger, MTRPairingStatus) {
  * Notify the delegate when pairing is completed
  *
  */
-- (void)onPairingComplete:(nullable NSError *)error;
+- (void)onPairingComplete:(NSError * _Nullable)error;
 
 /**
  * Notify the delegate when commissioning is completed
  *
  */
-- (void)onCommissioningComplete:(nullable NSError *)error;
+- (void)onCommissioningComplete:(NSError * _Nullable)error;
 
 /**
  * Notify the delegate when pairing is deleted
  *
  */
-- (void)onPairingDeleted:(nullable NSError *)error;
+- (void)onPairingDeleted:(NSError * _Nullable)error;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRError.h
+++ b/src/darwin/Framework/CHIP/MTRError.h
@@ -75,35 +75,26 @@ typedef NS_ERROR_ENUM(MTRErrorDomain, MTRErrorCode){
 // clang-format off
 typedef NS_ERROR_ENUM(MTRInteractionErrorDomain, MTRInteractionErrorCode){
     // These values come from the general status code table in the Matter
-    // Interaction Model specification.  Do not change these values unless the
-    // specification changes.
+    // Interaction Model specification.
     MTRInteractionErrorCodeFailure                = 0x01,
     MTRInteractionErrorCodeInvalidSubscription    = 0x7d,
     MTRInteractionErrorCodeUnsupportedAccess      = 0x7e,
     MTRInteractionErrorCodeUnsupportedEndpoint    = 0x7f,
     MTRInteractionErrorCodeInvalidAction          = 0x80,
     MTRInteractionErrorCodeUnsupportedCommand     = 0x81,
-    // Gap in values is intentional.
     MTRInteractionErrorCodeInvalidCommand         = 0x85,
     MTRInteractionErrorCodeUnsupportedAttribute   = 0x86,
     MTRInteractionErrorCodeConstraintError        = 0x87,
     MTRInteractionErrorCodeUnsupportedWrite       = 0x88,
     MTRInteractionErrorCodeResourceExhausted      = 0x89,
-    // Gap in values is intentional.
     MTRInteractionErrorCodeNotFound               = 0x8b,
     MTRInteractionErrorCodeUnreportableAttribute  = 0x8c,
     MTRInteractionErrorCodeInvalidDataType        = 0x8d,
-    // Gap in values is intentional.
     MTRInteractionErrorCodeUnsupportedRead        = 0x8f,
-    // Gap in values is intentional.
     MTRInteractionErrorCodeDataVersionMismatch    = 0x92,
-    // Gap in values is intentional.
     MTRInteractionErrorCodeTimeout                = 0x94,
-    // Gap in values is intentional.
     MTRInteractionErrorCodeBusy                   = 0x9c,
-    // Gap in values is intentional.
     MTRInteractionErrorCodeUnsupportedCluster     = 0xc3,
-    // Gap in values is intentional.
     MTRInteractionErrorCodeNoUpstreamSubscription = 0xc5,
     MTRInteractionErrorCodeNeedsTimedInteraction  = 0xc6,
     MTRInteractionErrorCodeUnsupportedEvent       = 0xc7,

--- a/src/darwin/Framework/CHIP/MTRError_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRError_Internal.h
@@ -23,8 +23,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRError : NSObject
-+ (nullable NSError *)errorForCHIPErrorCode:(CHIP_ERROR)errorCode;
-+ (nullable NSError *)errorForIMStatus:(const chip::app::StatusIB &)status;
++ (NSError * _Nullable)errorForCHIPErrorCode:(CHIP_ERROR)errorCode;
++ (NSError * _Nullable)errorForIMStatus:(const chip::app::StatusIB &)status;
 + (CHIP_ERROR)errorToCHIPErrorCode:(NSError * _Nullable)error;
 @end
 

--- a/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.h
+++ b/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 MTR_NEWLY_DEPRECATED("Please use [MTRSetupPayload setupPayloadWithOnboardingPayload")
 @interface MTRManualSetupPayloadParser : NSObject
 - (instancetype)initWithDecimalStringRepresentation:(NSString *)decimalStringRepresentation;
-- (nullable MTRSetupPayload *)populatePayload:(NSError * __autoreleasing *)error;
+- (MTRSetupPayload * _Nullable)populatePayload:(NSError * __autoreleasing *)error;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.h
+++ b/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.h
@@ -29,8 +29,8 @@ typedef NS_ENUM(NSUInteger, MTROnboardingPayloadType) {
 
 @interface MTROnboardingPayloadParser : NSObject
 
-+ (nullable MTRSetupPayload *)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload
-                                                         error:(NSError * __autoreleasing *)error;
++ (MTRSetupPayload * _Nullable)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload
+                                                          error:(NSError * __autoreleasing *)error;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.m
+++ b/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.m
@@ -27,8 +27,8 @@
     return [codeString hasPrefix:@"MT:"];
 }
 
-+ (nullable MTRSetupPayload *)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload
-                                                         error:(NSError * __autoreleasing *)error
++ (MTRSetupPayload * _Nullable)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload
+                                                          error:(NSError * __autoreleasing *)error
 {
     MTRSetupPayload * payload;
     // MTROnboardingPayloadTypeNFC is of type QR code and handled same as QR code
@@ -47,16 +47,16 @@
     return payload;
 }
 
-+ (nullable MTRSetupPayload *)setupPayloadForQRCodeOnboardingPayload:(NSString *)onboardingPayload
-                                                               error:(NSError * __autoreleasing *)error
++ (MTRSetupPayload * _Nullable)setupPayloadForQRCodeOnboardingPayload:(NSString *)onboardingPayload
+                                                                error:(NSError * __autoreleasing *)error
 {
     MTRQRCodeSetupPayloadParser * qrCodeParser =
         [[MTRQRCodeSetupPayloadParser alloc] initWithBase38Representation:onboardingPayload];
     return [qrCodeParser populatePayload:error];
 }
 
-+ (nullable MTRSetupPayload *)setupPayloadForManualCodeOnboardingPayload:(NSString *)onboardingPayload
-                                                                   error:(NSError * __autoreleasing *)error
++ (MTRSetupPayload * _Nullable)setupPayloadForManualCodeOnboardingPayload:(NSString *)onboardingPayload
+                                                                    error:(NSError * __autoreleasing *)error
 {
     MTRManualSetupPayloadParser * manualParser =
         [[MTRManualSetupPayloadParser alloc] initWithDecimalStringRepresentation:onboardingPayload];

--- a/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.h
+++ b/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 MTR_NEWLY_DEPRECATED("Please use [MTRSetupPayload setupPayloadWithOnboardingPayload")
 @interface MTRQRCodeSetupPayloadParser : NSObject
 - (instancetype)initWithBase38Representation:(NSString *)base38Representation;
-- (nullable MTRSetupPayload *)populatePayload:(NSError * __autoreleasing *)error;
+- (MTRSetupPayload * _Nullable)populatePayload:(NSError * __autoreleasing *)error;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -84,7 +84,7 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
 @property (nonatomic, copy) NSNumber * setupPasscode MTR_NEWLY_AVAILABLE;
 
 @property (nonatomic, copy, nullable) NSString * serialNumber;
-- (nullable NSArray<MTROptionalQRCodeInfo *> *)getAllOptionalVendorData:(NSError * __autoreleasing *)error;
+- (NSArray<MTROptionalQRCodeInfo *> * _Nullable)getAllOptionalVendorData:(NSError * __autoreleasing *)error;
 
 /**
  * Generate a random Matter-valid setup PIN.
@@ -113,7 +113,7 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
                         discriminator:(NSNumber *)discriminator API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2));
 
 /** Get 11 digit manual entry code from the setup payload. */
-- (nullable NSString *)manualEntryCode;
+- (NSString * _Nullable)manualEntryCode;
 
 /**
  * Get a QR code from the setup payload.

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -267,7 +267,7 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
     [coder encodeObject:self.serialNumber forKey:MTRSetupPayloadCodingKeySerialNumber];
 }
 
-- (nullable instancetype)initWithCoder:(NSCoder *)decoder
+- (instancetype _Nullable)initWithCoder:(NSCoder *)decoder
 {
     NSNumber * version = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeyVersion];
     NSNumber * vendorID = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeyVendorID];
@@ -295,7 +295,7 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
     return payload;
 }
 
-- (nullable NSString *)manualEntryCode
+- (NSString * _Nullable)manualEntryCode
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     std::string outDecimalString;

--- a/src/darwin/Framework/CHIP/MTRStorage.h
+++ b/src/darwin/Framework/CHIP/MTRStorage.h
@@ -33,7 +33,7 @@ MTR_NEWLY_AVAILABLE
  * Get the data for the given key.  Returns nil if there is no data for the
  * key.
  */
-- (nullable NSData *)storageDataForKey:(NSString *)key;
+- (NSData * _Nullable)storageDataForKey:(NSString *)key;
 
 /**
  * Set the data for the viven key to the given value.  Returns YES if the key

--- a/src/darwin/Framework/CHIP/MTRThreadOperationalDataset.h
+++ b/src/darwin/Framework/CHIP/MTRThreadOperationalDataset.h
@@ -80,18 +80,18 @@ extern size_t const MTRSizeThreadPANID MTR_NEWLY_AVAILABLE;
  *              returned.  In particular, it's expected to be a 16-bit unsigned
  *              integer stored as 2 bytes in host order.
  */
-- (nullable instancetype)initWithNetworkName:(NSString *)networkName
-                               extendedPANID:(NSData *)extendedPANID
-                                   masterKey:(NSData *)masterKey
-                                        PSKc:(NSData *)PSKc
-                               channelNumber:(NSNumber *)channelNumber
-                                       panID:(NSData *)panID MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithNetworkName:(NSString *)networkName
+                                extendedPANID:(NSData *)extendedPANID
+                                    masterKey:(NSData *)masterKey
+                                         PSKc:(NSData *)PSKc
+                                channelNumber:(NSNumber *)channelNumber
+                                        panID:(NSData *)panID MTR_NEWLY_AVAILABLE;
 
 /**
  * Create a Thread Operational Dataset object with a RCP formatted active operational dataset.
  * This initializer will return nil if the input data cannot be parsed correctly
  */
-- (nullable instancetype)initWithData:(NSData *)data;
+- (instancetype _Nullable)initWithData:(NSData *)data;
 
 /**
  * Get the underlying data that represents the Thread Active Operational Dataset

--- a/src/darwin/Framework/CHIP/MTRThreadOperationalDataset.mm
+++ b/src/darwin/Framework/CHIP/MTRThreadOperationalDataset.mm
@@ -37,12 +37,12 @@ size_t const MTRSizeThreadPANID = 2; // Thread's PAN ID is 2 bytes
 
 @implementation MTRThreadOperationalDataset
 
-- (nullable instancetype)initWithNetworkName:(NSString *)networkName
-                               extendedPANID:(NSData *)extendedPANID
-                                   masterKey:(NSData *)masterKey
-                                        PSKc:(NSData *)PSKc
-                               channelNumber:(NSNumber *)channelNumber
-                                       panID:(NSData *)panID
+- (instancetype _Nullable)initWithNetworkName:(NSString *)networkName
+                                extendedPANID:(NSData *)extendedPANID
+                                    masterKey:(NSData *)masterKey
+                                         PSKc:(NSData *)PSKc
+                                channelNumber:(NSNumber *)channelNumber
+                                        panID:(NSData *)panID
 {
     if (self = [super init]) {
         _networkName = [networkName copy];
@@ -112,7 +112,7 @@ size_t const MTRSizeThreadPANID = 2; // Thread's PAN ID is 2 bytes
     return YES;
 }
 
-- (nullable instancetype)initWithData:(NSData *)data
+- (instancetype _Nullable)initWithData:(NSData *)data
 {
     chip::ByteSpan span = chip::ByteSpan((uint8_t *) data.bytes, data.length);
     auto dataset = chip::Thread::OperationalDataset();

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -18,9 +18,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseCluster{{asUpperCamelCase name}} : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 {{#chip_cluster_commands}}
 - (void){{asLowerCamelCase name}}WithParams:(MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completion:({{>command_completion_type command=.}})completion MTR_NEWLY_AVAILABLE;

--- a/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
@@ -20,9 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRCluster{{asUpperCamelCase name}} : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 {{#chip_cluster_commands}}
 - (void){{asLowerCamelCase name}}WithParams:(MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion MTR_NEWLY_AVAILABLE;

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
   auto other = [[MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params alloc] init];
 

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 {{/zcl_commands}}
 {{/zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
   auto other = [[{{interfaceName}} alloc] init];
 
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
   auto other = [[MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event alloc] init];
 

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{/zcl_struct_items}}
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {{/inline}}
 {{! TODO: We need a better setup for the API_AVALABLE annotations here; this does not scale at all sanely. }}
 {{#if (isStrEqual (asUpperCamelCase parent.name) "Descriptor")}}
@@ -43,7 +43,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 {{/zcl_event_fields}}
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 {{/zcl_events}}

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -30,9 +30,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterIdentify : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)identifyWithParams:(MTRIdentifyClusterIdentifyParams *)params
                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -185,9 +185,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterGroups : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)addGroupWithParams:(MTRGroupsClusterAddGroupParams *)params
                 completion:(void (^)(MTRGroupsClusterAddGroupResponseParams * _Nullable data, NSError * _Nullable error))completion
@@ -330,9 +330,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterScenes : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)addSceneWithParams:(MTRScenesClusterAddSceneParams *)params
                 completion:(void (^)(MTRScenesClusterAddSceneResponseParams * _Nullable data, NSError * _Nullable error))completion
@@ -578,9 +578,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterOnOff : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)offWithParams:(MTROnOffClusterOffParams * _Nullable)params completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)offWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -807,9 +807,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterOnOffSwitchConfiguration : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeSwitchTypeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -958,9 +958,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterLevelControl : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)moveToLevelWithParams:(MTRLevelControlClusterMoveToLevelParams *)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -1375,9 +1375,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterBinaryInputBasic : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeActiveTextWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -1677,9 +1677,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterDescriptor : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeDeviceTypeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -1859,9 +1859,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterBinding : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeBindingWithParams:(MTRReadParams * _Nullable)params
                             completion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
@@ -1994,9 +1994,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterAccessControl : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeAclWithParams:(MTRReadParams * _Nullable)params
                         completion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
@@ -2208,9 +2208,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterActions : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)instantActionWithParams:(MTRActionsClusterInstantActionParams *)params
                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -2399,9 +2399,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterBasic : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)mfgSpecificPingWithParams:(MTRBasicClusterMfgSpecificPingParams * _Nullable)params
                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -2893,9 +2893,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterOtaSoftwareUpdateProvider : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)queryImageWithParams:(MTROtaSoftwareUpdateProviderClusterQueryImageParams *)params
                   completion:(void (^)(MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
@@ -3011,9 +3011,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterOtaSoftwareUpdateRequestor : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)announceOtaProviderWithParams:(MTROtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams *)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -3207,9 +3207,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterLocalizationConfiguration : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeActiveLocaleWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -3361,9 +3361,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterTimeFormatLocalization : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeHourFormatWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -3538,9 +3538,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterUnitLocalization : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeTemperatureUnitWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -3671,9 +3671,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterPowerSourceConfiguration : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeSourcesWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -3799,9 +3799,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterPowerSource : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeStatusWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -4493,9 +4493,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterGeneralCommissioning : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)armFailSafeWithParams:(MTRGeneralCommissioningClusterArmFailSafeParams *)params
                    completion:(void (^)(MTRGeneralCommissioningClusterArmFailSafeResponseParams * _Nullable data,
@@ -4720,9 +4720,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterNetworkCommissioning : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)scanNetworksWithParams:(MTRNetworkCommissioningClusterScanNetworksParams * _Nullable)params
                     completion:(void (^)(MTRNetworkCommissioningClusterScanNetworksResponseParams * _Nullable data,
@@ -5003,9 +5003,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterDiagnosticLogs : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)retrieveLogsRequestWithParams:(MTRDiagnosticLogsClusterRetrieveLogsRequestParams *)params
                            completion:(void (^)(MTRDiagnosticLogsClusterRetrieveLogsResponseParams * _Nullable data,
@@ -5117,9 +5117,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterGeneralDiagnostics : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)testEventTriggerWithParams:(MTRGeneralDiagnosticsClusterTestEventTriggerParams *)params
                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -5399,9 +5399,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterSoftwareDiagnostics : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)resetWatermarksWithParams:(MTRSoftwareDiagnosticsClusterResetWatermarksParams * _Nullable)params
                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -5590,9 +5590,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterThreadNetworkDiagnostics : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)resetCountsWithParams:(MTRThreadNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -6899,9 +6899,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterWiFiNetworkDiagnostics : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)resetCountsWithParams:(MTRWiFiNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -7255,9 +7255,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterEthernetNetworkDiagnostics : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)resetCountsWithParams:(MTREthernetNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -7538,9 +7538,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRBaseClusterBridgedDeviceBasic : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeVendorNameWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -7931,9 +7931,9 @@ light or a window shade.
  */
 @interface MTRBaseClusterSwitch : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeNumberOfPositionsWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -8097,9 +8097,9 @@ light or a window shade.
  */
 @interface MTRBaseClusterAdministratorCommissioning : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)openCommissioningWindowWithParams:(MTRAdministratorCommissioningClusterOpenCommissioningWindowParams *)params
                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -8271,9 +8271,9 @@ light or a window shade.
  */
 @interface MTRBaseClusterOperationalCredentials : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)attestationRequestWithParams:(MTROperationalCredentialsClusterAttestationRequestParams *)params
                           completion:(void (^)(MTROperationalCredentialsClusterAttestationResponseParams * _Nullable data,
@@ -8518,9 +8518,9 @@ light or a window shade.
  */
 @interface MTRBaseClusterGroupKeyManagement : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)keySetWriteWithParams:(MTRGroupKeyManagementClusterKeySetWriteParams *)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -8719,9 +8719,9 @@ labels.
  */
 @interface MTRBaseClusterFixedLabel : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeLabelListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -8846,9 +8846,9 @@ labels.
  */
 @interface MTRBaseClusterUserLabel : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeLabelListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -8977,9 +8977,9 @@ labels.
  */
 @interface MTRBaseClusterBooleanState : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeStateValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -9104,9 +9104,9 @@ labels.
  */
 @interface MTRBaseClusterModeSelect : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)changeToModeWithParams:(MTRModeSelectClusterChangeToModeParams *)params
                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -9335,9 +9335,9 @@ labels.
  */
 @interface MTRBaseClusterDoorLock : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)lockDoorWithParams:(MTRDoorLockClusterLockDoorParams * _Nullable)params
                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -10270,9 +10270,9 @@ labels.
  */
 @interface MTRBaseClusterWindowCovering : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)upOrOpenWithParams:(MTRWindowCoveringClusterUpOrOpenParams * _Nullable)params
                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -10829,9 +10829,9 @@ labels.
  */
 @interface MTRBaseClusterBarrierControl : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)barrierControlGoToPercentWithParams:(MTRBarrierControlClusterBarrierControlGoToPercentParams *)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -11166,9 +11166,9 @@ labels.
  */
 @interface MTRBaseClusterPumpConfigurationAndControl : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeMaxPressureWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -11720,9 +11720,9 @@ labels.
  */
 @interface MTRBaseClusterThermostat : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)setpointRaiseLowerWithParams:(MTRThermostatClusterSetpointRaiseLowerParams *)params
                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -12916,9 +12916,9 @@ labels.
  */
 @interface MTRBaseClusterFanControl : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeFanModeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -13255,9 +13255,9 @@ labels.
  */
 @interface MTRBaseClusterThermostatUserInterfaceConfiguration : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeTemperatureDisplayModeWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
@@ -13437,9 +13437,9 @@ labels.
  */
 @interface MTRBaseClusterColorControl : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)moveToHueWithParams:(MTRColorControlClusterMoveToHueParams *)params
                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -14619,9 +14619,9 @@ labels.
  */
 @interface MTRBaseClusterBallastConfiguration : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributePhysicalMinLevelWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -15038,9 +15038,9 @@ labels.
  */
 @interface MTRBaseClusterIlluminanceMeasurement : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -15241,9 +15241,9 @@ labels.
  */
 @interface MTRBaseClusterTemperatureMeasurement : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -15425,9 +15425,9 @@ labels.
  */
 @interface MTRBaseClusterPressureMeasurement : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -15702,9 +15702,9 @@ labels.
  */
 @interface MTRBaseClusterFlowMeasurement : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -15886,9 +15886,9 @@ labels.
  */
 @interface MTRBaseClusterRelativeHumidityMeasurement : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -16070,9 +16070,9 @@ labels.
  */
 @interface MTRBaseClusterOccupancySensing : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeOccupancyWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -16472,9 +16472,9 @@ labels.
  */
 @interface MTRBaseClusterWakeOnLan : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeMACAddressWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -16599,9 +16599,9 @@ labels.
  */
 @interface MTRBaseClusterChannel : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)changeChannelWithParams:(MTRChannelClusterChangeChannelParams *)params
                      completion:(void (^)(MTRChannelClusterChangeChannelResponseParams * _Nullable data,
@@ -16771,9 +16771,9 @@ labels.
  */
 @interface MTRBaseClusterTargetNavigator : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)navigateTargetWithParams:(MTRTargetNavigatorClusterNavigateTargetParams *)params
                       completion:(void (^)(MTRTargetNavigatorClusterNavigateTargetResponseParams * _Nullable data,
@@ -16922,9 +16922,9 @@ labels.
  */
 @interface MTRBaseClusterMediaPlayback : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)playWithParams:(MTRMediaPlaybackClusterPlayParams * _Nullable)params
             completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
@@ -17210,9 +17210,9 @@ labels.
  */
 @interface MTRBaseClusterMediaInput : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)selectInputWithParams:(MTRMediaInputClusterSelectInputParams *)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -17366,9 +17366,9 @@ labels.
  */
 @interface MTRBaseClusterLowPower : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)sleepWithParams:(MTRLowPowerClusterSleepParams * _Nullable)params
              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -17479,9 +17479,9 @@ labels.
  */
 @interface MTRBaseClusterKeypadInput : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)sendKeyWithParams:(MTRKeypadInputClusterSendKeyParams *)params
                completion:(void (^)(MTRKeypadInputClusterSendKeyResponseParams * _Nullable data,
@@ -17592,9 +17592,9 @@ labels.
  */
 @interface MTRBaseClusterContentLauncher : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)launchContentWithParams:(MTRContentLauncherClusterLaunchContentParams *)params
                      completion:(void (^)(MTRContentLauncherClusterLaunchResponseParams * _Nullable data,
@@ -17751,9 +17751,9 @@ labels.
  */
 @interface MTRBaseClusterAudioOutput : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)selectOutputWithParams:(MTRAudioOutputClusterSelectOutputParams *)params
                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -17902,9 +17902,9 @@ labels.
  */
 @interface MTRBaseClusterApplicationLauncher : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)launchAppWithParams:(MTRApplicationLauncherClusterLaunchAppParams *)params
                  completion:(void (^)(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data,
@@ -18063,9 +18063,9 @@ labels.
  */
 @interface MTRBaseClusterApplicationBasic : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)readAttributeVendorNameWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
@@ -18323,9 +18323,9 @@ labels.
  */
 @interface MTRBaseClusterAccountLogin : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)getSetupPINWithParams:(MTRAccountLoginClusterGetSetupPINParams *)params
                    completion:(void (^)(MTRAccountLoginClusterGetSetupPINResponseParams * _Nullable data,
@@ -18441,9 +18441,9 @@ labels.
  */
 @interface MTRBaseClusterElectricalMeasurement : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)getProfileInfoCommandWithParams:(MTRElectricalMeasurementClusterGetProfileInfoCommandParams * _Nullable)params
                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -21068,9 +21068,9 @@ labels.
  */
 @interface MTRBaseClusterTestCluster : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)testWithParams:(MTRTestClusterClusterTestParams * _Nullable)params
             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
@@ -32,9 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterIdentify : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)identifyWithParams:(MTRIdentifyClusterIdentifyParams *)params
             expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -75,9 +75,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterGroups : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)addGroupWithParams:(MTRGroupsClusterAddGroupParams *)params
             expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -134,9 +134,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterScenes : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)addSceneWithParams:(MTRScenesClusterAddSceneParams *)params
             expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -221,9 +221,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterOnOff : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)offWithParams:(MTROnOffClusterOffParams * _Nullable)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -308,9 +308,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterOnOffSwitchConfiguration : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeSwitchTypeWithParams:(MTRReadParams * _Nullable)params;
 
@@ -342,9 +342,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterLevelControl : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)moveToLevelWithParams:(MTRLevelControlClusterMoveToLevelParams *)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -467,9 +467,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterBinaryInputBasic : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeActiveTextWithParams:(MTRReadParams * _Nullable)params;
 - (void)writeAttributeActiveTextWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -541,9 +541,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterDescriptor : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeDeviceListWithParams:(MTRReadParams * _Nullable)params;
 
@@ -574,9 +574,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterBinding : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeBindingWithParams:(MTRReadParams * _Nullable)params;
 - (void)writeAttributeBindingWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -609,9 +609,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterAccessControl : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeAclWithParams:(MTRReadParams * _Nullable)params;
 - (void)writeAttributeAclWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -654,9 +654,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterActions : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)instantActionWithParams:(MTRActionsClusterInstantActionParams *)params
                  expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -736,9 +736,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterBasic : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)mfgSpecificPingWithParams:(MTRBasicClusterMfgSpecificPingParams * _Nullable)params
                    expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -824,9 +824,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterOtaSoftwareUpdateProvider : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)queryImageWithParams:(MTROtaSoftwareUpdateProviderClusterQueryImageParams *)params
               expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -864,9 +864,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterOtaSoftwareUpdateRequestor : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)announceOtaProviderWithParams:(MTROtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams *)params
                        expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -910,9 +910,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterLocalizationConfiguration : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeActiveLocaleWithParams:(MTRReadParams * _Nullable)params;
 - (void)writeAttributeActiveLocaleWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -947,9 +947,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterTimeFormatLocalization : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeHourFormatWithParams:(MTRReadParams * _Nullable)params;
 - (void)writeAttributeHourFormatWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -991,9 +991,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterUnitLocalization : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeTemperatureUnitWithParams:(MTRReadParams * _Nullable)params;
 - (void)writeAttributeTemperatureUnitWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -1023,9 +1023,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterPowerSourceConfiguration : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeSourcesWithParams:(MTRReadParams * _Nullable)params;
 
@@ -1051,9 +1051,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterPowerSource : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeStatusWithParams:(MTRReadParams * _Nullable)params;
 
@@ -1138,9 +1138,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterGeneralCommissioning : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)armFailSafeWithParams:(MTRGeneralCommissioningClusterArmFailSafeParams *)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1201,9 +1201,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterNetworkCommissioning : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)scanNetworksWithParams:(MTRNetworkCommissioningClusterScanNetworksParams * _Nullable)params
                 expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1278,9 +1278,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterDiagnosticLogs : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)retrieveLogsRequestWithParams:(MTRDiagnosticLogsClusterRetrieveLogsRequestParams *)params
                        expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1310,9 +1310,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterGeneralDiagnostics : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)testEventTriggerWithParams:(MTRGeneralDiagnosticsClusterTestEventTriggerParams *)params
                     expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1359,9 +1359,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterSoftwareDiagnostics : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)resetWatermarksWithParams:(MTRSoftwareDiagnosticsClusterResetWatermarksParams * _Nullable)params
                    expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1401,9 +1401,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterThreadNetworkDiagnostics : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)resetCountsWithParams:(MTRThreadNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1561,9 +1561,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterWiFiNetworkDiagnostics : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)resetCountsWithParams:(MTRWiFiNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1621,9 +1621,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterEthernetNetworkDiagnostics : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)resetCountsWithParams:(MTREthernetNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1675,9 +1675,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRClusterBridgedDeviceBasic : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeVendorNameWithParams:(MTRReadParams * _Nullable)params;
 
@@ -1740,9 +1740,9 @@ light or a window shade.
  */
 @interface MTRClusterSwitch : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeNumberOfPositionsWithParams:(MTRReadParams * _Nullable)params;
 
@@ -1771,9 +1771,9 @@ light or a window shade.
  */
 @interface MTRClusterAdministratorCommissioning : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)openCommissioningWindowWithParams:(MTRAdministratorCommissioningClusterOpenCommissioningWindowParams *)params
                            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1819,9 +1819,9 @@ light or a window shade.
  */
 @interface MTRClusterOperationalCredentials : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)attestationRequestWithParams:(MTROperationalCredentialsClusterAttestationRequestParams *)params
                       expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1896,9 +1896,9 @@ light or a window shade.
  */
 @interface MTRClusterGroupKeyManagement : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)keySetWriteWithParams:(MTRGroupKeyManagementClusterKeySetWriteParams *)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1954,9 +1954,9 @@ labels.
  */
 @interface MTRClusterFixedLabel : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeLabelListWithParams:(MTRReadParams * _Nullable)params;
 
@@ -1981,9 +1981,9 @@ labels.
  */
 @interface MTRClusterUserLabel : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeLabelListWithParams:(MTRReadParams * _Nullable)params;
 - (void)writeAttributeLabelListWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -2013,9 +2013,9 @@ labels.
  */
 @interface MTRClusterBooleanState : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeStateValueWithParams:(MTRReadParams * _Nullable)params;
 
@@ -2040,9 +2040,9 @@ labels.
  */
 @interface MTRClusterModeSelect : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)changeToModeWithParams:(MTRModeSelectClusterChangeToModeParams *)params
                 expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -2092,9 +2092,9 @@ labels.
  */
 @interface MTRClusterDoorLock : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)lockDoorWithParams:(MTRDoorLockClusterLockDoorParams * _Nullable)params
             expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -2358,9 +2358,9 @@ labels.
  */
 @interface MTRClusterWindowCovering : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)upOrOpenWithParams:(MTRWindowCoveringClusterUpOrOpenParams * _Nullable)params
             expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -2470,9 +2470,9 @@ labels.
  */
 @interface MTRClusterBarrierControl : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)barrierControlGoToPercentWithParams:(MTRBarrierControlClusterBarrierControlGoToPercentParams *)params
                              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -2557,9 +2557,9 @@ labels.
  */
 @interface MTRClusterPumpConfigurationAndControl : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxPressureWithParams:(MTRReadParams * _Nullable)params;
 
@@ -2648,9 +2648,9 @@ labels.
  */
 @interface MTRClusterThermostat : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)setpointRaiseLowerWithParams:(MTRThermostatClusterSetpointRaiseLowerParams *)params
                       expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -2927,9 +2927,9 @@ labels.
  */
 @interface MTRClusterFanControl : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeFanModeWithParams:(MTRReadParams * _Nullable)params;
 - (void)writeAttributeFanModeWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -3004,9 +3004,9 @@ labels.
  */
 @interface MTRClusterThermostatUserInterfaceConfiguration : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeTemperatureDisplayModeWithParams:(MTRReadParams * _Nullable)params;
 - (void)writeAttributeTemperatureDisplayModeWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -3050,9 +3050,9 @@ labels.
  */
 @interface MTRClusterColorControl : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)moveToHueWithParams:(MTRColorControlClusterMoveToHueParams *)params
              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -3321,9 +3321,9 @@ labels.
  */
 @interface MTRClusterBallastConfiguration : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributePhysicalMinLevelWithParams:(MTRReadParams * _Nullable)params;
 
@@ -3424,9 +3424,9 @@ labels.
  */
 @interface MTRClusterIlluminanceMeasurement : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredValueWithParams:(MTRReadParams * _Nullable)params;
 
@@ -3459,9 +3459,9 @@ labels.
  */
 @interface MTRClusterTemperatureMeasurement : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredValueWithParams:(MTRReadParams * _Nullable)params;
 
@@ -3492,9 +3492,9 @@ labels.
  */
 @interface MTRClusterPressureMeasurement : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredValueWithParams:(MTRReadParams * _Nullable)params;
 
@@ -3535,9 +3535,9 @@ labels.
  */
 @interface MTRClusterFlowMeasurement : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredValueWithParams:(MTRReadParams * _Nullable)params;
 
@@ -3568,9 +3568,9 @@ labels.
  */
 @interface MTRClusterRelativeHumidityMeasurement : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredValueWithParams:(MTRReadParams * _Nullable)params;
 
@@ -3601,9 +3601,9 @@ labels.
  */
 @interface MTRClusterOccupancySensing : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeOccupancyWithParams:(MTRReadParams * _Nullable)params;
 
@@ -3696,9 +3696,9 @@ labels.
  */
 @interface MTRClusterWakeOnLan : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeMACAddressWithParams:(MTRReadParams * _Nullable)params;
 
@@ -3723,9 +3723,9 @@ labels.
  */
 @interface MTRClusterChannel : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)changeChannelWithParams:(MTRChannelClusterChangeChannelParams *)params
                  expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -3768,9 +3768,9 @@ labels.
  */
 @interface MTRClusterTargetNavigator : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)navigateTargetWithParams:(MTRTargetNavigatorClusterNavigateTargetParams *)params
                   expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -3804,9 +3804,9 @@ labels.
  */
 @interface MTRClusterMediaPlayback : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)playWithParams:(MTRMediaPlaybackClusterPlayParams * _Nullable)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -3931,9 +3931,9 @@ labels.
  */
 @interface MTRClusterMediaInput : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)selectInputWithParams:(MTRMediaInputClusterSelectInputParams *)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -3983,9 +3983,9 @@ labels.
  */
 @interface MTRClusterLowPower : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)sleepWithParams:(MTRLowPowerClusterSleepParams * _Nullable)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -4016,9 +4016,9 @@ labels.
  */
 @interface MTRClusterKeypadInput : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)sendKeyWithParams:(MTRKeypadInputClusterSendKeyParams *)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -4047,9 +4047,9 @@ labels.
  */
 @interface MTRClusterContentLauncher : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)launchContentWithParams:(MTRContentLauncherClusterLaunchContentParams *)params
                  expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -4092,9 +4092,9 @@ labels.
  */
 @interface MTRClusterAudioOutput : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)selectOutputWithParams:(MTRAudioOutputClusterSelectOutputParams *)params
                 expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -4130,9 +4130,9 @@ labels.
  */
 @interface MTRClusterApplicationLauncher : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)launchAppWithParams:(MTRApplicationLauncherClusterLaunchAppParams *)params
              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -4181,9 +4181,9 @@ labels.
  */
 @interface MTRClusterApplicationBasic : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> *)readAttributeVendorNameWithParams:(MTRReadParams * _Nullable)params;
 
@@ -4224,9 +4224,9 @@ labels.
  */
 @interface MTRClusterAccountLogin : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)getSetupPINWithParams:(MTRAccountLoginClusterGetSetupPINParams *)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -4267,9 +4267,9 @@ labels.
  */
 @interface MTRClusterElectricalMeasurement : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)getProfileInfoCommandWithParams:(MTRElectricalMeasurementClusterGetProfileInfoCommandParams * _Nullable)params
                          expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -4600,9 +4600,9 @@ labels.
  */
 @interface MTRClusterTestCluster : MTRCluster
 
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                             endpointID:(NSNumber *)endpointID
-                                  queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 - (void)testWithParams:(MTRTestClusterClusterTestParams * _Nullable)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRIdentifyClusterTriggerEffectParams : NSObject <NSCopying>
 
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupsClusterAddGroupParams : NSObject <NSCopying>
 
@@ -88,7 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupsClusterAddGroupResponseParams : NSObject <NSCopying>
 
@@ -112,7 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupsClusterViewGroupParams : NSObject <NSCopying>
 
@@ -134,7 +134,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupsClusterViewGroupResponseParams : NSObject <NSCopying>
 
@@ -160,7 +160,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupsClusterGetGroupMembershipParams : NSObject <NSCopying>
 
@@ -182,7 +182,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupsClusterGetGroupMembershipResponseParams : NSObject <NSCopying>
 
@@ -206,7 +206,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupsClusterRemoveGroupParams : NSObject <NSCopying>
 
@@ -228,7 +228,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupsClusterRemoveGroupResponseParams : NSObject <NSCopying>
 
@@ -252,7 +252,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupsClusterRemoveAllGroupsParams : NSObject <NSCopying>
 /**
@@ -272,7 +272,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupsClusterAddGroupIfIdentifyingParams : NSObject <NSCopying>
 
@@ -296,7 +296,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterAddSceneParams : NSObject <NSCopying>
 
@@ -326,7 +326,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterAddSceneResponseParams : NSObject <NSCopying>
 
@@ -352,7 +352,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterViewSceneParams : NSObject <NSCopying>
 
@@ -376,7 +376,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterViewSceneResponseParams : NSObject <NSCopying>
 
@@ -408,7 +408,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterRemoveSceneParams : NSObject <NSCopying>
 
@@ -432,7 +432,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterRemoveSceneResponseParams : NSObject <NSCopying>
 
@@ -458,7 +458,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterRemoveAllScenesParams : NSObject <NSCopying>
 
@@ -480,7 +480,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterRemoveAllScenesResponseParams : NSObject <NSCopying>
 
@@ -504,7 +504,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterStoreSceneParams : NSObject <NSCopying>
 
@@ -528,7 +528,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterStoreSceneResponseParams : NSObject <NSCopying>
 
@@ -554,7 +554,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterRecallSceneParams : NSObject <NSCopying>
 
@@ -580,7 +580,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterGetSceneMembershipParams : NSObject <NSCopying>
 
@@ -602,7 +602,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterGetSceneMembershipResponseParams : NSObject <NSCopying>
 
@@ -630,7 +630,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterEnhancedAddSceneParams : NSObject <NSCopying>
 
@@ -660,7 +660,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterEnhancedAddSceneResponseParams : NSObject <NSCopying>
 
@@ -686,7 +686,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterEnhancedViewSceneParams : NSObject <NSCopying>
 
@@ -710,7 +710,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterEnhancedViewSceneResponseParams : NSObject <NSCopying>
 
@@ -742,7 +742,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterCopySceneParams : NSObject <NSCopying>
 
@@ -772,7 +772,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRScenesClusterCopySceneResponseParams : NSObject <NSCopying>
 
@@ -798,7 +798,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROnOffClusterOffParams : NSObject <NSCopying>
 /**
@@ -818,7 +818,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROnOffClusterOnParams : NSObject <NSCopying>
 /**
@@ -838,7 +838,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROnOffClusterToggleParams : NSObject <NSCopying>
 /**
@@ -858,7 +858,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROnOffClusterOffWithEffectParams : NSObject <NSCopying>
 
@@ -882,7 +882,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROnOffClusterOnWithRecallGlobalSceneParams : NSObject <NSCopying>
 /**
@@ -902,7 +902,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROnOffClusterOnWithTimedOffParams : NSObject <NSCopying>
 
@@ -928,7 +928,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRLevelControlClusterMoveToLevelParams : NSObject <NSCopying>
 
@@ -956,7 +956,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRLevelControlClusterMoveParams : NSObject <NSCopying>
 
@@ -984,7 +984,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRLevelControlClusterStepParams : NSObject <NSCopying>
 
@@ -1014,7 +1014,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRLevelControlClusterStopParams : NSObject <NSCopying>
 
@@ -1038,7 +1038,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRLevelControlClusterMoveToLevelWithOnOffParams : NSObject <NSCopying>
 
@@ -1066,7 +1066,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRLevelControlClusterMoveWithOnOffParams : NSObject <NSCopying>
 
@@ -1094,7 +1094,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRLevelControlClusterStepWithOnOffParams : NSObject <NSCopying>
 
@@ -1124,7 +1124,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRLevelControlClusterStopWithOnOffParams : NSObject <NSCopying>
 
@@ -1148,7 +1148,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRLevelControlClusterMoveToClosestFrequencyParams : NSObject <NSCopying>
 
@@ -1170,7 +1170,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRActionsClusterInstantActionParams : NSObject <NSCopying>
 
@@ -1194,7 +1194,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRActionsClusterInstantActionWithTransitionParams : NSObject <NSCopying>
 
@@ -1220,7 +1220,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRActionsClusterStartActionParams : NSObject <NSCopying>
 
@@ -1244,7 +1244,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRActionsClusterStartActionWithDurationParams : NSObject <NSCopying>
 
@@ -1270,7 +1270,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRActionsClusterStopActionParams : NSObject <NSCopying>
 
@@ -1294,7 +1294,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRActionsClusterPauseActionParams : NSObject <NSCopying>
 
@@ -1318,7 +1318,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRActionsClusterPauseActionWithDurationParams : NSObject <NSCopying>
 
@@ -1344,7 +1344,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRActionsClusterResumeActionParams : NSObject <NSCopying>
 
@@ -1368,7 +1368,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRActionsClusterEnableActionParams : NSObject <NSCopying>
 
@@ -1392,7 +1392,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRActionsClusterEnableActionWithDurationParams : NSObject <NSCopying>
 
@@ -1418,7 +1418,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRActionsClusterDisableActionParams : NSObject <NSCopying>
 
@@ -1442,7 +1442,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRActionsClusterDisableActionWithDurationParams : NSObject <NSCopying>
 
@@ -1468,7 +1468,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRBasicClusterMfgSpecificPingParams : NSObject <NSCopying>
 /**
@@ -1488,7 +1488,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROtaSoftwareUpdateProviderClusterQueryImageParams : NSObject <NSCopying>
 
@@ -1524,7 +1524,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams : NSObject <NSCopying>
 
@@ -1560,7 +1560,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams : NSObject <NSCopying>
 
@@ -1584,7 +1584,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams : NSObject <NSCopying>
 
@@ -1608,7 +1608,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams : NSObject <NSCopying>
 
@@ -1632,7 +1632,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams : NSObject <NSCopying>
 
@@ -1662,7 +1662,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGeneralCommissioningClusterArmFailSafeParams : NSObject <NSCopying>
 
@@ -1686,7 +1686,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGeneralCommissioningClusterArmFailSafeResponseParams : NSObject <NSCopying>
 
@@ -1710,7 +1710,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGeneralCommissioningClusterSetRegulatoryConfigParams : NSObject <NSCopying>
 
@@ -1736,7 +1736,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGeneralCommissioningClusterSetRegulatoryConfigResponseParams : NSObject <NSCopying>
 
@@ -1760,7 +1760,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGeneralCommissioningClusterCommissioningCompleteParams : NSObject <NSCopying>
 /**
@@ -1780,7 +1780,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGeneralCommissioningClusterCommissioningCompleteResponseParams : NSObject <NSCopying>
 
@@ -1804,7 +1804,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRNetworkCommissioningClusterScanNetworksParams : NSObject <NSCopying>
 
@@ -1828,7 +1828,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRNetworkCommissioningClusterScanNetworksResponseParams : NSObject <NSCopying>
 
@@ -1856,7 +1856,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRNetworkCommissioningClusterAddOrUpdateWiFiNetworkParams : NSObject <NSCopying>
 
@@ -1882,7 +1882,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRNetworkCommissioningClusterAddOrUpdateThreadNetworkParams : NSObject <NSCopying>
 
@@ -1906,7 +1906,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRNetworkCommissioningClusterRemoveNetworkParams : NSObject <NSCopying>
 
@@ -1930,7 +1930,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRNetworkCommissioningClusterNetworkConfigResponseParams : NSObject <NSCopying>
 
@@ -1956,7 +1956,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRNetworkCommissioningClusterConnectNetworkParams : NSObject <NSCopying>
 
@@ -1980,7 +1980,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRNetworkCommissioningClusterConnectNetworkResponseParams : NSObject <NSCopying>
 
@@ -2006,7 +2006,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRNetworkCommissioningClusterReorderNetworkParams : NSObject <NSCopying>
 
@@ -2032,7 +2032,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDiagnosticLogsClusterRetrieveLogsRequestParams : NSObject <NSCopying>
 
@@ -2058,7 +2058,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDiagnosticLogsClusterRetrieveLogsResponseParams : NSObject <NSCopying>
 
@@ -2086,7 +2086,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGeneralDiagnosticsClusterTestEventTriggerParams : NSObject <NSCopying>
 
@@ -2110,7 +2110,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRSoftwareDiagnosticsClusterResetWatermarksParams : NSObject <NSCopying>
 /**
@@ -2130,7 +2130,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRThreadNetworkDiagnosticsClusterResetCountsParams : NSObject <NSCopying>
 /**
@@ -2150,7 +2150,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRWiFiNetworkDiagnosticsClusterResetCountsParams : NSObject <NSCopying>
 /**
@@ -2170,7 +2170,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTREthernetNetworkDiagnosticsClusterResetCountsParams : NSObject <NSCopying>
 /**
@@ -2190,7 +2190,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTimeSynchronizationClusterSetUtcTimeParams : NSObject <NSCopying>
 
@@ -2216,7 +2216,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRAdministratorCommissioningClusterOpenCommissioningWindowParams : NSObject <NSCopying>
 
@@ -2246,7 +2246,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRAdministratorCommissioningClusterOpenBasicCommissioningWindowParams : NSObject <NSCopying>
 
@@ -2268,7 +2268,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRAdministratorCommissioningClusterRevokeCommissioningParams : NSObject <NSCopying>
 /**
@@ -2288,7 +2288,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROperationalCredentialsClusterAttestationRequestParams : NSObject <NSCopying>
 
@@ -2310,7 +2310,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROperationalCredentialsClusterAttestationResponseParams : NSObject <NSCopying>
 
@@ -2334,7 +2334,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROperationalCredentialsClusterCertificateChainRequestParams : NSObject <NSCopying>
 
@@ -2356,7 +2356,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROperationalCredentialsClusterCertificateChainResponseParams : NSObject <NSCopying>
 
@@ -2378,7 +2378,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROperationalCredentialsClusterCSRRequestParams : NSObject <NSCopying>
 
@@ -2402,7 +2402,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROperationalCredentialsClusterCSRResponseParams : NSObject <NSCopying>
 
@@ -2426,7 +2426,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROperationalCredentialsClusterAddNOCParams : NSObject <NSCopying>
 
@@ -2456,7 +2456,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROperationalCredentialsClusterUpdateNOCParams : NSObject <NSCopying>
 
@@ -2480,7 +2480,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROperationalCredentialsClusterNOCResponseParams : NSObject <NSCopying>
 
@@ -2506,7 +2506,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROperationalCredentialsClusterUpdateFabricLabelParams : NSObject <NSCopying>
 
@@ -2528,7 +2528,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROperationalCredentialsClusterRemoveFabricParams : NSObject <NSCopying>
 
@@ -2550,7 +2550,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTROperationalCredentialsClusterAddTrustedRootCertificateParams : NSObject <NSCopying>
 
@@ -2572,7 +2572,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupKeyManagementClusterKeySetWriteParams : NSObject <NSCopying>
 
@@ -2594,7 +2594,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupKeyManagementClusterKeySetReadParams : NSObject <NSCopying>
 
@@ -2616,7 +2616,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupKeyManagementClusterKeySetReadResponseParams : NSObject <NSCopying>
 
@@ -2638,7 +2638,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupKeyManagementClusterKeySetRemoveParams : NSObject <NSCopying>
 
@@ -2660,7 +2660,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupKeyManagementClusterKeySetReadAllIndicesParams : NSObject <NSCopying>
 
@@ -2682,7 +2682,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRGroupKeyManagementClusterKeySetReadAllIndicesResponseParams : NSObject <NSCopying>
 
@@ -2704,7 +2704,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRModeSelectClusterChangeToModeParams : NSObject <NSCopying>
 
@@ -2726,7 +2726,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterLockDoorParams : NSObject <NSCopying>
 
@@ -2748,7 +2748,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterUnlockDoorParams : NSObject <NSCopying>
 
@@ -2770,7 +2770,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterUnlockWithTimeoutParams : NSObject <NSCopying>
 
@@ -2794,7 +2794,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterSetWeekDayScheduleParams : NSObject <NSCopying>
 
@@ -2828,7 +2828,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterGetWeekDayScheduleParams : NSObject <NSCopying>
 
@@ -2852,7 +2852,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterGetWeekDayScheduleResponseParams : NSObject <NSCopying>
 
@@ -2888,7 +2888,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterClearWeekDayScheduleParams : NSObject <NSCopying>
 
@@ -2912,7 +2912,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterSetYearDayScheduleParams : NSObject <NSCopying>
 
@@ -2940,7 +2940,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterGetYearDayScheduleParams : NSObject <NSCopying>
 
@@ -2964,7 +2964,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterGetYearDayScheduleResponseParams : NSObject <NSCopying>
 
@@ -2994,7 +2994,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterClearYearDayScheduleParams : NSObject <NSCopying>
 
@@ -3018,7 +3018,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterSetHolidayScheduleParams : NSObject <NSCopying>
 
@@ -3046,7 +3046,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterGetHolidayScheduleParams : NSObject <NSCopying>
 
@@ -3068,7 +3068,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterGetHolidayScheduleResponseParams : NSObject <NSCopying>
 
@@ -3098,7 +3098,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterClearHolidayScheduleParams : NSObject <NSCopying>
 
@@ -3120,7 +3120,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterSetUserParams : NSObject <NSCopying>
 
@@ -3154,7 +3154,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterGetUserParams : NSObject <NSCopying>
 
@@ -3176,7 +3176,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterGetUserResponseParams : NSObject <NSCopying>
 
@@ -3216,7 +3216,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterClearUserParams : NSObject <NSCopying>
 
@@ -3238,7 +3238,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterSetCredentialParams : NSObject <NSCopying>
 
@@ -3270,7 +3270,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterSetCredentialResponseParams : NSObject <NSCopying>
 
@@ -3296,7 +3296,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterGetCredentialStatusParams : NSObject <NSCopying>
 
@@ -3318,7 +3318,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterGetCredentialStatusResponseParams : NSObject <NSCopying>
 
@@ -3348,7 +3348,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRDoorLockClusterClearCredentialParams : NSObject <NSCopying>
 
@@ -3370,7 +3370,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRWindowCoveringClusterUpOrOpenParams : NSObject <NSCopying>
 /**
@@ -3390,7 +3390,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRWindowCoveringClusterDownOrCloseParams : NSObject <NSCopying>
 /**
@@ -3410,7 +3410,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRWindowCoveringClusterStopMotionParams : NSObject <NSCopying>
 /**
@@ -3430,7 +3430,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRWindowCoveringClusterGoToLiftValueParams : NSObject <NSCopying>
 
@@ -3452,7 +3452,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRWindowCoveringClusterGoToLiftPercentageParams : NSObject <NSCopying>
 
@@ -3474,7 +3474,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRWindowCoveringClusterGoToTiltValueParams : NSObject <NSCopying>
 
@@ -3496,7 +3496,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRWindowCoveringClusterGoToTiltPercentageParams : NSObject <NSCopying>
 
@@ -3518,7 +3518,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRBarrierControlClusterBarrierControlGoToPercentParams : NSObject <NSCopying>
 
@@ -3540,7 +3540,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRBarrierControlClusterBarrierControlStopParams : NSObject <NSCopying>
 /**
@@ -3560,7 +3560,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRThermostatClusterSetpointRaiseLowerParams : NSObject <NSCopying>
 
@@ -3584,7 +3584,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRThermostatClusterGetWeeklyScheduleResponseParams : NSObject <NSCopying>
 
@@ -3612,7 +3612,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRThermostatClusterSetWeeklyScheduleParams : NSObject <NSCopying>
 
@@ -3640,7 +3640,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRThermostatClusterGetWeeklyScheduleParams : NSObject <NSCopying>
 
@@ -3664,7 +3664,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRThermostatClusterClearWeeklyScheduleParams : NSObject <NSCopying>
 /**
@@ -3684,7 +3684,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterMoveToHueParams : NSObject <NSCopying>
 
@@ -3714,7 +3714,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterMoveHueParams : NSObject <NSCopying>
 
@@ -3742,7 +3742,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterStepHueParams : NSObject <NSCopying>
 
@@ -3772,7 +3772,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterMoveToSaturationParams : NSObject <NSCopying>
 
@@ -3800,7 +3800,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterMoveSaturationParams : NSObject <NSCopying>
 
@@ -3828,7 +3828,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterStepSaturationParams : NSObject <NSCopying>
 
@@ -3858,7 +3858,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterMoveToHueAndSaturationParams : NSObject <NSCopying>
 
@@ -3888,7 +3888,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterMoveToColorParams : NSObject <NSCopying>
 
@@ -3918,7 +3918,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterMoveColorParams : NSObject <NSCopying>
 
@@ -3946,7 +3946,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterStepColorParams : NSObject <NSCopying>
 
@@ -3976,7 +3976,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterMoveToColorTemperatureParams : NSObject <NSCopying>
 
@@ -4004,7 +4004,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterEnhancedMoveToHueParams : NSObject <NSCopying>
 
@@ -4034,7 +4034,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterEnhancedMoveHueParams : NSObject <NSCopying>
 
@@ -4062,7 +4062,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterEnhancedStepHueParams : NSObject <NSCopying>
 
@@ -4092,7 +4092,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterEnhancedMoveToHueAndSaturationParams : NSObject <NSCopying>
 
@@ -4122,7 +4122,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterColorLoopSetParams : NSObject <NSCopying>
 
@@ -4156,7 +4156,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterStopMoveStepParams : NSObject <NSCopying>
 
@@ -4180,7 +4180,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterMoveColorTemperatureParams : NSObject <NSCopying>
 
@@ -4212,7 +4212,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRColorControlClusterStepColorTemperatureParams : NSObject <NSCopying>
 
@@ -4246,7 +4246,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRChannelClusterChangeChannelParams : NSObject <NSCopying>
 
@@ -4268,7 +4268,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRChannelClusterChangeChannelResponseParams : NSObject <NSCopying>
 
@@ -4292,7 +4292,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRChannelClusterChangeChannelByNumberParams : NSObject <NSCopying>
 
@@ -4316,7 +4316,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRChannelClusterSkipChannelParams : NSObject <NSCopying>
 
@@ -4338,7 +4338,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTargetNavigatorClusterNavigateTargetParams : NSObject <NSCopying>
 
@@ -4362,7 +4362,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTargetNavigatorClusterNavigateTargetResponseParams : NSObject <NSCopying>
 
@@ -4386,7 +4386,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaPlaybackClusterPlayParams : NSObject <NSCopying>
 /**
@@ -4406,7 +4406,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaPlaybackClusterPauseParams : NSObject <NSCopying>
 /**
@@ -4426,7 +4426,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaPlaybackClusterStopPlaybackParams : NSObject <NSCopying>
 /**
@@ -4446,7 +4446,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaPlaybackClusterStartOverParams : NSObject <NSCopying>
 /**
@@ -4466,7 +4466,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaPlaybackClusterPreviousParams : NSObject <NSCopying>
 /**
@@ -4486,7 +4486,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaPlaybackClusterNextParams : NSObject <NSCopying>
 /**
@@ -4506,7 +4506,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaPlaybackClusterRewindParams : NSObject <NSCopying>
 /**
@@ -4526,7 +4526,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaPlaybackClusterFastForwardParams : NSObject <NSCopying>
 /**
@@ -4546,7 +4546,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaPlaybackClusterSkipForwardParams : NSObject <NSCopying>
 
@@ -4568,7 +4568,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaPlaybackClusterSkipBackwardParams : NSObject <NSCopying>
 
@@ -4590,7 +4590,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaPlaybackClusterPlaybackResponseParams : NSObject <NSCopying>
 
@@ -4614,7 +4614,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaPlaybackClusterSeekParams : NSObject <NSCopying>
 
@@ -4636,7 +4636,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaInputClusterSelectInputParams : NSObject <NSCopying>
 
@@ -4658,7 +4658,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaInputClusterShowInputStatusParams : NSObject <NSCopying>
 /**
@@ -4678,7 +4678,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaInputClusterHideInputStatusParams : NSObject <NSCopying>
 /**
@@ -4698,7 +4698,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRMediaInputClusterRenameInputParams : NSObject <NSCopying>
 
@@ -4722,7 +4722,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRLowPowerClusterSleepParams : NSObject <NSCopying>
 /**
@@ -4742,7 +4742,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRKeypadInputClusterSendKeyParams : NSObject <NSCopying>
 
@@ -4764,7 +4764,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRKeypadInputClusterSendKeyResponseParams : NSObject <NSCopying>
 
@@ -4786,7 +4786,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRContentLauncherClusterLaunchContentParams : NSObject <NSCopying>
 
@@ -4812,7 +4812,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRContentLauncherClusterLaunchURLParams : NSObject <NSCopying>
 
@@ -4838,7 +4838,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRContentLauncherClusterLaunchResponseParams : NSObject <NSCopying>
 
@@ -4862,7 +4862,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRAudioOutputClusterSelectOutputParams : NSObject <NSCopying>
 
@@ -4884,7 +4884,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRAudioOutputClusterRenameOutputParams : NSObject <NSCopying>
 
@@ -4908,7 +4908,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRApplicationLauncherClusterLaunchAppParams : NSObject <NSCopying>
 
@@ -4932,7 +4932,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRApplicationLauncherClusterStopAppParams : NSObject <NSCopying>
 
@@ -4954,7 +4954,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRApplicationLauncherClusterHideAppParams : NSObject <NSCopying>
 
@@ -4976,7 +4976,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRApplicationLauncherClusterLauncherResponseParams : NSObject <NSCopying>
 
@@ -5000,7 +5000,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRAccountLoginClusterGetSetupPINParams : NSObject <NSCopying>
 
@@ -5022,7 +5022,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRAccountLoginClusterGetSetupPINResponseParams : NSObject <NSCopying>
 
@@ -5044,7 +5044,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRAccountLoginClusterLoginParams : NSObject <NSCopying>
 
@@ -5068,7 +5068,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRAccountLoginClusterLogoutParams : NSObject <NSCopying>
 /**
@@ -5088,7 +5088,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRElectricalMeasurementClusterGetProfileInfoResponseCommandParams : NSObject <NSCopying>
 
@@ -5116,7 +5116,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRElectricalMeasurementClusterGetProfileInfoCommandParams : NSObject <NSCopying>
 /**
@@ -5136,7 +5136,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRElectricalMeasurementClusterGetMeasurementProfileResponseCommandParams : NSObject <NSCopying>
 
@@ -5168,7 +5168,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRElectricalMeasurementClusterGetMeasurementProfileCommandParams : NSObject <NSCopying>
 
@@ -5194,7 +5194,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestParams : NSObject <NSCopying>
 /**
@@ -5214,7 +5214,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestSpecificResponseParams : NSObject <NSCopying>
 
@@ -5236,7 +5236,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestNotHandledParams : NSObject <NSCopying>
 /**
@@ -5256,7 +5256,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestAddArgumentsResponseParams : NSObject <NSCopying>
 
@@ -5278,7 +5278,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestSpecificParams : NSObject <NSCopying>
 /**
@@ -5298,7 +5298,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestSimpleArgumentResponseParams : NSObject <NSCopying>
 
@@ -5320,7 +5320,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestUnknownCommandParams : NSObject <NSCopying>
 /**
@@ -5340,7 +5340,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestStructArrayArgumentResponseParams : NSObject <NSCopying>
 
@@ -5372,7 +5372,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestAddArgumentsParams : NSObject <NSCopying>
 
@@ -5396,7 +5396,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestListInt8UReverseResponseParams : NSObject <NSCopying>
 
@@ -5418,7 +5418,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestSimpleArgumentRequestParams : NSObject <NSCopying>
 
@@ -5440,7 +5440,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestEnumsResponseParams : NSObject <NSCopying>
 
@@ -5464,7 +5464,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestStructArrayArgumentRequestParams : NSObject <NSCopying>
 
@@ -5496,7 +5496,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestNullableOptionalResponseParams : NSObject <NSCopying>
 
@@ -5524,7 +5524,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestStructArgumentRequestParams : NSObject <NSCopying>
 
@@ -5546,7 +5546,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestComplexNullableOptionalResponseParams : NSObject <NSCopying>
 
@@ -5622,7 +5622,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestNestedStructArgumentRequestParams : NSObject <NSCopying>
 
@@ -5644,7 +5644,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterBooleanResponseParams : NSObject <NSCopying>
 
@@ -5666,7 +5666,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestListStructArgumentRequestParams : NSObject <NSCopying>
 
@@ -5688,7 +5688,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterSimpleStructResponseParams : NSObject <NSCopying>
 
@@ -5710,7 +5710,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestListInt8UArgumentRequestParams : NSObject <NSCopying>
 
@@ -5732,7 +5732,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestEmitTestEventResponseParams : NSObject <NSCopying>
 
@@ -5754,7 +5754,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestNestedStructListArgumentRequestParams : NSObject <NSCopying>
 
@@ -5776,7 +5776,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestEmitTestFabricScopedEventResponseParams : NSObject <NSCopying>
 
@@ -5798,7 +5798,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestListNestedStructListArgumentRequestParams : NSObject <NSCopying>
 
@@ -5820,7 +5820,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestListInt8UReverseRequestParams : NSObject <NSCopying>
 
@@ -5842,7 +5842,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestEnumsRequestParams : NSObject <NSCopying>
 
@@ -5866,7 +5866,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestNullableOptionalRequestParams : NSObject <NSCopying>
 
@@ -5888,7 +5888,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestComplexNullableOptionalRequestParams : NSObject <NSCopying>
 
@@ -5932,7 +5932,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterSimpleStructEchoRequestParams : NSObject <NSCopying>
 
@@ -5954,7 +5954,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTimedInvokeRequestParams : NSObject <NSCopying>
 /**
@@ -5974,7 +5974,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestSimpleOptionalArgumentRequestParams : NSObject <NSCopying>
 
@@ -5996,7 +5996,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestEmitTestEventRequestParams : NSObject <NSCopying>
 
@@ -6022,7 +6022,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRTestClusterClusterTestEmitTestFabricScopedEventRequestParams : NSObject <NSCopying>
 
@@ -6044,7 +6044,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRFaultInjectionClusterFailAtFaultParams : NSObject <NSCopying>
 
@@ -6074,7 +6074,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 @interface MTRFaultInjectionClusterFailRandomlyAtFaultParams : NSObject <NSCopying>
 
@@ -6100,7 +6100,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRIdentifyClusterIdentifyParams alloc] init];
 
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRIdentifyClusterTriggerEffectParams alloc] init];
 
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupsClusterAddGroupParams alloc] init];
 
@@ -125,7 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupsClusterAddGroupResponseParams alloc] init];
 
@@ -155,7 +155,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupsClusterViewGroupParams alloc] init];
 
@@ -187,7 +187,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupsClusterViewGroupResponseParams alloc] init];
 
@@ -218,7 +218,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupsClusterGetGroupMembershipParams alloc] init];
 
@@ -248,7 +248,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupsClusterGetGroupMembershipResponseParams alloc] init];
 
@@ -278,7 +278,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupsClusterRemoveGroupParams alloc] init];
 
@@ -308,7 +308,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupsClusterRemoveGroupResponseParams alloc] init];
 
@@ -336,7 +336,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupsClusterRemoveAllGroupsParams alloc] init];
 
@@ -365,7 +365,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupsClusterAddGroupIfIdentifyingParams alloc] init];
 
@@ -403,7 +403,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterAddSceneParams alloc] init];
 
@@ -441,7 +441,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterAddSceneResponseParams alloc] init];
 
@@ -474,7 +474,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterViewSceneParams alloc] init];
 
@@ -514,7 +514,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterViewSceneResponseParams alloc] init];
 
@@ -551,7 +551,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterRemoveSceneParams alloc] init];
 
@@ -585,7 +585,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterRemoveSceneResponseParams alloc] init];
 
@@ -616,7 +616,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterRemoveAllScenesParams alloc] init];
 
@@ -646,7 +646,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterRemoveAllScenesResponseParams alloc] init];
 
@@ -678,7 +678,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterStoreSceneParams alloc] init];
 
@@ -712,7 +712,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterStoreSceneResponseParams alloc] init];
 
@@ -747,7 +747,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterRecallSceneParams alloc] init];
 
@@ -778,7 +778,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterGetSceneMembershipParams alloc] init];
 
@@ -812,7 +812,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterGetSceneMembershipResponseParams alloc] init];
 
@@ -852,7 +852,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterEnhancedAddSceneParams alloc] init];
 
@@ -890,7 +890,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterEnhancedAddSceneResponseParams alloc] init];
 
@@ -923,7 +923,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterEnhancedViewSceneParams alloc] init];
 
@@ -963,7 +963,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterEnhancedViewSceneResponseParams alloc] init];
 
@@ -1006,7 +1006,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterCopySceneParams alloc] init];
 
@@ -1044,7 +1044,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRScenesClusterCopySceneResponseParams alloc] init];
 
@@ -1073,7 +1073,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROnOffClusterOffParams alloc] init];
 
@@ -1098,7 +1098,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROnOffClusterOnParams alloc] init];
 
@@ -1123,7 +1123,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROnOffClusterToggleParams alloc] init];
 
@@ -1152,7 +1152,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROnOffClusterOffWithEffectParams alloc] init];
 
@@ -1180,7 +1180,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROnOffClusterOnWithRecallGlobalSceneParams alloc] init];
 
@@ -1211,7 +1211,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROnOffClusterOnWithTimedOffParams alloc] init];
 
@@ -1248,7 +1248,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRLevelControlClusterMoveToLevelParams alloc] init];
 
@@ -1287,7 +1287,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRLevelControlClusterMoveParams alloc] init];
 
@@ -1327,7 +1327,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRLevelControlClusterStepParams alloc] init];
 
@@ -1363,7 +1363,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRLevelControlClusterStopParams alloc] init];
 
@@ -1399,7 +1399,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRLevelControlClusterMoveToLevelWithOnOffParams alloc] init];
 
@@ -1438,7 +1438,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRLevelControlClusterMoveWithOnOffParams alloc] init];
 
@@ -1478,7 +1478,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRLevelControlClusterStepWithOnOffParams alloc] init];
 
@@ -1514,7 +1514,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRLevelControlClusterStopWithOnOffParams alloc] init];
 
@@ -1544,7 +1544,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRLevelControlClusterMoveToClosestFrequencyParams alloc] init];
 
@@ -1574,7 +1574,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRActionsClusterInstantActionParams alloc] init];
 
@@ -1608,7 +1608,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRActionsClusterInstantActionWithTransitionParams alloc] init];
 
@@ -1641,7 +1641,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRActionsClusterStartActionParams alloc] init];
 
@@ -1675,7 +1675,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRActionsClusterStartActionWithDurationParams alloc] init];
 
@@ -1708,7 +1708,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRActionsClusterStopActionParams alloc] init];
 
@@ -1740,7 +1740,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRActionsClusterPauseActionParams alloc] init];
 
@@ -1774,7 +1774,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRActionsClusterPauseActionWithDurationParams alloc] init];
 
@@ -1807,7 +1807,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRActionsClusterResumeActionParams alloc] init];
 
@@ -1839,7 +1839,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRActionsClusterEnableActionParams alloc] init];
 
@@ -1873,7 +1873,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRActionsClusterEnableActionWithDurationParams alloc] init];
 
@@ -1906,7 +1906,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRActionsClusterDisableActionParams alloc] init];
 
@@ -1940,7 +1940,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRActionsClusterDisableActionWithDurationParams alloc] init];
 
@@ -1969,7 +1969,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRBasicClusterMfgSpecificPingParams alloc] init];
 
@@ -2010,7 +2010,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROtaSoftwareUpdateProviderClusterQueryImageParams alloc] init];
 
@@ -2063,7 +2063,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams alloc] init];
 
@@ -2105,7 +2105,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams alloc] init];
 
@@ -2138,7 +2138,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams alloc] init];
 
@@ -2170,7 +2170,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams alloc] init];
 
@@ -2209,7 +2209,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams alloc] init];
 
@@ -2246,7 +2246,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGeneralCommissioningClusterArmFailSafeParams alloc] init];
 
@@ -2278,7 +2278,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGeneralCommissioningClusterArmFailSafeResponseParams alloc] init];
 
@@ -2312,7 +2312,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGeneralCommissioningClusterSetRegulatoryConfigParams alloc] init];
 
@@ -2345,7 +2345,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGeneralCommissioningClusterSetRegulatoryConfigResponseParams alloc] init];
 
@@ -2373,7 +2373,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGeneralCommissioningClusterCommissioningCompleteParams alloc] init];
 
@@ -2402,7 +2402,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGeneralCommissioningClusterCommissioningCompleteResponseParams alloc] init];
 
@@ -2434,7 +2434,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRNetworkCommissioningClusterScanNetworksParams alloc] init];
 
@@ -2470,7 +2470,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRNetworkCommissioningClusterScanNetworksResponseParams alloc] init];
 
@@ -2507,7 +2507,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRNetworkCommissioningClusterAddOrUpdateWiFiNetworkParams alloc] init];
 
@@ -2541,7 +2541,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRNetworkCommissioningClusterAddOrUpdateThreadNetworkParams alloc] init];
 
@@ -2574,7 +2574,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRNetworkCommissioningClusterRemoveNetworkParams alloc] init];
 
@@ -2609,7 +2609,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRNetworkCommissioningClusterNetworkConfigResponseParams alloc] init];
 
@@ -2642,7 +2642,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRNetworkCommissioningClusterConnectNetworkParams alloc] init];
 
@@ -2677,7 +2677,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRNetworkCommissioningClusterConnectNetworkResponseParams alloc] init];
 
@@ -2712,7 +2712,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRNetworkCommissioningClusterReorderNetworkParams alloc] init];
 
@@ -2748,7 +2748,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDiagnosticLogsClusterRetrieveLogsRequestParams alloc] init];
 
@@ -2786,7 +2786,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDiagnosticLogsClusterRetrieveLogsResponseParams alloc] init];
 
@@ -2821,7 +2821,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGeneralDiagnosticsClusterTestEventTriggerParams alloc] init];
 
@@ -2850,7 +2850,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRSoftwareDiagnosticsClusterResetWatermarksParams alloc] init];
 
@@ -2875,7 +2875,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRThreadNetworkDiagnosticsClusterResetCountsParams alloc] init];
 
@@ -2900,7 +2900,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRWiFiNetworkDiagnosticsClusterResetCountsParams alloc] init];
 
@@ -2925,7 +2925,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTREthernetNetworkDiagnosticsClusterResetCountsParams alloc] init];
 
@@ -2956,7 +2956,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTimeSynchronizationClusterSetUtcTimeParams alloc] init];
 
@@ -2995,7 +2995,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRAdministratorCommissioningClusterOpenCommissioningWindowParams alloc] init];
 
@@ -3030,7 +3030,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRAdministratorCommissioningClusterOpenBasicCommissioningWindowParams alloc] init];
 
@@ -3057,7 +3057,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRAdministratorCommissioningClusterRevokeCommissioningParams alloc] init];
 
@@ -3084,7 +3084,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROperationalCredentialsClusterAttestationRequestParams alloc] init];
 
@@ -3115,7 +3115,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROperationalCredentialsClusterAttestationResponseParams alloc] init];
 
@@ -3146,7 +3146,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROperationalCredentialsClusterCertificateChainRequestParams alloc] init];
 
@@ -3175,7 +3175,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROperationalCredentialsClusterCertificateChainResponseParams alloc] init];
 
@@ -3206,7 +3206,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROperationalCredentialsClusterCSRRequestParams alloc] init];
 
@@ -3239,7 +3239,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROperationalCredentialsClusterCSRResponseParams alloc] init];
 
@@ -3278,7 +3278,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROperationalCredentialsClusterAddNOCParams alloc] init];
 
@@ -3316,7 +3316,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROperationalCredentialsClusterUpdateNOCParams alloc] init];
 
@@ -3351,7 +3351,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROperationalCredentialsClusterNOCResponseParams alloc] init];
 
@@ -3382,7 +3382,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROperationalCredentialsClusterUpdateFabricLabelParams alloc] init];
 
@@ -3410,7 +3410,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROperationalCredentialsClusterRemoveFabricParams alloc] init];
 
@@ -3439,7 +3439,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTROperationalCredentialsClusterAddTrustedRootCertificateParams alloc] init];
 
@@ -3468,7 +3468,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupKeyManagementClusterKeySetWriteParams alloc] init];
 
@@ -3497,7 +3497,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupKeyManagementClusterKeySetReadParams alloc] init];
 
@@ -3526,7 +3526,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupKeyManagementClusterKeySetReadResponseParams alloc] init];
 
@@ -3555,7 +3555,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupKeyManagementClusterKeySetRemoveParams alloc] init];
 
@@ -3584,7 +3584,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupKeyManagementClusterKeySetReadAllIndicesParams alloc] init];
 
@@ -3613,7 +3613,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRGroupKeyManagementClusterKeySetReadAllIndicesResponseParams alloc] init];
 
@@ -3642,7 +3642,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRModeSelectClusterChangeToModeParams alloc] init];
 
@@ -3670,7 +3670,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterLockDoorParams alloc] init];
 
@@ -3699,7 +3699,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterUnlockDoorParams alloc] init];
 
@@ -3730,7 +3730,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterUnlockWithTimeoutParams alloc] init];
 
@@ -3772,7 +3772,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterSetWeekDayScheduleParams alloc] init];
 
@@ -3811,7 +3811,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterGetWeekDayScheduleParams alloc] init];
 
@@ -3855,7 +3855,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterGetWeekDayScheduleResponseParams alloc] init];
 
@@ -3895,7 +3895,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterClearWeekDayScheduleParams alloc] init];
 
@@ -3931,7 +3931,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterSetYearDayScheduleParams alloc] init];
 
@@ -3966,7 +3966,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterGetYearDayScheduleParams alloc] init];
 
@@ -4004,7 +4004,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterGetYearDayScheduleResponseParams alloc] init];
 
@@ -4040,7 +4040,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterClearYearDayScheduleParams alloc] init];
 
@@ -4076,7 +4076,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterSetHolidayScheduleParams alloc] init];
 
@@ -4109,7 +4109,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterGetHolidayScheduleParams alloc] init];
 
@@ -4146,7 +4146,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterGetHolidayScheduleResponseParams alloc] init];
 
@@ -4180,7 +4180,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterClearHolidayScheduleParams alloc] init];
 
@@ -4221,7 +4221,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterSetUserParams alloc] init];
 
@@ -4259,7 +4259,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterGetUserParams alloc] init];
 
@@ -4305,7 +4305,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterGetUserResponseParams alloc] init];
 
@@ -4346,7 +4346,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterClearUserParams alloc] init];
 
@@ -4384,7 +4384,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterSetCredentialParams alloc] init];
 
@@ -4424,7 +4424,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterSetCredentialResponseParams alloc] init];
 
@@ -4455,7 +4455,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterGetCredentialStatusParams alloc] init];
 
@@ -4492,7 +4492,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterGetCredentialStatusResponseParams alloc] init];
 
@@ -4528,7 +4528,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRDoorLockClusterClearCredentialParams alloc] init];
 
@@ -4555,7 +4555,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRWindowCoveringClusterUpOrOpenParams alloc] init];
 
@@ -4580,7 +4580,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRWindowCoveringClusterDownOrCloseParams alloc] init];
 
@@ -4605,7 +4605,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRWindowCoveringClusterStopMotionParams alloc] init];
 
@@ -4632,7 +4632,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRWindowCoveringClusterGoToLiftValueParams alloc] init];
 
@@ -4660,7 +4660,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRWindowCoveringClusterGoToLiftPercentageParams alloc] init];
 
@@ -4689,7 +4689,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRWindowCoveringClusterGoToTiltValueParams alloc] init];
 
@@ -4717,7 +4717,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRWindowCoveringClusterGoToTiltPercentageParams alloc] init];
 
@@ -4746,7 +4746,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRBarrierControlClusterBarrierControlGoToPercentParams alloc] init];
 
@@ -4773,7 +4773,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRBarrierControlClusterBarrierControlStopParams alloc] init];
 
@@ -4802,7 +4802,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRThermostatClusterSetpointRaiseLowerParams alloc] init];
 
@@ -4838,7 +4838,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRThermostatClusterGetWeeklyScheduleResponseParams alloc] init];
 
@@ -4877,7 +4877,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRThermostatClusterSetWeeklyScheduleParams alloc] init];
 
@@ -4912,7 +4912,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRThermostatClusterGetWeeklyScheduleParams alloc] init];
 
@@ -4940,7 +4940,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRThermostatClusterClearWeeklyScheduleParams alloc] init];
 
@@ -4975,7 +4975,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterMoveToHueParams alloc] init];
 
@@ -5015,7 +5015,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterMoveHueParams alloc] init];
 
@@ -5055,7 +5055,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterStepHueParams alloc] init];
 
@@ -5095,7 +5095,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterMoveToSaturationParams alloc] init];
 
@@ -5134,7 +5134,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterMoveSaturationParams alloc] init];
 
@@ -5174,7 +5174,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterStepSaturationParams alloc] init];
 
@@ -5216,7 +5216,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterMoveToHueAndSaturationParams alloc] init];
 
@@ -5258,7 +5258,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterMoveToColorParams alloc] init];
 
@@ -5298,7 +5298,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterMoveColorParams alloc] init];
 
@@ -5338,7 +5338,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterStepColorParams alloc] init];
 
@@ -5378,7 +5378,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterMoveToColorTemperatureParams alloc] init];
 
@@ -5419,7 +5419,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterEnhancedMoveToHueParams alloc] init];
 
@@ -5459,7 +5459,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterEnhancedMoveHueParams alloc] init];
 
@@ -5499,7 +5499,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterEnhancedStepHueParams alloc] init];
 
@@ -5541,7 +5541,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterEnhancedMoveToHueAndSaturationParams alloc] init];
 
@@ -5587,7 +5587,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterColorLoopSetParams alloc] init];
 
@@ -5626,7 +5626,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterStopMoveStepParams alloc] init];
 
@@ -5666,7 +5666,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterMoveColorTemperatureParams alloc] init];
 
@@ -5715,7 +5715,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRColorControlClusterStepColorTemperatureParams alloc] init];
 
@@ -5753,7 +5753,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRChannelClusterChangeChannelParams alloc] init];
 
@@ -5783,7 +5783,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRChannelClusterChangeChannelResponseParams alloc] init];
 
@@ -5815,7 +5815,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRChannelClusterChangeChannelByNumberParams alloc] init];
 
@@ -5845,7 +5845,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRChannelClusterSkipChannelParams alloc] init];
 
@@ -5875,7 +5875,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTargetNavigatorClusterNavigateTargetParams alloc] init];
 
@@ -5907,7 +5907,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTargetNavigatorClusterNavigateTargetResponseParams alloc] init];
 
@@ -5935,7 +5935,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaPlaybackClusterPlayParams alloc] init];
 
@@ -5960,7 +5960,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaPlaybackClusterPauseParams alloc] init];
 
@@ -5985,7 +5985,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaPlaybackClusterStopPlaybackParams alloc] init];
 
@@ -6010,7 +6010,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaPlaybackClusterStartOverParams alloc] init];
 
@@ -6035,7 +6035,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaPlaybackClusterPreviousParams alloc] init];
 
@@ -6060,7 +6060,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaPlaybackClusterNextParams alloc] init];
 
@@ -6085,7 +6085,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaPlaybackClusterRewindParams alloc] init];
 
@@ -6110,7 +6110,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaPlaybackClusterFastForwardParams alloc] init];
 
@@ -6137,7 +6137,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaPlaybackClusterSkipForwardParams alloc] init];
 
@@ -6166,7 +6166,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaPlaybackClusterSkipBackwardParams alloc] init];
 
@@ -6197,7 +6197,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaPlaybackClusterPlaybackResponseParams alloc] init];
 
@@ -6227,7 +6227,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaPlaybackClusterSeekParams alloc] init];
 
@@ -6255,7 +6255,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaInputClusterSelectInputParams alloc] init];
 
@@ -6281,7 +6281,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaInputClusterShowInputStatusParams alloc] init];
 
@@ -6306,7 +6306,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaInputClusterHideInputStatusParams alloc] init];
 
@@ -6335,7 +6335,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRMediaInputClusterRenameInputParams alloc] init];
 
@@ -6363,7 +6363,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRLowPowerClusterSleepParams alloc] init];
 
@@ -6390,7 +6390,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRKeypadInputClusterSendKeyParams alloc] init];
 
@@ -6418,7 +6418,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRKeypadInputClusterSendKeyResponseParams alloc] init];
 
@@ -6450,7 +6450,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRContentLauncherClusterLaunchContentParams alloc] init];
 
@@ -6485,7 +6485,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRContentLauncherClusterLaunchURLParams alloc] init];
 
@@ -6518,7 +6518,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRContentLauncherClusterLaunchResponseParams alloc] init];
 
@@ -6548,7 +6548,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRAudioOutputClusterSelectOutputParams alloc] init];
 
@@ -6578,7 +6578,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRAudioOutputClusterRenameOutputParams alloc] init];
 
@@ -6610,7 +6610,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRApplicationLauncherClusterLaunchAppParams alloc] init];
 
@@ -6640,7 +6640,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRApplicationLauncherClusterStopAppParams alloc] init];
 
@@ -6669,7 +6669,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRApplicationLauncherClusterHideAppParams alloc] init];
 
@@ -6700,7 +6700,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRApplicationLauncherClusterLauncherResponseParams alloc] init];
 
@@ -6730,7 +6730,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRAccountLoginClusterGetSetupPINParams alloc] init];
 
@@ -6759,7 +6759,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRAccountLoginClusterGetSetupPINResponseParams alloc] init];
 
@@ -6789,7 +6789,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRAccountLoginClusterLoginParams alloc] init];
 
@@ -6817,7 +6817,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRAccountLoginClusterLogoutParams alloc] init];
 
@@ -6850,7 +6850,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRElectricalMeasurementClusterGetProfileInfoResponseCommandParams alloc] init];
 
@@ -6881,7 +6881,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRElectricalMeasurementClusterGetProfileInfoCommandParams alloc] init];
 
@@ -6918,7 +6918,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRElectricalMeasurementClusterGetMeasurementProfileResponseCommandParams alloc] init];
 
@@ -6958,7 +6958,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRElectricalMeasurementClusterGetMeasurementProfileCommandParams alloc] init];
 
@@ -6987,7 +6987,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestParams alloc] init];
 
@@ -7014,7 +7014,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestSpecificResponseParams alloc] init];
 
@@ -7041,7 +7041,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestNotHandledParams alloc] init];
 
@@ -7068,7 +7068,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestAddArgumentsResponseParams alloc] init];
 
@@ -7095,7 +7095,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestSpecificParams alloc] init];
 
@@ -7122,7 +7122,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestSimpleArgumentResponseParams alloc] init];
 
@@ -7149,7 +7149,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestUnknownCommandParams alloc] init];
 
@@ -7186,7 +7186,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestStructArrayArgumentResponseParams alloc] init];
 
@@ -7222,7 +7222,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestAddArgumentsParams alloc] init];
 
@@ -7252,7 +7252,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestListInt8UReverseResponseParams alloc] init];
 
@@ -7280,7 +7280,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestSimpleArgumentRequestParams alloc] init];
 
@@ -7310,7 +7310,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestEnumsResponseParams alloc] init];
 
@@ -7350,7 +7350,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestStructArrayArgumentRequestParams alloc] init];
 
@@ -7390,7 +7390,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestNullableOptionalResponseParams alloc] init];
 
@@ -7422,7 +7422,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestStructArgumentRequestParams alloc] init];
 
@@ -7504,7 +7504,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestComplexNullableOptionalResponseParams alloc] init];
 
@@ -7574,7 +7574,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestNestedStructArgumentRequestParams alloc] init];
 
@@ -7602,7 +7602,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterBooleanResponseParams alloc] init];
 
@@ -7630,7 +7630,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestListStructArgumentRequestParams alloc] init];
 
@@ -7658,7 +7658,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterSimpleStructResponseParams alloc] init];
 
@@ -7686,7 +7686,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestListInt8UArgumentRequestParams alloc] init];
 
@@ -7714,7 +7714,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestEmitTestEventResponseParams alloc] init];
 
@@ -7742,7 +7742,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestNestedStructListArgumentRequestParams alloc] init];
 
@@ -7770,7 +7770,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestEmitTestFabricScopedEventResponseParams alloc] init];
 
@@ -7798,7 +7798,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestListNestedStructListArgumentRequestParams alloc] init];
 
@@ -7826,7 +7826,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestListInt8UReverseRequestParams alloc] init];
 
@@ -7856,7 +7856,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestEnumsRequestParams alloc] init];
 
@@ -7886,7 +7886,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestNullableOptionalRequestParams alloc] init];
 
@@ -7936,7 +7936,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestComplexNullableOptionalRequestParams alloc] init];
 
@@ -7981,7 +7981,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterSimpleStructEchoRequestParams alloc] init];
 
@@ -8007,7 +8007,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTimedInvokeRequestParams alloc] init];
 
@@ -8034,7 +8034,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestSimpleOptionalArgumentRequestParams alloc] init];
 
@@ -8066,7 +8066,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestEmitTestEventRequestParams alloc] init];
 
@@ -8097,7 +8097,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRTestClusterClusterTestEmitTestFabricScopedEventRequestParams alloc] init];
 
@@ -8133,7 +8133,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRFaultInjectionClusterFailAtFaultParams alloc] init];
 
@@ -8171,7 +8171,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 {
     auto other = [[MTRFaultInjectionClusterFailRandomlyAtFaultParams alloc] init];
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSArray * _Nonnull attributeValue;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRScenesClusterExtensionFieldSet : NSObject <NSCopying>
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSArray * _Nonnull attributeValueList;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
@@ -41,7 +41,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull revision;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRDescriptorClusterDeviceType : NSObject <NSCopying>
@@ -49,7 +49,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull revision;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRBindingClusterTargetStruct : NSObject <NSCopying>
@@ -60,7 +60,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRAccessControlClusterTarget : NSObject <NSCopying>
@@ -69,7 +69,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nullable deviceType;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRAccessControlClusterAccessControlEntry : NSObject <NSCopying>
@@ -80,7 +80,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRAccessControlClusterExtensionEntry : NSObject <NSCopying>
@@ -88,7 +88,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRAccessControlClusterAccessControlEntryChangedEvent : NSObject <NSCopying>
@@ -99,7 +99,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRAccessControlClusterAccessControlExtensionChangedEvent : NSObject <NSCopying>
@@ -110,7 +110,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRActionsClusterActionStruct : NSObject <NSCopying>
@@ -122,7 +122,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull state;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRActionsClusterEndpointListStruct : NSObject <NSCopying>
@@ -132,7 +132,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nonnull endpoints;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRActionsClusterStateChangedEvent : NSObject <NSCopying>
@@ -141,7 +141,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy, getter=getNewState) NSNumber * _Nonnull newState;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRActionsClusterActionFailedEvent : NSObject <NSCopying>
@@ -151,7 +151,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull error;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRBasicClusterCapabilityMinimaStruct : NSObject <NSCopying>
@@ -159,34 +159,34 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull subscriptionsPerFabric;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRBasicClusterStartUpEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull softwareVersion;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRBasicClusterShutDownEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRBasicClusterLeaveEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRBasicClusterReachableChangedEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull reachableNewValue;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTROtaSoftwareUpdateRequestorClusterProviderLocation : NSObject <NSCopying>
@@ -195,7 +195,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTROtaSoftwareUpdateRequestorClusterStateTransitionEvent : NSObject <NSCopying>
@@ -205,7 +205,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nullable targetSoftwareVersion;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTROtaSoftwareUpdateRequestorClusterVersionAppliedEvent : NSObject <NSCopying>
@@ -213,7 +213,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull productID;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTROtaSoftwareUpdateRequestorClusterDownloadErrorEvent : NSObject <NSCopying>
@@ -223,7 +223,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nullable platformCode;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPowerSourceClusterBatChargeFaultChangeType : NSObject <NSCopying>
@@ -231,7 +231,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nonnull previous;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPowerSourceClusterBatFaultChangeType : NSObject <NSCopying>
@@ -239,7 +239,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nonnull previous;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPowerSourceClusterWiredFaultChangeType : NSObject <NSCopying>
@@ -247,7 +247,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nonnull previous;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRGeneralCommissioningClusterBasicCommissioningInfo : NSObject <NSCopying>
@@ -255,7 +255,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull maxCumulativeFailsafeSeconds;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRNetworkCommissioningClusterNetworkInfo : NSObject <NSCopying>
@@ -263,7 +263,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull connected;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRNetworkCommissioningClusterThreadInterfaceScanResult : NSObject <NSCopying>
@@ -277,7 +277,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull lqi;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRNetworkCommissioningClusterWiFiInterfaceScanResult : NSObject <NSCopying>
@@ -289,7 +289,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull rssi;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRGeneralDiagnosticsClusterNetworkInterfaceType : NSObject <NSCopying>
@@ -303,7 +303,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull type;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRGeneralDiagnosticsClusterHardwareFaultChangeEvent : NSObject <NSCopying>
@@ -311,7 +311,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nonnull previous;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRGeneralDiagnosticsClusterRadioFaultChangeEvent : NSObject <NSCopying>
@@ -319,7 +319,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nonnull previous;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRGeneralDiagnosticsClusterNetworkFaultChangeEvent : NSObject <NSCopying>
@@ -327,14 +327,14 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nonnull previous;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRGeneralDiagnosticsClusterBootReasonEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull bootReason;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRSoftwareDiagnosticsClusterThreadMetrics : NSObject <NSCopying>
@@ -345,7 +345,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nullable stackSize;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRSoftwareDiagnosticsClusterSoftwareFaultEvent : NSObject <NSCopying>
@@ -354,7 +354,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSData * _Nullable faultRecording;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRThreadNetworkDiagnosticsClusterNeighborTable : NSObject <NSCopying>
@@ -374,7 +374,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull isChild;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRThreadNetworkDiagnosticsClusterOperationalDatasetComponents : NSObject <NSCopying>
@@ -392,7 +392,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull channelMaskPresent;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRThreadNetworkDiagnosticsClusterRouteTable : NSObject <NSCopying>
@@ -408,7 +408,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull linkEstablished;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRThreadNetworkDiagnosticsClusterSecurityPolicy : NSObject <NSCopying>
@@ -416,14 +416,14 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull flags;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRThreadNetworkDiagnosticsClusterConnectionStatusEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull connectionStatus;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRThreadNetworkDiagnosticsClusterNetworkFaultChangeEvent : NSObject <NSCopying>
@@ -431,14 +431,14 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nonnull previous;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRWiFiNetworkDiagnosticsClusterDisconnectionEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull reasonCode;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRWiFiNetworkDiagnosticsClusterAssociationFailureEvent : NSObject <NSCopying>
@@ -446,14 +446,14 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull status;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRWiFiNetworkDiagnosticsClusterConnectionStatusEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull connectionStatus;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRTimeSynchronizationClusterDstOffsetType : NSObject <NSCopying>
@@ -462,7 +462,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull validUntil;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRTimeSynchronizationClusterTimeZoneType : NSObject <NSCopying>
@@ -471,68 +471,68 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSString * _Nullable name;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRBridgedDeviceBasicClusterStartUpEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull softwareVersion;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRBridgedDeviceBasicClusterShutDownEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRBridgedDeviceBasicClusterLeaveEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRBridgedDeviceBasicClusterReachableChangedEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull reachableNewValue;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRSwitchClusterSwitchLatchedEvent : NSObject <NSCopying>
 @property (nonatomic, copy, getter=getNewPosition) NSNumber * _Nonnull newPosition;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRSwitchClusterInitialPressEvent : NSObject <NSCopying>
 @property (nonatomic, copy, getter=getNewPosition) NSNumber * _Nonnull newPosition;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRSwitchClusterLongPressEvent : NSObject <NSCopying>
 @property (nonatomic, copy, getter=getNewPosition) NSNumber * _Nonnull newPosition;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRSwitchClusterShortReleaseEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull previousPosition;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRSwitchClusterLongReleaseEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull previousPosition;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRSwitchClusterMultiPressOngoingEvent : NSObject <NSCopying>
@@ -540,7 +540,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull currentNumberOfPressesCounted;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRSwitchClusterMultiPressCompleteEvent : NSObject <NSCopying>
@@ -548,7 +548,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull totalNumberOfPressesCounted;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTROperationalCredentialsClusterFabricDescriptor : NSObject <NSCopying>
@@ -560,7 +560,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTROperationalCredentialsClusterNOCStruct : NSObject <NSCopying>
@@ -569,7 +569,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRGroupKeyManagementClusterGroupInfoMapStruct : NSObject <NSCopying>
@@ -579,7 +579,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRGroupKeyManagementClusterGroupKeyMapStruct : NSObject <NSCopying>
@@ -588,7 +588,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRGroupKeyManagementClusterGroupKeySetStruct : NSObject <NSCopying>
@@ -602,7 +602,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nullable epochStartTime2;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRFixedLabelClusterLabelStruct : NSObject <NSCopying>
@@ -610,7 +610,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSString * _Nonnull value;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRUserLabelClusterLabelStruct : NSObject <NSCopying>
@@ -618,14 +618,14 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSString * _Nonnull value;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRBooleanStateClusterStateChangeEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull stateValue;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRModeSelectClusterSemanticTag : NSObject <NSCopying>
@@ -633,7 +633,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull value;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRModeSelectClusterModeOptionStruct : NSObject <NSCopying>
@@ -642,7 +642,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nonnull semanticTags;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRDoorLockClusterDlCredential : NSObject <NSCopying>
@@ -650,21 +650,21 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull credentialIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRDoorLockClusterDoorLockAlarmEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull alarmCode;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRDoorLockClusterDoorStateChangeEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull doorState;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRDoorLockClusterLockOperationEvent : NSObject <NSCopying>
@@ -676,7 +676,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nullable credentials;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRDoorLockClusterLockOperationErrorEvent : NSObject <NSCopying>
@@ -689,7 +689,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nullable credentials;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRDoorLockClusterLockUserChangeEvent : NSObject <NSCopying>
@@ -702,109 +702,109 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nullable dataIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterSupplyVoltageLowEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterSupplyVoltageHighEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterPowerMissingPhaseEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterSystemPressureLowEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterSystemPressureHighEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterDryRunningEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterMotorTemperatureHighEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterPumpMotorFatalFailureEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterElectronicTemperatureHighEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterPumpBlockedEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterSensorFailureEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterElectronicNonFatalFailureEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterElectronicFatalFailureEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterGeneralFaultEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterLeakageEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterAirDetectionEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRPumpConfigurationAndControlClusterTurbineOperationEvent : NSObject <NSCopying>
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRThermostatClusterThermostatScheduleTransition : NSObject <NSCopying>
@@ -813,7 +813,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nullable coolSetpoint;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRChannelClusterChannelInfo : NSObject <NSCopying>
@@ -824,7 +824,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSString * _Nullable affiliateCallSign;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRChannelClusterLineupInfo : NSObject <NSCopying>
@@ -834,7 +834,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull lineupInfoType;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRTargetNavigatorClusterTargetInfo : NSObject <NSCopying>
@@ -842,7 +842,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSString * _Nonnull name;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRMediaPlaybackClusterPlaybackPosition : NSObject <NSCopying>
@@ -850,7 +850,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nullable position;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRMediaInputClusterInputInfo : NSObject <NSCopying>
@@ -860,7 +860,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSString * _Nonnull descriptionString;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRContentLauncherClusterDimension : NSObject <NSCopying>
@@ -869,7 +869,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull metric;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRContentLauncherClusterAdditionalInfo : NSObject <NSCopying>
@@ -877,7 +877,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSString * _Nonnull value;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRContentLauncherClusterParameter : NSObject <NSCopying>
@@ -886,14 +886,14 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nullable externalIDList;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRContentLauncherClusterContentSearch : NSObject <NSCopying>
 @property (nonatomic, copy) NSArray * _Nonnull parameterList;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRContentLauncherClusterStyleInformation : NSObject <NSCopying>
@@ -902,7 +902,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) MTRContentLauncherClusterDimension * _Nullable size;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRContentLauncherClusterBrandingInformation : NSObject <NSCopying>
@@ -914,7 +914,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) MTRContentLauncherClusterStyleInformation * _Nullable waterMark;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRAudioOutputClusterOutputInfo : NSObject <NSCopying>
@@ -923,7 +923,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSString * _Nonnull name;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRApplicationLauncherClusterApplication : NSObject <NSCopying>
@@ -931,7 +931,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSString * _Nonnull applicationId;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRApplicationLauncherClusterApplicationEP : NSObject <NSCopying>
@@ -939,7 +939,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nullable endpoint;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRApplicationBasicClusterApplicationBasicApplication : NSObject <NSCopying>
@@ -947,7 +947,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSString * _Nonnull applicationId;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRTestClusterClusterSimpleStruct : NSObject <NSCopying>
@@ -961,7 +961,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull h;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRTestClusterClusterTestFabricScoped : NSObject <NSCopying>
@@ -975,7 +975,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRTestClusterClusterNullablesAndOptionalsStruct : NSObject <NSCopying>
@@ -993,7 +993,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nullable nullableOptionalList;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRTestClusterClusterNestedStruct : NSObject <NSCopying>
@@ -1002,7 +1002,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nonnull c;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRTestClusterClusterNestedStructList : NSObject <NSCopying>
@@ -1015,14 +1015,14 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nonnull g;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRTestClusterClusterDoubleNestedStructList : NSObject <NSCopying>
 @property (nonatomic, copy) NSArray * _Nonnull a;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRTestClusterClusterTestListStructOctet : NSObject <NSCopying>
@@ -1030,7 +1030,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSData * _Nonnull member2;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRTestClusterClusterTestEventEvent : NSObject <NSCopying>
@@ -1042,14 +1042,14 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @property (nonatomic, copy) NSArray * _Nonnull arg6;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 @interface MTRTestClusterClusterTestFabricScopedEventEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
 - (instancetype)init;
-- (id)copyWithZone:(nullable NSZone *)zone;
+- (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRScenesClusterAttributeValuePair alloc] init];
 
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRScenesClusterExtensionFieldSet alloc] init];
 
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRDescriptorClusterDeviceTypeStruct alloc] init];
 
@@ -124,7 +124,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRDescriptorClusterDeviceType alloc] init];
 
@@ -161,7 +161,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRBindingClusterTargetStruct alloc] init];
 
@@ -197,7 +197,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRAccessControlClusterTarget alloc] init];
 
@@ -235,7 +235,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRAccessControlClusterAccessControlEntry alloc] init];
 
@@ -270,7 +270,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRAccessControlClusterExtensionEntry alloc] init];
 
@@ -307,7 +307,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRAccessControlClusterAccessControlEntryChangedEvent alloc] init];
 
@@ -348,7 +348,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRAccessControlClusterAccessControlExtensionChangedEvent alloc] init];
 
@@ -391,7 +391,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRActionsClusterActionStruct alloc] init];
 
@@ -431,7 +431,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRActionsClusterEndpointListStruct alloc] init];
 
@@ -466,7 +466,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRActionsClusterStateChangedEvent alloc] init];
 
@@ -502,7 +502,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRActionsClusterActionFailedEvent alloc] init];
 
@@ -535,7 +535,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRBasicClusterCapabilityMinimaStruct alloc] init];
 
@@ -564,7 +564,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRBasicClusterStartUpEvent alloc] init];
 
@@ -590,7 +590,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRBasicClusterShutDownEvent alloc] init];
 
@@ -615,7 +615,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRBasicClusterLeaveEvent alloc] init];
 
@@ -643,7 +643,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRBasicClusterReachableChangedEvent alloc] init];
 
@@ -675,7 +675,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTROtaSoftwareUpdateRequestorClusterProviderLocation alloc] init];
 
@@ -711,7 +711,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTROtaSoftwareUpdateRequestorClusterStateTransitionEvent alloc] init];
 
@@ -745,7 +745,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTROtaSoftwareUpdateRequestorClusterVersionAppliedEvent alloc] init];
 
@@ -780,7 +780,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTROtaSoftwareUpdateRequestorClusterDownloadErrorEvent alloc] init];
 
@@ -814,7 +814,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPowerSourceClusterBatChargeFaultChangeType alloc] init];
 
@@ -845,7 +845,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPowerSourceClusterBatFaultChangeType alloc] init];
 
@@ -876,7 +876,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPowerSourceClusterWiredFaultChangeType alloc] init];
 
@@ -907,7 +907,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRGeneralCommissioningClusterBasicCommissioningInfo alloc] init];
 
@@ -939,7 +939,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRNetworkCommissioningClusterNetworkInfo alloc] init];
 
@@ -983,7 +983,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRNetworkCommissioningClusterThreadInterfaceScanResult alloc] init];
 
@@ -1031,7 +1031,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRNetworkCommissioningClusterWiFiInterfaceScanResult alloc] init];
 
@@ -1080,7 +1080,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRGeneralDiagnosticsClusterNetworkInterfaceType alloc] init];
 
@@ -1120,7 +1120,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRGeneralDiagnosticsClusterHardwareFaultChangeEvent alloc] init];
 
@@ -1151,7 +1151,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRGeneralDiagnosticsClusterRadioFaultChangeEvent alloc] init];
 
@@ -1182,7 +1182,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRGeneralDiagnosticsClusterNetworkFaultChangeEvent alloc] init];
 
@@ -1211,7 +1211,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRGeneralDiagnosticsClusterBootReasonEvent alloc] init];
 
@@ -1247,7 +1247,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRSoftwareDiagnosticsClusterThreadMetrics alloc] init];
 
@@ -1284,7 +1284,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRSoftwareDiagnosticsClusterSoftwareFaultEvent alloc] init];
 
@@ -1341,7 +1341,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRThreadNetworkDiagnosticsClusterNeighborTable alloc] init];
 
@@ -1408,7 +1408,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRThreadNetworkDiagnosticsClusterOperationalDatasetComponents alloc] init];
 
@@ -1470,7 +1470,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRThreadNetworkDiagnosticsClusterRouteTable alloc] init];
 
@@ -1512,7 +1512,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRThreadNetworkDiagnosticsClusterSecurityPolicy alloc] init];
 
@@ -1541,7 +1541,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRThreadNetworkDiagnosticsClusterConnectionStatusEvent alloc] init];
 
@@ -1571,7 +1571,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRThreadNetworkDiagnosticsClusterNetworkFaultChangeEvent alloc] init];
 
@@ -1600,7 +1600,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRWiFiNetworkDiagnosticsClusterDisconnectionEvent alloc] init];
 
@@ -1630,7 +1630,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRWiFiNetworkDiagnosticsClusterAssociationFailureEvent alloc] init];
 
@@ -1659,7 +1659,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRWiFiNetworkDiagnosticsClusterConnectionStatusEvent alloc] init];
 
@@ -1691,7 +1691,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRTimeSynchronizationClusterDstOffsetType alloc] init];
 
@@ -1725,7 +1725,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRTimeSynchronizationClusterTimeZoneType alloc] init];
 
@@ -1755,7 +1755,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRBridgedDeviceBasicClusterStartUpEvent alloc] init];
 
@@ -1781,7 +1781,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRBridgedDeviceBasicClusterShutDownEvent alloc] init];
 
@@ -1804,7 +1804,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRBridgedDeviceBasicClusterLeaveEvent alloc] init];
 
@@ -1829,7 +1829,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRBridgedDeviceBasicClusterReachableChangedEvent alloc] init];
 
@@ -1857,7 +1857,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRSwitchClusterSwitchLatchedEvent alloc] init];
 
@@ -1885,7 +1885,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRSwitchClusterInitialPressEvent alloc] init];
 
@@ -1913,7 +1913,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRSwitchClusterLongPressEvent alloc] init];
 
@@ -1941,7 +1941,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRSwitchClusterShortReleaseEvent alloc] init];
 
@@ -1969,7 +1969,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRSwitchClusterLongReleaseEvent alloc] init];
 
@@ -1999,7 +1999,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRSwitchClusterMultiPressOngoingEvent alloc] init];
 
@@ -2030,7 +2030,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRSwitchClusterMultiPressCompleteEvent alloc] init];
 
@@ -2069,7 +2069,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTROperationalCredentialsClusterFabricDescriptor alloc] init];
 
@@ -2108,7 +2108,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTROperationalCredentialsClusterNOCStruct alloc] init];
 
@@ -2145,7 +2145,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRGroupKeyManagementClusterGroupInfoMapStruct alloc] init];
 
@@ -2180,7 +2180,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRGroupKeyManagementClusterGroupKeyMapStruct alloc] init];
 
@@ -2224,7 +2224,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRGroupKeyManagementClusterGroupKeySetStruct alloc] init];
 
@@ -2265,7 +2265,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRFixedLabelClusterLabelStruct alloc] init];
 
@@ -2296,7 +2296,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRUserLabelClusterLabelStruct alloc] init];
 
@@ -2325,7 +2325,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRBooleanStateClusterStateChangeEvent alloc] init];
 
@@ -2355,7 +2355,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRModeSelectClusterSemanticTag alloc] init];
 
@@ -2388,7 +2388,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRModeSelectClusterModeOptionStruct alloc] init];
 
@@ -2420,7 +2420,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRDoorLockClusterDlCredential alloc] init];
 
@@ -2449,7 +2449,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRDoorLockClusterDoorLockAlarmEvent alloc] init];
 
@@ -2476,7 +2476,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRDoorLockClusterDoorStateChangeEvent alloc] init];
 
@@ -2513,7 +2513,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRDoorLockClusterLockOperationEvent alloc] init];
 
@@ -2560,7 +2560,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRDoorLockClusterLockOperationErrorEvent alloc] init];
 
@@ -2608,7 +2608,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRDoorLockClusterLockUserChangeEvent alloc] init];
 
@@ -2642,7 +2642,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterSupplyVoltageLowEvent alloc] init];
 
@@ -2665,7 +2665,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterSupplyVoltageHighEvent alloc] init];
 
@@ -2688,7 +2688,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterPowerMissingPhaseEvent alloc] init];
 
@@ -2711,7 +2711,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterSystemPressureLowEvent alloc] init];
 
@@ -2734,7 +2734,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterSystemPressureHighEvent alloc] init];
 
@@ -2757,7 +2757,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterDryRunningEvent alloc] init];
 
@@ -2780,7 +2780,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterMotorTemperatureHighEvent alloc] init];
 
@@ -2803,7 +2803,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterPumpMotorFatalFailureEvent alloc] init];
 
@@ -2826,7 +2826,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterElectronicTemperatureHighEvent alloc] init];
 
@@ -2849,7 +2849,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterPumpBlockedEvent alloc] init];
 
@@ -2872,7 +2872,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterSensorFailureEvent alloc] init];
 
@@ -2895,7 +2895,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterElectronicNonFatalFailureEvent alloc] init];
 
@@ -2918,7 +2918,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterElectronicFatalFailureEvent alloc] init];
 
@@ -2941,7 +2941,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterGeneralFaultEvent alloc] init];
 
@@ -2964,7 +2964,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterLeakageEvent alloc] init];
 
@@ -2987,7 +2987,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterAirDetectionEvent alloc] init];
 
@@ -3010,7 +3010,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRPumpConfigurationAndControlClusterTurbineOperationEvent alloc] init];
 
@@ -3039,7 +3039,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRThermostatClusterThermostatScheduleTransition alloc] init];
 
@@ -3077,7 +3077,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRChannelClusterChannelInfo alloc] init];
 
@@ -3116,7 +3116,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRChannelClusterLineupInfo alloc] init];
 
@@ -3150,7 +3150,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRTargetNavigatorClusterTargetInfo alloc] init];
 
@@ -3181,7 +3181,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRMediaPlaybackClusterPlaybackPosition alloc] init];
 
@@ -3216,7 +3216,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRMediaInputClusterInputInfo alloc] init];
 
@@ -3251,7 +3251,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRContentLauncherClusterDimension alloc] init];
 
@@ -3283,7 +3283,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRContentLauncherClusterAdditionalInfo alloc] init];
 
@@ -3316,7 +3316,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRContentLauncherClusterParameter alloc] init];
 
@@ -3346,7 +3346,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRContentLauncherClusterContentSearch alloc] init];
 
@@ -3378,7 +3378,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRContentLauncherClusterStyleInformation alloc] init];
 
@@ -3418,7 +3418,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRContentLauncherClusterBrandingInformation alloc] init];
 
@@ -3456,7 +3456,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRAudioOutputClusterOutputInfo alloc] init];
 
@@ -3488,7 +3488,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRApplicationLauncherClusterApplication alloc] init];
 
@@ -3519,7 +3519,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRApplicationLauncherClusterApplicationEP alloc] init];
 
@@ -3550,7 +3550,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRApplicationBasicClusterApplicationBasicApplication alloc] init];
 
@@ -3593,7 +3593,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRTestClusterClusterSimpleStruct alloc] init];
 
@@ -3643,7 +3643,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRTestClusterClusterTestFabricScoped alloc] init];
 
@@ -3705,7 +3705,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRTestClusterClusterNullablesAndOptionalsStruct alloc] init];
 
@@ -3753,7 +3753,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRTestClusterClusterNestedStruct alloc] init];
 
@@ -3795,7 +3795,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRTestClusterClusterNestedStructList alloc] init];
 
@@ -3829,7 +3829,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRTestClusterClusterDoubleNestedStructList alloc] init];
 
@@ -3858,7 +3858,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRTestClusterClusterTestListStructOctet alloc] init];
 
@@ -3897,7 +3897,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRTestClusterClusterTestEventEvent alloc] init];
 
@@ -3930,7 +3930,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone
+- (id)copyWithZone:(NSZone * _Nullable)zone
 {
     auto other = [[MTRTestClusterClusterTestFabricScopedEventEvent alloc] init];
 

--- a/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
@@ -32,7 +32,7 @@
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:testKeys issuerID:nil fabricID:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates createRootCertificate:testKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 }
 
@@ -41,18 +41,18 @@
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
 
-    __auto_type * intermediateCert = [MTRCertificates generateIntermediateCertificate:rootKeys
-                                                                      rootCertificate:rootCert
-                                                                intermediatePublicKey:intermediateKeys.publicKey
-                                                                             issuerID:nil
-                                                                             fabricID:nil
-                                                                                error:nil];
+    __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
+                                                                    rootCertificate:rootCert
+                                                              intermediatePublicKey:intermediateKeys.publicKey
+                                                                           issuerID:nil
+                                                                           fabricID:nil
+                                                                              error:nil];
     XCTAssertNotNil(intermediateCert);
 }
 
@@ -61,7 +61,7 @@
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
@@ -73,13 +73,13 @@
     [cats addObject:@0x00020001];
     [cats addObject:@0x0003FFFF];
 
-    __auto_type * operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
-                                                                 signingCertificate:rootCert
-                                                               operationalPublicKey:operationalKeys.publicKey
-                                                                           fabricID:@1
-                                                                             nodeID:@1
-                                                              caseAuthenticatedTags:cats
-                                                                              error:nil];
+    __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
+                                                               signingCertificate:rootCert
+                                                             operationalPublicKey:operationalKeys.publicKey
+                                                                         fabricID:@1
+                                                                           nodeID:@1
+                                                            caseAuthenticatedTags:cats
+                                                                            error:nil];
     XCTAssertNotNil(operationalCert);
 }
 
@@ -88,30 +88,30 @@
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
 
-    __auto_type * intermediateCert = [MTRCertificates generateIntermediateCertificate:rootKeys
-                                                                      rootCertificate:rootCert
-                                                                intermediatePublicKey:intermediateKeys.publicKey
-                                                                             issuerID:nil
-                                                                             fabricID:nil
-                                                                                error:nil];
+    __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
+                                                                    rootCertificate:rootCert
+                                                              intermediatePublicKey:intermediateKeys.publicKey
+                                                                           issuerID:nil
+                                                                           fabricID:nil
+                                                                              error:nil];
     XCTAssertNotNil(intermediateCert);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
 
-    __auto_type * operationalCert = [MTRCertificates generateOperationalCertificate:intermediateKeys
-                                                                 signingCertificate:intermediateCert
-                                                               operationalPublicKey:operationalKeys.publicKey
-                                                                           fabricID:@1
-                                                                             nodeID:@1
-                                                              caseAuthenticatedTags:nil
-                                                                              error:nil];
+    __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:intermediateKeys
+                                                               signingCertificate:intermediateCert
+                                                             operationalPublicKey:operationalKeys.publicKey
+                                                                         fabricID:@1
+                                                                           nodeID:@1
+                                                            caseAuthenticatedTags:nil
+                                                                            error:nil];
     XCTAssertNotNil(operationalCert);
 }
 
@@ -120,7 +120,7 @@
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
@@ -150,93 +150,93 @@
     [catsWithInvalidVersion addObject:@0x00020000];
 
     // Check basic case works
-    __auto_type * operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
-                                                                 signingCertificate:rootCert
-                                                               operationalPublicKey:operationalKeys.publicKey
-                                                                           fabricID:@1
-                                                                             nodeID:@1
-                                                              caseAuthenticatedTags:nil
-                                                                              error:nil];
+    __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
+                                                               signingCertificate:rootCert
+                                                             operationalPublicKey:operationalKeys.publicKey
+                                                                         fabricID:@1
+                                                                           nodeID:@1
+                                                            caseAuthenticatedTags:nil
+                                                                            error:nil];
     XCTAssertNotNil(operationalCert);
 
     // CATs too long
-    operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
-                                                   signingCertificate:rootCert
-                                                 operationalPublicKey:operationalKeys.publicKey
-                                                             fabricID:@1
-                                                               nodeID:@1
-                                                caseAuthenticatedTags:longCats
-                                                                error:nil];
+    operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
+                                                 signingCertificate:rootCert
+                                               operationalPublicKey:operationalKeys.publicKey
+                                                           fabricID:@1
+                                                             nodeID:@1
+                                              caseAuthenticatedTags:longCats
+                                                              error:nil];
     XCTAssertNil(operationalCert);
 
     // Multiple CATs with the same identifier but different versions
-    operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
-                                                   signingCertificate:rootCert
-                                                 operationalPublicKey:operationalKeys.publicKey
-                                                             fabricID:@1
-                                                               nodeID:@1
-                                                caseAuthenticatedTags:catsWithSameIdentifier
-                                                                error:nil];
+    operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
+                                                 signingCertificate:rootCert
+                                               operationalPublicKey:operationalKeys.publicKey
+                                                           fabricID:@1
+                                                             nodeID:@1
+                                              caseAuthenticatedTags:catsWithSameIdentifier
+                                                              error:nil];
     XCTAssertNil(operationalCert);
 
     // Multiple CATs with the same identifier and same version
-    operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
-                                                   signingCertificate:rootCert
-                                                 operationalPublicKey:operationalKeys.publicKey
-                                                             fabricID:@1
-                                                               nodeID:@1
-                                                caseAuthenticatedTags:catsWithDuplicatedCAT
-                                                                error:nil];
+    operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
+                                                 signingCertificate:rootCert
+                                               operationalPublicKey:operationalKeys.publicKey
+                                                           fabricID:@1
+                                                             nodeID:@1
+                                              caseAuthenticatedTags:catsWithDuplicatedCAT
+                                                              error:nil];
     XCTAssertNil(operationalCert);
 
     // CAT with invalid version
-    operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
-                                                   signingCertificate:rootCert
-                                                 operationalPublicKey:operationalKeys.publicKey
-                                                             fabricID:@1
-                                                               nodeID:@1
-                                                caseAuthenticatedTags:catsWithInvalidVersion
-                                                                error:nil];
+    operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
+                                                 signingCertificate:rootCert
+                                               operationalPublicKey:operationalKeys.publicKey
+                                                           fabricID:@1
+                                                             nodeID:@1
+                                              caseAuthenticatedTags:catsWithInvalidVersion
+                                                              error:nil];
     XCTAssertNil(operationalCert);
 
     // Signing key mismatch
-    operationalCert = [MTRCertificates generateOperationalCertificate:operationalKeys
-                                                   signingCertificate:rootCert
-                                                 operationalPublicKey:operationalKeys.publicKey
-                                                             fabricID:@1
-                                                               nodeID:@1
-                                                caseAuthenticatedTags:nil
-                                                                error:nil];
+    operationalCert = [MTRCertificates createOperationalCertificate:operationalKeys
+                                                 signingCertificate:rootCert
+                                               operationalPublicKey:operationalKeys.publicKey
+                                                           fabricID:@1
+                                                             nodeID:@1
+                                              caseAuthenticatedTags:nil
+                                                              error:nil];
     XCTAssertNil(operationalCert);
 
     // Invalid fabric id
-    operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
-                                                   signingCertificate:rootCert
-                                                 operationalPublicKey:operationalKeys.publicKey
-                                                             fabricID:@0
-                                                               nodeID:@1
-                                                caseAuthenticatedTags:nil
-                                                                error:nil];
+    operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
+                                                 signingCertificate:rootCert
+                                               operationalPublicKey:operationalKeys.publicKey
+                                                           fabricID:@0
+                                                             nodeID:@1
+                                              caseAuthenticatedTags:nil
+                                                              error:nil];
     XCTAssertNil(operationalCert);
 
     // Undefined node id
-    operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
-                                                   signingCertificate:rootCert
-                                                 operationalPublicKey:operationalKeys.publicKey
-                                                             fabricID:@1
-                                                               nodeID:@0
-                                                caseAuthenticatedTags:nil
-                                                                error:nil];
+    operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
+                                                 signingCertificate:rootCert
+                                               operationalPublicKey:operationalKeys.publicKey
+                                                           fabricID:@1
+                                                             nodeID:@0
+                                              caseAuthenticatedTags:nil
+                                                              error:nil];
     XCTAssertNil(operationalCert);
 
     // Non-operational node id
-    operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
-                                                   signingCertificate:rootCert
-                                                 operationalPublicKey:operationalKeys.publicKey
-                                                             fabricID:@1
-                                                               nodeID:@(0xFFFFFFFFFFFFFFFFLLU)
-                                                caseAuthenticatedTags:nil
-                                                                error:nil];
+    operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
+                                                 signingCertificate:rootCert
+                                               operationalPublicKey:operationalKeys.publicKey
+                                                           fabricID:@1
+                                                             nodeID:@(0xFFFFFFFFFFFFFFFFLLU)
+                                              caseAuthenticatedTags:nil
+                                                              error:nil];
     XCTAssertNil(operationalCert);
 }
 
@@ -245,7 +245,7 @@
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * csr = [MTRCertificates generateCertificateSigningRequest:testKeys error:nil];
+    __auto_type * csr = [MTRCertificates createCertificateSigningRequest:testKeys error:nil];
     XCTAssertNotNil(csr);
 
     // Wish there was something we could test here about the CSR.

--- a/src/darwin/Framework/CHIPTests/MTRControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRControllerTests.m
@@ -395,13 +395,13 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * root1 = [MTRCertificates generateRootCertificate:testKeys issuerID:@1 fabricID:@1 error:nil];
+    __auto_type * root1 = [MTRCertificates createRootCertificate:testKeys issuerID:@1 fabricID:@1 error:nil];
     XCTAssertNotNil(root1);
 
-    __auto_type * root2 = [MTRCertificates generateRootCertificate:testKeys issuerID:@1 fabricID:@1 error:nil];
+    __auto_type * root2 = [MTRCertificates createRootCertificate:testKeys issuerID:@1 fabricID:@1 error:nil];
     XCTAssertNotNil(root2);
 
-    __auto_type * root3 = [MTRCertificates generateRootCertificate:testKeys issuerID:@2 fabricID:@1 error:nil];
+    __auto_type * root3 = [MTRCertificates createRootCertificate:testKeys issuerID:@2 fabricID:@1 error:nil];
     XCTAssertNotNil(root3);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
@@ -465,10 +465,10 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * root1 = [MTRCertificates generateRootCertificate:testKeys issuerID:@1 fabricID:@1 error:nil];
+    __auto_type * root1 = [MTRCertificates createRootCertificate:testKeys issuerID:@1 fabricID:@1 error:nil];
     XCTAssertNotNil(root1);
 
-    __auto_type * root2 = [MTRCertificates generateRootCertificate:testKeys issuerID:@1 fabricID:@2 error:nil];
+    __auto_type * root2 = [MTRCertificates createRootCertificate:testKeys issuerID:@1 fabricID:@2 error:nil];
     XCTAssertNotNil(root2);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
@@ -526,7 +526,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * signerKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(signerKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
+    __auto_type * root = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:signerKeys
@@ -559,18 +559,18 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
+    __auto_type * root = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
 
-    __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
-                                                                  rootCertificate:root
-                                                            intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerID:nil
-                                                                         fabricID:nil
-                                                                            error:nil];
+    __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
+                                                                rootCertificate:root
+                                                          intermediatePublicKey:intermediateKeys.publicKey
+                                                                       issuerID:nil
+                                                                       fabricID:nil
+                                                                          error:nil];
     XCTAssertNotNil(intermediate);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
@@ -811,18 +811,18 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
+    __auto_type * root = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
 
-    __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
-                                                                  rootCertificate:root
-                                                            intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerID:nil
-                                                                         fabricID:nil
-                                                                            error:nil];
+    __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
+                                                                rootCertificate:root
+                                                          intermediatePublicKey:intermediateKeys.publicKey
+                                                                       issuerID:nil
+                                                                       fabricID:nil
+                                                                          error:nil];
     XCTAssertNotNil(intermediate);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
@@ -875,18 +875,18 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
+    __auto_type * root = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
 
-    __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
-                                                                  rootCertificate:root
-                                                            intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerID:nil
-                                                                         fabricID:nil
-                                                                            error:nil];
+    __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
+                                                                rootCertificate:root
+                                                          intermediatePublicKey:intermediateKeys.publicKey
+                                                                       issuerID:nil
+                                                                       fabricID:nil
+                                                                          error:nil];
     XCTAssertNotNil(intermediate);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys
@@ -939,29 +939,29 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
+    __auto_type * root = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys1 = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys1);
 
-    __auto_type * intermediate1 = [MTRCertificates generateIntermediateCertificate:rootKeys
-                                                                   rootCertificate:root
-                                                             intermediatePublicKey:intermediateKeys1.publicKey
-                                                                          issuerID:nil
-                                                                          fabricID:nil
-                                                                             error:nil];
+    __auto_type * intermediate1 = [MTRCertificates createIntermediateCertificate:rootKeys
+                                                                 rootCertificate:root
+                                                           intermediatePublicKey:intermediateKeys1.publicKey
+                                                                        issuerID:nil
+                                                                        fabricID:nil
+                                                                           error:nil];
     XCTAssertNotNil(intermediate1);
 
     __auto_type * intermediateKeys2 = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys2);
 
-    __auto_type * intermediate2 = [MTRCertificates generateIntermediateCertificate:rootKeys
-                                                                   rootCertificate:root
-                                                             intermediatePublicKey:intermediateKeys2.publicKey
-                                                                          issuerID:nil
-                                                                          fabricID:nil
-                                                                             error:nil];
+    __auto_type * intermediate2 = [MTRCertificates createIntermediateCertificate:rootKeys
+                                                                 rootCertificate:root
+                                                           intermediatePublicKey:intermediateKeys2.publicKey
+                                                                        issuerID:nil
+                                                                        fabricID:nil
+                                                                           error:nil];
     XCTAssertNotNil(intermediate2);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys1
@@ -1014,18 +1014,18 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
+    __auto_type * root = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
 
-    __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
-                                                                  rootCertificate:root
-                                                            intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerID:nil
-                                                                         fabricID:nil
-                                                                            error:nil];
+    __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
+                                                                rootCertificate:root
+                                                          intermediatePublicKey:intermediateKeys.publicKey
+                                                                       issuerID:nil
+                                                                       fabricID:nil
+                                                                          error:nil];
     XCTAssertNotNil(intermediate);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys
@@ -1057,30 +1057,30 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
+    __auto_type * root = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
 
-    __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
-                                                                  rootCertificate:root
-                                                            intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerID:nil
-                                                                         fabricID:nil
-                                                                            error:nil];
+    __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
+                                                                rootCertificate:root
+                                                          intermediatePublicKey:intermediateKeys.publicKey
+                                                                       issuerID:nil
+                                                                       fabricID:nil
+                                                                          error:nil];
     XCTAssertNotNil(intermediate);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
 
-    __auto_type * operational = [MTRCertificates generateOperationalCertificate:intermediateKeys
-                                                             signingCertificate:intermediate
-                                                           operationalPublicKey:operationalKeys.publicKey
-                                                                       fabricID:@123
-                                                                         nodeID:@456
-                                                          caseAuthenticatedTags:nil
-                                                                          error:nil];
+    __auto_type * operational = [MTRCertificates createOperationalCertificate:intermediateKeys
+                                                           signingCertificate:intermediate
+                                                         operationalPublicKey:operationalKeys.publicKey
+                                                                     fabricID:@123
+                                                                       nodeID:@456
+                                                        caseAuthenticatedTags:nil
+                                                                        error:nil];
     XCTAssertNotNil(operational);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithOperationalKeypair:operationalKeys
@@ -1132,19 +1132,19 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
+    __auto_type * root = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
 
-    __auto_type * operational = [MTRCertificates generateOperationalCertificate:rootKeys
-                                                             signingCertificate:root
-                                                           operationalPublicKey:operationalKeys.publicKey
-                                                                       fabricID:@123
-                                                                         nodeID:@456
-                                                          caseAuthenticatedTags:nil
-                                                                          error:nil];
+    __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
+                                                           signingCertificate:root
+                                                         operationalPublicKey:operationalKeys.publicKey
+                                                                     fabricID:@123
+                                                                       nodeID:@456
+                                                        caseAuthenticatedTags:nil
+                                                                        error:nil];
     XCTAssertNotNil(operational);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithOperationalKeypair:operationalKeys
@@ -1182,19 +1182,19 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:@111 error:nil];
+    __auto_type * root = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:@111 error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
 
-    __auto_type * operational = [MTRCertificates generateOperationalCertificate:rootKeys
-                                                             signingCertificate:root
-                                                           operationalPublicKey:operationalKeys.publicKey
-                                                                       fabricID:@123
-                                                                         nodeID:@456
-                                                          caseAuthenticatedTags:nil
-                                                                          error:nil];
+    __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
+                                                           signingCertificate:root
+                                                         operationalPublicKey:operationalKeys.publicKey
+                                                                     fabricID:@123
+                                                                       nodeID:@456
+                                                        caseAuthenticatedTags:nil
+                                                                        error:nil];
     XCTAssertNotNil(operational);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithOperationalKeypair:operationalKeys
@@ -1226,30 +1226,30 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:@123 error:nil];
+    __auto_type * root = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:@123 error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
 
-    __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
-                                                                  rootCertificate:root
-                                                            intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerID:nil
-                                                                         fabricID:@111
-                                                                            error:nil];
+    __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
+                                                                rootCertificate:root
+                                                          intermediatePublicKey:intermediateKeys.publicKey
+                                                                       issuerID:nil
+                                                                       fabricID:@111
+                                                                          error:nil];
     XCTAssertNotNil(intermediate);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
 
-    __auto_type * operational = [MTRCertificates generateOperationalCertificate:intermediateKeys
-                                                             signingCertificate:intermediate
-                                                           operationalPublicKey:operationalKeys.publicKey
-                                                                       fabricID:@123
-                                                                         nodeID:@456
-                                                          caseAuthenticatedTags:nil
-                                                                          error:nil];
+    __auto_type * operational = [MTRCertificates createOperationalCertificate:intermediateKeys
+                                                           signingCertificate:intermediate
+                                                         operationalPublicKey:operationalKeys.publicKey
+                                                                     fabricID:@123
+                                                                       nodeID:@456
+                                                        caseAuthenticatedTags:nil
+                                                                        error:nil];
     XCTAssertNotNil(operational);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithOperationalKeypair:operationalKeys

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -253,31 +253,31 @@ static MTRBaseDevice * GetConnectedDevice(void)
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributePathWithEndpointID:nil
-                                  clusterID:@29
-                                attributeID:@0
-                                     params:nil
-                                      queue:queue
-                                 completion:^(id _Nullable values, NSError * _Nullable error) {
-                                     NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+    [device readAttributesWithEndpointID:nil
+                               clusterID:@29
+                             attributeID:@0
+                                  params:nil
+                                   queue:queue
+                              completion:^(id _Nullable values, NSError * _Nullable error) {
+                                  NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
 
-                                     XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
+                                  XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
 
-                                     {
-                                         XCTAssertTrue([values isKindOfClass:[NSArray class]]);
-                                         NSArray * resultArray = values;
-                                         for (NSDictionary * result in resultArray) {
-                                             MTRAttributePath * path = result[@"attributePath"];
-                                             XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
-                                             XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
-                                             XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
-                                             XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
-                                         }
-                                         XCTAssertTrue([resultArray count] > 0);
-                                     }
+                                  {
+                                      XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                      NSArray * resultArray = values;
+                                      for (NSDictionary * result in resultArray) {
+                                          MTRAttributePath * path = result[@"attributePath"];
+                                          XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
+                                          XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
+                                          XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
+                                          XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
+                                      }
+                                      XCTAssertTrue([resultArray count] > 0);
+                                  }
 
-                                     [expectation fulfill];
-                                 }];
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -431,7 +431,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributePathWithEndpointID:@1
+    [device subscribeToAttributesWithEndpointID:@1
         clusterID:@6
         attributeID:@0
         minInterval:@1
@@ -572,20 +572,20 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributePathWithEndpointID:@0
-                                  clusterID:@10000
-                                attributeID:@0
-                                     params:nil
-                                      queue:queue
-                                 completion:^(id _Nullable values, NSError * _Nullable error) {
-                                     NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+    [device
+        readAttributesWithEndpointID:@0
+                           clusterID:@10000
+                         attributeID:@0
+                              params:nil
+                               queue:queue
+                          completion:^(id _Nullable values, NSError * _Nullable error) {
+                              NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
 
-                                     XCTAssertNil(values);
-                                     XCTAssertEqual(
-                                         [MTRErrorTestUtils errorToZCLErrorCode:error], EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER);
+                              XCTAssertNil(values);
+                              XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER);
 
-                                     [expectation fulfill];
-                                 }];
+                              [expectation fulfill];
+                          }];
 
     [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:kTimeoutInSeconds];
 }
@@ -692,7 +692,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     __auto_type * params = [[MTRSubscribeParams alloc] init];
     params.autoResubscribe = @(NO);
-    [device subscribeAttributePathWithEndpointID:@10000
+    [device subscribeToAttributesWithEndpointID:@10000
         clusterID:@6
         attributeID:@0
         minInterval:@2
@@ -729,30 +729,30 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributePathWithEndpointID:@1
-                                  clusterID:@29
-                                attributeID:nil
-                                     params:nil
-                                      queue:queue
-                                 completion:^(id _Nullable values, NSError * _Nullable error) {
-                                     NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+    [device readAttributesWithEndpointID:@1
+                               clusterID:@29
+                             attributeID:nil
+                                  params:nil
+                                   queue:queue
+                              completion:^(id _Nullable values, NSError * _Nullable error) {
+                                  NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
 
-                                     XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
+                                  XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
 
-                                     {
-                                         XCTAssertTrue([values isKindOfClass:[NSArray class]]);
-                                         NSArray * resultArray = values;
-                                         for (NSDictionary * result in resultArray) {
-                                             MTRAttributePath * path = result[@"attributePath"];
-                                             XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
-                                             XCTAssertEqual([path.endpoint unsignedIntegerValue], 1);
-                                             XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
-                                         }
-                                         XCTAssertTrue([resultArray count] > 0);
-                                     }
+                                  {
+                                      XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                      NSArray * resultArray = values;
+                                      for (NSDictionary * result in resultArray) {
+                                          MTRAttributePath * path = result[@"attributePath"];
+                                          XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
+                                          XCTAssertEqual([path.endpoint unsignedIntegerValue], 1);
+                                          XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
+                                      }
+                                      XCTAssertTrue([resultArray count] > 0);
+                                  }
 
-                                     [expectation fulfill];
-                                 }];
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:kTimeoutInSeconds];
 }
@@ -1039,7 +1039,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributePathWithEndpointID:@1
+    [device subscribeToAttributesWithEndpointID:@1
         clusterID:@6
         attributeID:@0
         minInterval:@1
@@ -1417,7 +1417,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
     __block void (^reportHandler)(id _Nullable values, NSError * _Nullable error) = nil;
 
-    [device subscribeAttributePathWithEndpointID:@1
+    [device subscribeToAttributesWithEndpointID:@1
         clusterID:@6
         attributeID:@0xffffffff
         minInterval:@2

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -253,31 +253,31 @@ static MTRBaseDevice * GetConnectedDevice(void)
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributeWithEndpointID:nil
-                              clusterID:@29
-                            attributeID:@0
-                                 params:nil
-                                  queue:queue
-                             completion:^(id _Nullable values, NSError * _Nullable error) {
-                                 NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+    [device readAttributePathWithEndpointID:nil
+                                  clusterID:@29
+                                attributeID:@0
+                                     params:nil
+                                      queue:queue
+                                 completion:^(id _Nullable values, NSError * _Nullable error) {
+                                     NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
 
-                                 XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
+                                     XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
 
-                                 {
-                                     XCTAssertTrue([values isKindOfClass:[NSArray class]]);
-                                     NSArray * resultArray = values;
-                                     for (NSDictionary * result in resultArray) {
-                                         MTRAttributePath * path = result[@"attributePath"];
-                                         XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
-                                         XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
-                                         XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
-                                         XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
+                                     {
+                                         XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                         NSArray * resultArray = values;
+                                         for (NSDictionary * result in resultArray) {
+                                             MTRAttributePath * path = result[@"attributePath"];
+                                             XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
+                                             XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
+                                             XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
+                                             XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
+                                         }
+                                         XCTAssertTrue([resultArray count] > 0);
                                      }
-                                     XCTAssertTrue([resultArray count] > 0);
-                                 }
 
-                                 [expectation fulfill];
-                             }];
+                                     [expectation fulfill];
+                                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -431,7 +431,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointID:@1
+    [device subscribeAttributePathWithEndpointID:@1
         clusterID:@6
         attributeID:@0
         minInterval:@1
@@ -572,20 +572,20 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device
-        readAttributeWithEndpointID:@0
-                          clusterID:@10000
-                        attributeID:@0
-                             params:nil
-                              queue:queue
-                         completion:^(id _Nullable values, NSError * _Nullable error) {
-                             NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+    [device readAttributePathWithEndpointID:@0
+                                  clusterID:@10000
+                                attributeID:@0
+                                     params:nil
+                                      queue:queue
+                                 completion:^(id _Nullable values, NSError * _Nullable error) {
+                                     NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
 
-                             XCTAssertNil(values);
-                             XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER);
+                                     XCTAssertNil(values);
+                                     XCTAssertEqual(
+                                         [MTRErrorTestUtils errorToZCLErrorCode:error], EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER);
 
-                             [expectation fulfill];
-                         }];
+                                     [expectation fulfill];
+                                 }];
 
     [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:kTimeoutInSeconds];
 }
@@ -692,7 +692,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     __auto_type * params = [[MTRSubscribeParams alloc] init];
     params.autoResubscribe = @(NO);
-    [device subscribeAttributeWithEndpointID:@10000
+    [device subscribeAttributePathWithEndpointID:@10000
         clusterID:@6
         attributeID:@0
         minInterval:@2
@@ -729,30 +729,30 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributeWithEndpointID:@1
-                              clusterID:@29
-                            attributeID:nil
-                                 params:nil
-                                  queue:queue
-                             completion:^(id _Nullable values, NSError * _Nullable error) {
-                                 NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+    [device readAttributePathWithEndpointID:@1
+                                  clusterID:@29
+                                attributeID:nil
+                                     params:nil
+                                      queue:queue
+                                 completion:^(id _Nullable values, NSError * _Nullable error) {
+                                     NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
 
-                                 XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
+                                     XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
 
-                                 {
-                                     XCTAssertTrue([values isKindOfClass:[NSArray class]]);
-                                     NSArray * resultArray = values;
-                                     for (NSDictionary * result in resultArray) {
-                                         MTRAttributePath * path = result[@"attributePath"];
-                                         XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
-                                         XCTAssertEqual([path.endpoint unsignedIntegerValue], 1);
-                                         XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
+                                     {
+                                         XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                         NSArray * resultArray = values;
+                                         for (NSDictionary * result in resultArray) {
+                                             MTRAttributePath * path = result[@"attributePath"];
+                                             XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
+                                             XCTAssertEqual([path.endpoint unsignedIntegerValue], 1);
+                                             XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
+                                         }
+                                         XCTAssertTrue([resultArray count] > 0);
                                      }
-                                     XCTAssertTrue([resultArray count] > 0);
-                                 }
 
-                                 [expectation fulfill];
-                             }];
+                                     [expectation fulfill];
+                                 }];
 
     [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:kTimeoutInSeconds];
 }
@@ -1039,7 +1039,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointID:@1
+    [device subscribeAttributePathWithEndpointID:@1
         clusterID:@6
         attributeID:@0
         minInterval:@1
@@ -1417,7 +1417,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
     __block void (^reportHandler)(id _Nullable values, NSError * _Nullable error) = nil;
 
-    [device subscribeAttributeWithEndpointID:@1
+    [device subscribeAttributePathWithEndpointID:@1
         clusterID:@6
         attributeID:@0xffffffff
         minInterval:@2

--- a/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
@@ -628,31 +628,31 @@ static MTRBaseDevice * GetConnectedDevice(void)
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributeWithEndpointID:nil
-                              clusterID:@29
-                            attributeID:@0
-                                 params:nil
-                                  queue:queue
-                             completion:^(id _Nullable values, NSError * _Nullable error) {
-                                 NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+    [device readAttributePathWithEndpointID:nil
+                                  clusterID:@29
+                                attributeID:@0
+                                     params:nil
+                                      queue:queue
+                                 completion:^(id _Nullable values, NSError * _Nullable error) {
+                                     NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
 
-                                 XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
+                                     XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
 
-                                 {
-                                     XCTAssertTrue([values isKindOfClass:[NSArray class]]);
-                                     NSArray * resultArray = values;
-                                     for (NSDictionary * result in resultArray) {
-                                         MTRAttributePath * path = result[@"attributePath"];
-                                         XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
-                                         XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
-                                         XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
-                                         XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
+                                     {
+                                         XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                         NSArray * resultArray = values;
+                                         for (NSDictionary * result in resultArray) {
+                                             MTRAttributePath * path = result[@"attributePath"];
+                                             XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
+                                             XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
+                                             XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
+                                             XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
+                                         }
+                                         XCTAssertTrue([resultArray count] > 0);
                                      }
-                                     XCTAssertTrue([resultArray count] > 0);
-                                 }
 
-                                 [expectation fulfill];
-                             }];
+                                     [expectation fulfill];
+                                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -761,7 +761,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device subscribeAttributeWithEndpointID:@1
+    [device subscribeAttributePathWithEndpointID:@1
         clusterID:@6
         attributeID:@0
         minInterval:@2
@@ -852,22 +852,22 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributeWithEndpointID:@0
-                              clusterID:@10000
-                            attributeID:@0
-                                 params:nil
-                                  queue:queue
-                             completion:^(id _Nullable values, NSError * _Nullable error) {
-                                 NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+    [device readAttributePathWithEndpointID:@0
+                                  clusterID:@10000
+                                attributeID:@0
+                                     params:nil
+                                      queue:queue
+                                 completion:^(id _Nullable values, NSError * _Nullable error) {
+                                     NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
 
-                                 XCTAssertNil(values);
-                                 // Error is copied over XPC and hence cannot use MTRErrorTestUtils utility which checks against
-                                 // a local domain string object.
-                                 XCTAssertTrue([error.domain isEqualToString:MTRInteractionErrorDomain]);
-                                 XCTAssertEqual(error.code, EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER);
+                                     XCTAssertNil(values);
+                                     // Error is copied over XPC and hence cannot use MTRErrorTestUtils utility which checks against
+                                     // a local domain string object.
+                                     XCTAssertTrue([error.domain isEqualToString:MTRInteractionErrorDomain]);
+                                     XCTAssertEqual(error.code, EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER);
 
-                                 [expectation fulfill];
-                             }];
+                                     [expectation fulfill];
+                                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -975,7 +975,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     __auto_type * params = [[MTRSubscribeParams alloc] init];
     params.autoResubscribe = @(NO);
-    [device subscribeAttributeWithEndpointID:@10000
+    [device subscribeAttributePathWithEndpointID:@10000
         clusterID:@6
         attributeID:@0
         minInterval:@2
@@ -1014,31 +1014,31 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     MTRReadParams * readParams = [[MTRReadParams alloc] init];
     readParams.fabricFiltered = @NO;
-    [device readAttributeWithEndpointID:nil
-                              clusterID:@29
-                            attributeID:@0
-                                 params:readParams
-                                  queue:queue
-                             completion:^(id _Nullable values, NSError * _Nullable error) {
-                                 NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+    [device readAttributePathWithEndpointID:nil
+                                  clusterID:@29
+                                attributeID:@0
+                                     params:readParams
+                                      queue:queue
+                                 completion:^(id _Nullable values, NSError * _Nullable error) {
+                                     NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
 
-                                 XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
+                                     XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
 
-                                 {
-                                     XCTAssertTrue([values isKindOfClass:[NSArray class]]);
-                                     NSArray * resultArray = values;
-                                     for (NSDictionary * result in resultArray) {
-                                         MTRAttributePath * path = result[@"attributePath"];
-                                         XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
-                                         XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
-                                         XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
-                                         XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
+                                     {
+                                         XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                         NSArray * resultArray = values;
+                                         for (NSDictionary * result in resultArray) {
+                                             MTRAttributePath * path = result[@"attributePath"];
+                                             XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
+                                             XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
+                                             XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
+                                             XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
+                                         }
+                                         XCTAssertTrue([resultArray count] > 0);
                                      }
-                                     XCTAssertTrue([resultArray count] > 0);
-                                 }
 
-                                 [expectation fulfill];
-                             }];
+                                     [expectation fulfill];
+                                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -1064,7 +1064,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointID:@1
+    [device subscribeAttributePathWithEndpointID:@1
         clusterID:@6
         attributeID:@0
         minInterval:@2
@@ -1090,7 +1090,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Setup 2nd subscriber
     subscribeExpectation = [self expectationWithDescription:@"subscribe CurrentLevel attribute"];
-    [device subscribeAttributeWithEndpointID:@1
+    [device subscribeAttributePathWithEndpointID:@1
         clusterID:@8
         attributeID:@0
         minInterval:@2
@@ -1243,7 +1243,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointID:@1
+    [device subscribeAttributePathWithEndpointID:@1
         clusterID:@6
         attributeID:@0
         minInterval:@2
@@ -1271,7 +1271,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRSubscribeParams * myParams = [[MTRSubscribeParams alloc] init];
     myParams.keepPreviousSubscriptions = @NO;
     subscribeExpectation = [self expectationWithDescription:@"subscribe CurrentLevel attribute"];
-    [device subscribeAttributeWithEndpointID:@1
+    [device subscribeAttributePathWithEndpointID:@1
         clusterID:@8
         attributeID:@0
         minInterval:@2
@@ -1431,7 +1431,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointID:@1
+    [device subscribeAttributePathWithEndpointID:@1
         clusterID:@6
         attributeID:@0
         minInterval:@2
@@ -1459,7 +1459,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     subscribeExpectation = [self expectationWithDescription:@"subscribe CurrentLevel attribute"];
     MTRSubscribeParams * myParams = [[MTRSubscribeParams alloc] init];
     myParams.keepPreviousSubscriptions = @YES;
-    [device subscribeAttributeWithEndpointID:@1
+    [device subscribeAttributePathWithEndpointID:@1
         clusterID:@8
         attributeID:@0
         minInterval:@2
@@ -1666,7 +1666,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // subscribe, which should get the new value at the timeout
     expectation = [self expectationWithDescription:@"Subscribed"];
     __block void (^reportHandler)(id _Nullable values, NSError * _Nullable error);
-    [device subscribeAttributeWithEndpointID:@1
+    [device subscribeAttributePathWithEndpointID:@1
             clusterID:@8
             attributeID:@17
             minInterval:@2
@@ -1709,7 +1709,8 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Read back to see if the timed write has taken effect
     expectation = [self expectationWithDescription:@"Read LevelControl Brightness attribute after pause"];
-    [device readAttributeWithEndpointID:@1
+    [device
+        readAttributePathWithEndpointID:@1
                               clusterID:@8
                             attributeID:@17
                                  params:nil

--- a/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
@@ -628,31 +628,31 @@ static MTRBaseDevice * GetConnectedDevice(void)
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributePathWithEndpointID:nil
-                                  clusterID:@29
-                                attributeID:@0
-                                     params:nil
-                                      queue:queue
-                                 completion:^(id _Nullable values, NSError * _Nullable error) {
-                                     NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+    [device readAttributesWithEndpointID:nil
+                               clusterID:@29
+                             attributeID:@0
+                                  params:nil
+                                   queue:queue
+                              completion:^(id _Nullable values, NSError * _Nullable error) {
+                                  NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
 
-                                     XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
+                                  XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
 
-                                     {
-                                         XCTAssertTrue([values isKindOfClass:[NSArray class]]);
-                                         NSArray * resultArray = values;
-                                         for (NSDictionary * result in resultArray) {
-                                             MTRAttributePath * path = result[@"attributePath"];
-                                             XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
-                                             XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
-                                             XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
-                                             XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
-                                         }
-                                         XCTAssertTrue([resultArray count] > 0);
-                                     }
+                                  {
+                                      XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                      NSArray * resultArray = values;
+                                      for (NSDictionary * result in resultArray) {
+                                          MTRAttributePath * path = result[@"attributePath"];
+                                          XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
+                                          XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
+                                          XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
+                                          XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
+                                      }
+                                      XCTAssertTrue([resultArray count] > 0);
+                                  }
 
-                                     [expectation fulfill];
-                                 }];
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -761,7 +761,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device subscribeAttributePathWithEndpointID:@1
+    [device subscribeToAttributesWithEndpointID:@1
         clusterID:@6
         attributeID:@0
         minInterval:@2
@@ -852,22 +852,22 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributePathWithEndpointID:@0
-                                  clusterID:@10000
-                                attributeID:@0
-                                     params:nil
-                                      queue:queue
-                                 completion:^(id _Nullable values, NSError * _Nullable error) {
-                                     NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+    [device readAttributesWithEndpointID:@0
+                               clusterID:@10000
+                             attributeID:@0
+                                  params:nil
+                                   queue:queue
+                              completion:^(id _Nullable values, NSError * _Nullable error) {
+                                  NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
 
-                                     XCTAssertNil(values);
-                                     // Error is copied over XPC and hence cannot use MTRErrorTestUtils utility which checks against
-                                     // a local domain string object.
-                                     XCTAssertTrue([error.domain isEqualToString:MTRInteractionErrorDomain]);
-                                     XCTAssertEqual(error.code, EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER);
+                                  XCTAssertNil(values);
+                                  // Error is copied over XPC and hence cannot use MTRErrorTestUtils utility which checks against
+                                  // a local domain string object.
+                                  XCTAssertTrue([error.domain isEqualToString:MTRInteractionErrorDomain]);
+                                  XCTAssertEqual(error.code, EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER);
 
-                                     [expectation fulfill];
-                                 }];
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -975,7 +975,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     __auto_type * params = [[MTRSubscribeParams alloc] init];
     params.autoResubscribe = @(NO);
-    [device subscribeAttributePathWithEndpointID:@10000
+    [device subscribeToAttributesWithEndpointID:@10000
         clusterID:@6
         attributeID:@0
         minInterval:@2
@@ -1014,31 +1014,31 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     MTRReadParams * readParams = [[MTRReadParams alloc] init];
     readParams.fabricFiltered = @NO;
-    [device readAttributePathWithEndpointID:nil
-                                  clusterID:@29
-                                attributeID:@0
-                                     params:readParams
-                                      queue:queue
-                                 completion:^(id _Nullable values, NSError * _Nullable error) {
-                                     NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+    [device readAttributesWithEndpointID:nil
+                               clusterID:@29
+                             attributeID:@0
+                                  params:readParams
+                                   queue:queue
+                              completion:^(id _Nullable values, NSError * _Nullable error) {
+                                  NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
 
-                                     XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
+                                  XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
 
-                                     {
-                                         XCTAssertTrue([values isKindOfClass:[NSArray class]]);
-                                         NSArray * resultArray = values;
-                                         for (NSDictionary * result in resultArray) {
-                                             MTRAttributePath * path = result[@"attributePath"];
-                                             XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
-                                             XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
-                                             XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
-                                             XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
-                                         }
-                                         XCTAssertTrue([resultArray count] > 0);
-                                     }
+                                  {
+                                      XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                      NSArray * resultArray = values;
+                                      for (NSDictionary * result in resultArray) {
+                                          MTRAttributePath * path = result[@"attributePath"];
+                                          XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
+                                          XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
+                                          XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
+                                          XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
+                                      }
+                                      XCTAssertTrue([resultArray count] > 0);
+                                  }
 
-                                     [expectation fulfill];
-                                 }];
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -1064,7 +1064,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributePathWithEndpointID:@1
+    [device subscribeToAttributesWithEndpointID:@1
         clusterID:@6
         attributeID:@0
         minInterval:@2
@@ -1090,7 +1090,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Setup 2nd subscriber
     subscribeExpectation = [self expectationWithDescription:@"subscribe CurrentLevel attribute"];
-    [device subscribeAttributePathWithEndpointID:@1
+    [device subscribeToAttributesWithEndpointID:@1
         clusterID:@8
         attributeID:@0
         minInterval:@2
@@ -1243,7 +1243,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributePathWithEndpointID:@1
+    [device subscribeToAttributesWithEndpointID:@1
         clusterID:@6
         attributeID:@0
         minInterval:@2
@@ -1271,7 +1271,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRSubscribeParams * myParams = [[MTRSubscribeParams alloc] init];
     myParams.keepPreviousSubscriptions = @NO;
     subscribeExpectation = [self expectationWithDescription:@"subscribe CurrentLevel attribute"];
-    [device subscribeAttributePathWithEndpointID:@1
+    [device subscribeToAttributesWithEndpointID:@1
         clusterID:@8
         attributeID:@0
         minInterval:@2
@@ -1431,7 +1431,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributePathWithEndpointID:@1
+    [device subscribeToAttributesWithEndpointID:@1
         clusterID:@6
         attributeID:@0
         minInterval:@2
@@ -1459,7 +1459,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     subscribeExpectation = [self expectationWithDescription:@"subscribe CurrentLevel attribute"];
     MTRSubscribeParams * myParams = [[MTRSubscribeParams alloc] init];
     myParams.keepPreviousSubscriptions = @YES;
-    [device subscribeAttributePathWithEndpointID:@1
+    [device subscribeToAttributesWithEndpointID:@1
         clusterID:@8
         attributeID:@0
         minInterval:@2
@@ -1666,7 +1666,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // subscribe, which should get the new value at the timeout
     expectation = [self expectationWithDescription:@"Subscribed"];
     __block void (^reportHandler)(id _Nullable values, NSError * _Nullable error);
-    [device subscribeAttributePathWithEndpointID:@1
+    [device subscribeToAttributesWithEndpointID:@1
             clusterID:@8
             attributeID:@17
             minInterval:@2
@@ -1709,25 +1709,24 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Read back to see if the timed write has taken effect
     expectation = [self expectationWithDescription:@"Read LevelControl Brightness attribute after pause"];
-    [device
-        readAttributePathWithEndpointID:@1
-                              clusterID:@8
-                            attributeID:@17
-                                 params:nil
-                                  queue:queue
-                             completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
-                                 NSLog(@"read attribute: LevelControl Brightness values: %@, error: %@", values, error);
-                                 XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
-                                 for (NSDictionary<NSString *, id> * value in values) {
-                                     MTRAttributePath * path = value[@"attributePath"];
-                                     XCTAssertEqual([path.endpoint unsignedShortValue], 1);
-                                     XCTAssertEqual([path.cluster unsignedLongValue], 8);
-                                     XCTAssertEqual([path.attribute unsignedLongValue], 17);
-                                     XCTAssertTrue([value[@"data"][@"type"] isEqualToString:@"UnsignedInteger"]);
-                                     XCTAssertEqual([value[@"data"][@"value"] unsignedIntegerValue], 100);
-                                 }
-                                 [expectation fulfill];
-                             }];
+    [device readAttributesWithEndpointID:@1
+                               clusterID:@8
+                             attributeID:@17
+                                  params:nil
+                                   queue:queue
+                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                                  NSLog(@"read attribute: LevelControl Brightness values: %@, error: %@", values, error);
+                                  XCTAssertEqual([MTRErrorTestUtils errorToZCLErrorCode:error], 0);
+                                  for (NSDictionary<NSString *, id> * value in values) {
+                                      MTRAttributePath * path = value[@"attributePath"];
+                                      XCTAssertEqual([path.endpoint unsignedShortValue], 1);
+                                      XCTAssertEqual([path.cluster unsignedLongValue], 8);
+                                      XCTAssertEqual([path.attribute unsignedLongValue], 17);
+                                      XCTAssertTrue([value[@"data"][@"type"] isEqualToString:@"UnsignedInteger"]);
+                                      XCTAssertEqual([value[@"data"][@"value"] unsignedIntegerValue], 100);
+                                  }
+                                  [expectation fulfill];
+                              }];
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 

--- a/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
@@ -376,20 +376,20 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                     XCTAssertNotNil(device);
                                     XCTAssertNil(error);
                                     NSLog(@"Device acquired. Reading...");
-                                    [device readAttributePathWithEndpointID:myEndpointId
-                                                                  clusterID:myClusterId
-                                                                attributeID:myAttributeId
-                                                                     params:nil
-                                                                      queue:dispatch_get_main_queue()
-                                                                 completion:^(id _Nullable value, NSError * _Nullable error) {
-                                                                     NSLog(@"Read value: %@", value);
-                                                                     XCTAssertNotNil(value);
-                                                                     XCTAssertNil(error);
-                                                                     XCTAssertTrue([myValues isEqual:value]);
-                                                                     [responseExpectation fulfill];
-                                                                     self.xpcDisconnectExpectation =
-                                                                         [self expectationWithDescription:@"XPC Disconnected"];
-                                                                 }];
+                                    [device readAttributesWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId
+                                                                  params:nil
+                                                                   queue:dispatch_get_main_queue()
+                                                              completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                                  NSLog(@"Read value: %@", value);
+                                                                  XCTAssertNotNil(value);
+                                                                  XCTAssertNil(error);
+                                                                  XCTAssertTrue([myValues isEqual:value]);
+                                                                  [responseExpectation fulfill];
+                                                                  self.xpcDisconnectExpectation =
+                                                                      [self expectationWithDescription:@"XPC Disconnected"];
+                                                              }];
                                 }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
@@ -438,20 +438,20 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                     XCTAssertNotNil(device);
                                     XCTAssertNil(error);
                                     NSLog(@"Device acquired. Reading...");
-                                    [device readAttributePathWithEndpointID:myEndpointId
-                                                                  clusterID:myClusterId
-                                                                attributeID:myAttributeId
-                                                                     params:myParams
-                                                                      queue:dispatch_get_main_queue()
-                                                                 completion:^(id _Nullable value, NSError * _Nullable error) {
-                                                                     NSLog(@"Read value: %@", value);
-                                                                     XCTAssertNotNil(value);
-                                                                     XCTAssertNil(error);
-                                                                     XCTAssertTrue([myValues isEqual:value]);
-                                                                     [responseExpectation fulfill];
-                                                                     self.xpcDisconnectExpectation =
-                                                                         [self expectationWithDescription:@"XPC Disconnected"];
-                                                                 }];
+                                    [device readAttributesWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId
+                                                                  params:myParams
+                                                                   queue:dispatch_get_main_queue()
+                                                              completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                                  NSLog(@"Read value: %@", value);
+                                                                  XCTAssertNotNil(value);
+                                                                  XCTAssertNil(error);
+                                                                  XCTAssertTrue([myValues isEqual:value]);
+                                                                  [responseExpectation fulfill];
+                                                                  self.xpcDisconnectExpectation =
+                                                                      [self expectationWithDescription:@"XPC Disconnected"];
+                                                              }];
                                 }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
@@ -491,19 +491,19 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                     XCTAssertNotNil(device);
                                     XCTAssertNil(error);
                                     NSLog(@"Device acquired. Reading...");
-                                    [device readAttributePathWithEndpointID:myEndpointId
-                                                                  clusterID:myClusterId
-                                                                attributeID:myAttributeId
-                                                                     params:nil
-                                                                      queue:dispatch_get_main_queue()
-                                                                 completion:^(id _Nullable value, NSError * _Nullable error) {
-                                                                     NSLog(@"Read value: %@", value);
-                                                                     XCTAssertNil(value);
-                                                                     XCTAssertNotNil(error);
-                                                                     [responseExpectation fulfill];
-                                                                     self.xpcDisconnectExpectation =
-                                                                         [self expectationWithDescription:@"XPC Disconnected"];
-                                                                 }];
+                                    [device readAttributesWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId
+                                                                  params:nil
+                                                                   queue:dispatch_get_main_queue()
+                                                              completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                                  NSLog(@"Read value: %@", value);
+                                                                  XCTAssertNil(value);
+                                                                  XCTAssertNotNil(error);
+                                                                  [responseExpectation fulfill];
+                                                                  self.xpcDisconnectExpectation =
+                                                                      [self expectationWithDescription:@"XPC Disconnected"];
+                                                              }];
                                 }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
@@ -917,7 +917,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributePathWithEndpointID:myEndpointId
+               [device subscribeToAttributesWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1037,7 +1037,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributePathWithEndpointID:myEndpointId
+               [device subscribeToAttributesWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1152,7 +1152,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributePathWithEndpointID:myEndpointId
+               [device subscribeToAttributesWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1266,7 +1266,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributePathWithEndpointID:myEndpointId
+               [device subscribeToAttributesWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1382,7 +1382,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributePathWithEndpointID:myEndpointId
+               [device subscribeToAttributesWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1498,7 +1498,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributePathWithEndpointID:myEndpointId
+               [device subscribeToAttributesWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1614,7 +1614,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributePathWithEndpointID:myEndpointId
+               [device subscribeToAttributesWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1729,7 +1729,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributePathWithEndpointID:nil
+               [device subscribeToAttributesWithEndpointID:nil
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1844,7 +1844,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributePathWithEndpointID:myEndpointId
+               [device subscribeToAttributesWithEndpointID:myEndpointId
                    clusterID:nil
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1959,7 +1959,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributePathWithEndpointID:myEndpointId
+               [device subscribeToAttributesWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:nil
                    minInterval:myMinInterval
@@ -2085,7 +2085,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                    XCTAssertNotNil(device);
                    XCTAssertNil(error);
                    NSLog(@"Device acquired. Subscribing...");
-                   [device subscribeAttributePathWithEndpointID:myEndpointId
+                   [device subscribeToAttributesWithEndpointID:myEndpointId
                        clusterID:myClusterId
                        attributeID:myAttributeId
                        minInterval:myMinInterval
@@ -2549,17 +2549,17 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                     XCTAssertNotNil(device);
                                     XCTAssertNil(error);
                                     NSLog(@"Device acquired. Reading...");
-                                    [device readAttributePathWithEndpointID:myEndpointId
-                                                                  clusterID:myClusterId
-                                                                attributeID:myAttributeId
-                                                                     params:nil
-                                                                      queue:dispatch_get_main_queue()
-                                                                 completion:^(id _Nullable value, NSError * _Nullable error) {
-                                                                     NSLog(@"Read value: %@", value);
-                                                                     XCTAssertNil(value);
-                                                                     XCTAssertNotNil(error);
-                                                                     [responseExpectation fulfill];
-                                                                 }];
+                                    [device readAttributesWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId
+                                                                  params:nil
+                                                                   queue:dispatch_get_main_queue()
+                                                              completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                                  NSLog(@"Read value: %@", value);
+                                                                  XCTAssertNil(value);
+                                                                  XCTAssertNotNil(error);
+                                                                  [responseExpectation fulfill];
+                                                              }];
                                 }];
 
     [self waitForExpectations:@[ responseExpectation ] timeout:kTimeoutInSeconds];

--- a/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
@@ -376,20 +376,20 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                     XCTAssertNotNil(device);
                                     XCTAssertNil(error);
                                     NSLog(@"Device acquired. Reading...");
-                                    [device readAttributeWithEndpointID:myEndpointId
-                                                              clusterID:myClusterId
-                                                            attributeID:myAttributeId
-                                                                 params:nil
-                                                                  queue:dispatch_get_main_queue()
-                                                             completion:^(id _Nullable value, NSError * _Nullable error) {
-                                                                 NSLog(@"Read value: %@", value);
-                                                                 XCTAssertNotNil(value);
-                                                                 XCTAssertNil(error);
-                                                                 XCTAssertTrue([myValues isEqual:value]);
-                                                                 [responseExpectation fulfill];
-                                                                 self.xpcDisconnectExpectation =
-                                                                     [self expectationWithDescription:@"XPC Disconnected"];
-                                                             }];
+                                    [device readAttributePathWithEndpointID:myEndpointId
+                                                                  clusterID:myClusterId
+                                                                attributeID:myAttributeId
+                                                                     params:nil
+                                                                      queue:dispatch_get_main_queue()
+                                                                 completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                                     NSLog(@"Read value: %@", value);
+                                                                     XCTAssertNotNil(value);
+                                                                     XCTAssertNil(error);
+                                                                     XCTAssertTrue([myValues isEqual:value]);
+                                                                     [responseExpectation fulfill];
+                                                                     self.xpcDisconnectExpectation =
+                                                                         [self expectationWithDescription:@"XPC Disconnected"];
+                                                                 }];
                                 }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
@@ -438,20 +438,20 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                     XCTAssertNotNil(device);
                                     XCTAssertNil(error);
                                     NSLog(@"Device acquired. Reading...");
-                                    [device readAttributeWithEndpointID:myEndpointId
-                                                              clusterID:myClusterId
-                                                            attributeID:myAttributeId
-                                                                 params:myParams
-                                                                  queue:dispatch_get_main_queue()
-                                                             completion:^(id _Nullable value, NSError * _Nullable error) {
-                                                                 NSLog(@"Read value: %@", value);
-                                                                 XCTAssertNotNil(value);
-                                                                 XCTAssertNil(error);
-                                                                 XCTAssertTrue([myValues isEqual:value]);
-                                                                 [responseExpectation fulfill];
-                                                                 self.xpcDisconnectExpectation =
-                                                                     [self expectationWithDescription:@"XPC Disconnected"];
-                                                             }];
+                                    [device readAttributePathWithEndpointID:myEndpointId
+                                                                  clusterID:myClusterId
+                                                                attributeID:myAttributeId
+                                                                     params:myParams
+                                                                      queue:dispatch_get_main_queue()
+                                                                 completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                                     NSLog(@"Read value: %@", value);
+                                                                     XCTAssertNotNil(value);
+                                                                     XCTAssertNil(error);
+                                                                     XCTAssertTrue([myValues isEqual:value]);
+                                                                     [responseExpectation fulfill];
+                                                                     self.xpcDisconnectExpectation =
+                                                                         [self expectationWithDescription:@"XPC Disconnected"];
+                                                                 }];
                                 }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
@@ -491,19 +491,19 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                     XCTAssertNotNil(device);
                                     XCTAssertNil(error);
                                     NSLog(@"Device acquired. Reading...");
-                                    [device readAttributeWithEndpointID:myEndpointId
-                                                              clusterID:myClusterId
-                                                            attributeID:myAttributeId
-                                                                 params:nil
-                                                                  queue:dispatch_get_main_queue()
-                                                             completion:^(id _Nullable value, NSError * _Nullable error) {
-                                                                 NSLog(@"Read value: %@", value);
-                                                                 XCTAssertNil(value);
-                                                                 XCTAssertNotNil(error);
-                                                                 [responseExpectation fulfill];
-                                                                 self.xpcDisconnectExpectation =
-                                                                     [self expectationWithDescription:@"XPC Disconnected"];
-                                                             }];
+                                    [device readAttributePathWithEndpointID:myEndpointId
+                                                                  clusterID:myClusterId
+                                                                attributeID:myAttributeId
+                                                                     params:nil
+                                                                      queue:dispatch_get_main_queue()
+                                                                 completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                                     NSLog(@"Read value: %@", value);
+                                                                     XCTAssertNil(value);
+                                                                     XCTAssertNotNil(error);
+                                                                     [responseExpectation fulfill];
+                                                                     self.xpcDisconnectExpectation =
+                                                                         [self expectationWithDescription:@"XPC Disconnected"];
+                                                                 }];
                                 }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
@@ -917,7 +917,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributeWithEndpointID:myEndpointId
+               [device subscribeAttributePathWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1037,7 +1037,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributeWithEndpointID:myEndpointId
+               [device subscribeAttributePathWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1152,7 +1152,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributeWithEndpointID:myEndpointId
+               [device subscribeAttributePathWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1266,7 +1266,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributeWithEndpointID:myEndpointId
+               [device subscribeAttributePathWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1382,7 +1382,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributeWithEndpointID:myEndpointId
+               [device subscribeAttributePathWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1498,7 +1498,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributeWithEndpointID:myEndpointId
+               [device subscribeAttributePathWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1614,7 +1614,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributeWithEndpointID:myEndpointId
+               [device subscribeAttributePathWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1729,7 +1729,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributeWithEndpointID:nil
+               [device subscribeAttributePathWithEndpointID:nil
                    clusterID:myClusterId
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1844,7 +1844,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributeWithEndpointID:myEndpointId
+               [device subscribeAttributePathWithEndpointID:myEndpointId
                    clusterID:nil
                    attributeID:myAttributeId
                    minInterval:myMinInterval
@@ -1959,7 +1959,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                XCTAssertNotNil(device);
                XCTAssertNil(error);
                NSLog(@"Device acquired. Subscribing...");
-               [device subscribeAttributeWithEndpointID:myEndpointId
+               [device subscribeAttributePathWithEndpointID:myEndpointId
                    clusterID:myClusterId
                    attributeID:nil
                    minInterval:myMinInterval
@@ -2085,7 +2085,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                    XCTAssertNotNil(device);
                    XCTAssertNil(error);
                    NSLog(@"Device acquired. Subscribing...");
-                   [device subscribeAttributeWithEndpointID:myEndpointId
+                   [device subscribeAttributePathWithEndpointID:myEndpointId
                        clusterID:myClusterId
                        attributeID:myAttributeId
                        minInterval:myMinInterval
@@ -2549,17 +2549,17 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                     XCTAssertNotNil(device);
                                     XCTAssertNil(error);
                                     NSLog(@"Device acquired. Reading...");
-                                    [device readAttributeWithEndpointID:myEndpointId
-                                                              clusterID:myClusterId
-                                                            attributeID:myAttributeId
-                                                                 params:nil
-                                                                  queue:dispatch_get_main_queue()
-                                                             completion:^(id _Nullable value, NSError * _Nullable error) {
-                                                                 NSLog(@"Read value: %@", value);
-                                                                 XCTAssertNil(value);
-                                                                 XCTAssertNotNil(error);
-                                                                 [responseExpectation fulfill];
-                                                             }];
+                                    [device readAttributePathWithEndpointID:myEndpointId
+                                                                  clusterID:myClusterId
+                                                                attributeID:myAttributeId
+                                                                     params:nil
+                                                                      queue:dispatch_get_main_queue()
+                                                                 completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                                     NSLog(@"Read value: %@", value);
+                                                                     XCTAssertNil(value);
+                                                                     XCTAssertNotNil(error);
+                                                                     [responseExpectation fulfill];
+                                                                 }];
                                 }];
 
     [self waitForExpectations:@[ responseExpectation ] timeout:kTimeoutInSeconds];


### PR DESCRIPTION
This is a re-landing of PR #22574.

* Rename readAttributeWithEndpointID to readAttributePathWithEndpointID
* Document readAttributePathWithEndpointID
* Rename subscribeAttributeWithEndpointID to subscribeAttributePathWithEndpointID
* Document subscribeAttributePathWithEndpointID
* Switch various things from "strong" to "copy" for paths, reports, etc.
* Remove redundant "nonnull" declarations on properties.
* Create typedefs for the NSData representations of certificates, for readability
* Replace "(nullable X *)" with "(X * _Nullable)" in various places.
* Fix various documentation.
* Rename "failSafeExpiryTimeoutSecs" to "failSafeExpiryTimeout".

The nullable to _Nullable change we might want to undo, but keeping it for now to make re-landing other PRs that were on top of #22574 easier.

The header changes not accompanied by backwards-compat shims are OK for the following reasons:

* The changes to MTRBaseDevice.h are all to MTR_NEWLY_AVAILABLE APIs or fixing obvious API bugs (replacing "strong" with "copy").
* MTRBaseDevice_Internal.h is not public API.
* The changes to MTRCertificates.h are all to MTR_NEWLY_AVAILABLE APIs or are source+binary compatible.
* The changes to MTRCluster.h are source+binary compatible.
* MTRCluster_internal.h is not public API.
* The changes to MTRDeviceController.h are source+binary compatible.
* The changes to MTRDeviceControllerStartupParams.h are source+binary compatible.
* MTRDeviceControllerStartupParams_Internal.h is not public API.
* The changes to MTRDevicePairingDelegate.h are source+binary compatible.
* The changes to MTRError.h are source+binary compatible.
* MTRError_Internal.h is not public API.
* The changes to MTRManualSetupPayloadParser.h are source+binary compatible.
* The changes to MTROnboardingPayloadParser.h are source+binary compatible.
* The changes to MTRPersistentStorageDelegate.h are source+binary compatible.
* The changes to MTRQRCodeSetupPayloadParser.h are source+binary compatible.
* The changes to MTRSetupPayload.h are source+binary compatible.
* The changes to MTRThreadOperationalDataset.h are source+binary compatible.
* The changes to MTRBaseClusters.h are source+binary compatible.
* The changes to MTRClusters.h are source+binary compatible.
* The changes to MTRCommandPayloadsObjc.h are source+binary compatible.
* The changes to MTRStructsObjc.h are source+binary compatible.

