### PR TITLE
Enable Absolute Position to Window-app zap

### DIFF
--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -1965,7 +1965,7 @@ endpoint 1 {
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute attributeList;
-    ram      attribute featureMap default = 0x0017;
+    ram      attribute featureMap default = 0x001F;
     ram      attribute clusterRevision default = 5;
   }
 }

--- a/examples/window-app/common/window-app.zap
+++ b/examples/window-app/common/window-app.zap
@@ -7650,7 +7650,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x0017",
+              "defaultValue": "0x001F",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,
@@ -9241,5 +9241,6 @@
       "endpointVersion": 2,
       "deviceIdentifier": 514
     }
-  ]
+  ],
+  "log": []
 }

--- a/zzz_generated/window-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/window-app/zap-generated/endpoint_config.h
@@ -518,7 +518,7 @@
               ZAP_ATTRIBUTE_MASK(MIN_MAX) | ZAP_ATTRIBUTE_MASK(TOKENIZE) | ZAP_ATTRIBUTE_MASK(WRITABLE),                           \
               ZAP_MIN_MAX_DEFAULTS_INDEX(1) },                                    /* Mode */                                       \
             { 0x0000001A, ZAP_TYPE(BITMAP16), 2, 0, ZAP_SIMPLE_DEFAULT(0x0000) }, /* SafetyStatus */                               \
-            { 0x0000FFFC, ZAP_TYPE(BITMAP32), 4, 0, ZAP_SIMPLE_DEFAULT(0x0017) }, /* FeatureMap */                                 \
+            { 0x0000FFFC, ZAP_TYPE(BITMAP32), 4, 0, ZAP_SIMPLE_DEFAULT(0x001F) }, /* FeatureMap */                                 \
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(5) },        /* ClusterRevision */                            \
                                                                                                                                    \
             /* Endpoint: 2, Cluster: Identify (server) */                                                                          \


### PR DESCRIPTION
#### Description
Enabled absolute position support to window-app zap file

#### Testing
Regen and manual tests with chip-tool to validate `go-to-*-value` commands are accepted
