### PR TITLE
Don't use EmberAfPluginDoorLockUserInfo if findUserIndexByCredential failed.

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -571,12 +571,12 @@ struct EmberAfPluginDoorLockCredentialInfo
  */
 struct EmberAfPluginDoorLockUserInfo
 {
-    chip::CharSpan userName;                    /**< Name of the user. */
-    chip::Span<const DlCredential> credentials; /**< Credentials that are associated with user (without data).*/
-    uint32_t userUniqueId;                      /**< Unique user identifier. */
-    DlUserStatus userStatus;                    /**< Status of the user slot (available/occupied). */
-    DlUserType userType;                        /**< Type of the user. */
-    DlCredentialRule credentialRule;            /**< Number of supported credentials. */
+    chip::CharSpan userName;                            /**< Name of the user. */
+    chip::Span<const DlCredential> credentials;         /**< Credentials that are associated with user (without data).*/
+    uint32_t userUniqueId;                              /**< Unique user identifier. */
+    DlUserStatus userStatus = DlUserStatus::kAvailable; /**< Status of the user slot (available/occupied). */
+    DlUserType userType;                                /**< Type of the user. */
+    DlCredentialRule credentialRule;                    /**< Number of supported credentials. */
 
     DlAssetSource creationSource;
     chip::FabricIndex createdBy; /**< ID of the fabric that created the user. */


### PR DESCRIPTION
A few changes here:

* Initialize the user status in EmberAfPluginDoorLockUserInfo to Available, to represent no user.
* If we fail to find a user for the given PIN, don't include a bogus user index and credential index in the operation error event we send.
* If we fail to find a user for the given PIN, send InvalidCredential as the operation error, not Unspecified.

