### PR TITLE
Add generic-callback-stubs.cpp to the Darwin framework for now.

### DIFF
--- a/src/app/util/generic-callback-stubs.cpp
+++ b/src/app/util/generic-callback-stubs.cpp
@@ -41,22 +41,6 @@ bool __attribute__((weak)) emberAfAttributeWriteAccessCallback(EndpointId endpoi
     return true;
 }
 
-bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
-{
-    return false;
-}
-
-bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
-{
-    return false;
-}
-
-bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
-                                                      uint16_t msgLen, uint8_t * message, EmberStatus status)
-{
-    return false;
-}
-
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, const EmberAfAttributeMetadata * attributeMetadata,
                                      uint8_t * buffer, uint16_t maxReadLength)
@@ -69,12 +53,6 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
                                       uint8_t * buffer)
 {
     return EMBER_ZCL_STATUS_FAILURE;
-}
-
-bool __attribute__((weak))
-emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
-{
-    return false;
 }
 
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}

--- a/src/app/zap-templates/templates/app/callback.zapt
+++ b/src/app/zap-templates/templates/app/callback.zapt
@@ -198,54 +198,6 @@ bool emberAfAttributeReadAccessCallback(chip::EndpointId endpoint, chip::Cluster
  */
 bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId);
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.
- * @param commandId The command identifier to which this is a response.
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.
- */
-bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
-
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.
- * @param status A pointer to the status code value that will be returned to the
- * caller.
- */
-bool emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status);
-
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- */
-bool emberAfMessageSentCallback(const chip::MessageSendDestination & destination, EmberApsFrame * apsFrame,
-                                uint16_t msgLen, uint8_t * message, EmberStatus status);
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -322,25 +274,6 @@ EmberAfStatus emberAfExternalAttributeReadCallback(chip::EndpointId endpoint, ch
 EmberAfStatus emberAfExternalAttributeWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                     const EmberAfAttributeMetadata * attributeMetadata,
                                                     uint8_t * buffer);
-
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
-bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo);
 
 /** @brief Registration Abort
  *

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		5136661628067D550025EDAE /* MTRControllerFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 5136661228067D550025EDAE /* MTRControllerFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		513DDB862761F69300DAA01A /* MTRAttributeTLVValueDecoder_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 513DDB852761F69300DAA01A /* MTRAttributeTLVValueDecoder_Internal.h */; };
 		513DDB8A2761F6F900DAA01A /* MTRAttributeTLVValueDecoder.mm in Sources */ = {isa = PBXBuildFile; fileRef = 513DDB892761F6F900DAA01A /* MTRAttributeTLVValueDecoder.mm */; };
+		514304202914CED9004DC7FE /* generic-callback-stubs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5143041F2914CED9004DC7FE /* generic-callback-stubs.cpp */; };
 		51431AF927D2973E008A7943 /* MTRIMDispatch.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51431AF827D2973E008A7943 /* MTRIMDispatch.mm */; };
 		51431AFB27D29CA4008A7943 /* ota-provider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51431AFA27D29CA4008A7943 /* ota-provider.cpp */; };
 		515C1C6F284F9FFB00A48F0C /* MTRMemory.mm in Sources */ = {isa = PBXBuildFile; fileRef = 515C1C6D284F9FFB00A48F0C /* MTRMemory.mm */; };
@@ -188,6 +189,7 @@
 		5136661228067D550025EDAE /* MTRControllerFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRControllerFactory.h; sourceTree = "<group>"; };
 		513DDB852761F69300DAA01A /* MTRAttributeTLVValueDecoder_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRAttributeTLVValueDecoder_Internal.h; sourceTree = "<group>"; };
 		513DDB892761F6F900DAA01A /* MTRAttributeTLVValueDecoder.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MTRAttributeTLVValueDecoder.mm; path = "zap-generated/MTRAttributeTLVValueDecoder.mm"; sourceTree = "<group>"; };
+		5143041F2914CED9004DC7FE /* generic-callback-stubs.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "generic-callback-stubs.cpp"; path = "../../../app/util/generic-callback-stubs.cpp"; sourceTree = "<group>"; };
 		51431AF827D2973E008A7943 /* MTRIMDispatch.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRIMDispatch.mm; sourceTree = "<group>"; };
 		51431AFA27D29CA4008A7943 /* ota-provider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "ota-provider.cpp"; path = "../../../app/clusters/ota-provider/ota-provider.cpp"; sourceTree = "<group>"; };
 		515C1C6D284F9FFB00A48F0C /* MTRMemory.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRMemory.mm; sourceTree = "<group>"; };
@@ -308,6 +310,7 @@
 				5112F605287CD2C100B827E7 /* privilege-storage.cpp */,
 				2FD775542695557E00FF4B12 /* error-mapping.cpp */,
 				51431AFA27D29CA4008A7943 /* ota-provider.cpp */,
+				5143041F2914CED9004DC7FE /* generic-callback-stubs.cpp */,
 			);
 			name = CHIPApp;
 			sourceTree = "<group>";
@@ -702,6 +705,7 @@
 				3CF134A9289D8D800017A19E /* MTRCSRInfo.m in Sources */,
 				991DC0892475F47D00C13860 /* MTRDeviceController.mm in Sources */,
 				B2E0D7B7245B0B5C003C5B48 /* MTRQRCodeSetupPayloadParser.mm in Sources */,
+				514304202914CED9004DC7FE /* generic-callback-stubs.cpp in Sources */,
 				1EDCE546289049A100E41EC9 /* MTROTAHeader.mm in Sources */,
 				1EC4CE5D25CC26E900D7304F /* MTRBaseClusters.mm in Sources */,
 				51E0310127EA20D20083DC9C /* MTRControllerAccessControl.mm in Sources */,

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -8969,54 +8969,6 @@ bool emberAfAttributeReadAccessCallback(chip::EndpointId endpoint, chip::Cluster
  */
 bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId);
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.
- * @param commandId The command identifier to which this is a response.
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.
- */
-bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
-
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.
- * @param status A pointer to the status code value that will be returned to the
- * caller.
- */
-bool emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status);
-
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- */
-bool emberAfMessageSentCallback(const chip::MessageSendDestination & destination, EmberApsFrame * apsFrame, uint16_t msgLen,
-                                uint8_t * message, EmberStatus status);
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -9092,26 +9044,6 @@ EmberAfStatus emberAfExternalAttributeReadCallback(chip::EndpointId endpoint, ch
  */
 EmberAfStatus emberAfExternalAttributeWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                     const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer);
-
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
-bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
-                                    EmberAfEndpointInfoStruct * returnEndpointInfo);
 
 /** @brief Registration Abort
  *


### PR DESCRIPTION
These callback bits used to be in callback-stub.cpp, which is included in the framwork.

Also removes some completely unused callbacks.

Fixes https://github.com/project-chip/connectedhomeip/issues/23442
