### PR TITLE
Pre-build glib-2.0 libraries with TSAN enabled

### DIFF
--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -49,6 +49,7 @@ RUN set -x \
     libusb-dev \
     libxml2-dev \
     make \
+    meson \
     net-tools \
     ninja-build \
     openjdk-8-jdk \
@@ -130,4 +131,20 @@ RUN set -x \
     && ln -s /opt/node/bin/* /usr/bin \
     && cd .. \
     && rm -rf node_js \
+    && : # last line
+
+# Build glib-2.0 from source with enabled thread sanitizer. This is needed for
+# running CHIP tests with TSAN enabled. When running applications with TSAN
+# all shared libraries should be built with TSAN enabled, otherwise TSAN might
+# report false positives. This case is most prominent with glib-2.0, which has
+# a lot of threads-related APIs.
+ENV LD_LIBRARY_PATH_TSAN=/usr/lib/x86_64-linux-gnu-tsan
+RUN set -x \
+    && mkdir -p $LD_LIBRARY_PATH_TSAN \
+    && GLIB_VERSION=$(pkg-config --modversion glib-2.0) \
+    && git clone --depth=1 --branch=$GLIB_VERSION https://github.com/GNOME/glib.git \
+    && CFLAGS="-O2 -g -fsanitize=thread" meson glib/build glib \
+    && DESTDIR=../build-image ninja -C glib/build install \
+    && mv glib/build-image/usr/local/lib/x86_64-linux-gnu/lib* $LD_LIBRARY_PATH_TSAN \
+    && rm -rf glib \
     && : # last line

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.06 Version bump reason: [Telink] Update Telink Docker.
+0.6.07 Version bump reason: Build glib-2.0 libs with TSAN


### PR DESCRIPTION
### Problem

Testing application with TSAN requires all shared libraries to be compiled with TSAN as well. Otherwise, one can get lots of false positive reports. The case is most prominent with glib-2.0 which has lots of threads-related APIs.

From [TSAN wiki](https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual#non-instrumented-code):

> TSAN generally requires all code to be compiled with -fsanitize=thread. If some code (e.g. dynamic libraries) is not compiled with the flag, it can lead to false positive race reports, false negative race reports and/or missed stack frames in reports depending on the nature of non-instrumented code.

Related with #14710 

There will be a follow-up PR for CI changes.

### Changes

Add glib-2.0 with TSAN enabled to chip-build Docker image and place them in the location defined in `LD_LIBRARY_PATH_TSAN` env variable. When testing CHIP apps with TSAN one can add `LD_LIBRARY_PATH_TSAN` to `LD_LIBRARY_PATH`.

### Testing

```
# This shows lots of false positive TSAN warnings
out/linux-x64-lock-tsan/chip-lock-app

# This does not show any false positive warnings
LD_LIBRARY_PATH=$LD_LIBRARY_PATH_TSAN out/linux-x64-lock-tsan/chip-lock-app
```