### PR TITLE
[Chef] Implement Z2 flashing through flash.sh script

### DIFF
--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -715,6 +715,7 @@ def main() -> int:
             elif config['ameba']['MODEL'] == 'Z2':
                 shell.run_cmd(
                     f"cd {config['ameba']['AMEBA_SDK']}/project/realtek_amebaz2_v0_example/GCC-RELEASE")
+                shell.run_cmd("rm -f project_include.mk")
                 with open(f"{config['ameba']['AMEBA_SDK']}/project/realtek_amebaz2_v0_example/GCC-RELEASE/project_include.mk", "w") as f:
                     f.write(textwrap.dedent(f"""\
                         SAMPLE_NAME = {options.sample_device_type_name}
@@ -840,8 +841,11 @@ def main() -> int:
                 shell.run_cmd(
                     f"{config['ameba']['AMEBA_SDK']}/tools/AmebaD/Image_Tool_Linux/flash.sh {config['ameba']['TTY']} {config['ameba']['AMEBA_SDK']}/project/realtek_amebaD_va0_example/GCC-RELEASE/out", raise_on_returncode=False)
             else:
-                flush_print(
-                    "Ameba Z2 currently does not support flashing image through script, stil WIP")
+                shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}/ameba")
+                shell.run_cmd(
+                    f"cd {config['ameba']['AMEBA_SDK']}/tools/AmebaZ2/Image_Tool_Linux")
+                shell.run_cmd(
+                    f"{config['ameba']['AMEBA_SDK']}/tools/AmebaZ2/Image_Tool_Linux/flash.sh {config['ameba']['TTY']} {config['ameba']['AMEBA_SDK']}/project/realtek_amebaz2_v0_example/GCC-RELEASE/application_is/Debug/bin", raise_on_returncode=False)
 
     #
     # Terminal interaction


### PR DESCRIPTION
- Previously AmebaZ2 platform does not support automatic image flashing for chef app
- This platform implements the flashing of image for AmebaZ2 platform through a script for chef app
- This is a cherry-pick of PR #23011 from master