### PR TITLE
Add nrfconnect light-switch app to NRF builder

### DIFF
--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -38,6 +38,8 @@ class NrfApp(Enum):
             return 'examples/all-clusters-minimal-app'
         elif self == NrfApp.LIGHT:
             return 'examples/lighting-app'
+        elif self == NrfApp.SWITCH:
+            return 'examples/light-switch-app'
         elif self == NrfApp.LOCK:
             return 'examples/lock-app'
         elif self == NrfApp.SHELL:
@@ -60,6 +62,8 @@ class NrfApp(Enum):
             return 'chip-nrf-all-clusters-minimal-example'
         elif self == NrfApp.LIGHT:
             return 'chip-nrf-lighting-example'
+        elif self == NrfApp.SWITCH:
+            return 'chip-nrf-light-switch-example'
         elif self == NrfApp.LOCK:
             return 'chip-nrf-lock-example'
         elif self == NrfApp.SHELL:
@@ -82,6 +86,8 @@ class NrfApp(Enum):
             return 'chip-nrfconnect-all-clusters-minimal-app-example'
         elif self == NrfApp.LIGHT:
             return 'chip-nrfconnect-lighting-example'
+        elif self == NrfApp.SWITCH:
+            return 'chip-nrfconnect-ligh-switch-example'
         elif self == NrfApp.LOCK:
             return 'chip-nrfconnect-lock-example'
         elif self == NrfApp.SHELL:


### PR DESCRIPTION
Refers to Matter nRF Connect Window Covering Example Application 
https://github.com/project-chip/connectedhomeip/tree/master/examples/light-switch-app/nrfconnect


Fixes #23450 [Platform] Missing nrfconnect light-switch app in NRF builder

