### PR TITLE
Add a spec reference to the chip-tool docs for timedInteractionTimeoutMs.

### DIFF
--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -140,7 +140,8 @@ protected:
     void AddArguments()
     {
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs,
-                    "If provided, do a timed invoke with the given timed interaction timeout.");
+                    "If provided, do a timed invoke with the given timed interaction timeout. See \"7.6.10. Timed Interaction\" in "
+                    "the Matter specification.");
         AddArgument("suppressResponse", 0, 1, &mSuppressResponse);
         AddArgument("repeat-count", 1, UINT16_MAX, &mRepeatCount);
         AddArgument("repeat-delay-ms", 0, UINT16_MAX, &mRepeatDelayInMs);

--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -200,7 +200,8 @@ protected:
     void AddArguments()
     {
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs,
-                    "If provided, do a timed write with the given timed interaction timeout.");
+                    "If provided, do a timed write with the given timed interaction timeout. See \"7.6.10. Timed Interaction\" in "
+                    "the Matter specification.");
         AddArgument("data-version", 0, UINT32_MAX, &mDataVersions,
                     "Comma-separated list of data versions for the clusters being written.");
         AddArgument("suppressResponse", 0, 1, &mSuppressResponse);

--- a/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
@@ -117,7 +117,8 @@ protected:
     void AddArguments()
     {
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs,
-            "If provided, do a timed invoke with the given timed interaction timeout.");
+            "If provided, do a timed invoke with the given timed interaction timeout. See \"7.6.10. Timed Interaction\" in the "
+            "Matter specification.");
         AddArgument("repeat-count", 1, UINT16_MAX, &mRepeatCount);
         AddArgument("repeat-delay-ms", 0, UINT16_MAX, &mRepeatDelayInMs);
         ModelCommand::AddArguments();

--- a/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
@@ -107,7 +107,8 @@ protected:
     void AddArguments()
     {
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs,
-            "If provided, do a timed write with the given timed interaction timeout.");
+            "If provided, do a timed write with the given timed interaction timeout. See \"7.6.10. Timed Interaction\" in the "
+            "Matter specification.");
         ModelCommand::AddArguments();
     }
 


### PR DESCRIPTION
People keep being confused by what this means, if they don't know what timed interactions are.  Point to the spec section they should read to figure that out.

