### PR TITLE
Add missing Nrf Apps to build targets script

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -237,9 +237,11 @@ def BuildNrfTarget():
         TargetPart('all-clusters-minimal', app=NrfApp.ALL_CLUSTERS_MINIMAL),
         TargetPart('lock', app=NrfApp.LOCK),
         TargetPart('light', app=NrfApp.LIGHT),
+        TargetPart('switch', app=NrfApp.SWITCH),
         TargetPart('shell', app=NrfApp.SHELL),
         TargetPart('pump', app=NrfApp.PUMP),
         TargetPart('pump-controller', app=NrfApp.PUMP_CONTROLLER),
+        TargetPart('window-covering', app=NrfApp.WINDOW_COVERING),
     ])
 
     target.AppendModifier('rpc', enable_rpcs=True)


### PR DESCRIPTION
Fixes #23448 by add the missing Nrf Apps to build targets script:

- TargetPart --> 'switch'
- TargetPart --> 'window-covering'

