### PR TITLE
Replace `operator const char *` from StorageKeyName with an explicit call

### DIFF
--- a/examples/platform/linux/testing/CustomCSRResponseOperationalKeyStore.cpp
+++ b/examples/platform/linux/testing/CustomCSRResponseOperationalKeyStore.cpp
@@ -71,7 +71,8 @@ CHIP_ERROR CustomCSRResponseOperationalKeyStore::ReuseOpKeypair(FabricIndex fabr
 
         // In order to retrieve a keypair that has already been registered, assume the device
         // as already been commissioned and fabric index 1 is the registered fabric.
-        CHIP_ERROR err = mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::FabricOpKey(1 /* fabricIndex */), buf.Bytes(), size);
+        CHIP_ERROR err =
+            mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::FabricOpKey(1 /* fabricIndex */).KeyName(), buf.Bytes(), size);
         if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
         {
             err = CHIP_ERROR_INVALID_FABRIC_INDEX;

--- a/examples/providers/DeviceInfoProviderImpl.cpp
+++ b/examples/providers/DeviceInfoProviderImpl.cpp
@@ -145,13 +145,15 @@ CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelAt(EndpointId endpoint, size_t in
     ReturnErrorOnFailure(writer.PutString(kLabelValueTag, userLabel.value));
     ReturnErrorOnFailure(writer.EndContainer(outerType));
 
-    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::UserLabelIndexKey(endpoint, static_cast<uint32_t>(index)), buf,
-                                     static_cast<uint16_t>(writer.GetLengthWritten()));
+    return mStorage->SyncSetKeyValue(
+        DefaultStorageKeyAllocator::UserLabelIndexKey(endpoint, static_cast<uint32_t>(index)).KeyName(), buf,
+        static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
 CHIP_ERROR DeviceInfoProviderImpl::DeleteUserLabelAt(EndpointId endpoint, size_t index)
 {
-    return mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::UserLabelIndexKey(endpoint, static_cast<uint32_t>(index)));
+    return mStorage->SyncDeleteKeyValue(
+        DefaultStorageKeyAllocator::UserLabelIndexKey(endpoint, static_cast<uint32_t>(index)).KeyName());
 }
 
 DeviceInfoProvider::UserLabelIterator * DeviceInfoProviderImpl::IterateUserLabel(EndpointId endpoint)
@@ -180,7 +182,7 @@ bool DeviceInfoProviderImpl::UserLabelIteratorImpl::Next(UserLabelType & output)
     uint16_t len = static_cast<uint16_t>(sizeof(buf));
 
     err = mProvider.mStorage->SyncGetKeyValue(
-        DefaultStorageKeyAllocator::UserLabelIndexKey(mEndpoint, static_cast<uint32_t>(mIndex)), buf, len);
+        DefaultStorageKeyAllocator::UserLabelIndexKey(mEndpoint, static_cast<uint32_t>(mIndex)).KeyName(), buf, len);
     VerifyOrReturnError(err == CHIP_NO_ERROR, false);
 
     TLV::ContiguousBufferTLVReader reader;

--- a/examples/providers/DeviceInfoProviderImpl.cpp
+++ b/examples/providers/DeviceInfoProviderImpl.cpp
@@ -120,7 +120,7 @@ bool DeviceInfoProviderImpl::FixedLabelIteratorImpl::Next(FixedLabelType & outpu
 
 CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelLength(EndpointId endpoint, size_t val)
 {
-    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::UserLabelLengthKey(endpoint), &val,
+    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::UserLabelLengthKey(endpoint).KeyName(), &val,
                                      static_cast<uint16_t>(sizeof(val)));
 }
 
@@ -128,7 +128,7 @@ CHIP_ERROR DeviceInfoProviderImpl::GetUserLabelLength(EndpointId endpoint, size_
 {
     uint16_t len = static_cast<uint16_t>(sizeof(val));
 
-    return mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::UserLabelLengthKey(endpoint), &val, len);
+    return mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::UserLabelLengthKey(endpoint).KeyName(), &val, len);
 }
 
 CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel)

--- a/src/app/DefaultAttributePersistenceProvider.cpp
+++ b/src/app/DefaultAttributePersistenceProvider.cpp
@@ -35,8 +35,8 @@ CHIP_ERROR DefaultAttributePersistenceProvider::WriteValue(const ConcreteAttribu
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
     return mStorage->SyncSetKeyValue(
-        DefaultStorageKeyAllocator::AttributeValue(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId), aValue.data(),
-        static_cast<uint16_t>(aValue.size()));
+        DefaultStorageKeyAllocator::AttributeValue(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId).KeyName(),
+        aValue.data(), static_cast<uint16_t>(aValue.size()));
 }
 
 CHIP_ERROR DefaultAttributePersistenceProvider::ReadValue(const ConcreteAttributePath & aPath,
@@ -46,7 +46,8 @@ CHIP_ERROR DefaultAttributePersistenceProvider::ReadValue(const ConcreteAttribut
 
     uint16_t size = static_cast<uint16_t>(min(aValue.size(), static_cast<size_t>(UINT16_MAX)));
     ReturnErrorOnFailure(mStorage->SyncGetKeyValue(
-        DefaultStorageKeyAllocator::AttributeValue(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId), aValue.data(), size));
+        DefaultStorageKeyAllocator::AttributeValue(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId).KeyName(),
+        aValue.data(), size));
     EmberAfAttributeType type = aMetadata->attributeType;
     if (emberAfIsStringAttributeType(type))
     {

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -299,8 +299,8 @@ CHIP_ERROR AccessControlAttribute::WriteExtension(const ConcreteDataAttributePat
 
     uint8_t buffer[kExtensionDataMaxLength] = { 0 };
     uint16_t size                           = static_cast<uint16_t>(sizeof(buffer));
-    CHIP_ERROR errStorage =
-        storage.SyncGetKeyValue(DefaultStorageKeyAllocator::AccessControlExtensionEntry(accessingFabricIndex), buffer, size);
+    CHIP_ERROR errStorage                   = storage.SyncGetKeyValue(
+        DefaultStorageKeyAllocator::AccessControlExtensionEntry(accessingFabricIndex).KeyName(), buffer, size);
     ReturnErrorCodeIf(errStorage == CHIP_ERROR_BUFFER_TOO_SMALL, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorCodeIf(errStorage != CHIP_NO_ERROR && errStorage != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND, errStorage);
 
@@ -315,8 +315,8 @@ CHIP_ERROR AccessControlAttribute::WriteExtension(const ConcreteDataAttributePat
         if (count == 0)
         {
             ReturnErrorCodeIf(errStorage == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND, CHIP_NO_ERROR);
-            ReturnErrorOnFailure(
-                storage.SyncDeleteKeyValue(DefaultStorageKeyAllocator::AccessControlExtensionEntry(accessingFabricIndex)));
+            ReturnErrorOnFailure(storage.SyncDeleteKeyValue(
+                DefaultStorageKeyAllocator::AccessControlExtensionEntry(accessingFabricIndex).KeyName()));
             AccessControlCluster::Structs::ExtensionEntry::Type item = {
                 .data        = ByteSpan(buffer, size),
                 .fabricIndex = accessingFabricIndex,
@@ -340,7 +340,7 @@ CHIP_ERROR AccessControlAttribute::WriteExtension(const ConcreteDataAttributePat
             ReturnErrorOnFailure(CheckExtensionEntryDataFormat(item.data));
 
             ReturnErrorOnFailure(
-                storage.SyncSetKeyValue(DefaultStorageKeyAllocator::AccessControlExtensionEntry(accessingFabricIndex),
+                storage.SyncSetKeyValue(DefaultStorageKeyAllocator::AccessControlExtensionEntry(accessingFabricIndex).KeyName(),
                                         item.data.data(), static_cast<uint16_t>(item.data.size())));
             ReturnErrorOnFailure(LogExtensionChangedEvent(item, aDecoder.GetSubjectDescriptor(),
                                                           errStorage == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND
@@ -362,8 +362,9 @@ CHIP_ERROR AccessControlAttribute::WriteExtension(const ConcreteDataAttributePat
 
         ReturnErrorOnFailure(CheckExtensionEntryDataFormat(item.data));
 
-        ReturnErrorOnFailure(storage.SyncSetKeyValue(DefaultStorageKeyAllocator::AccessControlExtensionEntry(accessingFabricIndex),
-                                                     item.data.data(), static_cast<uint16_t>(item.data.size())));
+        ReturnErrorOnFailure(
+            storage.SyncSetKeyValue(DefaultStorageKeyAllocator::AccessControlExtensionEntry(accessingFabricIndex).KeyName(),
+                                    item.data.data(), static_cast<uint16_t>(item.data.size())));
         ReturnErrorOnFailure(
             LogExtensionChangedEvent(item, aDecoder.GetSubjectDescriptor(), AccessControlCluster::ChangeTypeEnum::kAdded));
     }

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -200,7 +200,7 @@ CHIP_ERROR AccessControlAttribute::ReadExtension(AttributeValueEncoder & aEncode
             uint8_t buffer[kExtensionDataMaxLength] = { 0 };
             uint16_t size                           = static_cast<uint16_t>(sizeof(buffer));
             CHIP_ERROR errStorage                   = storage.SyncGetKeyValue(
-                                  DefaultStorageKeyAllocator::AccessControlExtensionEntry(fabric.GetFabricIndex()).KeyName(), buffer, size);
+                DefaultStorageKeyAllocator::AccessControlExtensionEntry(fabric.GetFabricIndex()).KeyName(), buffer, size);
             ReturnErrorCodeIf(errStorage == CHIP_ERROR_BUFFER_TOO_SMALL, CHIP_ERROR_INCORRECT_STATE);
             if (errStorage == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
             {
@@ -300,7 +300,7 @@ CHIP_ERROR AccessControlAttribute::WriteExtension(const ConcreteDataAttributePat
     uint8_t buffer[kExtensionDataMaxLength] = { 0 };
     uint16_t size                           = static_cast<uint16_t>(sizeof(buffer));
     CHIP_ERROR errStorage                   = storage.SyncGetKeyValue(
-                          DefaultStorageKeyAllocator::AccessControlExtensionEntry(accessingFabricIndex).KeyName(), buffer, size);
+        DefaultStorageKeyAllocator::AccessControlExtensionEntry(accessingFabricIndex).KeyName(), buffer, size);
     ReturnErrorCodeIf(errStorage == CHIP_ERROR_BUFFER_TOO_SMALL, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorCodeIf(errStorage != CHIP_NO_ERROR && errStorage != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND, errStorage);
 

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -200,7 +200,7 @@ CHIP_ERROR AccessControlAttribute::ReadExtension(AttributeValueEncoder & aEncode
             uint8_t buffer[kExtensionDataMaxLength] = { 0 };
             uint16_t size                           = static_cast<uint16_t>(sizeof(buffer));
             CHIP_ERROR errStorage                   = storage.SyncGetKeyValue(
-                DefaultStorageKeyAllocator::AccessControlExtensionEntry(fabric.GetFabricIndex()), buffer, size);
+                                  DefaultStorageKeyAllocator::AccessControlExtensionEntry(fabric.GetFabricIndex()).KeyName(), buffer, size);
             ReturnErrorCodeIf(errStorage == CHIP_ERROR_BUFFER_TOO_SMALL, CHIP_ERROR_INCORRECT_STATE);
             if (errStorage == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
             {
@@ -300,7 +300,7 @@ CHIP_ERROR AccessControlAttribute::WriteExtension(const ConcreteDataAttributePat
     uint8_t buffer[kExtensionDataMaxLength] = { 0 };
     uint16_t size                           = static_cast<uint16_t>(sizeof(buffer));
     CHIP_ERROR errStorage                   = storage.SyncGetKeyValue(
-        DefaultStorageKeyAllocator::AccessControlExtensionEntry(accessingFabricIndex).KeyName(), buffer, size);
+                          DefaultStorageKeyAllocator::AccessControlExtensionEntry(accessingFabricIndex).KeyName(), buffer, size);
     ReturnErrorCodeIf(errStorage == CHIP_ERROR_BUFFER_TOO_SMALL, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorCodeIf(errStorage != CHIP_NO_ERROR && errStorage != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND, errStorage);
 

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
@@ -55,7 +55,7 @@ CHIP_ERROR DefaultOTARequestorStorage::StoreDefaultProviders(const ProviderLocat
 
     ReturnErrorOnFailure(writer.EndContainer(outerType));
 
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTADefaultProviders(), buffer,
+    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTADefaultProviders().KeyName(), buffer,
                                                static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
@@ -64,7 +64,7 @@ CHIP_ERROR DefaultOTARequestorStorage::LoadDefaultProviders(ProviderLocationList
     uint8_t buffer[kProviderListMaxSerializedSize];
     MutableByteSpan bufferSpan(buffer);
 
-    ReturnErrorOnFailure(Load(DefaultStorageKeyAllocator::OTADefaultProviders(), bufferSpan));
+    ReturnErrorOnFailure(Load(DefaultStorageKeyAllocator::OTADefaultProviders().KeyName(), bufferSpan));
 
     TLV::TLVReader reader;
     TLV::TLVType outerType;
@@ -93,13 +93,13 @@ CHIP_ERROR DefaultOTARequestorStorage::StoreCurrentProviderLocation(const Provid
     writer.Init(buffer);
     ReturnErrorOnFailure(provider.EncodeForRead(writer, TLV::AnonymousTag(), provider.fabricIndex));
 
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTACurrentProvider(), buffer,
+    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTACurrentProvider().KeyName(), buffer,
                                                static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::ClearCurrentProviderLocation()
 {
-    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTACurrentProvider());
+    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTACurrentProvider().KeyName());
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::LoadCurrentProviderLocation(ProviderLocationType & provider)
@@ -107,7 +107,7 @@ CHIP_ERROR DefaultOTARequestorStorage::LoadCurrentProviderLocation(ProviderLocat
     uint8_t buffer[kProviderMaxSerializedSize];
     MutableByteSpan bufferSpan(buffer);
 
-    ReturnErrorOnFailure(Load(DefaultStorageKeyAllocator::OTACurrentProvider(), bufferSpan));
+    ReturnErrorOnFailure(Load(DefaultStorageKeyAllocator::OTACurrentProvider().KeyName(), bufferSpan));
 
     TLV::TLVReader reader;
 
@@ -120,23 +120,23 @@ CHIP_ERROR DefaultOTARequestorStorage::LoadCurrentProviderLocation(ProviderLocat
 
 CHIP_ERROR DefaultOTARequestorStorage::StoreUpdateToken(ByteSpan updateToken)
 {
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTAUpdateToken(), updateToken.data(),
+    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTAUpdateToken().KeyName(), updateToken.data(),
                                                static_cast<uint16_t>(updateToken.size()));
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::ClearUpdateToken()
 {
-    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTAUpdateToken());
+    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTAUpdateToken().KeyName());
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::LoadUpdateToken(MutableByteSpan & updateToken)
 {
-    return Load(DefaultStorageKeyAllocator::OTAUpdateToken(), updateToken);
+    return Load(DefaultStorageKeyAllocator::OTAUpdateToken().KeyName(), updateToken);
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::StoreCurrentUpdateState(OTAUpdateStateEnum currentUpdateState)
 {
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTACurrentUpdateState(), &currentUpdateState,
+    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTACurrentUpdateState().KeyName(), &currentUpdateState,
                                                sizeof(currentUpdateState));
 }
 
@@ -144,17 +144,18 @@ CHIP_ERROR DefaultOTARequestorStorage::LoadCurrentUpdateState(OTAUpdateStateEnum
 {
     uint16_t size = static_cast<uint16_t>(sizeof(currentUpdateState));
 
-    return mPersistentStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::OTACurrentUpdateState(), &currentUpdateState, size);
+    return mPersistentStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::OTACurrentUpdateState().KeyName(), &currentUpdateState,
+                                               size);
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::ClearCurrentUpdateState()
 {
-    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTACurrentUpdateState());
+    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTACurrentUpdateState().KeyName());
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::StoreTargetVersion(uint32_t targetVersion)
 {
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTATargetVersion(), &targetVersion,
+    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTATargetVersion().KeyName(), &targetVersion,
                                                sizeof(targetVersion));
 }
 
@@ -162,12 +163,12 @@ CHIP_ERROR DefaultOTARequestorStorage::LoadTargetVersion(uint32_t & targetVersio
 {
     uint16_t size = static_cast<uint16_t>(sizeof(targetVersion));
 
-    return mPersistentStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::OTATargetVersion(), &targetVersion, size);
+    return mPersistentStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::OTATargetVersion().KeyName(), &targetVersion, size);
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::ClearTargetVersion()
 {
-    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTATargetVersion());
+    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTATargetVersion().KeyName());
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::Load(const char * key, MutableByteSpan & buffer)

--- a/src/app/server/DefaultAclStorage.cpp
+++ b/src/app/server/DefaultAclStorage.cpp
@@ -86,7 +86,7 @@ public:
             {
                 uint16_t size = static_cast<uint16_t>(sizeof(buffer));
                 err           = mPersistentStorage->SyncGetKeyValue(
-                              DefaultStorageKeyAllocator::AccessControlAclEntry(fabric, index + 1).KeyName(), buffer, size);
+                    DefaultStorageKeyAllocator::AccessControlAclEntry(fabric, index + 1).KeyName(), buffer, size);
                 if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
                 {
                     break;

--- a/src/app/server/DefaultAclStorage.cpp
+++ b/src/app/server/DefaultAclStorage.cpp
@@ -85,19 +85,19 @@ public:
             while (true)
             {
                 uint16_t size = static_cast<uint16_t>(sizeof(buffer));
-                err = mPersistentStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::AccessControlAclEntry(fabric, index + 1),
-                                                          buffer, size);
+                err           = mPersistentStorage->SyncGetKeyValue(
+                              DefaultStorageKeyAllocator::AccessControlAclEntry(fabric, index + 1).KeyName(), buffer, size);
                 if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
                 {
                     break;
                 }
                 SuccessOrExit(err);
                 SuccessOrExit(err = mPersistentStorage->SyncSetKeyValue(
-                                  DefaultStorageKeyAllocator::AccessControlAclEntry(fabric, index), buffer, size));
+                                  DefaultStorageKeyAllocator::AccessControlAclEntry(fabric, index).KeyName(), buffer, size));
                 index++;
             }
-            SuccessOrExit(
-                err = mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::AccessControlAclEntry(fabric, index)));
+            SuccessOrExit(err = mPersistentStorage->SyncDeleteKeyValue(
+                              DefaultStorageKeyAllocator::AccessControlAclEntry(fabric, index).KeyName()));
         }
         else
         {
@@ -107,9 +107,9 @@ public:
             writer.Init(buffer);
             EncodableEntry encodableEntry(*entry);
             SuccessOrExit(err = encodableEntry.EncodeForWrite(writer, TLV::AnonymousTag()));
-            SuccessOrExit(err =
-                              mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::AccessControlAclEntry(fabric, index),
-                                                                  buffer, static_cast<uint16_t>(writer.GetLengthWritten())));
+            SuccessOrExit(err = mPersistentStorage->SyncSetKeyValue(
+                              DefaultStorageKeyAllocator::AccessControlAclEntry(fabric, index).KeyName(), buffer,
+                              static_cast<uint16_t>(writer.GetLengthWritten())));
         }
 
         return;
@@ -147,7 +147,8 @@ CHIP_ERROR DefaultAclStorage::Init(PersistentStorageDelegate & persistentStorage
         {
             uint8_t buffer[kEncodedEntryTotalBytes] = { 0 };
             uint16_t size                           = static_cast<uint16_t>(sizeof(buffer));
-            err = persistentStorage.SyncGetKeyValue(DefaultStorageKeyAllocator::AccessControlAclEntry(fabric, index), buffer, size);
+            err = persistentStorage.SyncGetKeyValue(DefaultStorageKeyAllocator::AccessControlAclEntry(fabric, index).KeyName(),
+                                                    buffer, size);
             if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
             {
                 break;

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -446,7 +446,7 @@ private:
 
             //  Remove ACL extension entry for the given fabricIndex.
             auto & storage = mServer->GetPersistentStorage();
-            aclErr         = storage.SyncDeleteKeyValue(DefaultStorageKeyAllocator::AccessControlExtensionEntry(fabricIndex));
+            aclErr = storage.SyncDeleteKeyValue(DefaultStorageKeyAllocator::AccessControlExtensionEntry(fabricIndex).KeyName());
 
             if (aclErr != CHIP_NO_ERROR && aclErr != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
             {

--- a/src/app/util/binding-table.cpp
+++ b/src/app/util/binding-table.cpp
@@ -260,7 +260,7 @@ CHIP_ERROR BindingTable::RemoveAt(Iterator & iter)
     if (error == CHIP_NO_ERROR)
     {
         // The remove is considered "submitted" once the change on prev node takes effect
-        if (mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::BindingTableEntry(iter.mIndex)) != CHIP_NO_ERROR)
+        if (mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::BindingTableEntry(iter.mIndex).KeyName()) != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "Failed to remove binding table entry %u from storage", iter.mIndex);
         }

--- a/src/app/util/binding-table.cpp
+++ b/src/app/util/binding-table.cpp
@@ -55,7 +55,7 @@ CHIP_ERROR BindingTable::Add(const EmberBindingTableEntry & entry)
         }
         if (error != CHIP_NO_ERROR)
         {
-            mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::BindingTableEntry(newIndex));
+            mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::BindingTableEntry(newIndex).KeyName());
         }
     }
     if (error != CHIP_NO_ERROR)
@@ -112,7 +112,7 @@ CHIP_ERROR BindingTable::SaveEntryToStorage(uint8_t index, uint8_t nextIndex)
     ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kTagNextEntry), nextIndex));
     ReturnErrorOnFailure(writer.EndContainer(container));
     ReturnErrorOnFailure(writer.Finalize());
-    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::BindingTableEntry(index), buffer,
+    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::BindingTableEntry(index).KeyName(), buffer,
                                      static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
@@ -127,7 +127,7 @@ CHIP_ERROR BindingTable::SaveListInfo(uint8_t head)
     ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kTagHead), head));
     ReturnErrorOnFailure(writer.EndContainer(container));
     ReturnErrorOnFailure(writer.Finalize());
-    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::BindingTable(), buffer,
+    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::BindingTable().KeyName(), buffer,
                                      static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
@@ -138,7 +138,7 @@ CHIP_ERROR BindingTable::LoadFromStorage()
     uint16_t size                        = sizeof(buffer);
     CHIP_ERROR error;
 
-    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::BindingTable(), buffer, size));
+    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::BindingTable().KeyName(), buffer, size));
     TLV::TLVReader reader;
     reader.Init(buffer, size);
 
@@ -184,7 +184,7 @@ CHIP_ERROR BindingTable::LoadEntryFromStorage(uint8_t index, uint8_t & nextIndex
     uint16_t size                     = sizeof(buffer);
     EmberBindingTableEntry entry;
 
-    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::BindingTableEntry(index), buffer, size));
+    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::BindingTableEntry(index).KeyName(), buffer, size));
     TLV::TLVReader reader;
     reader.Init(buffer, size);
 

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -140,7 +140,7 @@ CHIP_ERROR FabricInfo::CommitToStorage(PersistentStorageDelegate * storage) cons
 
         const auto metadataLength = writer.GetLengthWritten();
         VerifyOrReturnError(CanCastTo<uint16_t>(metadataLength), CHIP_ERROR_BUFFER_TOO_SMALL);
-        ReturnErrorOnFailure(storage->SyncSetKeyValue(DefaultStorageKeyAllocator::FabricMetadata(mFabricIndex), buf,
+        ReturnErrorOnFailure(storage->SyncSetKeyValue(DefaultStorageKeyAllocator::FabricMetadata(mFabricIndex).KeyName(), buf,
                                                       static_cast<uint16_t>(metadataLength)));
     }
 
@@ -175,7 +175,8 @@ CHIP_ERROR FabricInfo::LoadFromStorage(PersistentStorageDelegate * storage, Fabr
     {
         uint8_t buf[MetadataTLVMaxSize()];
         uint16_t size = sizeof(buf);
-        ReturnErrorOnFailure(storage->SyncGetKeyValue(DefaultStorageKeyAllocator::FabricMetadata(mFabricIndex), buf, size));
+        ReturnErrorOnFailure(
+            storage->SyncGetKeyValue(DefaultStorageKeyAllocator::FabricMetadata(mFabricIndex).KeyName(), buf, size));
         TLV::ContiguousBufferTLVReader reader;
         reader.Init(buf, size);
 
@@ -214,7 +215,7 @@ CHIP_ERROR FabricTable::DeleteMetadataFromStorage(FabricIndex fabricIndex)
     VerifyOrReturnError(IsValidFabricIndex(fabricIndex), CHIP_ERROR_INVALID_FABRIC_INDEX);
     VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    CHIP_ERROR deleteErr = mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricMetadata(fabricIndex));
+    CHIP_ERROR deleteErr = mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricMetadata(fabricIndex).KeyName());
 
     if (deleteErr != CHIP_NO_ERROR)
     {
@@ -1055,7 +1056,7 @@ CHIP_ERROR FabricTable::Init(const FabricTable::InitParams & initParams)
 
     uint8_t buf[IndexInfoTLVMaxSize()];
     uint16_t size  = sizeof(buf);
-    CHIP_ERROR err = mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::FabricIndexInfo(), buf, size);
+    CHIP_ERROR err = mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::FabricIndexInfo().KeyName(), buf, size);
     if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         // No fabrics yet.  Nothing to be done here.
@@ -1303,8 +1304,8 @@ CHIP_ERROR FabricTable::StoreFabricIndexInfo() const
     const auto indexInfoLength = writer.GetLengthWritten();
     VerifyOrReturnError(CanCastTo<uint16_t>(indexInfoLength), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    ReturnErrorOnFailure(
-        mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::FabricIndexInfo(), buf, static_cast<uint16_t>(indexInfoLength)));
+    ReturnErrorOnFailure(mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::FabricIndexInfo().KeyName(), buf,
+                                                   static_cast<uint16_t>(indexInfoLength)));
 
     return CHIP_NO_ERROR;
 }
@@ -1422,7 +1423,7 @@ CHIP_ERROR FabricTable::StoreCommitMarker(const CommitMarker & commitMarker)
     const auto markerContextTLVLength = writer.GetLengthWritten();
     VerifyOrReturnError(CanCastTo<uint16_t>(markerContextTLVLength), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::FailSafeCommitMarkerKey(), tlvBuf,
+    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::FailSafeCommitMarkerKey().KeyName(), tlvBuf,
                                      static_cast<uint16_t>(markerContextTLVLength));
 }
 
@@ -1430,7 +1431,8 @@ CHIP_ERROR FabricTable::GetCommitMarker(CommitMarker & outCommitMarker)
 {
     uint8_t tlvBuf[CommitMarkerContextTLVMaxSize()];
     uint16_t tlvSize = sizeof(tlvBuf);
-    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::FailSafeCommitMarkerKey(), tlvBuf, tlvSize));
+    ReturnErrorOnFailure(
+        mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::FailSafeCommitMarkerKey().KeyName(), tlvBuf, tlvSize));
 
     // If buffer was too small, we won't reach here.
     TLV::ContiguousBufferTLVReader reader;
@@ -1454,7 +1456,7 @@ CHIP_ERROR FabricTable::GetCommitMarker(CommitMarker & outCommitMarker)
 
 void FabricTable::ClearCommitMarker()
 {
-    mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::FailSafeCommitMarkerKey());
+    mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::FailSafeCommitMarkerKey().KeyName());
 }
 
 bool FabricTable::HasOperationalKeyForFabric(FabricIndex fabricIndex) const

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -59,7 +59,7 @@ struct PersistentData
         ReturnErrorOnFailure(Serialize(writer));
 
         // Save serialized data
-        return storage->SyncSetKeyValue(key, buffer, static_cast<uint16_t>(writer.GetLengthWritten()));
+        return storage->SyncSetKeyValue(key.KeyName(), buffer, static_cast<uint16_t>(writer.GetLengthWritten()));
     }
 
     CHIP_ERROR Load(PersistentStorageDelegate * storage)
@@ -75,7 +75,7 @@ struct PersistentData
 
         // Load the serialized data
         uint16_t size  = static_cast<uint16_t>(sizeof(buffer));
-        CHIP_ERROR err = storage->SyncGetKeyValue(key, buffer, size);
+        CHIP_ERROR err = storage->SyncGetKeyValue(key.KeyName(), buffer, size);
         VerifyOrReturnError(CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND != err, CHIP_ERROR_NOT_FOUND);
         ReturnErrorOnFailure(err);
 
@@ -92,7 +92,7 @@ struct PersistentData
         StorageKeyName key = StorageKeyName::Uninitialized();
         ReturnErrorOnFailure(UpdateKey(key));
 
-        return storage->SyncDeleteKeyValue(key);
+        return storage->SyncDeleteKeyValue(key.KeyName());
     }
 };
 

--- a/src/credentials/LastKnownGoodTime.cpp
+++ b/src/credentials/LastKnownGoodTime.cpp
@@ -52,7 +52,7 @@ CHIP_ERROR LastKnownGoodTime::LoadLastKnownGoodChipEpochTime(System::Clock::Seco
     uint8_t buf[LastKnownGoodTimeTLVMaxSize()];
     uint16_t size = sizeof(buf);
     uint32_t seconds;
-    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::LastKnownGoodTimeKey(), buf, size));
+    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::LastKnownGoodTimeKey().KeyName(), buf, size));
     TLV::ContiguousBufferTLVReader reader;
     reader.Init(buf, size);
     ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()));
@@ -75,8 +75,8 @@ CHIP_ERROR LastKnownGoodTime::StoreLastKnownGoodChipEpochTime(System::Clock::Sec
     ReturnErrorOnFailure(writer.EndContainer(outerType));
     const auto length = writer.GetLengthWritten();
     VerifyOrReturnError(CanCastTo<uint16_t>(length), CHIP_ERROR_BUFFER_TOO_SMALL);
-    ReturnErrorOnFailure(
-        mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::LastKnownGoodTimeKey(), buf, static_cast<uint16_t>(length)));
+    ReturnErrorOnFailure(mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::LastKnownGoodTimeKey().KeyName(), buf,
+                                                   static_cast<uint16_t>(length)));
     return CHIP_NO_ERROR;
 }
 

--- a/src/credentials/PersistentStorageOpCertStore.cpp
+++ b/src/credentials/PersistentStorageOpCertStore.cpp
@@ -70,7 +70,7 @@ bool StorageHasCertificate(PersistentStorageDelegate * storage, FabricIndex fabr
     uint8_t placeHolderCertBuffer[kMaxCHIPCertLength];
 
     uint16_t keySize = sizeof(placeHolderCertBuffer);
-    CHIP_ERROR err   = storage->SyncGetKeyValue(storageKey, &placeHolderCertBuffer[0], keySize);
+    CHIP_ERROR err   = storage->SyncGetKeyValue(storageKey.KeyName(), &placeHolderCertBuffer[0], keySize);
 
     return (err == CHIP_NO_ERROR);
 }
@@ -85,7 +85,7 @@ CHIP_ERROR LoadCertFromStorage(PersistentStorageDelegate * storage, FabricIndex 
     }
 
     uint16_t keySize = static_cast<uint16_t>(outCert.size());
-    CHIP_ERROR err   = storage->SyncGetKeyValue(storageKey, outCert.data(), keySize);
+    CHIP_ERROR err   = storage->SyncGetKeyValue(storageKey.KeyName(), outCert.data(), keySize);
 
     // Not finding an ICAC means we don't have one, so adjust to meet the API contract, where
     // outCert.empty() will be true;
@@ -121,7 +121,7 @@ CHIP_ERROR SaveCertToStorage(PersistentStorageDelegate * storage, FabricIndex fa
     // If provided an empty ICAC, we delete the ICAC key previously used. If not there, it's OK
     if ((element == CertChainElement::kIcac) && (cert.empty()))
     {
-        CHIP_ERROR err = storage->SyncDeleteKeyValue(storageKey);
+        CHIP_ERROR err = storage->SyncDeleteKeyValue(storageKey.KeyName());
         if ((err == CHIP_NO_ERROR) || (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND))
         {
             return CHIP_NO_ERROR;
@@ -129,7 +129,7 @@ CHIP_ERROR SaveCertToStorage(PersistentStorageDelegate * storage, FabricIndex fa
         return err;
     }
 
-    return storage->SyncSetKeyValue(storageKey, cert.data(), static_cast<uint16_t>(cert.size()));
+    return storage->SyncSetKeyValue(storageKey.KeyName(), cert.data(), static_cast<uint16_t>(cert.size()));
 }
 
 CHIP_ERROR DeleteCertFromStorage(PersistentStorageDelegate * storage, FabricIndex fabricIndex, CertChainElement element)
@@ -139,7 +139,7 @@ CHIP_ERROR DeleteCertFromStorage(PersistentStorageDelegate * storage, FabricInde
     {
         return CHIP_ERROR_INTERNAL;
     }
-    return storage->SyncDeleteKeyValue(storageKey);
+    return storage->SyncDeleteKeyValue(storageKey.KeyName());
 }
 
 } // namespace

--- a/src/credentials/tests/TestPersistentStorageOpCertStore.cpp
+++ b/src/credentials/tests/TestPersistentStorageOpCertStore.cpp
@@ -65,7 +65,7 @@ void TestAddNocFlow(nlTestSuite * inSuite, void * inContext)
     // same fabric but succeed GetCertificate.
     const uint8_t kTestRcacBufExists[] = { 'r', 'c', 'a', 'c', ' ', 'e', 'x', 'i', 's', 't', 's' };
 
-    err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricRCAC(kFabricIndex1), kTestRcacBufExists,
+    err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricRCAC(kFabricIndex1).KeyName(), kTestRcacBufExists,
                                           sizeof(kTestRcacBufExists));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 1);
@@ -123,12 +123,12 @@ void TestAddNocFlow(nlTestSuite * inSuite, void * inContext)
     const uint8_t kTestIcacBufExists[] = { 'i', 'c', 'a', 'c', ' ', 'e', 'x', 'i', 's', 't', 's' };
     const uint8_t kTestNocBufExists[]  = { 'n', 'o', 'c', ' ', 'e', 'x', 'i', 's', 't', 's' };
 
-    err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricICAC(kFabricIndex2), kTestIcacBufExists,
+    err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricICAC(kFabricIndex2).KeyName(), kTestIcacBufExists,
                                           sizeof(kTestIcacBufExists));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 1);
 
-    err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricNOC(kFabricIndex2), kTestNocBufExists,
+    err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricNOC(kFabricIndex2).KeyName(), kTestNocBufExists,
                                           sizeof(kTestNocBufExists));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 2);
@@ -142,8 +142,8 @@ void TestAddNocFlow(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
     NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
 
-    storageDelegate.SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricICAC(kFabricIndex2));
-    storageDelegate.SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricNOC(kFabricIndex2));
+    storageDelegate.SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricICAC(kFabricIndex2).KeyName());
+    storageDelegate.SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricNOC(kFabricIndex2).KeyName());
     NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0);
 
     // Trying to do AddNewOpCertsForFabric for same fabric as that with pending RCAC should succeed
@@ -257,21 +257,21 @@ void TestUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
     MutableByteSpan largeSpan{ largeBuf };
 
     {
-        err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricRCAC(kFabricIndex1), kTestRcacBufExists,
+        err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricRCAC(kFabricIndex1).KeyName(), kTestRcacBufExists,
                                               sizeof(kTestRcacBufExists));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 1);
         NL_TEST_ASSERT(inSuite,
                        opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kRcac) == true); //< From manual add
 
-        err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricICAC(kFabricIndex1), kTestIcacBufExists,
+        err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricICAC(kFabricIndex1).KeyName(), kTestIcacBufExists,
                                               sizeof(kTestIcacBufExists));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 2);
         NL_TEST_ASSERT(inSuite,
                        opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kIcac) == true); //< From manual add
 
-        err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricNOC(kFabricIndex1), kTestNocBufExists,
+        err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricNOC(kFabricIndex1).KeyName(), kTestNocBufExists,
                                               sizeof(kTestNocBufExists));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 3);
@@ -347,8 +347,8 @@ void TestUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
 
     // Committing writes the new values (we even "background-remove" the old ICAC/NOC before commit)
-    storageDelegate.SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricICAC(kFabricIndex1));
-    storageDelegate.SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricNOC(kFabricIndex1));
+    storageDelegate.SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricICAC(kFabricIndex1).KeyName());
+    storageDelegate.SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricNOC(kFabricIndex1).KeyName());
     NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 1); //< Root remains
 
     err = opCertStore.CommitOpCertsForFabric(kFabricIndex1);

--- a/src/crypto/PersistentStorageOperationalKeystore.cpp
+++ b/src/crypto/PersistentStorageOperationalKeystore.cpp
@@ -80,8 +80,8 @@ CHIP_ERROR StoreOperationalKey(FabricIndex fabricIndex, PersistentStorageDelegat
 
     const auto opKeyLength = writer.GetLengthWritten();
     VerifyOrReturnError(CanCastTo<uint16_t>(opKeyLength), CHIP_ERROR_BUFFER_TOO_SMALL);
-    ReturnErrorOnFailure(
-        storage->SyncSetKeyValue(DefaultStorageKeyAllocator::FabricOpKey(fabricIndex), buf, static_cast<uint16_t>(opKeyLength)));
+    ReturnErrorOnFailure(storage->SyncSetKeyValue(DefaultStorageKeyAllocator::FabricOpKey(fabricIndex).KeyName(), buf,
+                                                  static_cast<uint16_t>(opKeyLength)));
 
     return CHIP_NO_ERROR;
 }
@@ -111,8 +111,9 @@ CHIP_ERROR SignWithStoredOpKey(FabricIndex fabricIndex, PersistentStorageDelegat
         Crypto::CapacityBoundBuffer<OpKeyTLVMaxSize()> buf;
 
         // Load up the operational key structure from storage
-        uint16_t size  = static_cast<uint16_t>(buf.Capacity());
-        CHIP_ERROR err = storage->SyncGetKeyValue(DefaultStorageKeyAllocator::FabricOpKey(fabricIndex), buf.Bytes(), size);
+        uint16_t size = static_cast<uint16_t>(buf.Capacity());
+        CHIP_ERROR err =
+            storage->SyncGetKeyValue(DefaultStorageKeyAllocator::FabricOpKey(fabricIndex).KeyName(), buf.Bytes(), size);
         if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
         {
             err = CHIP_ERROR_INVALID_FABRIC_INDEX;
@@ -180,7 +181,8 @@ bool PersistentStorageOperationalKeystore::HasOpKeypairForFabric(FabricIndex fab
     Crypto::CapacityBoundBuffer<OpKeyTLVMaxSize()> buf;
 
     uint16_t keySize = static_cast<uint16_t>(buf.Capacity());
-    CHIP_ERROR err   = mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::FabricOpKey(fabricIndex), buf.Bytes(), keySize);
+    CHIP_ERROR err =
+        mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::FabricOpKey(fabricIndex).KeyName(), buf.Bytes(), keySize);
 
     return (err == CHIP_NO_ERROR);
 }
@@ -260,7 +262,7 @@ CHIP_ERROR PersistentStorageOperationalKeystore::RemoveOpKeypairForFabric(Fabric
         RevertPendingKeypair();
     }
 
-    CHIP_ERROR err = mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricOpKey(fabricIndex));
+    CHIP_ERROR err = mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricOpKey(fabricIndex).KeyName());
     if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         err = CHIP_ERROR_INVALID_FABRIC_INDEX;

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -44,8 +44,6 @@ public:
     bool IsUninitialized() const { return mKeyNameBuffer[0] == 0; }
     bool operator!() const { return IsUninitialized(); }
 
-    operator const char *() const { return mKeyNameBuffer; }
-
     static StorageKeyName FromConst(const char * value)
     {
         StorageKeyName result;

--- a/src/lib/support/PersistedCounter.h
+++ b/src/lib/support/PersistedCounter.h
@@ -79,7 +79,7 @@ public:
     CHIP_ERROR Init(PersistentStorageDelegate * aStorage, StorageKeyName aKey, T aEpoch)
     {
         VerifyOrReturnError(aStorage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-        VerifyOrReturnError(aKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(aKey.IsInitialized(), CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrReturnError(aEpoch > 0, CHIP_ERROR_INVALID_INTEGER_VALUE);
 
         mStorage = aStorage;
@@ -163,7 +163,7 @@ private:
 #endif
 
         T valueLE = Encoding::LittleEndian::HostSwap<T>(aStartValue);
-        return mStorage->SyncSetKeyValue(mKey, &valueLE, sizeof(valueLE));
+        return mStorage->SyncSetKeyValue(mKey.KeyName(), &valueLE, sizeof(valueLE));
     }
 
     /**
@@ -181,7 +181,7 @@ private:
 
         VerifyOrReturnError(mKey.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
-        CHIP_ERROR err = mStorage->SyncGetKeyValue(mKey, &valueLE, size);
+        CHIP_ERROR err = mStorage->SyncGetKeyValue(mKey.KeyName(), &valueLE, size);
         if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
         {
             // No previously-stored value, no worries, the counter is initialized to zero.

--- a/src/platform/ESP32/ESP32DeviceInfoProvider.cpp
+++ b/src/platform/ESP32/ESP32DeviceInfoProvider.cpp
@@ -120,14 +120,14 @@ CHIP_ERROR ESP32DeviceInfoProvider::SetUserLabelAt(EndpointId endpoint, size_t i
     ReturnErrorOnFailure(writer.PutString(kLabelValueTag, userLabel.value));
     ReturnErrorOnFailure(writer.EndContainer(outerType));
 
-    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::UserLabelIndexKey(endpoint, index), buf,
+    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::UserLabelIndexKey(endpoint, index).KeyName(), buf,
                                      static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
 CHIP_ERROR ESP32DeviceInfoProvider::DeleteUserLabelAt(EndpointId endpoint, size_t index)
 {
     VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    return mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::UserLabelIndexKey(endpoint, index));
+    return mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::UserLabelIndexKey(endpoint, index).KeyName());
 }
 
 DeviceInfoProvider::UserLabelIterator * ESP32DeviceInfoProvider::IterateUserLabel(EndpointId endpoint)
@@ -154,7 +154,7 @@ bool ESP32DeviceInfoProvider::UserLabelIteratorImpl::Next(UserLabelType & output
     uint16_t len = static_cast<uint16_t>(sizeof(buf));
 
     CHIP_ERROR err =
-        mProvider.mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::UserLabelIndexKey(mEndpoint, mIndex), buf, len);
+        mProvider.mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::UserLabelIndexKey(mEndpoint, mIndex).KeyName(), buf, len);
     VerifyOrReturnError(err == CHIP_NO_ERROR, false);
 
     TLV::ContiguousBufferTLVReader reader;

--- a/src/platform/ESP32/ESP32DeviceInfoProvider.cpp
+++ b/src/platform/ESP32/ESP32DeviceInfoProvider.cpp
@@ -96,7 +96,7 @@ bool ESP32DeviceInfoProvider::FixedLabelIteratorImpl::Next(FixedLabelType & outp
 CHIP_ERROR ESP32DeviceInfoProvider::SetUserLabelLength(EndpointId endpoint, size_t val)
 {
     VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::UserLabelLengthKey(endpoint), &val,
+    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::UserLabelLengthKey(endpoint).KeyName(), &val,
                                      static_cast<uint16_t>(sizeof(val)));
 }
 
@@ -104,7 +104,7 @@ CHIP_ERROR ESP32DeviceInfoProvider::GetUserLabelLength(EndpointId endpoint, size
 {
     VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
     uint16_t len = static_cast<uint16_t>(sizeof(val));
-    return mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::UserLabelLengthKey(endpoint), &val, len);
+    return mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::UserLabelLengthKey(endpoint).KeyName(), &val, len);
 }
 
 CHIP_ERROR ESP32DeviceInfoProvider::SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel)

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -67,7 +67,7 @@ CHIP_ERROR GenericThreadDriver::CommitConfiguration()
     // the backup, so that it cannot be restored. If no backup could be found, it means that the
     // configuration has not been modified since the fail-safe was armed, so return with no error.
 
-    CHIP_ERROR error = KeyValueStoreMgr().Delete(DefaultStorageKeyAllocator::FailSafeNetworkConfig());
+    CHIP_ERROR error = KeyValueStoreMgr().Delete(DefaultStorageKeyAllocator::FailSafeNetworkConfig().KeyName());
 
     return error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND ? CHIP_NO_ERROR : error;
 }
@@ -77,7 +77,7 @@ CHIP_ERROR GenericThreadDriver::RevertConfiguration()
     uint8_t datasetBytes[Thread::kSizeOperationalDataset];
     size_t datasetLength;
 
-    CHIP_ERROR error = KeyValueStoreMgr().Get(DefaultStorageKeyAllocator::FailSafeNetworkConfig(), datasetBytes,
+    CHIP_ERROR error = KeyValueStoreMgr().Get(DefaultStorageKeyAllocator::FailSafeNetworkConfig().KeyName(), datasetBytes,
                                               sizeof(datasetBytes), &datasetLength);
 
     // If no backup could be found, it means that the network configuration has not been modified
@@ -97,7 +97,7 @@ CHIP_ERROR GenericThreadDriver::RevertConfiguration()
     }
 
     // Always remove the backup, regardless if it can be successfully restored.
-    KeyValueStoreMgr().Delete(DefaultStorageKeyAllocator::FailSafeNetworkConfig());
+    KeyValueStoreMgr().Delete(DefaultStorageKeyAllocator::FailSafeNetworkConfig().KeyName());
 
     return error;
 }
@@ -200,7 +200,7 @@ Status GenericThreadDriver::MatchesNetworkId(const Thread::OperationalDataset & 
 CHIP_ERROR GenericThreadDriver::BackupConfiguration()
 {
     // If configuration is already backed up, return with no error
-    CHIP_ERROR err = KeyValueStoreMgr().Get(DefaultStorageKeyAllocator::FailSafeNetworkConfig(), nullptr, 0);
+    CHIP_ERROR err = KeyValueStoreMgr().Get(DefaultStorageKeyAllocator::FailSafeNetworkConfig().KeyName(), nullptr, 0);
 
     if (err == CHIP_NO_ERROR || err == CHIP_ERROR_BUFFER_TOO_SMALL)
     {
@@ -209,7 +209,7 @@ CHIP_ERROR GenericThreadDriver::BackupConfiguration()
 
     ByteSpan dataset = mStagingNetwork.AsByteSpan();
 
-    return KeyValueStoreMgr().Put(DefaultStorageKeyAllocator::FailSafeNetworkConfig(), dataset.data(), dataset.size());
+    return KeyValueStoreMgr().Put(DefaultStorageKeyAllocator::FailSafeNetworkConfig().KeyName(), dataset.data(), dataset.size());
 }
 
 size_t GenericThreadDriver::ThreadNetworkIterator::Count()

--- a/src/platform/nxp/mw320/DeviceInfoProviderImpl.cpp
+++ b/src/platform/nxp/mw320/DeviceInfoProviderImpl.cpp
@@ -144,14 +144,14 @@ CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelAt(EndpointId endpoint, size_t in
     ReturnErrorOnFailure(writer.PutString(kLabelValueTag, userLabel.value));
     ReturnErrorOnFailure(writer.EndContainer(outerType));
 
-    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::UserLabelIndexKey(endpoint, index), buf,
+    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::UserLabelIndexKey(endpoint, index).KeyName(), buf,
                                      static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
 CHIP_ERROR DeviceInfoProviderImpl::DeleteUserLabelAt(EndpointId endpoint, size_t index)
 {
     VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    return mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::UserLabelIndexKey(endpoint, index));
+    return mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::UserLabelIndexKey(endpoint, index).KeyName());
 }
 
 DeviceInfoProvider::UserLabelIterator * DeviceInfoProviderImpl::IterateUserLabel(EndpointId endpoint)
@@ -178,7 +178,7 @@ bool DeviceInfoProviderImpl::UserLabelIteratorImpl::Next(UserLabelType & output)
     uint8_t buf[UserLabelTLVMaxSize()];
     uint16_t len = static_cast<uint16_t>(sizeof(buf));
 
-    err = mProvider.mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::UserLabelIndexKey(mEndpoint, mIndex), buf, len);
+    err = mProvider.mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::UserLabelIndexKey(mEndpoint, mIndex).KeyName(), buf, len);
     VerifyOrReturnError(err == CHIP_NO_ERROR, false);
 
     TLV::ContiguousBufferTLVReader reader;

--- a/src/platform/nxp/mw320/DeviceInfoProviderImpl.cpp
+++ b/src/platform/nxp/mw320/DeviceInfoProviderImpl.cpp
@@ -121,7 +121,7 @@ bool DeviceInfoProviderImpl::FixedLabelIteratorImpl::Next(FixedLabelType & outpu
 
 CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelLength(EndpointId endpoint, size_t val)
 {
-    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::UserLabelLengthKey(endpoint), &val,
+    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::UserLabelLengthKey(endpoint).KeyName(), &val,
                                      static_cast<uint16_t>(sizeof(val)));
 }
 
@@ -129,7 +129,7 @@ CHIP_ERROR DeviceInfoProviderImpl::GetUserLabelLength(EndpointId endpoint, size_
 {
     uint16_t len = static_cast<uint16_t>(sizeof(val));
 
-    return mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::UserLabelLengthKey(endpoint), &val, len);
+    return mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::UserLabelLengthKey(endpoint).KeyName(), &val, len);
 }
 
 CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel)

--- a/src/protocols/secure_channel/SimpleSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/SimpleSessionResumptionStorage.cpp
@@ -149,7 +149,7 @@ CHIP_ERROR SimpleSessionResumptionStorage::SaveLink(ConstResumptionIdView resump
     const auto len = writer.GetLengthWritten();
     VerifyOrDie(CanCastTo<uint16_t>(len));
 
-    ReturnErrorOnFailure(mStorage->SyncSetKeyValue(GetStorageKey(resumptionId), buf.data(), static_cast<uint16_t>(len)));
+    ReturnErrorOnFailure(mStorage->SyncSetKeyValue(GetStorageKey(resumptionId).KeyName(), buf.data(), static_cast<uint16_t>(len)));
     return CHIP_NO_ERROR;
 }
 
@@ -158,7 +158,7 @@ CHIP_ERROR SimpleSessionResumptionStorage::LoadLink(ConstResumptionIdView resump
     std::array<uint8_t, MaxScopedNodeIdSize()> buf;
     uint16_t len = static_cast<uint16_t>(buf.size());
 
-    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(GetStorageKey(resumptionId), buf.data(), len));
+    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(GetStorageKey(resumptionId).KeyName(), buf.data(), len));
 
     TLV::ContiguousBufferTLVReader reader;
     reader.Init(buf.data(), len);
@@ -185,7 +185,7 @@ CHIP_ERROR SimpleSessionResumptionStorage::LoadLink(ConstResumptionIdView resump
 
 CHIP_ERROR SimpleSessionResumptionStorage::DeleteLink(ConstResumptionIdView resumptionId)
 {
-    ReturnErrorOnFailure(mStorage->SyncDeleteKeyValue(GetStorageKey(resumptionId)));
+    ReturnErrorOnFailure(mStorage->SyncDeleteKeyValue(GetStorageKey(resumptionId).KeyName()));
     return CHIP_NO_ERROR;
 }
 
@@ -213,7 +213,7 @@ CHIP_ERROR SimpleSessionResumptionStorage::SaveState(const ScopedNodeId & node, 
     const auto len = writer.GetLengthWritten();
     VerifyOrDie(CanCastTo<uint16_t>(len));
 
-    ReturnErrorOnFailure(mStorage->SyncSetKeyValue(GetStorageKey(node), buf.data(), static_cast<uint16_t>(len)));
+    ReturnErrorOnFailure(mStorage->SyncSetKeyValue(GetStorageKey(node).KeyName(), buf.data(), static_cast<uint16_t>(len)));
     return CHIP_NO_ERROR;
 }
 
@@ -223,7 +223,7 @@ CHIP_ERROR SimpleSessionResumptionStorage::LoadState(const ScopedNodeId & node, 
     std::array<uint8_t, MaxStateSize()> buf;
     uint16_t len = static_cast<uint16_t>(buf.size());
 
-    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(GetStorageKey(node), buf.data(), len));
+    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(GetStorageKey(node).KeyName(), buf.data(), len));
 
     TLV::ContiguousBufferTLVReader reader;
     reader.Init(buf.data(), len);
@@ -261,7 +261,7 @@ CHIP_ERROR SimpleSessionResumptionStorage::LoadState(const ScopedNodeId & node, 
 
 CHIP_ERROR SimpleSessionResumptionStorage::DeleteState(const ScopedNodeId & node)
 {
-    ReturnErrorOnFailure(mStorage->SyncDeleteKeyValue(GetStorageKey(node)));
+    ReturnErrorOnFailure(mStorage->SyncDeleteKeyValue(GetStorageKey(node).KeyName()));
     return CHIP_NO_ERROR;
 }
 

--- a/src/protocols/secure_channel/SimpleSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/SimpleSessionResumptionStorage.cpp
@@ -71,8 +71,8 @@ CHIP_ERROR SimpleSessionResumptionStorage::SaveIndex(const SessionIndex & index)
     const auto len = writer.GetLengthWritten();
     VerifyOrReturnError(CanCastTo<uint16_t>(len), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    ReturnErrorOnFailure(
-        mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::SessionResumptionIndex(), buf.data(), static_cast<uint16_t>(len)));
+    ReturnErrorOnFailure(mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::SessionResumptionIndex().KeyName(), buf.data(),
+                                                   static_cast<uint16_t>(len)));
 
     return CHIP_NO_ERROR;
 }
@@ -82,7 +82,7 @@ CHIP_ERROR SimpleSessionResumptionStorage::LoadIndex(SessionIndex & index)
     std::array<uint8_t, MaxIndexSize()> buf;
     uint16_t len = static_cast<uint16_t>(buf.size());
 
-    if (mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::SessionResumptionIndex(), buf.data(), len) != CHIP_NO_ERROR)
+    if (mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::SessionResumptionIndex().KeyName(), buf.data(), len) != CHIP_NO_ERROR)
     {
         index.mSize = 0;
         return CHIP_NO_ERROR;

--- a/src/protocols/secure_channel/tests/TestDefaultSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/tests/TestDefaultSessionResumptionStorage.cpp
@@ -256,14 +256,15 @@ void TestInPlaceSave(nlTestSuite * inSuite, void * inContext)
     for (const auto & node : nodes)
     {
         uint16_t size = 0;
-        auto rv       = storage.SyncGetKeyValue(chip::SimpleSessionResumptionStorage::GetStorageKey(node), nullptr, size);
+        auto rv       = storage.SyncGetKeyValue(chip::SimpleSessionResumptionStorage::GetStorageKey(node).KeyName(), nullptr, size);
         NL_TEST_ASSERT(inSuite, rv == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
     }
     // Verify no link table persistent storage entries were leaked.
     for (auto & vector : vectors)
     {
         uint16_t size = 0;
-        auto rv = storage.SyncGetKeyValue(chip::SimpleSessionResumptionStorage::GetStorageKey(vector.resumptionId), nullptr, size);
+        auto rv       = storage.SyncGetKeyValue(chip::SimpleSessionResumptionStorage::GetStorageKey(vector.resumptionId).KeyName(),
+                                                nullptr, size);
         NL_TEST_ASSERT(inSuite, rv == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
     }
 }
@@ -323,12 +324,13 @@ void TestDelete(nlTestSuite * inSuite, void * inContext)
     {
         uint16_t size = 0;
         {
-            auto rv = storage.SyncGetKeyValue(chip::SimpleSessionResumptionStorage::GetStorageKey(vector.node), nullptr, size);
+            auto rv =
+                storage.SyncGetKeyValue(chip::SimpleSessionResumptionStorage::GetStorageKey(vector.node).KeyName(), nullptr, size);
             NL_TEST_ASSERT(inSuite, rv == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
         }
         {
-            auto rv =
-                storage.SyncGetKeyValue(chip::SimpleSessionResumptionStorage::GetStorageKey(vector.resumptionId), nullptr, size);
+            auto rv = storage.SyncGetKeyValue(chip::SimpleSessionResumptionStorage::GetStorageKey(vector.resumptionId).KeyName(),
+                                              nullptr, size);
             NL_TEST_ASSERT(inSuite, rv == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
         }
     }
@@ -407,12 +409,13 @@ void TestDeleteAll(nlTestSuite * inSuite, void * inContext)
         {
             uint16_t size = 0;
             {
-                auto rv = storage.SyncGetKeyValue(chip::SimpleSessionResumptionStorage::GetStorageKey(node.node), nullptr, size);
+                auto rv = storage.SyncGetKeyValue(chip::SimpleSessionResumptionStorage::GetStorageKey(node.node).KeyName(), nullptr,
+                                                  size);
                 NL_TEST_ASSERT(inSuite, rv == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
             }
             {
-                auto rv =
-                    storage.SyncGetKeyValue(chip::SimpleSessionResumptionStorage::GetStorageKey(node.resumptionId), nullptr, size);
+                auto rv = storage.SyncGetKeyValue(chip::SimpleSessionResumptionStorage::GetStorageKey(node.resumptionId).KeyName(),
+                                                  nullptr, size);
                 NL_TEST_ASSERT(inSuite, rv == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
             }
         }

--- a/src/protocols/secure_channel/tests/TestDefaultSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/tests/TestDefaultSessionResumptionStorage.cpp
@@ -264,7 +264,7 @@ void TestInPlaceSave(nlTestSuite * inSuite, void * inContext)
     {
         uint16_t size = 0;
         auto rv       = storage.SyncGetKeyValue(chip::SimpleSessionResumptionStorage::GetStorageKey(vector.resumptionId).KeyName(),
-                                                nullptr, size);
+                                          nullptr, size);
         NL_TEST_ASSERT(inSuite, rv == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
     }
 }

--- a/src/transport/GroupPeerMessageCounter.cpp
+++ b/src/transport/GroupPeerMessageCounter.cpp
@@ -274,7 +274,7 @@ CHIP_ERROR GroupOutgoingCounters::Init(chip::PersistentStorageDelegate * storage
     uint16_t size = static_cast<uint16_t>(sizeof(uint32_t));
     uint32_t temp;
     CHIP_ERROR err;
-    err = mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::GroupControlCounter(), &temp, size);
+    err = mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::GroupControlCounter().KeyName(), &temp, size);
     if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         // might be the first time we retrieve the value
@@ -290,7 +290,7 @@ CHIP_ERROR GroupOutgoingCounters::Init(chip::PersistentStorageDelegate * storage
         mGroupControlCounter = temp;
     }
 
-    err = mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::GroupDataCounter(), &temp, size);
+    err = mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::GroupDataCounter().KeyName(), &temp, size);
     if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         // might be the first time we retrieve the value
@@ -308,11 +308,11 @@ CHIP_ERROR GroupOutgoingCounters::Init(chip::PersistentStorageDelegate * storage
 
     temp = mGroupControlCounter + GROUP_MSG_COUNTER_MIN_INCREMENT;
     size = static_cast<uint16_t>(sizeof(temp));
-    ReturnErrorOnFailure(mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::GroupControlCounter(), &temp, size));
+    ReturnErrorOnFailure(mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::GroupControlCounter().KeyName(), &temp, size));
 
     temp = mGroupDataCounter + GROUP_MSG_COUNTER_MIN_INCREMENT;
 
-    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::GroupDataCounter(), &temp, size);
+    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::GroupDataCounter().KeyName(), &temp, size);
 }
 
 uint32_t GroupOutgoingCounters::GetCounter(bool isControl)

--- a/src/transport/GroupPeerMessageCounter.cpp
+++ b/src/transport/GroupPeerMessageCounter.cpp
@@ -346,11 +346,11 @@ CHIP_ERROR GroupOutgoingCounters::IncrementCounter(bool isControl)
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
 
-    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(key, &temp, size));
+    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(key.KeyName(), &temp, size));
     if (temp == value)
     {
         temp = value + GROUP_MSG_COUNTER_MIN_INCREMENT;
-        return mStorage->SyncSetKeyValue(key, &temp, sizeof(uint32_t));
+        return mStorage->SyncSetKeyValue(key.KeyName(), &temp, sizeof(uint32_t));
     }
     return CHIP_NO_ERROR;
 }

--- a/src/transport/tests/TestGroupMessageCounter.cpp
+++ b/src/transport/tests/TestGroupMessageCounter.cpp
@@ -65,7 +65,7 @@ public:
 
         // Always Update storage for Test purposes
         temp = value + GROUP_MSG_COUNTER_MIN_INCREMENT;
-        mStorage->SyncSetKeyValue(key, &temp, sizeof(uint32_t));
+        mStorage->SyncSetKeyValue(key.KeyName(), &temp, sizeof(uint32_t));
     }
 };
 


### PR DESCRIPTION
This was based on feedback from Tennessee on #23422 - auto casting seems too much magic and maybe error prone. 