### PR TITLE
[linux] Fix the device failed to reconnect wifi after power cycle

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1060,25 +1060,24 @@ void ConnectivityManagerImpl::_ConnectWiFiNetworkAsyncCallback(GObject * source_
                 }
                 mpConnectCallback = nullptr;
             });
+
+            return;
+        }
+
+        GError * gerror = nullptr;
+
+        result = wpa_fi_w1_wpa_supplicant1_interface_call_save_config_sync(mWpaSupplicant.iface, nullptr, &gerror);
+        if (result)
+        {
+            ChipLogProgress(DeviceLayer, "wpa_supplicant: save config succeeded!");
         }
         else
         {
-            GError * gerror = nullptr;
-
-            result = wpa_fi_w1_wpa_supplicant1_interface_call_save_config_sync(mWpaSupplicant.iface, nullptr, &gerror);
-            if (result)
-            {
-                ChipLogProgress(DeviceLayer, "wpa_supplicant: save config succeeded!");
-            }
-            else
-            {
-                ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to save config: %s",
-                                gerror ? gerror->message : "unknown error");
-            }
-
-            if (gerror != nullptr)
-                g_error_free(gerror);
+            ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to save config: %s", gerror ? gerror->message : "unknown error");
         }
+
+        if (gerror != nullptr)
+            g_error_free(gerror);
     }
 }
 

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1061,6 +1061,24 @@ void ConnectivityManagerImpl::_ConnectWiFiNetworkAsyncCallback(GObject * source_
                 mpConnectCallback = nullptr;
             });
         }
+        else
+        {
+            GError * gerror = nullptr;
+
+            result = wpa_fi_w1_wpa_supplicant1_interface_call_save_config_sync(mWpaSupplicant.iface, nullptr, &gerror);
+            if (result)
+            {
+                ChipLogProgress(DeviceLayer, "wpa_supplicant: save config succeeded!");
+            }
+            else
+            {
+                ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to save config: %s",
+                                gerror ? gerror->message : "unknown error");
+            }
+
+            if (gerror != nullptr)
+                g_error_free(gerror);
+        }
     }
 }
 


### PR DESCRIPTION
After provision the Linux device to home network, the device failed to reconnect to the home network after I reboot the device. 

Test:
On Server Side:
sudo rm -rf /tmp/chip_*
./chip-all-clusters-app

On Client Side:
./chip-tool pairing code-wifi 12345 gaorui-2g 82045133 34970112332   

Reboot the device and confirm the device could connect back to the home network.
