### PR TITLE
Stop using ReadInteraction APIs for Darwin framework read/subscribe.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseClustersCpp_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRBaseClustersCpp_Internal.h
@@ -1,0 +1,263 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#import <Foundation/Foundation.h>
+
+#import "MTRBaseDevice.h"
+#import "MTRCluster_internal.h"
+#import "zap-generated/MTRCallbackBridge_internal.h"
+
+#include <app/ReadClient.h>
+#include <lib/core/CHIPTLV.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/support/CHIPMem.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Utility functions base clusters use for doing reads and subscribes.
+ */
+template <typename BridgeType, typename DecodableAttributeType>
+class MTRAttributeReportCallback : public chip::app::ReadClient::Callback {
+public:
+    MTRAttributeReportCallback(BridgeType * _Nonnull bridge, typename BridgeType::SuccessCallbackType _Nonnull onAttributeReport,
+        MTRErrorCallback _Nonnull onError, chip::ClusterId clusterID, chip::AttributeId attributeID)
+        : mBridge(bridge)
+        , mOnAttributeReport(onAttributeReport)
+        , mOnError(onError)
+        , mClusterID(clusterID)
+        , mAttributeID(attributeID)
+        , mBufferedReadAdapter(*this)
+    {
+    }
+
+    ~MTRAttributeReportCallback() {}
+
+    chip::app::BufferedReadCallback & GetBufferedCallback() { return mBufferedReadAdapter; }
+
+    void AdoptReadClient(chip::Platform::UniquePtr<chip::app::ReadClient> readClient) { mReadClient = std::move(readClient); }
+
+protected:
+    void OnAttributeData(
+        const chip::app::ConcreteDataAttributePath & path, chip::TLV::TLVReader * data, const chip::app::StatusIB & status) override
+    {
+        if (mCalledCallback && mReadClient->IsReadType()) {
+            return;
+        }
+        mCalledCallback = true;
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+        DecodableAttributeType value;
+
+        //
+        // We shouldn't be getting list item operations in the provided path since that should be handled by the buffered read
+        // callback. If we do, that's a bug.
+        //
+        VerifyOrDie(!path.IsListItemOperation());
+
+        VerifyOrExit(status.IsSuccess(), err = status.ToChipError());
+        VerifyOrExit(path.mClusterId == mClusterID && path.mAttributeId == mAttributeID, err = CHIP_ERROR_SCHEMA_MISMATCH);
+        VerifyOrExit(data != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+        SuccessOrExit(err = chip::app::DataModel::Decode(*data, value));
+
+        mOnAttributeReport(mBridge, value);
+
+    exit:
+        if (err != CHIP_NO_ERROR) {
+            mOnError(mBridge, err);
+        }
+    }
+
+    void OnError(CHIP_ERROR error) override
+    {
+        if (mCalledCallback && mReadClient->IsReadType()) {
+            return;
+        }
+        mCalledCallback = true;
+
+        mOnError(mBridge, error);
+    }
+
+    void OnDone(chip::app::ReadClient *) override { chip::Platform::Delete(this); }
+
+    BridgeType * _Nonnull mBridge;
+
+    chip::ClusterId mClusterID;
+    chip::AttributeId mAttributeID;
+    typename BridgeType::SuccessCallbackType mOnAttributeReport;
+    MTRErrorCallback mOnError;
+    chip::app::BufferedReadCallback mBufferedReadAdapter;
+    chip::Platform::UniquePtr<chip::app::ReadClient> mReadClient;
+    // For reads, we ensure that we make only one data/error callback to our consumer.
+    bool mCalledCallback = false;
+};
+
+template <typename SubscriptionBridgeType, typename DecodableAttributeType>
+class MTRAttributeSubscriptionCallback : public MTRAttributeReportCallback<SubscriptionBridgeType, DecodableAttributeType> {
+public:
+    MTRAttributeSubscriptionCallback(SubscriptionBridgeType * _Nonnull bridge,
+        typename SubscriptionBridgeType::SuccessCallbackType onAttributeReport, MTRErrorCallback onError, chip::ClusterId clusterID,
+        chip::AttributeId attributeID)
+        : MTRAttributeReportCallback<SubscriptionBridgeType, DecodableAttributeType>(
+            bridge, onAttributeReport, onError, clusterID, attributeID)
+    {
+    }
+
+    ~MTRAttributeSubscriptionCallback()
+    {
+        // Ensure we release the ReadClient before we tear down anything else,
+        // so it can call our OnDeallocatePaths properly.
+        this->mReadClient = nullptr;
+    }
+
+private:
+    // The superclass OnResubscriptionNeeded is fine for our purposes.
+
+    void OnDeallocatePaths(chip::app::ReadPrepareParams && readPrepareParams) override
+    {
+        VerifyOrDie(readPrepareParams.mAttributePathParamsListSize == 1 && readPrepareParams.mpAttributePathParamsList != nullptr);
+        chip::Platform::Delete<chip::app::AttributePathParams>(readPrepareParams.mpAttributePathParamsList);
+
+        if (readPrepareParams.mDataVersionFilterListSize == 1 && readPrepareParams.mpDataVersionFilterList != nullptr) {
+            chip::Platform::Delete<chip::app::DataVersionFilter>(readPrepareParams.mpDataVersionFilterList);
+        }
+    }
+
+    void OnSubscriptionEstablished(chip::SubscriptionId subscriptionId) override { this->mBridge->OnSubscriptionEstablished(); }
+
+    void OnDone(chip::app::ReadClient * readClient) override
+    {
+        this->mBridge->OnDone();
+        MTRAttributeReportCallback<SubscriptionBridgeType, DecodableAttributeType>::OnDone(readClient);
+    }
+};
+
+template <typename DecodableAttributeType, typename BridgeType>
+CHIP_ERROR MTRStartReadInteraction(BridgeType * _Nonnull bridge, MTRReadParams * params,
+    chip::Messaging::ExchangeManager & exchangeManager, const chip::SessionHandle & session,
+    typename BridgeType::SuccessCallbackType successCb, MTRErrorCallback failureCb, chip::EndpointId endpoint,
+    chip::ClusterId clusterID, chip::AttributeId attributeID)
+{
+    auto readPaths = chip::Platform::MakeUnique<chip::app::AttributePathParams>(endpoint, clusterID, attributeID);
+    VerifyOrReturnError(readPaths != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    chip::app::ReadPrepareParams readPrepareParams(session);
+    [params toReadPrepareParams:readPrepareParams];
+    readPrepareParams.mpAttributePathParamsList = readPaths.get();
+    readPrepareParams.mAttributePathParamsListSize = 1;
+
+    auto callback = chip::Platform::MakeUnique<MTRAttributeReportCallback<BridgeType, DecodableAttributeType>>(
+        bridge, successCb, failureCb, clusterID, attributeID);
+    VerifyOrReturnError(callback != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    auto readClient = chip::Platform::MakeUnique<chip::app::ReadClient>(chip::app::InteractionModelEngine::GetInstance(),
+        &exchangeManager, callback->GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
+    VerifyOrReturnError(readClient != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    CHIP_ERROR err = readClient->SendRequest(readPrepareParams);
+    ReturnErrorOnFailure(err);
+
+    callback->AdoptReadClient(std::move(readClient));
+    callback.release();
+
+    return CHIP_NO_ERROR;
+}
+
+template <typename DecodableAttributeType, typename BridgeType>
+CHIP_ERROR MTRStartSubscribeInteraction(BridgeType * _Nonnull bridge, MTRSubscribeParams * params,
+    chip::Messaging::ExchangeManager & exchangeManager, const chip::SessionHandle & session,
+    typename BridgeType::SuccessCallbackType successCb, MTRErrorCallback failureCb, chip::EndpointId endpoint,
+    chip::ClusterId clusterID, chip::AttributeId attributeID)
+{
+    auto readPaths = chip::Platform::MakeUnique<chip::app::AttributePathParams>(endpoint, clusterID, attributeID);
+    VerifyOrReturnError(readPaths != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    chip::app::ReadPrepareParams readPrepareParams(session);
+    [params toReadPrepareParams:readPrepareParams];
+    readPrepareParams.mpAttributePathParamsList = readPaths.get();
+    readPrepareParams.mAttributePathParamsListSize = 1;
+
+    auto callback = chip::Platform::MakeUnique<MTRAttributeSubscriptionCallback<BridgeType, DecodableAttributeType>>(
+        bridge, successCb, failureCb, clusterID, attributeID);
+    VerifyOrReturnError(callback != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    auto readClient = chip::Platform::MakeUnique<chip::app::ReadClient>(chip::app::InteractionModelEngine::GetInstance(),
+        &exchangeManager, callback->GetBufferedCallback(), chip::app::ReadClient::InteractionType::Subscribe);
+    VerifyOrReturnError(readClient != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    CHIP_ERROR err;
+    if (params.resubscribeIfLost) {
+        readPaths.release();
+
+        err = readClient->SendAutoResubscribeRequest(std::move(readPrepareParams));
+    } else {
+        err = readClient->SendRequest(readPrepareParams);
+    }
+    ReturnErrorOnFailure(err);
+
+    bridge->KeepAliveOnCallback();
+
+    callback->AdoptReadClient(std::move(readClient));
+    callback.release();
+
+    return CHIP_NO_ERROR;
+}
+
+template <typename SubscriptionBridgeType, typename AttributeObjCType, typename DecodableAttributeType>
+void MTRSubscribeAttribute(MTRSubscribeParams * _Nonnull params,
+    MTRSubscriptionEstablishedHandler _Nullable subscriptionEstablished,
+    void (^reportHandler)(AttributeObjCType * _Nullable value, NSError * _Nullable error), dispatch_queue_t callbackQueue,
+    MTRBaseDevice * device, chip::EndpointId endpoint, chip::ClusterId clusterID, chip::AttributeId attributeID)
+{
+    // Make a copy of params before we go async.
+    params = [params copy];
+    auto * callbackBridge = new SubscriptionBridgeType(
+        callbackQueue,
+        // This treats reportHandler as taking an id for the data.  This is
+        // not great from a type-safety perspective, of course.
+        reportHandler,
+        ^(chip::Messaging::ExchangeManager & exchangeManager, const chip::SessionHandle & session,
+            typename SubscriptionBridgeType::SuccessCallbackType successCb, MTRErrorCallback failureCb,
+            MTRCallbackBridgeBase * bridge) {
+            auto * subscriptionBridge = static_cast<SubscriptionBridgeType *>(bridge);
+            return MTRStartSubscribeInteraction<DecodableAttributeType>(
+                subscriptionBridge, params, exchangeManager, session, successCb, failureCb, endpoint, clusterID, attributeID);
+        },
+        subscriptionEstablished);
+    std::move(*callbackBridge).DispatchAction(device);
+}
+
+template <typename ReadBridgeType, typename AttributeObjCType, typename DecodableAttributeType>
+void MTRReadAttribute(MTRReadParams * _Nonnull params,
+    void (^reportHandler)(AttributeObjCType * _Nullable value, NSError * _Nullable error), dispatch_queue_t callbackQueue,
+    MTRBaseDevice * device, chip::EndpointId endpoint, chip::ClusterId clusterID, chip::AttributeId attributeID)
+{
+    // Make a copy of params before we go async.
+    params = [params copy];
+    auto * callbackBridge = new ReadBridgeType(callbackQueue,
+        // This treats reportHandler as taking an id for the data.  This is
+        // not great from a type-safety perspective, of course.
+        reportHandler,
+        ^(chip::Messaging::ExchangeManager & exchangeManager, const chip::SessionHandle & session,
+            typename ReadBridgeType::SuccessCallbackType successCb, MTRErrorCallback failureCb, MTRCallbackBridgeBase * bridge) {
+            auto * readBridge = static_cast<ReadBridgeType *>(bridge);
+            return MTRStartReadInteraction<DecodableAttributeType>(
+                readBridge, params, exchangeManager, session, successCb, failureCb, endpoint, clusterID, attributeID);
+        });
+    std::move(*callbackBridge).DispatchAction(device);
+}
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -21,6 +21,7 @@
 #import "MTRBaseSubscriptionCallback.h"
 #import "MTRCallbackBridgeBase_internal.h"
 #import "MTRCluster.h"
+#import "MTRCluster_internal.h"
 #import "MTRError_Internal.h"
 #import "MTREventTLVValueDecoder_Internal.h"
 #import "MTRLogging.h"
@@ -302,14 +303,11 @@ public:
                                       // We want to get event reports at the minInterval, not the maxInterval.
                                       eventPath->mIsUrgentEvent = true;
                                       ReadPrepareParams readParams(session.Value());
-                                      readParams.mMinIntervalFloorSeconds = [params.minInterval unsignedShortValue];
-                                      readParams.mMaxIntervalCeilingSeconds = [params.maxInterval unsignedShortValue];
+                                      [params toReadPrepareParams:readParams];
                                       readParams.mpAttributePathParamsList = attributePath.get();
                                       readParams.mAttributePathParamsListSize = 1;
                                       readParams.mpEventPathParamsList = eventPath.get();
                                       readParams.mEventPathParamsListSize = 1;
-                                      readParams.mIsFabricFiltered = params.filterByFabric;
-                                      readParams.mKeepSubscriptions = !params.replaceExistingSubscriptions;
 
                                       std::unique_ptr<ClusterStateCache> attributeCache;
                                       ReadClient::Callback * callbackForReadClient = nullptr;
@@ -831,9 +829,9 @@ private:
             CHIP_ERROR err = CHIP_NO_ERROR;
 
             chip::app::ReadPrepareParams readParams(session);
+            [params toReadPrepareParams:readParams];
             readParams.mpAttributePathParamsList = &attributePath;
             readParams.mAttributePathParamsListSize = 1;
-            readParams.mIsFabricFiltered = params.filterByFabric;
 
             auto onDone = [resultArray, resultSuccess, resultFailure, bridge, successCb, failureCb](
                               BufferedReadAttributeCallback<MTRDataValueDictionaryDecodableType> * callback) {
@@ -1200,12 +1198,9 @@ exit:
                    CHIP_ERROR err = CHIP_NO_ERROR;
 
                    chip::app::ReadPrepareParams readParams(session.Value());
+                   [params toReadPrepareParams:readParams];
                    readParams.mpAttributePathParamsList = container.pathParams;
                    readParams.mAttributePathParamsListSize = 1;
-                   readParams.mMinIntervalFloorSeconds = static_cast<uint16_t>([params.minInterval unsignedShortValue]);
-                   readParams.mMaxIntervalCeilingSeconds = static_cast<uint16_t>([params.maxInterval unsignedShortValue]);
-                   readParams.mIsFabricFiltered = params.filterByFabric;
-                   readParams.mKeepSubscriptions = !params.replaceExistingSubscriptions;
 
                    auto onDone = [container](BufferedReadAttributeCallback<MTRDataValueDictionaryDecodableType> * callback) {
                        [container onDone];

--- a/src/darwin/Framework/CHIP/MTRCallbackBridgeBase_internal.h
+++ b/src/darwin/Framework/CHIP/MTRCallbackBridgeBase_internal.h
@@ -67,6 +67,7 @@ template <class T> class MTRCallbackBridge : public MTRCallbackBridgeBase {
 public:
     using MTRActionBlock = MTRActionBlockT<T>;
     using MTRLocalActionBlock = MTRLocalActionBlockT<T>;
+    using SuccessCallbackType = T;
 
     /**
      * Construct a callback bridge, which can then have DispatcLocalAction() called

--- a/src/darwin/Framework/CHIP/MTRCluster.mm
+++ b/src/darwin/Framework/CHIP/MTRCluster.mm
@@ -77,6 +77,11 @@ using namespace ::chip;
     return other;
 }
 
+- (void)toReadPrepareParams:(chip::app::ReadPrepareParams &)readPrepareParams
+{
+    readPrepareParams.mIsFabricFiltered = self.filterByFabric;
+}
+
 @end
 
 @implementation MTRSubscribeParams
@@ -98,6 +103,14 @@ using namespace ::chip;
     other.replaceExistingSubscriptions = self.replaceExistingSubscriptions;
     other.resubscribeIfLost = self.resubscribeIfLost;
     return other;
+}
+
+- (void)toReadPrepareParams:(chip::app::ReadPrepareParams &)readPrepareParams
+{
+    [super toReadPrepareParams:readPrepareParams];
+    readPrepareParams.mMinIntervalFloorSeconds = self.minInterval.unsignedShortValue;
+    readPrepareParams.mMaxIntervalCeilingSeconds = self.maxInterval.unsignedShortValue;
+    readPrepareParams.mKeepSubscriptions = !self.replaceExistingSubscriptions;
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRCluster_internal.h
+++ b/src/darwin/Framework/CHIP/MTRCluster_internal.h
@@ -24,6 +24,8 @@
 #import "zap-generated/CHIPClusters.h"
 #import "zap-generated/MTRBaseClusters.h"
 
+#include <app/ReadPrepareParams.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRCluster ()
@@ -31,6 +33,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype _Nullable)initWithQueue:(dispatch_queue_t)queue;
 - (chip::ByteSpan)asByteSpan:(NSData *)value;
 - (chip::CharSpan)asCharSpan:(NSString *)value;
+@end
+
+@interface MTRReadParams ()
+/**
+ * Copy state from this MTRReadParams to the ReadPreparaParams.
+ */
+- (void)toReadPrepareParams:(chip::app::ReadPrepareParams &)readPrepareParams;
+@end
+
+@interface MTRSubscribeParams ()
+/**
+ * Copy state from this MTRReadParams to the ReadPreparaParams.
+ */
+- (void)toReadPrepareParams:(chip::app::ReadPrepareParams &)readPrepareParams;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
@@ -10,11 +10,11 @@
 #import "MTRCluster_internal.h"
 #import "MTRStructsObjc.h"
 #import "MTRCommandPayloadsObjc.h"
+#import "MTRBaseClustersCpp_Internal.h"
 
 #include <lib/support/CHIPListUtils.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <type_traits>
-#include <controller/TypedReadCallback.h>
 
 using chip::Callback::Callback;
 using chip::Callback::Cancelable;
@@ -114,21 +114,13 @@ using chip::SessionHandle;
     {{~#if_is_fabric_scoped_struct type}}
     // Make a copy of params before we go async.
     params = [params copy];
+    {{else}}
+    MTRReadParams * params = [[MTRReadParams alloc] init];
     {{/if_is_fabric_scoped_struct~}}
-    auto * bridge = new MTR{{>attribute_data_callback_name}}CallbackBridge(self.callbackQueue,
-      {{! This treats completion as taking an id for the data.  This is
-          not great from a type-safety perspective, of course. }}
-      completion,
-      ^(ExchangeManager & exchangeManager, const SessionHandle & session, {{>attribute_data_callback_name}}Callback successCb, MTRErrorCallback failureCb, MTRCallbackBridgeBase * bridge) {
-          using TypeInfo = {{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::TypeInfo;
-          chip::Controller::{{asUpperCamelCase parent.name}}Cluster cppCluster(exchangeManager, session, self->_endpoint);
-          return cppCluster.ReadAttribute<TypeInfo>(bridge, successCb, failureCb
-          {{~#if_is_fabric_scoped_struct type~}}
-          , params.filterByFabric
-          {{~/if_is_fabric_scoped_struct~}}
-          );
-      });
-    std::move(*bridge).DispatchAction(self.device);
+    using TypeInfo = {{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::TypeInfo;
+    return MTRReadAttribute<MTR{{>attribute_data_callback_name}}CallbackBridge,
+                         {{asObjectiveCClass type parent.name}},
+                         TypeInfo::DecodableType>(params, completion, self.callbackQueue, self.device, self->_endpoint, TypeInfo::GetClusterId(), TypeInfo::GetAttributeId());
 }
 
 {{#if isWritableAttribute}}
@@ -177,38 +169,11 @@ using chip::SessionHandle;
 {{/if}}
 {{#if isReportableAttribute}}
 - (void) subscribe{{>attribute}}WithParams:(MTRSubscribeParams * _Nonnull)params
-subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished 
+subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
 reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))reportHandler
 {
-    // Make a copy of params before we go async.
-    params = [params copy];
-    auto * bridge = new MTR{{>attribute_data_callback_name}}CallbackSubscriptionBridge(self.callbackQueue,
-      {{! This treats reportHandler as taking an id for the data.  This is
-          not great from a type-safety perspective, of course. }}
-      reportHandler,
-      ^(ExchangeManager & exchangeManager, const SessionHandle & session,  {{>attribute_data_callback_name}}Callback successCb, MTRErrorCallback failureCb, MTRCallbackBridgeBase * bridge) {
-          auto * typedBridge = static_cast<MTR{{>attribute_data_callback_name}}CallbackSubscriptionBridge *>(bridge);
-          if (!params.resubscribeIfLost) {
-              // We don't support disabling auto-resubscribe.
-              return CHIP_ERROR_INVALID_ARGUMENT;
-          }
-          using TypeInfo = {{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::TypeInfo;
-
-          chip::Controller::{{asUpperCamelCase parent.name}}Cluster cppCluster(exchangeManager, session, self->_endpoint);
-          CHIP_ERROR err = cppCluster.SubscribeAttribute<TypeInfo>(bridge, successCb, failureCb, [params.minInterval unsignedShortValue], [params.maxInterval unsignedShortValue], MTR{{>attribute_data_callback_name}}CallbackSubscriptionBridge::OnSubscriptionEstablished, nil,
-              params.filterByFabric,
-              !params.replaceExistingSubscriptions,
-              chip::NullOptional,
-              [typedBridge](void) { typedBridge->OnDone(); }
-          );
-          if (err == CHIP_NO_ERROR) {
-              // Now that we kicked off the subscribe, flag our callback bridge
-              // to stay alive until we get an OnDone.
-              typedBridge->KeepAliveOnCallback();
-          }
-          return err;
-      }, subscriptionEstablished);
-    std::move(*bridge).DispatchAction(self.device);
+    using TypeInfo = {{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::TypeInfo;
+    MTRSubscribeAttribute<MTR{{>attribute_data_callback_name}}CallbackSubscriptionBridge, {{asObjectiveCClass type parent.name}}, TypeInfo::DecodableType>(params, subscriptionEstablished, reportHandler, self.callbackQueue, self.device, self->_endpoint, TypeInfo::GetClusterId(), TypeInfo::GetAttributeId());
 }
 
 + (void) read{{>attribute}}WithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer endpoint:(NSNumber *)endpoint  queue:(dispatch_queue_t)queue completion:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))completion

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -46,10 +46,6 @@ MTR_NEWLY_AVAILABLE
 - (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name}})value params:(MTRWriteParams * _Nullable)params completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 {{/if}}
 {{#if isReportableAttribute}}
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void) subscribe{{>attribute}}WithParams:(MTRSubscribeParams *)params
 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))reportHandler MTR_NEWLY_AVAILABLE;
 + (void) read{{>attribute}}WithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue completion:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;

--- a/src/darwin/Framework/CHIP/templates/partials/MTRCallbackBridge.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/MTRCallbackBridge.zapt
@@ -47,7 +47,7 @@ public:
         mEstablishedHandler(establishedHandler)
       {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTR{{> @partial-block}}Bridge::OnDone;
     using MTR{{> @partial-block}}Bridge::KeepAliveOnCallback;
 
@@ -97,19 +97,18 @@ void MTR{{> @partial-block}}Bridge::OnSuccessFn(void * context
 };
 
 {{#unless partial-type}}
-void MTR{{> @partial-block}}SubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTR{{> @partial-block}}SubscriptionBridge::OnSubscriptionEstablished()
 {
-     auto * self = static_cast<MTR{{> @partial-block}}SubscriptionBridge *>(context);
-     if (!self->mQueue) {
+     if (!mQueue) {
          return;
      }
 
-     if (self->mEstablishedHandler != nil) {
-         dispatch_async(self->mQueue, self->mEstablishedHandler);
+     if (mEstablishedHandler != nil) {
+         dispatch_async(mQueue, mEstablishedHandler);
          // On failure, mEstablishedHandler will be cleaned up by our destructor,
          // but we can clean it up earlier on successful subscription
          // establishment.
-         self->mEstablishedHandler = nil;
+         mEstablishedHandler = nil;
      }
 }
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -46,10 +46,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeIdentifyTimeWithValue:(NSNumber * _Nonnull)value
                                      params:(MTRWriteParams * _Nullable)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeIdentifyTimeWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -62,10 +58,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeIdentifyTypeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeIdentifyTypeWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -78,10 +70,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -94,10 +82,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -110,10 +94,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -126,10 +106,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -142,10 +118,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -191,10 +163,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeNameSupportWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNameSupportWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -207,10 +175,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -223,10 +187,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -239,10 +199,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -255,10 +211,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -271,10 +223,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -332,10 +280,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSceneCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSceneCountWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -348,10 +292,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeCurrentSceneWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentSceneWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -364,10 +304,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeCurrentGroupWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentGroupWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -380,10 +316,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSceneValidWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSceneValidWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -396,10 +328,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeNameSupportWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNameSupportWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -412,10 +340,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeLastConfiguredByWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLastConfiguredByWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -428,10 +352,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -444,10 +364,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -460,10 +376,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -476,10 +388,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -492,10 +400,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -538,10 +442,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeOnOffWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOnOffWithParams:(MTRSubscribeParams *)params
                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                             reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -554,10 +454,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGlobalSceneControlWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGlobalSceneControlWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -574,10 +470,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeOnTimeWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOnTimeWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -595,10 +487,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeOffWaitTimeWithValue:(NSNumber * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOffWaitTimeWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -616,10 +504,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeStartUpOnOffWithValue:(NSNumber * _Nullable)value
                                      params:(MTRWriteParams * _Nullable)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeStartUpOnOffWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -632,10 +516,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -648,10 +528,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -664,10 +540,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -680,10 +552,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -696,10 +564,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -727,10 +591,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSwitchTypeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSwitchTypeWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -748,10 +608,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeSwitchActionsWithValue:(NSNumber * _Nonnull)value
                                       params:(MTRWriteParams * _Nullable)params
                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSwitchActionsWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -764,10 +620,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -780,10 +632,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -796,10 +644,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -812,10 +656,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -828,10 +668,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -875,10 +711,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeCurrentLevelWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentLevelWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -891,10 +723,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRemainingTimeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRemainingTimeWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -907,10 +735,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeMinLevelWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinLevelWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -923,10 +747,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeMaxLevelWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxLevelWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -939,10 +759,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeCurrentFrequencyWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentFrequencyWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -955,10 +771,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeMinFrequencyWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinFrequencyWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -971,10 +783,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeMaxFrequencyWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxFrequencyWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -991,10 +799,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeOptionsWithValue:(NSNumber * _Nonnull)value
                                 params:(MTRWriteParams * _Nullable)params
                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOptionsWithParams:(MTRSubscribeParams *)params
                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                               reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1012,10 +816,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeOnOffTransitionTimeWithValue:(NSNumber * _Nonnull)value
                                             params:(MTRWriteParams * _Nullable)params
                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOnOffTransitionTimeWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -1032,10 +832,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeOnLevelWithValue:(NSNumber * _Nullable)value
                                 params:(MTRWriteParams * _Nullable)params
                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOnLevelWithParams:(MTRSubscribeParams *)params
                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                               reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1053,10 +849,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeOnTransitionTimeWithValue:(NSNumber * _Nullable)value
                                          params:(MTRWriteParams * _Nullable)params
                                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOnTransitionTimeWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1074,10 +866,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeOffTransitionTimeWithValue:(NSNumber * _Nullable)value
                                           params:(MTRWriteParams * _Nullable)params
                                       completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOffTransitionTimeWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1095,10 +883,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeDefaultMoveRateWithValue:(NSNumber * _Nullable)value
                                         params:(MTRWriteParams * _Nullable)params
                                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDefaultMoveRateWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1116,10 +900,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeStartUpCurrentLevelWithValue:(NSNumber * _Nullable)value
                                             params:(MTRWriteParams * _Nullable)params
                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeStartUpCurrentLevelWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -1132,10 +912,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -1148,10 +924,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -1164,10 +936,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1180,10 +948,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1196,10 +960,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1231,10 +991,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeActiveTextWithValue:(NSString * _Nonnull)value
                                    params:(MTRWriteParams * _Nullable)params
                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActiveTextWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1252,10 +1008,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeDescriptionWithValue:(NSString * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDescriptionWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1273,10 +1025,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeInactiveTextWithValue:(NSString * _Nonnull)value
                                      params:(MTRWriteParams * _Nullable)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInactiveTextWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1294,10 +1042,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeOutOfServiceWithValue:(NSNumber * _Nonnull)value
                                      params:(MTRWriteParams * _Nullable)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOutOfServiceWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1310,10 +1054,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePolarityWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePolarityWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1331,10 +1071,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributePresentValueWithValue:(NSNumber * _Nonnull)value
                                      params:(MTRWriteParams * _Nullable)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePresentValueWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1352,10 +1088,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeReliabilityWithValue:(NSNumber * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeReliabilityWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1368,10 +1100,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeStatusFlagsWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeStatusFlagsWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1384,10 +1112,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeApplicationTypeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeApplicationTypeWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1400,10 +1124,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -1416,10 +1136,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -1432,10 +1148,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1448,10 +1160,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1464,10 +1172,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1496,10 +1200,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeDeviceTypeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDeviceTypeListWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1512,10 +1212,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeServerListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeServerListWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1528,10 +1224,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClientListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClientListWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1544,10 +1236,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePartsListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePartsListWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1560,10 +1248,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -1576,10 +1260,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -1592,10 +1272,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1608,10 +1284,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1624,10 +1296,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1660,10 +1328,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeBindingWithValue:(NSArray * _Nonnull)value
                                 params:(MTRWriteParams * _Nullable)params
                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBindingWithParams:(MTRSubscribeParams *)params
                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                               reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1676,10 +1340,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -1692,10 +1352,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -1708,10 +1364,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1724,10 +1376,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1740,10 +1388,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1778,10 +1422,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeAclWithValue:(NSArray * _Nonnull)value
                             params:(MTRWriteParams * _Nullable)params
                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAclWithParams:(MTRSubscribeParams *)params
                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                           reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1799,10 +1439,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeExtensionWithValue:(NSArray * _Nonnull)value
                                   params:(MTRWriteParams * _Nullable)params
                               completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeExtensionWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1815,10 +1451,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSubjectsPerAccessControlEntryWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                      NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSubjectsPerAccessControlEntryWithParams:(MTRSubscribeParams *)params
                                           subscriptionEstablished:
                                               (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -1832,10 +1464,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTargetsPerAccessControlEntryWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                     NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTargetsPerAccessControlEntryWithParams:(MTRSubscribeParams *)params
                                          subscriptionEstablished:
                                              (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -1849,10 +1477,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAccessControlEntriesPerFabricWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                      NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAccessControlEntriesPerFabricWithParams:(MTRSubscribeParams *)params
                                           subscriptionEstablished:
                                               (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -1866,10 +1490,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -1882,10 +1502,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -1898,10 +1514,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1914,10 +1526,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1930,10 +1538,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -1986,10 +1590,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeActionListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActionListWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2002,10 +1602,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeEndpointListsWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEndpointListsWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2018,10 +1614,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSetupURLWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSetupURLWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2034,10 +1626,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -2050,10 +1638,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -2066,10 +1650,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2082,10 +1662,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2098,10 +1674,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2135,10 +1707,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeDataModelRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDataModelRevisionWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2151,10 +1719,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeVendorNameWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeVendorNameWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2167,10 +1731,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeVendorIDWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeVendorIDWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2183,10 +1743,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeProductNameWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeProductNameWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2199,10 +1755,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeProductIDWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeProductIDWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2219,10 +1771,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeNodeLabelWithValue:(NSString * _Nonnull)value
                                   params:(MTRWriteParams * _Nullable)params
                               completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNodeLabelWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2239,10 +1787,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeLocationWithValue:(NSString * _Nonnull)value
                                  params:(MTRWriteParams * _Nullable)params
                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLocationWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2255,10 +1799,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeHardwareVersionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeHardwareVersionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2271,10 +1811,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeHardwareVersionStringWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeHardwareVersionStringWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSString * _Nullable value,
@@ -2287,10 +1823,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSoftwareVersionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSoftwareVersionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2303,10 +1835,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSoftwareVersionStringWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSoftwareVersionStringWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSString * _Nullable value,
@@ -2319,10 +1847,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeManufacturingDateWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeManufacturingDateWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2335,10 +1859,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePartNumberWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePartNumberWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2351,10 +1871,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeProductURLWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeProductURLWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2367,10 +1883,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeProductLabelWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeProductLabelWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2383,10 +1895,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSerialNumberWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSerialNumberWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2404,10 +1912,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeLocalConfigDisabledWithValue:(NSNumber * _Nonnull)value
                                             params:(MTRWriteParams * _Nullable)params
                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLocalConfigDisabledWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -2420,10 +1924,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeReachableWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeReachableWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2436,10 +1936,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeUniqueIDWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUniqueIDWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2452,10 +1948,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeCapabilityMinimaWithCompletion:(void (^)(MTRBasicClusterCapabilityMinimaStruct * _Nullable value,
                                                         NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCapabilityMinimaWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(MTRBasicClusterCapabilityMinimaStruct * _Nullable value,
@@ -2468,10 +1960,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -2484,10 +1972,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -2500,10 +1984,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2516,10 +1996,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2532,10 +2008,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2572,10 +2044,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -2588,10 +2056,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -2604,10 +2068,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2620,10 +2080,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2636,10 +2092,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2676,10 +2128,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeDefaultOtaProvidersWithValue:(NSArray * _Nonnull)value
                                             params:(MTRWriteParams * _Nullable)params
                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDefaultOtaProvidersWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -2692,10 +2140,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeUpdatePossibleWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUpdatePossibleWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2708,10 +2152,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeUpdateStateWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUpdateStateWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2724,10 +2164,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeUpdateStateProgressWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUpdateStateProgressWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -2740,10 +2176,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -2756,10 +2188,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -2772,10 +2200,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2788,10 +2212,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2804,10 +2224,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2843,10 +2259,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeActiveLocaleWithValue:(NSString * _Nonnull)value
                                      params:(MTRWriteParams * _Nullable)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActiveLocaleWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2859,10 +2271,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSupportedLocalesWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSupportedLocalesWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2875,10 +2283,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -2891,10 +2295,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -2907,10 +2307,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2923,10 +2319,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2939,10 +2331,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2977,10 +2365,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeHourFormatWithValue:(NSNumber * _Nonnull)value
                                    params:(MTRWriteParams * _Nullable)params
                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeHourFormatWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -2998,10 +2382,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeActiveCalendarTypeWithValue:(NSNumber * _Nonnull)value
                                            params:(MTRWriteParams * _Nullable)params
                                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActiveCalendarTypeWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -3014,10 +2394,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSupportedCalendarTypesWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSupportedCalendarTypesWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSArray * _Nullable value,
@@ -3030,10 +2406,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -3046,10 +2418,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -3062,10 +2430,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3078,10 +2442,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3094,10 +2454,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3133,10 +2489,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeTemperatureUnitWithValue:(NSNumber * _Nonnull)value
                                         params:(MTRWriteParams * _Nullable)params
                                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTemperatureUnitWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3149,10 +2501,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -3165,10 +2513,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -3181,10 +2525,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3197,10 +2537,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3213,10 +2549,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3244,10 +2576,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSourcesWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSourcesWithParams:(MTRSubscribeParams *)params
                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                               reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3260,10 +2588,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -3276,10 +2600,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -3292,10 +2612,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3308,10 +2624,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3324,10 +2636,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3356,10 +2664,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeStatusWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeStatusWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3372,10 +2676,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeOrderWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOrderWithParams:(MTRSubscribeParams *)params
                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                             reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3388,10 +2688,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeDescriptionWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDescriptionWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3404,10 +2700,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeWiredAssessedInputVoltageWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWiredAssessedInputVoltageWithParams:(MTRSubscribeParams *)params
                                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                 reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -3420,10 +2712,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeWiredAssessedInputFrequencyWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                    NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWiredAssessedInputFrequencyWithParams:(MTRSubscribeParams *)params
                                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                   reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -3436,10 +2724,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeWiredCurrentTypeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWiredCurrentTypeWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3452,10 +2736,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeWiredAssessedCurrentWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWiredAssessedCurrentWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -3468,10 +2748,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeWiredNominalVoltageWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWiredNominalVoltageWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -3484,10 +2760,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeWiredMaximumCurrentWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWiredMaximumCurrentWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -3500,10 +2772,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeWiredPresentWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWiredPresentWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3516,10 +2784,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeActiveWiredFaultsWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActiveWiredFaultsWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3532,10 +2796,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatVoltageWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatVoltageWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3548,10 +2808,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatPercentRemainingWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatPercentRemainingWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -3564,10 +2820,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatTimeRemainingWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatTimeRemainingWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3580,10 +2832,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatChargeLevelWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatChargeLevelWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3596,10 +2844,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatReplacementNeededWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatReplacementNeededWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -3612,10 +2856,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatReplaceabilityWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatReplaceabilityWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3628,10 +2868,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatPresentWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatPresentWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3644,10 +2880,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeActiveBatFaultsWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActiveBatFaultsWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3660,10 +2892,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatReplacementDescriptionWithCompletion:(void (^)(NSString * _Nullable value,
                                                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatReplacementDescriptionWithParams:(MTRSubscribeParams *)params
                                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                 reportHandler:(void (^)(NSString * _Nullable value,
@@ -3676,10 +2904,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatCommonDesignationWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatCommonDesignationWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -3692,10 +2916,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatANSIDesignationWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatANSIDesignationWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSString * _Nullable value,
@@ -3708,10 +2928,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatIECDesignationWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatIECDesignationWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3724,10 +2940,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatApprovedChemistryWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatApprovedChemistryWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -3740,10 +2952,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatCapacityWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatCapacityWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3756,10 +2964,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatQuantityWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatQuantityWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3772,10 +2976,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatChargeStateWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatChargeStateWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3788,10 +2988,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatTimeToFullChargeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatTimeToFullChargeWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -3804,10 +3000,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatFunctionalWhileChargingWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatFunctionalWhileChargingWithParams:(MTRSubscribeParams *)params
                                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                  reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -3820,10 +3012,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBatChargingCurrentWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBatChargingCurrentWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -3836,10 +3024,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeActiveBatChargeFaultsWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActiveBatChargeFaultsWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSArray * _Nullable value,
@@ -3852,10 +3036,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -3868,10 +3048,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -3884,10 +3060,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3900,10 +3072,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3916,10 +3084,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3965,10 +3129,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeBreadcrumbWithValue:(NSNumber * _Nonnull)value
                                    params:(MTRWriteParams * _Nullable)params
                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBreadcrumbWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -3982,10 +3142,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeBasicCommissioningInfoWithCompletion:
     (void (^)(MTRGeneralCommissioningClusterBasicCommissioningInfo * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBasicCommissioningInfoWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:
@@ -4001,10 +3157,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRegulatoryConfigWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRegulatoryConfigWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4017,10 +3169,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeLocationCapabilityWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLocationCapabilityWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -4033,10 +3181,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSupportsConcurrentConnectionWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                     NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSupportsConcurrentConnectionWithParams:(MTRSubscribeParams *)params
                                          subscriptionEstablished:
                                              (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -4050,10 +3194,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -4066,10 +3206,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -4082,10 +3218,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4098,10 +3230,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4114,10 +3242,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4164,10 +3288,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeMaxNetworksWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxNetworksWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4180,10 +3300,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeNetworksWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNetworksWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4196,10 +3312,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeScanMaxTimeSecondsWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeScanMaxTimeSecondsWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -4212,10 +3324,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeConnectMaxTimeSecondsWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeConnectMaxTimeSecondsWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -4233,10 +3341,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeInterfaceEnabledWithValue:(NSNumber * _Nonnull)value
                                          params:(MTRWriteParams * _Nullable)params
                                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInterfaceEnabledWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4249,10 +3353,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeLastNetworkingStatusWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLastNetworkingStatusWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -4265,10 +3365,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeLastNetworkIDWithCompletion:(void (^)(NSData * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLastNetworkIDWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSData * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4281,10 +3377,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeLastConnectErrorValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLastConnectErrorValueWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -4297,10 +3389,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -4313,10 +3401,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -4329,10 +3413,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4345,10 +3425,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4361,10 +3437,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4396,10 +3468,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -4412,10 +3480,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -4428,10 +3492,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4444,10 +3504,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4460,10 +3516,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4495,10 +3547,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeNetworkInterfacesWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNetworkInterfacesWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4511,10 +3559,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRebootCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRebootCountWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4527,10 +3571,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeUpTimeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUpTimeWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4543,10 +3583,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTotalOperationalHoursWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTotalOperationalHoursWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -4559,10 +3595,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBootReasonsWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBootReasonsWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4575,10 +3607,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeActiveHardwareFaultsWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActiveHardwareFaultsWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -4591,10 +3619,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeActiveRadioFaultsWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActiveRadioFaultsWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4607,10 +3631,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeActiveNetworkFaultsWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActiveNetworkFaultsWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -4623,10 +3643,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTestEventTriggersEnabledWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTestEventTriggersEnabledWithParams:(MTRSubscribeParams *)params
                                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -4639,10 +3655,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -4655,10 +3667,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -4671,10 +3679,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4687,10 +3691,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4703,10 +3703,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4739,10 +3735,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeThreadMetricsWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeThreadMetricsWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4755,10 +3747,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeCurrentHeapFreeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentHeapFreeWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4771,10 +3759,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeCurrentHeapUsedWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentHeapUsedWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4787,10 +3771,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeCurrentHeapHighWatermarkWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentHeapHighWatermarkWithParams:(MTRSubscribeParams *)params
                                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -4803,10 +3783,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -4819,10 +3795,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -4835,10 +3807,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4851,10 +3819,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4867,10 +3831,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4903,10 +3863,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeChannelWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeChannelWithParams:(MTRSubscribeParams *)params
                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                               reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4919,10 +3875,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRoutingRoleWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRoutingRoleWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4935,10 +3887,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeNetworkNameWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNetworkNameWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4951,10 +3899,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePanIdWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePanIdWithParams:(MTRSubscribeParams *)params
                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                             reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4967,10 +3911,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeExtendedPanIdWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeExtendedPanIdWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4983,10 +3923,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeMeshLocalPrefixWithCompletion:(void (^)(NSData * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeshLocalPrefixWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSData * _Nullable value, NSError * _Nullable error))reportHandler
@@ -4999,10 +3935,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeOverrunCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOverrunCountWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5015,10 +3947,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeNeighborTableListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNeighborTableListWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5031,10 +3959,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRouteTableListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRouteTableListWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5047,10 +3971,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePartitionIdWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePartitionIdWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5063,10 +3983,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeWeightingWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWeightingWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5079,10 +3995,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeDataVersionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDataVersionWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5095,10 +4007,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeStableDataVersionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeStableDataVersionWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5111,10 +4019,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeLeaderRouterIdWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLeaderRouterIdWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5127,10 +4031,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeDetachedRoleCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDetachedRoleCountWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5143,10 +4043,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeChildRoleCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeChildRoleCountWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5159,10 +4055,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRouterRoleCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRouterRoleCountWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5175,10 +4067,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeLeaderRoleCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLeaderRoleCountWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5191,10 +4079,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttachAttemptCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttachAttemptCountWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -5207,10 +4091,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePartitionIdChangeCountWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePartitionIdChangeCountWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -5223,10 +4103,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBetterPartitionAttachAttemptCountWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                          NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBetterPartitionAttachAttemptCountWithParams:(MTRSubscribeParams *)params
                                               subscriptionEstablished:
                                                   (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -5242,10 +4118,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeParentChangeCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeParentChangeCountWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5258,10 +4130,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxTotalCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxTotalCountWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5274,10 +4142,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxUnicastCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxUnicastCountWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5290,10 +4154,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxBroadcastCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxBroadcastCountWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5306,10 +4166,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxAckRequestedCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxAckRequestedCountWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -5322,10 +4178,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxAckedCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxAckedCountWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5338,10 +4190,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxNoAckRequestedCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxNoAckRequestedCountWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -5354,10 +4202,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxDataCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxDataCountWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5370,10 +4214,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxDataPollCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxDataPollCountWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5386,10 +4226,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxBeaconCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxBeaconCountWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5402,10 +4238,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxBeaconRequestCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxBeaconRequestCountWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -5418,10 +4250,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxOtherCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxOtherCountWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5434,10 +4262,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxRetryCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxRetryCountWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5450,10 +4274,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxDirectMaxRetryExpiryCountWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                    NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxDirectMaxRetryExpiryCountWithParams:(MTRSubscribeParams *)params
                                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                   reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -5466,10 +4286,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxIndirectMaxRetryExpiryCountWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                      NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxIndirectMaxRetryExpiryCountWithParams:(MTRSubscribeParams *)params
                                           subscriptionEstablished:
                                               (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -5483,10 +4299,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxErrCcaCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxErrCcaCountWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5499,10 +4311,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxErrAbortCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxErrAbortCountWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5515,10 +4323,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxErrBusyChannelCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxErrBusyChannelCountWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -5531,10 +4335,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxTotalCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxTotalCountWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5547,10 +4347,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxUnicastCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxUnicastCountWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5563,10 +4359,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxBroadcastCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxBroadcastCountWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5579,10 +4371,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxDataCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxDataCountWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5595,10 +4383,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxDataPollCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxDataPollCountWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5611,10 +4395,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxBeaconCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxBeaconCountWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5627,10 +4407,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxBeaconRequestCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxBeaconRequestCountWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -5643,10 +4419,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxOtherCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxOtherCountWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5659,10 +4431,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxAddressFilteredCountWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxAddressFilteredCountWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -5675,10 +4443,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxDestAddrFilteredCountWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxDestAddrFilteredCountWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -5691,10 +4455,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxDuplicatedCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxDuplicatedCountWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5707,10 +4467,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxErrNoFrameCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxErrNoFrameCountWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5723,10 +4479,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxErrUnknownNeighborCountWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxErrUnknownNeighborCountWithParams:(MTRSubscribeParams *)params
                                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                 reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -5739,10 +4491,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxErrInvalidSrcAddrCountWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxErrInvalidSrcAddrCountWithParams:(MTRSubscribeParams *)params
                                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -5755,10 +4503,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxErrSecCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxErrSecCountWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5771,10 +4515,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxErrFcsCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxErrFcsCountWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5787,10 +4527,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRxErrOtherCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRxErrOtherCountWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5803,10 +4539,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeActiveTimestampWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActiveTimestampWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5819,10 +4551,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePendingTimestampWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePendingTimestampWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5835,10 +4563,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeDelayWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDelayWithParams:(MTRSubscribeParams *)params
                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                             reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5851,10 +4575,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSecurityPolicyWithCompletion:(void (^)(MTRThreadNetworkDiagnosticsClusterSecurityPolicy * _Nullable value,
                                                       NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSecurityPolicyWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(MTRThreadNetworkDiagnosticsClusterSecurityPolicy * _Nullable value,
@@ -5867,10 +4587,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeChannelPage0MaskWithCompletion:(void (^)(NSData * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeChannelPage0MaskWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSData * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5884,10 +4600,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeOperationalDatasetComponentsWithCompletion:
     (void (^)(MTRThreadNetworkDiagnosticsClusterOperationalDatasetComponents * _Nullable value,
         NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)
     subscribeAttributeOperationalDatasetComponentsWithParams:(MTRSubscribeParams *)params
                                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -5906,10 +4618,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeActiveNetworkFaultsListWithCompletion:(void (^)(NSArray * _Nullable value,
                                                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActiveNetworkFaultsListWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSArray * _Nullable value,
@@ -5922,10 +4630,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -5938,10 +4642,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -5954,10 +4654,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5970,10 +4666,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -5986,10 +4678,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6022,10 +4710,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBssidWithCompletion:(void (^)(NSData * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBssidWithParams:(MTRSubscribeParams *)params
                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                             reportHandler:(void (^)(NSData * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6038,10 +4722,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSecurityTypeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSecurityTypeWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6054,10 +4734,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeWiFiVersionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWiFiVersionWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6070,10 +4746,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeChannelNumberWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeChannelNumberWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6086,10 +4758,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeRssiWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRssiWithParams:(MTRSubscribeParams *)params
                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                            reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6102,10 +4770,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBeaconLostCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBeaconLostCountWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6118,10 +4782,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeBeaconRxCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBeaconRxCountWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6134,10 +4794,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePacketMulticastRxCountWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePacketMulticastRxCountWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -6150,10 +4806,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePacketMulticastTxCountWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePacketMulticastTxCountWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -6166,10 +4818,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePacketUnicastRxCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePacketUnicastRxCountWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -6182,10 +4830,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePacketUnicastTxCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePacketUnicastTxCountWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -6198,10 +4842,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeCurrentMaxRateWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentMaxRateWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6214,10 +4854,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeOverrunCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOverrunCountWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6230,10 +4866,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -6246,10 +4878,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -6262,10 +4890,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6278,10 +4902,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6294,10 +4914,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6330,10 +4946,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePHYRateWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePHYRateWithParams:(MTRSubscribeParams *)params
                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                               reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6346,10 +4958,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFullDuplexWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFullDuplexWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6362,10 +4970,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePacketRxCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePacketRxCountWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6378,10 +4982,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePacketTxCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePacketTxCountWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6394,10 +4994,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTxErrCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTxErrCountWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6410,10 +5006,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeCollisionCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCollisionCountWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6426,10 +5018,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeOverrunCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOverrunCountWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6442,10 +5030,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeCarrierDetectWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCarrierDetectWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6458,10 +5042,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeTimeSinceResetWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTimeSinceResetWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6474,10 +5054,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -6490,10 +5066,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -6506,10 +5078,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6522,10 +5090,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6538,10 +5102,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6572,10 +5132,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeVendorNameWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeVendorNameWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6588,10 +5144,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeVendorIDWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeVendorIDWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6604,10 +5156,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeProductNameWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeProductNameWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6624,10 +5172,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributeNodeLabelWithValue:(NSString * _Nonnull)value
                                   params:(MTRWriteParams * _Nullable)params
                               completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNodeLabelWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6640,10 +5184,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeHardwareVersionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeHardwareVersionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6656,10 +5196,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeHardwareVersionStringWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeHardwareVersionStringWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSString * _Nullable value,
@@ -6672,10 +5208,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSoftwareVersionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSoftwareVersionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6688,10 +5220,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSoftwareVersionStringWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSoftwareVersionStringWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSString * _Nullable value,
@@ -6704,10 +5232,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeManufacturingDateWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeManufacturingDateWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6720,10 +5244,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePartNumberWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePartNumberWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6736,10 +5256,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeProductURLWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeProductURLWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6752,10 +5268,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeProductLabelWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeProductLabelWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6768,10 +5280,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeSerialNumberWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSerialNumberWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6784,10 +5292,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeReachableWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeReachableWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6800,10 +5304,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeUniqueIDWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUniqueIDWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6816,10 +5316,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -6832,10 +5328,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -6848,10 +5340,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6864,10 +5352,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6880,10 +5364,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6916,10 +5396,6 @@ light or a window shade.
 
 - (void)readAttributeNumberOfPositionsWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNumberOfPositionsWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6932,10 +5408,6 @@ light or a window shade.
 
 - (void)readAttributeCurrentPositionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentPositionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6948,10 +5420,6 @@ light or a window shade.
 
 - (void)readAttributeMultiPressMaxWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMultiPressMaxWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -6964,10 +5432,6 @@ light or a window shade.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -6980,10 +5444,6 @@ light or a window shade.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -6996,10 +5456,6 @@ light or a window shade.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7012,10 +5468,6 @@ light or a window shade.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7028,10 +5480,6 @@ light or a window shade.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7067,10 +5515,6 @@ light or a window shade.
 
 - (void)readAttributeWindowStatusWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWindowStatusWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7083,10 +5527,6 @@ light or a window shade.
 
 - (void)readAttributeAdminFabricIndexWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAdminFabricIndexWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7099,10 +5539,6 @@ light or a window shade.
 
 - (void)readAttributeAdminVendorIdWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAdminVendorIdWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7115,10 +5551,6 @@ light or a window shade.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -7131,10 +5563,6 @@ light or a window shade.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -7147,10 +5575,6 @@ light or a window shade.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7163,10 +5587,6 @@ light or a window shade.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7179,10 +5599,6 @@ light or a window shade.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7235,10 +5651,6 @@ light or a window shade.
 
 - (void)readAttributeNOCsWithParams:(MTRReadParams * _Nullable)params
                          completion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNOCsWithParams:(MTRSubscribeParams *)params
                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                            reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7252,10 +5664,6 @@ light or a window shade.
 - (void)readAttributeFabricsWithParams:(MTRReadParams * _Nullable)params
                             completion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFabricsWithParams:(MTRSubscribeParams *)params
                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                               reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7268,10 +5676,6 @@ light or a window shade.
 
 - (void)readAttributeSupportedFabricsWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSupportedFabricsWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7284,10 +5688,6 @@ light or a window shade.
 
 - (void)readAttributeCommissionedFabricsWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCommissionedFabricsWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -7300,10 +5700,6 @@ light or a window shade.
 
 - (void)readAttributeTrustedRootCertificatesWithCompletion:(void (^)(NSArray * _Nullable value,
                                                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTrustedRootCertificatesWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSArray * _Nullable value,
@@ -7316,10 +5712,6 @@ light or a window shade.
 
 - (void)readAttributeCurrentFabricIndexWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentFabricIndexWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -7332,10 +5724,6 @@ light or a window shade.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -7348,10 +5736,6 @@ light or a window shade.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -7364,10 +5748,6 @@ light or a window shade.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7380,10 +5760,6 @@ light or a window shade.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7396,10 +5772,6 @@ light or a window shade.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7443,10 +5815,6 @@ light or a window shade.
 - (void)writeAttributeGroupKeyMapWithValue:(NSArray * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGroupKeyMapWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7460,10 +5828,6 @@ light or a window shade.
 - (void)readAttributeGroupTableWithParams:(MTRReadParams * _Nullable)params
                                completion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGroupTableWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7476,10 +5840,6 @@ light or a window shade.
 
 - (void)readAttributeMaxGroupsPerFabricWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxGroupsPerFabricWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -7492,10 +5852,6 @@ light or a window shade.
 
 - (void)readAttributeMaxGroupKeysPerFabricWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxGroupKeysPerFabricWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -7508,10 +5864,6 @@ light or a window shade.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -7524,10 +5876,6 @@ light or a window shade.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -7540,10 +5888,6 @@ light or a window shade.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7556,10 +5900,6 @@ light or a window shade.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7572,10 +5912,6 @@ light or a window shade.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7604,10 +5940,6 @@ labels.
 
 - (void)readAttributeLabelListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLabelListWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7620,10 +5952,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -7636,10 +5964,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -7652,10 +5976,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7668,10 +5988,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7684,10 +6000,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7719,10 +6031,6 @@ labels.
 - (void)writeAttributeLabelListWithValue:(NSArray * _Nonnull)value
                                   params:(MTRWriteParams * _Nullable)params
                               completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLabelListWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7735,10 +6043,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -7751,10 +6055,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -7767,10 +6067,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7783,10 +6079,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7799,10 +6091,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7830,10 +6118,6 @@ labels.
 
 - (void)readAttributeStateValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeStateValueWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7846,10 +6130,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -7862,10 +6142,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -7878,10 +6154,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7894,10 +6166,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7910,10 +6178,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7944,10 +6208,6 @@ labels.
 
 - (void)readAttributeDescriptionWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDescriptionWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7960,10 +6220,6 @@ labels.
 
 - (void)readAttributeStandardNamespaceWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeStandardNamespaceWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7976,10 +6232,6 @@ labels.
 
 - (void)readAttributeSupportedModesWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSupportedModesWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -7992,10 +6244,6 @@ labels.
 
 - (void)readAttributeCurrentModeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentModeWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8013,10 +6261,6 @@ labels.
 - (void)writeAttributeStartUpModeWithValue:(NSNumber * _Nullable)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeStartUpModeWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8033,10 +6277,6 @@ labels.
 - (void)writeAttributeOnModeWithValue:(NSNumber * _Nullable)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOnModeWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8049,10 +6289,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -8065,10 +6301,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -8081,10 +6313,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8097,10 +6325,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8113,10 +6337,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8186,10 +6406,6 @@ labels.
 
 - (void)readAttributeLockStateWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLockStateWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8202,10 +6418,6 @@ labels.
 
 - (void)readAttributeLockTypeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLockTypeWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8218,10 +6430,6 @@ labels.
 
 - (void)readAttributeActuatorEnabledWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActuatorEnabledWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8234,10 +6442,6 @@ labels.
 
 - (void)readAttributeDoorStateWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDoorStateWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8255,10 +6459,6 @@ labels.
 - (void)writeAttributeDoorOpenEventsWithValue:(NSNumber * _Nonnull)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDoorOpenEventsWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8276,10 +6476,6 @@ labels.
 - (void)writeAttributeDoorClosedEventsWithValue:(NSNumber * _Nonnull)value
                                          params:(MTRWriteParams * _Nullable)params
                                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDoorClosedEventsWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8296,10 +6492,6 @@ labels.
 - (void)writeAttributeOpenPeriodWithValue:(NSNumber * _Nonnull)value
                                    params:(MTRWriteParams * _Nullable)params
                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOpenPeriodWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8312,10 +6504,6 @@ labels.
 
 - (void)readAttributeNumberOfTotalUsersSupportedWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                    NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNumberOfTotalUsersSupportedWithParams:(MTRSubscribeParams *)params
                                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                   reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -8328,10 +6516,6 @@ labels.
 
 - (void)readAttributeNumberOfPINUsersSupportedWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNumberOfPINUsersSupportedWithParams:(MTRSubscribeParams *)params
                                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                 reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -8344,10 +6528,6 @@ labels.
 
 - (void)readAttributeNumberOfRFIDUsersSupportedWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNumberOfRFIDUsersSupportedWithParams:(MTRSubscribeParams *)params
                                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                  reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -8360,10 +6540,6 @@ labels.
 
 - (void)readAttributeNumberOfWeekDaySchedulesSupportedPerUserWithCompletion:
     (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNumberOfWeekDaySchedulesSupportedPerUserWithParams:(MTRSubscribeParams *)params
                                                      subscriptionEstablished:
                                                          (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -8380,10 +6556,6 @@ labels.
 
 - (void)readAttributeNumberOfYearDaySchedulesSupportedPerUserWithCompletion:
     (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNumberOfYearDaySchedulesSupportedPerUserWithParams:(MTRSubscribeParams *)params
                                                      subscriptionEstablished:
                                                          (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -8400,10 +6572,6 @@ labels.
 
 - (void)readAttributeNumberOfHolidaySchedulesSupportedWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                          NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNumberOfHolidaySchedulesSupportedWithParams:(MTRSubscribeParams *)params
                                               subscriptionEstablished:
                                                   (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -8419,10 +6587,6 @@ labels.
 
 - (void)readAttributeMaxPINCodeLengthWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxPINCodeLengthWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8435,10 +6599,6 @@ labels.
 
 - (void)readAttributeMinPINCodeLengthWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinPINCodeLengthWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8451,10 +6611,6 @@ labels.
 
 - (void)readAttributeMaxRFIDCodeLengthWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxRFIDCodeLengthWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8467,10 +6623,6 @@ labels.
 
 - (void)readAttributeMinRFIDCodeLengthWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinRFIDCodeLengthWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8483,10 +6635,6 @@ labels.
 
 - (void)readAttributeCredentialRulesSupportWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCredentialRulesSupportWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -8499,10 +6647,6 @@ labels.
 
 - (void)readAttributeNumberOfCredentialsSupportedPerUserWithCompletion:
     (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNumberOfCredentialsSupportedPerUserWithParams:(MTRSubscribeParams *)params
                                                 subscriptionEstablished:
                                                     (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -8522,10 +6666,6 @@ labels.
 - (void)writeAttributeLanguageWithValue:(NSString * _Nonnull)value
                                  params:(MTRWriteParams * _Nullable)params
                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLanguageWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8543,10 +6683,6 @@ labels.
 - (void)writeAttributeLEDSettingsWithValue:(NSNumber * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLEDSettingsWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8564,10 +6700,6 @@ labels.
 - (void)writeAttributeAutoRelockTimeWithValue:(NSNumber * _Nonnull)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAutoRelockTimeWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8585,10 +6717,6 @@ labels.
 - (void)writeAttributeSoundVolumeWithValue:(NSNumber * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSoundVolumeWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8606,10 +6734,6 @@ labels.
 - (void)writeAttributeOperatingModeWithValue:(NSNumber * _Nonnull)value
                                       params:(MTRWriteParams * _Nullable)params
                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOperatingModeWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8622,10 +6746,6 @@ labels.
 
 - (void)readAttributeSupportedOperatingModesWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSupportedOperatingModesWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -8638,10 +6758,6 @@ labels.
 
 - (void)readAttributeDefaultConfigurationRegisterWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                     NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDefaultConfigurationRegisterWithParams:(MTRSubscribeParams *)params
                                          subscriptionEstablished:
                                              (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -8660,10 +6776,6 @@ labels.
 - (void)writeAttributeEnableLocalProgrammingWithValue:(NSNumber * _Nonnull)value
                                                params:(MTRWriteParams * _Nullable)params
                                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEnableLocalProgrammingWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -8681,10 +6793,6 @@ labels.
 - (void)writeAttributeEnableOneTouchLockingWithValue:(NSNumber * _Nonnull)value
                                               params:(MTRWriteParams * _Nullable)params
                                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEnableOneTouchLockingWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -8702,10 +6810,6 @@ labels.
 - (void)writeAttributeEnableInsideStatusLEDWithValue:(NSNumber * _Nonnull)value
                                               params:(MTRWriteParams * _Nullable)params
                                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEnableInsideStatusLEDWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -8723,10 +6827,6 @@ labels.
 - (void)writeAttributeEnablePrivacyModeButtonWithValue:(NSNumber * _Nonnull)value
                                                 params:(MTRWriteParams * _Nullable)params
                                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEnablePrivacyModeButtonWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -8744,10 +6844,6 @@ labels.
 - (void)writeAttributeLocalProgrammingFeaturesWithValue:(NSNumber * _Nonnull)value
                                                  params:(MTRWriteParams * _Nullable)params
                                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLocalProgrammingFeaturesWithParams:(MTRSubscribeParams *)params
                                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -8765,10 +6861,6 @@ labels.
 - (void)writeAttributeWrongCodeEntryLimitWithValue:(NSNumber * _Nonnull)value
                                             params:(MTRWriteParams * _Nullable)params
                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWrongCodeEntryLimitWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -8786,10 +6878,6 @@ labels.
 - (void)writeAttributeUserCodeTemporaryDisableTimeWithValue:(NSNumber * _Nonnull)value
                                                      params:(MTRWriteParams * _Nullable)params
                                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUserCodeTemporaryDisableTimeWithParams:(MTRSubscribeParams *)params
                                          subscriptionEstablished:
                                              (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -8808,10 +6896,6 @@ labels.
 - (void)writeAttributeSendPINOverTheAirWithValue:(NSNumber * _Nonnull)value
                                           params:(MTRWriteParams * _Nullable)params
                                       completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSendPINOverTheAirWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8829,10 +6913,6 @@ labels.
 - (void)writeAttributeRequirePINforRemoteOperationWithValue:(NSNumber * _Nonnull)value
                                                      params:(MTRWriteParams * _Nullable)params
                                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRequirePINforRemoteOperationWithParams:(MTRSubscribeParams *)params
                                          subscriptionEstablished:
                                              (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -8851,10 +6931,6 @@ labels.
 - (void)writeAttributeExpiringUserTimeoutWithValue:(NSNumber * _Nonnull)value
                                             params:(MTRWriteParams * _Nullable)params
                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeExpiringUserTimeoutWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -8867,10 +6943,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -8883,10 +6955,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -8899,10 +6967,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8915,10 +6979,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8931,10 +6991,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8980,10 +7036,6 @@ labels.
 
 - (void)readAttributeTypeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTypeWithParams:(MTRSubscribeParams *)params
                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                            reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -8996,10 +7048,6 @@ labels.
 
 - (void)readAttributePhysicalClosedLimitLiftWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePhysicalClosedLimitLiftWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9012,10 +7060,6 @@ labels.
 
 - (void)readAttributePhysicalClosedLimitTiltWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePhysicalClosedLimitTiltWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9028,10 +7072,6 @@ labels.
 
 - (void)readAttributeCurrentPositionLiftWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentPositionLiftWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9044,10 +7084,6 @@ labels.
 
 - (void)readAttributeCurrentPositionTiltWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentPositionTiltWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9060,10 +7096,6 @@ labels.
 
 - (void)readAttributeNumberOfActuationsLiftWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNumberOfActuationsLiftWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9076,10 +7108,6 @@ labels.
 
 - (void)readAttributeNumberOfActuationsTiltWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNumberOfActuationsTiltWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9092,10 +7120,6 @@ labels.
 
 - (void)readAttributeConfigStatusWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeConfigStatusWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9108,10 +7132,6 @@ labels.
 
 - (void)readAttributeCurrentPositionLiftPercentageWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                      NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentPositionLiftPercentageWithParams:(MTRSubscribeParams *)params
                                           subscriptionEstablished:
                                               (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -9125,10 +7145,6 @@ labels.
 
 - (void)readAttributeCurrentPositionTiltPercentageWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                      NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentPositionTiltPercentageWithParams:(MTRSubscribeParams *)params
                                           subscriptionEstablished:
                                               (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -9142,10 +7158,6 @@ labels.
 
 - (void)readAttributeOperationalStatusWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOperationalStatusWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9158,10 +7170,6 @@ labels.
 
 - (void)readAttributeTargetPositionLiftPercent100thsWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                        NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTargetPositionLiftPercent100thsWithParams:(MTRSubscribeParams *)params
                                             subscriptionEstablished:
                                                 (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -9177,10 +7185,6 @@ labels.
 
 - (void)readAttributeTargetPositionTiltPercent100thsWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                        NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTargetPositionTiltPercent100thsWithParams:(MTRSubscribeParams *)params
                                             subscriptionEstablished:
                                                 (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -9196,10 +7200,6 @@ labels.
 
 - (void)readAttributeEndProductTypeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEndProductTypeWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9212,10 +7212,6 @@ labels.
 
 - (void)readAttributeCurrentPositionLiftPercent100thsWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                         NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentPositionLiftPercent100thsWithParams:(MTRSubscribeParams *)params
                                              subscriptionEstablished:
                                                  (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -9231,10 +7227,6 @@ labels.
 
 - (void)readAttributeCurrentPositionTiltPercent100thsWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                         NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentPositionTiltPercent100thsWithParams:(MTRSubscribeParams *)params
                                              subscriptionEstablished:
                                                  (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -9250,10 +7242,6 @@ labels.
 
 - (void)readAttributeInstalledOpenLimitLiftWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInstalledOpenLimitLiftWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9266,10 +7254,6 @@ labels.
 
 - (void)readAttributeInstalledClosedLimitLiftWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInstalledClosedLimitLiftWithParams:(MTRSubscribeParams *)params
                                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9282,10 +7266,6 @@ labels.
 
 - (void)readAttributeInstalledOpenLimitTiltWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInstalledOpenLimitTiltWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9298,10 +7278,6 @@ labels.
 
 - (void)readAttributeInstalledClosedLimitTiltWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInstalledClosedLimitTiltWithParams:(MTRSubscribeParams *)params
                                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9318,10 +7294,6 @@ labels.
 - (void)writeAttributeModeWithValue:(NSNumber * _Nonnull)value
                              params:(MTRWriteParams * _Nullable)params
                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeModeWithParams:(MTRSubscribeParams *)params
                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                            reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9334,10 +7306,6 @@ labels.
 
 - (void)readAttributeSafetyStatusWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSafetyStatusWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9350,10 +7318,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -9366,10 +7330,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -9382,10 +7342,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9398,10 +7354,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9414,10 +7366,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9451,10 +7399,6 @@ labels.
 
 - (void)readAttributeBarrierMovingStateWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBarrierMovingStateWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9467,10 +7411,6 @@ labels.
 
 - (void)readAttributeBarrierSafetyStatusWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBarrierSafetyStatusWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9483,10 +7423,6 @@ labels.
 
 - (void)readAttributeBarrierCapabilitiesWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBarrierCapabilitiesWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9504,10 +7440,6 @@ labels.
 - (void)writeAttributeBarrierOpenEventsWithValue:(NSNumber * _Nonnull)value
                                           params:(MTRWriteParams * _Nullable)params
                                       completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBarrierOpenEventsWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9525,10 +7457,6 @@ labels.
 - (void)writeAttributeBarrierCloseEventsWithValue:(NSNumber * _Nonnull)value
                                            params:(MTRWriteParams * _Nullable)params
                                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBarrierCloseEventsWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9546,10 +7474,6 @@ labels.
 - (void)writeAttributeBarrierCommandOpenEventsWithValue:(NSNumber * _Nonnull)value
                                                  params:(MTRWriteParams * _Nullable)params
                                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBarrierCommandOpenEventsWithParams:(MTRSubscribeParams *)params
                                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9567,10 +7491,6 @@ labels.
 - (void)writeAttributeBarrierCommandCloseEventsWithValue:(NSNumber * _Nonnull)value
                                                   params:(MTRWriteParams * _Nullable)params
                                               completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBarrierCommandCloseEventsWithParams:(MTRSubscribeParams *)params
                                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                 reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9588,10 +7508,6 @@ labels.
 - (void)writeAttributeBarrierOpenPeriodWithValue:(NSNumber * _Nonnull)value
                                           params:(MTRWriteParams * _Nullable)params
                                       completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBarrierOpenPeriodWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9609,10 +7525,6 @@ labels.
 - (void)writeAttributeBarrierClosePeriodWithValue:(NSNumber * _Nonnull)value
                                            params:(MTRWriteParams * _Nullable)params
                                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBarrierClosePeriodWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9625,10 +7537,6 @@ labels.
 
 - (void)readAttributeBarrierPositionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBarrierPositionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9641,10 +7549,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -9657,10 +7561,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -9673,10 +7573,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9689,10 +7585,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9705,10 +7597,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9736,10 +7624,6 @@ labels.
 
 - (void)readAttributeMaxPressureWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxPressureWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9752,10 +7636,6 @@ labels.
 
 - (void)readAttributeMaxSpeedWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxSpeedWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9768,10 +7648,6 @@ labels.
 
 - (void)readAttributeMaxFlowWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxFlowWithParams:(MTRSubscribeParams *)params
                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                               reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9784,10 +7660,6 @@ labels.
 
 - (void)readAttributeMinConstPressureWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinConstPressureWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9800,10 +7672,6 @@ labels.
 
 - (void)readAttributeMaxConstPressureWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxConstPressureWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9816,10 +7684,6 @@ labels.
 
 - (void)readAttributeMinCompPressureWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinCompPressureWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9832,10 +7696,6 @@ labels.
 
 - (void)readAttributeMaxCompPressureWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxCompPressureWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9848,10 +7708,6 @@ labels.
 
 - (void)readAttributeMinConstSpeedWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinConstSpeedWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9864,10 +7720,6 @@ labels.
 
 - (void)readAttributeMaxConstSpeedWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxConstSpeedWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9880,10 +7732,6 @@ labels.
 
 - (void)readAttributeMinConstFlowWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinConstFlowWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9896,10 +7744,6 @@ labels.
 
 - (void)readAttributeMaxConstFlowWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxConstFlowWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9912,10 +7756,6 @@ labels.
 
 - (void)readAttributeMinConstTempWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinConstTempWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9928,10 +7768,6 @@ labels.
 
 - (void)readAttributeMaxConstTempWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxConstTempWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9944,10 +7780,6 @@ labels.
 
 - (void)readAttributePumpStatusWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePumpStatusWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -9960,10 +7792,6 @@ labels.
 
 - (void)readAttributeEffectiveOperationModeWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEffectiveOperationModeWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9976,10 +7804,6 @@ labels.
 
 - (void)readAttributeEffectiveControlModeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEffectiveControlModeWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -9992,10 +7816,6 @@ labels.
 
 - (void)readAttributeCapacityWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCapacityWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10008,10 +7828,6 @@ labels.
 
 - (void)readAttributeSpeedWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSpeedWithParams:(MTRSubscribeParams *)params
                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                             reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10029,10 +7845,6 @@ labels.
 - (void)writeAttributeLifetimeRunningHoursWithValue:(NSNumber * _Nullable)value
                                              params:(MTRWriteParams * _Nullable)params
                                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLifetimeRunningHoursWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10045,10 +7857,6 @@ labels.
 
 - (void)readAttributePowerWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePowerWithParams:(MTRSubscribeParams *)params
                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                             reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10066,10 +7874,6 @@ labels.
 - (void)writeAttributeLifetimeEnergyConsumedWithValue:(NSNumber * _Nullable)value
                                                params:(MTRWriteParams * _Nullable)params
                                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLifetimeEnergyConsumedWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10087,10 +7891,6 @@ labels.
 - (void)writeAttributeOperationModeWithValue:(NSNumber * _Nonnull)value
                                       params:(MTRWriteParams * _Nullable)params
                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOperationModeWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10108,10 +7908,6 @@ labels.
 - (void)writeAttributeControlModeWithValue:(NSNumber * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeControlModeWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10124,10 +7920,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -10140,10 +7932,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -10156,10 +7944,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10172,10 +7956,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10188,10 +7968,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10230,10 +8006,6 @@ labels.
 
 - (void)readAttributeLocalTemperatureWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLocalTemperatureWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10246,10 +8018,6 @@ labels.
 
 - (void)readAttributeOutdoorTemperatureWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOutdoorTemperatureWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10262,10 +8030,6 @@ labels.
 
 - (void)readAttributeOccupancyWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOccupancyWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10278,10 +8042,6 @@ labels.
 
 - (void)readAttributeAbsMinHeatSetpointLimitWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAbsMinHeatSetpointLimitWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10294,10 +8054,6 @@ labels.
 
 - (void)readAttributeAbsMaxHeatSetpointLimitWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAbsMaxHeatSetpointLimitWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10310,10 +8066,6 @@ labels.
 
 - (void)readAttributeAbsMinCoolSetpointLimitWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAbsMinCoolSetpointLimitWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10326,10 +8078,6 @@ labels.
 
 - (void)readAttributeAbsMaxCoolSetpointLimitWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAbsMaxCoolSetpointLimitWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10342,10 +8090,6 @@ labels.
 
 - (void)readAttributePICoolingDemandWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePICoolingDemandWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10358,10 +8102,6 @@ labels.
 
 - (void)readAttributePIHeatingDemandWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePIHeatingDemandWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10379,10 +8119,6 @@ labels.
 - (void)writeAttributeHVACSystemTypeConfigurationWithValue:(NSNumber * _Nonnull)value
                                                     params:(MTRWriteParams * _Nullable)params
                                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeHVACSystemTypeConfigurationWithParams:(MTRSubscribeParams *)params
                                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                   reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10400,10 +8136,6 @@ labels.
 - (void)writeAttributeLocalTemperatureCalibrationWithValue:(NSNumber * _Nonnull)value
                                                     params:(MTRWriteParams * _Nullable)params
                                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLocalTemperatureCalibrationWithParams:(MTRSubscribeParams *)params
                                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                   reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10421,10 +8153,6 @@ labels.
 - (void)writeAttributeOccupiedCoolingSetpointWithValue:(NSNumber * _Nonnull)value
                                                 params:(MTRWriteParams * _Nullable)params
                                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOccupiedCoolingSetpointWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10442,10 +8170,6 @@ labels.
 - (void)writeAttributeOccupiedHeatingSetpointWithValue:(NSNumber * _Nonnull)value
                                                 params:(MTRWriteParams * _Nullable)params
                                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOccupiedHeatingSetpointWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10463,10 +8187,6 @@ labels.
 - (void)writeAttributeUnoccupiedCoolingSetpointWithValue:(NSNumber * _Nonnull)value
                                                   params:(MTRWriteParams * _Nullable)params
                                               completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUnoccupiedCoolingSetpointWithParams:(MTRSubscribeParams *)params
                                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                 reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10484,10 +8204,6 @@ labels.
 - (void)writeAttributeUnoccupiedHeatingSetpointWithValue:(NSNumber * _Nonnull)value
                                                   params:(MTRWriteParams * _Nullable)params
                                               completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUnoccupiedHeatingSetpointWithParams:(MTRSubscribeParams *)params
                                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                 reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10505,10 +8221,6 @@ labels.
 - (void)writeAttributeMinHeatSetpointLimitWithValue:(NSNumber * _Nonnull)value
                                              params:(MTRWriteParams * _Nullable)params
                                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinHeatSetpointLimitWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10526,10 +8238,6 @@ labels.
 - (void)writeAttributeMaxHeatSetpointLimitWithValue:(NSNumber * _Nonnull)value
                                              params:(MTRWriteParams * _Nullable)params
                                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxHeatSetpointLimitWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10547,10 +8255,6 @@ labels.
 - (void)writeAttributeMinCoolSetpointLimitWithValue:(NSNumber * _Nonnull)value
                                              params:(MTRWriteParams * _Nullable)params
                                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinCoolSetpointLimitWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10568,10 +8272,6 @@ labels.
 - (void)writeAttributeMaxCoolSetpointLimitWithValue:(NSNumber * _Nonnull)value
                                              params:(MTRWriteParams * _Nullable)params
                                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxCoolSetpointLimitWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10589,10 +8289,6 @@ labels.
 - (void)writeAttributeMinSetpointDeadBandWithValue:(NSNumber * _Nonnull)value
                                             params:(MTRWriteParams * _Nullable)params
                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinSetpointDeadBandWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10610,10 +8306,6 @@ labels.
 - (void)writeAttributeRemoteSensingWithValue:(NSNumber * _Nonnull)value
                                       params:(MTRWriteParams * _Nullable)params
                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRemoteSensingWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10631,10 +8323,6 @@ labels.
 - (void)writeAttributeControlSequenceOfOperationWithValue:(NSNumber * _Nonnull)value
                                                    params:(MTRWriteParams * _Nullable)params
                                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeControlSequenceOfOperationWithParams:(MTRSubscribeParams *)params
                                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                  reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10651,10 +8339,6 @@ labels.
 - (void)writeAttributeSystemModeWithValue:(NSNumber * _Nonnull)value
                                    params:(MTRWriteParams * _Nullable)params
                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSystemModeWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10667,10 +8351,6 @@ labels.
 
 - (void)readAttributeThermostatRunningModeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeThermostatRunningModeWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10683,10 +8363,6 @@ labels.
 
 - (void)readAttributeStartOfWeekWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeStartOfWeekWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10699,10 +8375,6 @@ labels.
 
 - (void)readAttributeNumberOfWeeklyTransitionsWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNumberOfWeeklyTransitionsWithParams:(MTRSubscribeParams *)params
                                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                 reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10715,10 +8387,6 @@ labels.
 
 - (void)readAttributeNumberOfDailyTransitionsWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNumberOfDailyTransitionsWithParams:(MTRSubscribeParams *)params
                                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10736,10 +8404,6 @@ labels.
 - (void)writeAttributeTemperatureSetpointHoldWithValue:(NSNumber * _Nonnull)value
                                                 params:(MTRWriteParams * _Nullable)params
                                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTemperatureSetpointHoldWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10757,10 +8421,6 @@ labels.
 - (void)writeAttributeTemperatureSetpointHoldDurationWithValue:(NSNumber * _Nullable)value
                                                         params:(MTRWriteParams * _Nullable)params
                                                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTemperatureSetpointHoldDurationWithParams:(MTRSubscribeParams *)params
                                             subscriptionEstablished:
                                                 (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -10781,10 +8441,6 @@ labels.
 - (void)writeAttributeThermostatProgrammingOperationModeWithValue:(NSNumber * _Nonnull)value
                                                            params:(MTRWriteParams * _Nullable)params
                                                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeThermostatProgrammingOperationModeWithParams:(MTRSubscribeParams *)params
                                                subscriptionEstablished:
                                                    (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -10800,10 +8456,6 @@ labels.
 
 - (void)readAttributeThermostatRunningStateWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeThermostatRunningStateWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10816,10 +8468,6 @@ labels.
 
 - (void)readAttributeSetpointChangeSourceWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSetpointChangeSourceWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10832,10 +8480,6 @@ labels.
 
 - (void)readAttributeSetpointChangeAmountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSetpointChangeAmountWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10848,10 +8492,6 @@ labels.
 
 - (void)readAttributeSetpointChangeSourceTimestampWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                      NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSetpointChangeSourceTimestampWithParams:(MTRSubscribeParams *)params
                                           subscriptionEstablished:
                                               (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -10870,10 +8510,6 @@ labels.
 - (void)writeAttributeOccupiedSetbackWithValue:(NSNumber * _Nullable)value
                                         params:(MTRWriteParams * _Nullable)params
                                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOccupiedSetbackWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10886,10 +8522,6 @@ labels.
 
 - (void)readAttributeOccupiedSetbackMinWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOccupiedSetbackMinWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10902,10 +8534,6 @@ labels.
 
 - (void)readAttributeOccupiedSetbackMaxWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOccupiedSetbackMaxWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10923,10 +8551,6 @@ labels.
 - (void)writeAttributeUnoccupiedSetbackWithValue:(NSNumber * _Nullable)value
                                           params:(MTRWriteParams * _Nullable)params
                                       completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUnoccupiedSetbackWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -10939,10 +8563,6 @@ labels.
 
 - (void)readAttributeUnoccupiedSetbackMinWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUnoccupiedSetbackMinWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10955,10 +8575,6 @@ labels.
 
 - (void)readAttributeUnoccupiedSetbackMaxWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUnoccupiedSetbackMaxWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10976,10 +8592,6 @@ labels.
 - (void)writeAttributeEmergencyHeatDeltaWithValue:(NSNumber * _Nonnull)value
                                            params:(MTRWriteParams * _Nullable)params
                                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEmergencyHeatDeltaWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -10996,10 +8608,6 @@ labels.
 - (void)writeAttributeACTypeWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeACTypeWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11016,10 +8624,6 @@ labels.
 - (void)writeAttributeACCapacityWithValue:(NSNumber * _Nonnull)value
                                    params:(MTRWriteParams * _Nullable)params
                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeACCapacityWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11037,10 +8641,6 @@ labels.
 - (void)writeAttributeACRefrigerantTypeWithValue:(NSNumber * _Nonnull)value
                                           params:(MTRWriteParams * _Nullable)params
                                       completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeACRefrigerantTypeWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11058,10 +8658,6 @@ labels.
 - (void)writeAttributeACCompressorTypeWithValue:(NSNumber * _Nonnull)value
                                          params:(MTRWriteParams * _Nullable)params
                                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeACCompressorTypeWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11079,10 +8675,6 @@ labels.
 - (void)writeAttributeACErrorCodeWithValue:(NSNumber * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeACErrorCodeWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11100,10 +8692,6 @@ labels.
 - (void)writeAttributeACLouverPositionWithValue:(NSNumber * _Nonnull)value
                                          params:(MTRWriteParams * _Nullable)params
                                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeACLouverPositionWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11116,10 +8704,6 @@ labels.
 
 - (void)readAttributeACCoilTemperatureWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeACCoilTemperatureWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11137,10 +8721,6 @@ labels.
 - (void)writeAttributeACCapacityformatWithValue:(NSNumber * _Nonnull)value
                                          params:(MTRWriteParams * _Nullable)params
                                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeACCapacityformatWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11153,10 +8733,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -11169,10 +8745,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -11185,10 +8757,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11201,10 +8769,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11217,10 +8781,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11252,10 +8812,6 @@ labels.
 - (void)writeAttributeFanModeWithValue:(NSNumber * _Nonnull)value
                                 params:(MTRWriteParams * _Nullable)params
                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFanModeWithParams:(MTRSubscribeParams *)params
                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                               reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11273,10 +8829,6 @@ labels.
 - (void)writeAttributeFanModeSequenceWithValue:(NSNumber * _Nonnull)value
                                         params:(MTRWriteParams * _Nullable)params
                                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFanModeSequenceWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11294,10 +8846,6 @@ labels.
 - (void)writeAttributePercentSettingWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePercentSettingWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11310,10 +8858,6 @@ labels.
 
 - (void)readAttributePercentCurrentWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePercentCurrentWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11326,10 +8870,6 @@ labels.
 
 - (void)readAttributeSpeedMaxWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSpeedMaxWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11347,10 +8887,6 @@ labels.
 - (void)writeAttributeSpeedSettingWithValue:(NSNumber * _Nullable)value
                                      params:(MTRWriteParams * _Nullable)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSpeedSettingWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11363,10 +8899,6 @@ labels.
 
 - (void)readAttributeSpeedCurrentWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSpeedCurrentWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11379,10 +8911,6 @@ labels.
 
 - (void)readAttributeRockSupportWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRockSupportWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11400,10 +8928,6 @@ labels.
 - (void)writeAttributeRockSettingWithValue:(NSNumber * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRockSettingWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11416,10 +8940,6 @@ labels.
 
 - (void)readAttributeWindSupportWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWindSupportWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11437,10 +8957,6 @@ labels.
 - (void)writeAttributeWindSettingWithValue:(NSNumber * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWindSettingWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11453,10 +8969,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -11469,10 +8981,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -11485,10 +8993,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11501,10 +9005,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11517,10 +9017,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11553,10 +9049,6 @@ labels.
 - (void)writeAttributeTemperatureDisplayModeWithValue:(NSNumber * _Nonnull)value
                                                params:(MTRWriteParams * _Nullable)params
                                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTemperatureDisplayModeWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -11574,10 +9066,6 @@ labels.
 - (void)writeAttributeKeypadLockoutWithValue:(NSNumber * _Nonnull)value
                                       params:(MTRWriteParams * _Nullable)params
                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeKeypadLockoutWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11595,10 +9083,6 @@ labels.
 - (void)writeAttributeScheduleProgrammingVisibilityWithValue:(NSNumber * _Nonnull)value
                                                       params:(MTRWriteParams * _Nullable)params
                                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeScheduleProgrammingVisibilityWithParams:(MTRSubscribeParams *)params
                                           subscriptionEstablished:
                                               (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -11612,10 +9096,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -11628,10 +9108,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -11644,10 +9120,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11660,10 +9132,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11676,10 +9144,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11746,10 +9210,6 @@ labels.
 
 - (void)readAttributeCurrentHueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentHueWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11762,10 +9222,6 @@ labels.
 
 - (void)readAttributeCurrentSaturationWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentSaturationWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11778,10 +9234,6 @@ labels.
 
 - (void)readAttributeRemainingTimeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRemainingTimeWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11794,10 +9246,6 @@ labels.
 
 - (void)readAttributeCurrentXWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentXWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11810,10 +9258,6 @@ labels.
 
 - (void)readAttributeCurrentYWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentYWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11826,10 +9270,6 @@ labels.
 
 - (void)readAttributeDriftCompensationWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDriftCompensationWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11842,10 +9282,6 @@ labels.
 
 - (void)readAttributeCompensationTextWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCompensationTextWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11858,10 +9294,6 @@ labels.
 
 - (void)readAttributeColorTemperatureMiredsWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorTemperatureMiredsWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -11874,10 +9306,6 @@ labels.
 
 - (void)readAttributeColorModeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorModeWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11894,10 +9322,6 @@ labels.
 - (void)writeAttributeOptionsWithValue:(NSNumber * _Nonnull)value
                                 params:(MTRWriteParams * _Nullable)params
                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOptionsWithParams:(MTRSubscribeParams *)params
                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                               reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11910,10 +9334,6 @@ labels.
 
 - (void)readAttributeNumberOfPrimariesWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNumberOfPrimariesWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11926,10 +9346,6 @@ labels.
 
 - (void)readAttributePrimary1XWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary1XWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11942,10 +9358,6 @@ labels.
 
 - (void)readAttributePrimary1YWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary1YWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11958,10 +9370,6 @@ labels.
 
 - (void)readAttributePrimary1IntensityWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary1IntensityWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11974,10 +9382,6 @@ labels.
 
 - (void)readAttributePrimary2XWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary2XWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -11990,10 +9394,6 @@ labels.
 
 - (void)readAttributePrimary2YWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary2YWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12006,10 +9406,6 @@ labels.
 
 - (void)readAttributePrimary2IntensityWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary2IntensityWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12022,10 +9418,6 @@ labels.
 
 - (void)readAttributePrimary3XWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary3XWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12038,10 +9430,6 @@ labels.
 
 - (void)readAttributePrimary3YWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary3YWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12054,10 +9442,6 @@ labels.
 
 - (void)readAttributePrimary3IntensityWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary3IntensityWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12070,10 +9454,6 @@ labels.
 
 - (void)readAttributePrimary4XWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary4XWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12086,10 +9466,6 @@ labels.
 
 - (void)readAttributePrimary4YWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary4YWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12102,10 +9478,6 @@ labels.
 
 - (void)readAttributePrimary4IntensityWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary4IntensityWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12118,10 +9490,6 @@ labels.
 
 - (void)readAttributePrimary5XWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary5XWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12134,10 +9502,6 @@ labels.
 
 - (void)readAttributePrimary5YWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary5YWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12150,10 +9514,6 @@ labels.
 
 - (void)readAttributePrimary5IntensityWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary5IntensityWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12166,10 +9526,6 @@ labels.
 
 - (void)readAttributePrimary6XWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary6XWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12182,10 +9538,6 @@ labels.
 
 - (void)readAttributePrimary6YWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary6YWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12198,10 +9550,6 @@ labels.
 
 - (void)readAttributePrimary6IntensityWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePrimary6IntensityWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12219,10 +9567,6 @@ labels.
 - (void)writeAttributeWhitePointXWithValue:(NSNumber * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWhitePointXWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12240,10 +9584,6 @@ labels.
 - (void)writeAttributeWhitePointYWithValue:(NSNumber * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWhitePointYWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12261,10 +9601,6 @@ labels.
 - (void)writeAttributeColorPointRXWithValue:(NSNumber * _Nonnull)value
                                      params:(MTRWriteParams * _Nullable)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorPointRXWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12282,10 +9618,6 @@ labels.
 - (void)writeAttributeColorPointRYWithValue:(NSNumber * _Nonnull)value
                                      params:(MTRWriteParams * _Nullable)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorPointRYWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12303,10 +9635,6 @@ labels.
 - (void)writeAttributeColorPointRIntensityWithValue:(NSNumber * _Nullable)value
                                              params:(MTRWriteParams * _Nullable)params
                                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorPointRIntensityWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -12324,10 +9652,6 @@ labels.
 - (void)writeAttributeColorPointGXWithValue:(NSNumber * _Nonnull)value
                                      params:(MTRWriteParams * _Nullable)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorPointGXWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12345,10 +9669,6 @@ labels.
 - (void)writeAttributeColorPointGYWithValue:(NSNumber * _Nonnull)value
                                      params:(MTRWriteParams * _Nullable)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorPointGYWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12366,10 +9686,6 @@ labels.
 - (void)writeAttributeColorPointGIntensityWithValue:(NSNumber * _Nullable)value
                                              params:(MTRWriteParams * _Nullable)params
                                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorPointGIntensityWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -12387,10 +9703,6 @@ labels.
 - (void)writeAttributeColorPointBXWithValue:(NSNumber * _Nonnull)value
                                      params:(MTRWriteParams * _Nullable)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorPointBXWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12408,10 +9720,6 @@ labels.
 - (void)writeAttributeColorPointBYWithValue:(NSNumber * _Nonnull)value
                                      params:(MTRWriteParams * _Nullable)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorPointBYWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12429,10 +9737,6 @@ labels.
 - (void)writeAttributeColorPointBIntensityWithValue:(NSNumber * _Nullable)value
                                              params:(MTRWriteParams * _Nullable)params
                                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorPointBIntensityWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -12445,10 +9749,6 @@ labels.
 
 - (void)readAttributeEnhancedCurrentHueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEnhancedCurrentHueWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -12461,10 +9761,6 @@ labels.
 
 - (void)readAttributeEnhancedColorModeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEnhancedColorModeWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12477,10 +9773,6 @@ labels.
 
 - (void)readAttributeColorLoopActiveWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorLoopActiveWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12493,10 +9785,6 @@ labels.
 
 - (void)readAttributeColorLoopDirectionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorLoopDirectionWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -12509,10 +9797,6 @@ labels.
 
 - (void)readAttributeColorLoopTimeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorLoopTimeWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12525,10 +9809,6 @@ labels.
 
 - (void)readAttributeColorLoopStartEnhancedHueWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorLoopStartEnhancedHueWithParams:(MTRSubscribeParams *)params
                                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                 reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -12541,10 +9821,6 @@ labels.
 
 - (void)readAttributeColorLoopStoredEnhancedHueWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorLoopStoredEnhancedHueWithParams:(MTRSubscribeParams *)params
                                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                  reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -12557,10 +9833,6 @@ labels.
 
 - (void)readAttributeColorCapabilitiesWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorCapabilitiesWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12573,10 +9845,6 @@ labels.
 
 - (void)readAttributeColorTempPhysicalMinMiredsWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorTempPhysicalMinMiredsWithParams:(MTRSubscribeParams *)params
                                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                  reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -12589,10 +9857,6 @@ labels.
 
 - (void)readAttributeColorTempPhysicalMaxMiredsWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeColorTempPhysicalMaxMiredsWithParams:(MTRSubscribeParams *)params
                                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                  reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -12605,10 +9869,6 @@ labels.
 
 - (void)readAttributeCoupleColorTempToLevelMinMiredsWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                        NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCoupleColorTempToLevelMinMiredsWithParams:(MTRSubscribeParams *)params
                                             subscriptionEstablished:
                                                 (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -12629,10 +9889,6 @@ labels.
 - (void)writeAttributeStartUpColorTemperatureMiredsWithValue:(NSNumber * _Nullable)value
                                                       params:(MTRWriteParams * _Nullable)params
                                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeStartUpColorTemperatureMiredsWithParams:(MTRSubscribeParams *)params
                                           subscriptionEstablished:
                                               (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -12646,10 +9902,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -12662,10 +9914,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -12678,10 +9926,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12694,10 +9938,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12710,10 +9950,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12741,10 +9977,6 @@ labels.
 
 - (void)readAttributePhysicalMinLevelWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePhysicalMinLevelWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12757,10 +9989,6 @@ labels.
 
 - (void)readAttributePhysicalMaxLevelWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePhysicalMaxLevelWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12773,10 +10001,6 @@ labels.
 
 - (void)readAttributeBallastStatusWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBallastStatusWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12793,10 +10017,6 @@ labels.
 - (void)writeAttributeMinLevelWithValue:(NSNumber * _Nonnull)value
                                  params:(MTRWriteParams * _Nullable)params
                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinLevelWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12813,10 +10033,6 @@ labels.
 - (void)writeAttributeMaxLevelWithValue:(NSNumber * _Nonnull)value
                                  params:(MTRWriteParams * _Nullable)params
                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxLevelWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12834,10 +10050,6 @@ labels.
 - (void)writeAttributeIntrinsicBalanceFactorWithValue:(NSNumber * _Nullable)value
                                                params:(MTRWriteParams * _Nullable)params
                                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeIntrinsicBalanceFactorWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -12855,10 +10067,6 @@ labels.
 - (void)writeAttributeBallastFactorAdjustmentWithValue:(NSNumber * _Nullable)value
                                                 params:(MTRWriteParams * _Nullable)params
                                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBallastFactorAdjustmentWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -12871,10 +10079,6 @@ labels.
 
 - (void)readAttributeLampQuantityWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLampQuantityWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12891,10 +10095,6 @@ labels.
 - (void)writeAttributeLampTypeWithValue:(NSString * _Nonnull)value
                                  params:(MTRWriteParams * _Nullable)params
                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLampTypeWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12912,10 +10112,6 @@ labels.
 - (void)writeAttributeLampManufacturerWithValue:(NSString * _Nonnull)value
                                          params:(MTRWriteParams * _Nullable)params
                                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLampManufacturerWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12933,10 +10129,6 @@ labels.
 - (void)writeAttributeLampRatedHoursWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLampRatedHoursWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12954,10 +10146,6 @@ labels.
 - (void)writeAttributeLampBurnHoursWithValue:(NSNumber * _Nullable)value
                                       params:(MTRWriteParams * _Nullable)params
                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLampBurnHoursWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12975,10 +10163,6 @@ labels.
 - (void)writeAttributeLampAlarmModeWithValue:(NSNumber * _Nonnull)value
                                       params:(MTRWriteParams * _Nullable)params
                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLampAlarmModeWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -12996,10 +10180,6 @@ labels.
 - (void)writeAttributeLampBurnHoursTripPointWithValue:(NSNumber * _Nullable)value
                                                params:(MTRWriteParams * _Nullable)params
                                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLampBurnHoursTripPointWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -13012,10 +10192,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -13028,10 +10204,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -13044,10 +10216,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13060,10 +10228,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13076,10 +10240,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13107,10 +10267,6 @@ labels.
 
 - (void)readAttributeMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasuredValueWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13123,10 +10279,6 @@ labels.
 
 - (void)readAttributeMinMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinMeasuredValueWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13139,10 +10291,6 @@ labels.
 
 - (void)readAttributeMaxMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxMeasuredValueWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13155,10 +10303,6 @@ labels.
 
 - (void)readAttributeToleranceWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeToleranceWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13171,10 +10315,6 @@ labels.
 
 - (void)readAttributeLightSensorTypeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLightSensorTypeWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13187,10 +10327,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -13203,10 +10339,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -13219,10 +10351,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13235,10 +10363,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13251,10 +10375,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13282,10 +10402,6 @@ labels.
 
 - (void)readAttributeMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasuredValueWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13298,10 +10414,6 @@ labels.
 
 - (void)readAttributeMinMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinMeasuredValueWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13314,10 +10426,6 @@ labels.
 
 - (void)readAttributeMaxMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxMeasuredValueWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13330,10 +10438,6 @@ labels.
 
 - (void)readAttributeToleranceWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeToleranceWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13346,10 +10450,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -13362,10 +10462,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -13378,10 +10474,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13394,10 +10486,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13410,10 +10498,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13441,10 +10525,6 @@ labels.
 
 - (void)readAttributeMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasuredValueWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13457,10 +10537,6 @@ labels.
 
 - (void)readAttributeMinMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinMeasuredValueWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13473,10 +10549,6 @@ labels.
 
 - (void)readAttributeMaxMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxMeasuredValueWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13489,10 +10561,6 @@ labels.
 
 - (void)readAttributeToleranceWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeToleranceWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13505,10 +10573,6 @@ labels.
 
 - (void)readAttributeScaledValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeScaledValueWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13521,10 +10585,6 @@ labels.
 
 - (void)readAttributeMinScaledValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinScaledValueWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13537,10 +10597,6 @@ labels.
 
 - (void)readAttributeMaxScaledValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxScaledValueWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13553,10 +10609,6 @@ labels.
 
 - (void)readAttributeScaledToleranceWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeScaledToleranceWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13569,10 +10621,6 @@ labels.
 
 - (void)readAttributeScaleWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeScaleWithParams:(MTRSubscribeParams *)params
                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                             reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13585,10 +10633,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -13601,10 +10645,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -13617,10 +10657,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13633,10 +10669,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13649,10 +10681,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13680,10 +10708,6 @@ labels.
 
 - (void)readAttributeMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasuredValueWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13696,10 +10720,6 @@ labels.
 
 - (void)readAttributeMinMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinMeasuredValueWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13712,10 +10732,6 @@ labels.
 
 - (void)readAttributeMaxMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxMeasuredValueWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13728,10 +10744,6 @@ labels.
 
 - (void)readAttributeToleranceWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeToleranceWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13744,10 +10756,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -13760,10 +10768,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -13776,10 +10780,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13792,10 +10792,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13808,10 +10804,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13839,10 +10831,6 @@ labels.
 
 - (void)readAttributeMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasuredValueWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13855,10 +10843,6 @@ labels.
 
 - (void)readAttributeMinMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMinMeasuredValueWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13871,10 +10855,6 @@ labels.
 
 - (void)readAttributeMaxMeasuredValueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMaxMeasuredValueWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13887,10 +10867,6 @@ labels.
 
 - (void)readAttributeToleranceWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeToleranceWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13903,10 +10879,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -13919,10 +10891,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -13935,10 +10903,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13951,10 +10915,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13967,10 +10927,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -13998,10 +10954,6 @@ labels.
 
 - (void)readAttributeOccupancyWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOccupancyWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14014,10 +10966,6 @@ labels.
 
 - (void)readAttributeOccupancySensorTypeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOccupancySensorTypeWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -14030,10 +10978,6 @@ labels.
 
 - (void)readAttributeOccupancySensorTypeBitmapWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOccupancySensorTypeBitmapWithParams:(MTRSubscribeParams *)params
                                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                 reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -14051,10 +10995,6 @@ labels.
 - (void)writeAttributePirOccupiedToUnoccupiedDelayWithValue:(NSNumber * _Nonnull)value
                                                      params:(MTRWriteParams * _Nullable)params
                                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePirOccupiedToUnoccupiedDelayWithParams:(MTRSubscribeParams *)params
                                          subscriptionEstablished:
                                              (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -14073,10 +11013,6 @@ labels.
 - (void)writeAttributePirUnoccupiedToOccupiedDelayWithValue:(NSNumber * _Nonnull)value
                                                      params:(MTRWriteParams * _Nullable)params
                                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePirUnoccupiedToOccupiedDelayWithParams:(MTRSubscribeParams *)params
                                          subscriptionEstablished:
                                              (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -14095,10 +11031,6 @@ labels.
 - (void)writeAttributePirUnoccupiedToOccupiedThresholdWithValue:(NSNumber * _Nonnull)value
                                                          params:(MTRWriteParams * _Nullable)params
                                                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePirUnoccupiedToOccupiedThresholdWithParams:(MTRSubscribeParams *)params
                                              subscriptionEstablished:
                                                  (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -14119,10 +11051,6 @@ labels.
 - (void)writeAttributeUltrasonicOccupiedToUnoccupiedDelayWithValue:(NSNumber * _Nonnull)value
                                                             params:(MTRWriteParams * _Nullable)params
                                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUltrasonicOccupiedToUnoccupiedDelayWithParams:(MTRSubscribeParams *)params
                                                 subscriptionEstablished:
                                                     (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -14143,10 +11071,6 @@ labels.
 - (void)writeAttributeUltrasonicUnoccupiedToOccupiedDelayWithValue:(NSNumber * _Nonnull)value
                                                             params:(MTRWriteParams * _Nullable)params
                                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUltrasonicUnoccupiedToOccupiedDelayWithParams:(MTRSubscribeParams *)params
                                                 subscriptionEstablished:
                                                     (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -14167,10 +11091,6 @@ labels.
 - (void)writeAttributeUltrasonicUnoccupiedToOccupiedThresholdWithValue:(NSNumber * _Nonnull)value
                                                                 params:(MTRWriteParams * _Nullable)params
                                                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUltrasonicUnoccupiedToOccupiedThresholdWithParams:(MTRSubscribeParams *)params
                                                     subscriptionEstablished:
                                                         (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -14191,10 +11111,6 @@ labels.
 - (void)writeAttributePhysicalContactOccupiedToUnoccupiedDelayWithValue:(NSNumber * _Nonnull)value
                                                                  params:(MTRWriteParams * _Nullable)params
                                                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePhysicalContactOccupiedToUnoccupiedDelayWithParams:(MTRSubscribeParams *)params
                                                      subscriptionEstablished:
                                                          (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -14216,10 +11132,6 @@ labels.
 - (void)writeAttributePhysicalContactUnoccupiedToOccupiedDelayWithValue:(NSNumber * _Nonnull)value
                                                                  params:(MTRWriteParams * _Nullable)params
                                                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePhysicalContactUnoccupiedToOccupiedDelayWithParams:(MTRSubscribeParams *)params
                                                      subscriptionEstablished:
                                                          (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -14241,10 +11153,6 @@ labels.
 - (void)writeAttributePhysicalContactUnoccupiedToOccupiedThresholdWithValue:(NSNumber * _Nonnull)value
                                                                      params:(MTRWriteParams * _Nullable)params
                                                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePhysicalContactUnoccupiedToOccupiedThresholdWithParams:(MTRSubscribeParams *)params
                                                          subscriptionEstablished:
                                                              (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -14261,10 +11169,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -14277,10 +11181,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -14293,10 +11193,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14309,10 +11205,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14325,10 +11217,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14356,10 +11244,6 @@ labels.
 
 - (void)readAttributeMACAddressWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMACAddressWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14372,10 +11256,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -14388,10 +11268,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -14404,10 +11280,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14420,10 +11292,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14436,10 +11304,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14475,10 +11339,6 @@ labels.
 
 - (void)readAttributeChannelListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeChannelListWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14491,10 +11351,6 @@ labels.
 
 - (void)readAttributeLineupWithCompletion:(void (^)(MTRChannelClusterLineupInfo * _Nullable value,
                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLineupWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(MTRChannelClusterLineupInfo * _Nullable value,
@@ -14507,10 +11363,6 @@ labels.
 
 - (void)readAttributeCurrentChannelWithCompletion:(void (^)(MTRChannelClusterChannelInfo * _Nullable value,
                                                       NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentChannelWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(MTRChannelClusterChannelInfo * _Nullable value,
@@ -14523,10 +11375,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -14539,10 +11387,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -14555,10 +11399,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14571,10 +11411,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14587,10 +11423,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14622,10 +11454,6 @@ labels.
 
 - (void)readAttributeTargetListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTargetListWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14638,10 +11466,6 @@ labels.
 
 - (void)readAttributeCurrentTargetWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentTargetWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14654,10 +11478,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -14670,10 +11490,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -14686,10 +11502,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14702,10 +11514,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14718,10 +11526,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14800,10 +11604,6 @@ labels.
 
 - (void)readAttributeCurrentStateWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentStateWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14816,10 +11616,6 @@ labels.
 
 - (void)readAttributeStartTimeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeStartTimeWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14832,10 +11628,6 @@ labels.
 
 - (void)readAttributeDurationWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDurationWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14848,10 +11640,6 @@ labels.
 
 - (void)readAttributeSampledPositionWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackPosition * _Nullable value,
                                                        NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSampledPositionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(MTRMediaPlaybackClusterPlaybackPosition * _Nullable value,
@@ -14864,10 +11652,6 @@ labels.
 
 - (void)readAttributePlaybackSpeedWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePlaybackSpeedWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14880,10 +11664,6 @@ labels.
 
 - (void)readAttributeSeekRangeEndWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSeekRangeEndWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14896,10 +11676,6 @@ labels.
 
 - (void)readAttributeSeekRangeStartWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSeekRangeStartWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14912,10 +11688,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -14928,10 +11700,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -14944,10 +11712,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14960,10 +11724,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -14976,10 +11736,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15018,10 +11774,6 @@ labels.
 
 - (void)readAttributeInputListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInputListWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15034,10 +11786,6 @@ labels.
 
 - (void)readAttributeCurrentInputWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentInputWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15050,10 +11798,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -15066,10 +11810,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -15082,10 +11822,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15098,10 +11834,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15114,10 +11846,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15149,10 +11877,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -15165,10 +11889,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -15181,10 +11901,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15197,10 +11913,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15213,10 +11925,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15248,10 +11956,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -15264,10 +11968,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -15280,10 +11980,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15296,10 +11992,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15312,10 +12004,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15350,10 +12038,6 @@ labels.
 
 - (void)readAttributeAcceptHeaderWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptHeaderWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15371,10 +12055,6 @@ labels.
 - (void)writeAttributeSupportedStreamingProtocolsWithValue:(NSNumber * _Nonnull)value
                                                     params:(MTRWriteParams * _Nullable)params
                                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeSupportedStreamingProtocolsWithParams:(MTRSubscribeParams *)params
                                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                   reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -15387,10 +12067,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -15403,10 +12079,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -15419,10 +12091,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15435,10 +12103,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15451,10 +12115,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15487,10 +12147,6 @@ labels.
 
 - (void)readAttributeOutputListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOutputListWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15503,10 +12159,6 @@ labels.
 
 - (void)readAttributeCurrentOutputWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentOutputWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15519,10 +12171,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -15535,10 +12183,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -15551,10 +12195,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15567,10 +12207,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15583,10 +12219,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15624,10 +12256,6 @@ labels.
 
 - (void)readAttributeCatalogListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCatalogListWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15645,10 +12273,6 @@ labels.
 - (void)writeAttributeCurrentAppWithValue:(MTRApplicationLauncherClusterApplicationEP * _Nullable)value
                                    params:(MTRWriteParams * _Nullable)params
                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentAppWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(MTRApplicationLauncherClusterApplicationEP * _Nullable value,
@@ -15661,10 +12285,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -15677,10 +12297,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -15693,10 +12309,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15709,10 +12321,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15725,10 +12333,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15757,10 +12361,6 @@ labels.
 
 - (void)readAttributeVendorNameWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeVendorNameWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15773,10 +12373,6 @@ labels.
 
 - (void)readAttributeVendorIDWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeVendorIDWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15789,10 +12385,6 @@ labels.
 
 - (void)readAttributeApplicationNameWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeApplicationNameWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15805,10 +12397,6 @@ labels.
 
 - (void)readAttributeProductIDWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeProductIDWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15821,10 +12409,6 @@ labels.
 
 - (void)readAttributeApplicationWithCompletion:(void (^)(MTRApplicationBasicClusterApplicationBasicApplication * _Nullable value,
                                                    NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeApplicationWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(MTRApplicationBasicClusterApplicationBasicApplication * _Nullable value,
@@ -15838,10 +12422,6 @@ labels.
 
 - (void)readAttributeStatusWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeStatusWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15854,10 +12434,6 @@ labels.
 
 - (void)readAttributeApplicationVersionWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeApplicationVersionWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSString * _Nullable value,
@@ -15870,10 +12446,6 @@ labels.
 
 - (void)readAttributeAllowedVendorListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAllowedVendorListWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15886,10 +12458,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -15902,10 +12470,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -15918,10 +12482,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15934,10 +12494,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15950,10 +12506,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -15991,10 +12543,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -16007,10 +12555,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -16023,10 +12567,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16039,10 +12579,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16055,10 +12591,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16093,10 +12625,6 @@ labels.
 
 - (void)readAttributeMeasurementTypeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasurementTypeWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16109,10 +12637,6 @@ labels.
 
 - (void)readAttributeDcVoltageWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcVoltageWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16125,10 +12649,6 @@ labels.
 
 - (void)readAttributeDcVoltageMinWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcVoltageMinWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16141,10 +12661,6 @@ labels.
 
 - (void)readAttributeDcVoltageMaxWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcVoltageMaxWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16157,10 +12673,6 @@ labels.
 
 - (void)readAttributeDcCurrentWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcCurrentWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16173,10 +12685,6 @@ labels.
 
 - (void)readAttributeDcCurrentMinWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcCurrentMinWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16189,10 +12697,6 @@ labels.
 
 - (void)readAttributeDcCurrentMaxWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcCurrentMaxWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16205,10 +12709,6 @@ labels.
 
 - (void)readAttributeDcPowerWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcPowerWithParams:(MTRSubscribeParams *)params
                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                               reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16221,10 +12721,6 @@ labels.
 
 - (void)readAttributeDcPowerMinWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcPowerMinWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16237,10 +12733,6 @@ labels.
 
 - (void)readAttributeDcPowerMaxWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcPowerMaxWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16253,10 +12745,6 @@ labels.
 
 - (void)readAttributeDcVoltageMultiplierWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcVoltageMultiplierWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16269,10 +12757,6 @@ labels.
 
 - (void)readAttributeDcVoltageDivisorWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcVoltageDivisorWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16285,10 +12769,6 @@ labels.
 
 - (void)readAttributeDcCurrentMultiplierWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcCurrentMultiplierWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16301,10 +12781,6 @@ labels.
 
 - (void)readAttributeDcCurrentDivisorWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcCurrentDivisorWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16317,10 +12793,6 @@ labels.
 
 - (void)readAttributeDcPowerMultiplierWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcPowerMultiplierWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16333,10 +12805,6 @@ labels.
 
 - (void)readAttributeDcPowerDivisorWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeDcPowerDivisorWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16349,10 +12817,6 @@ labels.
 
 - (void)readAttributeAcFrequencyWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcFrequencyWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16365,10 +12829,6 @@ labels.
 
 - (void)readAttributeAcFrequencyMinWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcFrequencyMinWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16381,10 +12841,6 @@ labels.
 
 - (void)readAttributeAcFrequencyMaxWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcFrequencyMaxWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16397,10 +12853,6 @@ labels.
 
 - (void)readAttributeNeutralCurrentWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNeutralCurrentWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16413,10 +12865,6 @@ labels.
 
 - (void)readAttributeTotalActivePowerWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTotalActivePowerWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16429,10 +12877,6 @@ labels.
 
 - (void)readAttributeTotalReactivePowerWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTotalReactivePowerWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16445,10 +12889,6 @@ labels.
 
 - (void)readAttributeTotalApparentPowerWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTotalApparentPowerWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16461,10 +12901,6 @@ labels.
 
 - (void)readAttributeMeasured1stHarmonicCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasured1stHarmonicCurrentWithParams:(MTRSubscribeParams *)params
                                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                  reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16477,10 +12913,6 @@ labels.
 
 - (void)readAttributeMeasured3rdHarmonicCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasured3rdHarmonicCurrentWithParams:(MTRSubscribeParams *)params
                                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                  reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16493,10 +12925,6 @@ labels.
 
 - (void)readAttributeMeasured5thHarmonicCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasured5thHarmonicCurrentWithParams:(MTRSubscribeParams *)params
                                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                  reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16509,10 +12937,6 @@ labels.
 
 - (void)readAttributeMeasured7thHarmonicCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasured7thHarmonicCurrentWithParams:(MTRSubscribeParams *)params
                                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                  reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16525,10 +12949,6 @@ labels.
 
 - (void)readAttributeMeasured9thHarmonicCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasured9thHarmonicCurrentWithParams:(MTRSubscribeParams *)params
                                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                  reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16541,10 +12961,6 @@ labels.
 
 - (void)readAttributeMeasured11thHarmonicCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                    NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasured11thHarmonicCurrentWithParams:(MTRSubscribeParams *)params
                                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                   reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16557,10 +12973,6 @@ labels.
 
 - (void)readAttributeMeasuredPhase1stHarmonicCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                        NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasuredPhase1stHarmonicCurrentWithParams:(MTRSubscribeParams *)params
                                             subscriptionEstablished:
                                                 (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -16576,10 +12988,6 @@ labels.
 
 - (void)readAttributeMeasuredPhase3rdHarmonicCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                        NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasuredPhase3rdHarmonicCurrentWithParams:(MTRSubscribeParams *)params
                                             subscriptionEstablished:
                                                 (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -16595,10 +13003,6 @@ labels.
 
 - (void)readAttributeMeasuredPhase5thHarmonicCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                        NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasuredPhase5thHarmonicCurrentWithParams:(MTRSubscribeParams *)params
                                             subscriptionEstablished:
                                                 (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -16614,10 +13018,6 @@ labels.
 
 - (void)readAttributeMeasuredPhase7thHarmonicCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                        NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasuredPhase7thHarmonicCurrentWithParams:(MTRSubscribeParams *)params
                                             subscriptionEstablished:
                                                 (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -16633,10 +13033,6 @@ labels.
 
 - (void)readAttributeMeasuredPhase9thHarmonicCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                        NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasuredPhase9thHarmonicCurrentWithParams:(MTRSubscribeParams *)params
                                             subscriptionEstablished:
                                                 (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -16652,10 +13048,6 @@ labels.
 
 - (void)readAttributeMeasuredPhase11thHarmonicCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                         NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeMeasuredPhase11thHarmonicCurrentWithParams:(MTRSubscribeParams *)params
                                              subscriptionEstablished:
                                                  (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -16671,10 +13063,6 @@ labels.
 
 - (void)readAttributeAcFrequencyMultiplierWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcFrequencyMultiplierWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16687,10 +13075,6 @@ labels.
 
 - (void)readAttributeAcFrequencyDivisorWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcFrequencyDivisorWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16703,10 +13087,6 @@ labels.
 
 - (void)readAttributePowerMultiplierWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePowerMultiplierWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16719,10 +13099,6 @@ labels.
 
 - (void)readAttributePowerDivisorWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePowerDivisorWithParams:(MTRSubscribeParams *)params
                          subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                    reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16735,10 +13111,6 @@ labels.
 
 - (void)readAttributeHarmonicCurrentMultiplierWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeHarmonicCurrentMultiplierWithParams:(MTRSubscribeParams *)params
                                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                 reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16751,10 +13123,6 @@ labels.
 
 - (void)readAttributePhaseHarmonicCurrentMultiplierWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                       NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePhaseHarmonicCurrentMultiplierWithParams:(MTRSubscribeParams *)params
                                            subscriptionEstablished:
                                                (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -16768,10 +13136,6 @@ labels.
 
 - (void)readAttributeInstantaneousVoltageWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInstantaneousVoltageWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16784,10 +13148,6 @@ labels.
 
 - (void)readAttributeInstantaneousLineCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInstantaneousLineCurrentWithParams:(MTRSubscribeParams *)params
                                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16800,10 +13160,6 @@ labels.
 
 - (void)readAttributeInstantaneousActiveCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInstantaneousActiveCurrentWithParams:(MTRSubscribeParams *)params
                                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                  reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16816,10 +13172,6 @@ labels.
 
 - (void)readAttributeInstantaneousReactiveCurrentWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                     NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInstantaneousReactiveCurrentWithParams:(MTRSubscribeParams *)params
                                          subscriptionEstablished:
                                              (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -16833,10 +13185,6 @@ labels.
 
 - (void)readAttributeInstantaneousPowerWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInstantaneousPowerWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -16849,10 +13197,6 @@ labels.
 
 - (void)readAttributeRmsVoltageWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16865,10 +13209,6 @@ labels.
 
 - (void)readAttributeRmsVoltageMinWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageMinWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16881,10 +13221,6 @@ labels.
 
 - (void)readAttributeRmsVoltageMaxWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageMaxWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16897,10 +13233,6 @@ labels.
 
 - (void)readAttributeRmsCurrentWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsCurrentWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16913,10 +13245,6 @@ labels.
 
 - (void)readAttributeRmsCurrentMinWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsCurrentMinWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16929,10 +13257,6 @@ labels.
 
 - (void)readAttributeRmsCurrentMaxWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsCurrentMaxWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16945,10 +13269,6 @@ labels.
 
 - (void)readAttributeActivePowerWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActivePowerWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16961,10 +13281,6 @@ labels.
 
 - (void)readAttributeActivePowerMinWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActivePowerMinWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16977,10 +13293,6 @@ labels.
 
 - (void)readAttributeActivePowerMaxWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActivePowerMaxWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -16993,10 +13305,6 @@ labels.
 
 - (void)readAttributeReactivePowerWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeReactivePowerWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17009,10 +13317,6 @@ labels.
 
 - (void)readAttributeApparentPowerWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeApparentPowerWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17025,10 +13329,6 @@ labels.
 
 - (void)readAttributePowerFactorWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePowerFactorWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17046,10 +13346,6 @@ labels.
 - (void)writeAttributeAverageRmsVoltageMeasurementPeriodWithValue:(NSNumber * _Nonnull)value
                                                            params:(MTRWriteParams * _Nullable)params
                                                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAverageRmsVoltageMeasurementPeriodWithParams:(MTRSubscribeParams *)params
                                                subscriptionEstablished:
                                                    (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -17070,10 +13366,6 @@ labels.
 - (void)writeAttributeAverageRmsUnderVoltageCounterWithValue:(NSNumber * _Nonnull)value
                                                       params:(MTRWriteParams * _Nullable)params
                                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAverageRmsUnderVoltageCounterWithParams:(MTRSubscribeParams *)params
                                           subscriptionEstablished:
                                               (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -17092,10 +13384,6 @@ labels.
 - (void)writeAttributeRmsExtremeOverVoltagePeriodWithValue:(NSNumber * _Nonnull)value
                                                     params:(MTRWriteParams * _Nullable)params
                                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsExtremeOverVoltagePeriodWithParams:(MTRSubscribeParams *)params
                                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                   reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17113,10 +13401,6 @@ labels.
 - (void)writeAttributeRmsExtremeUnderVoltagePeriodWithValue:(NSNumber * _Nonnull)value
                                                      params:(MTRWriteParams * _Nullable)params
                                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsExtremeUnderVoltagePeriodWithParams:(MTRSubscribeParams *)params
                                          subscriptionEstablished:
                                              (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -17135,10 +13419,6 @@ labels.
 - (void)writeAttributeRmsVoltageSagPeriodWithValue:(NSNumber * _Nonnull)value
                                             params:(MTRWriteParams * _Nullable)params
                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageSagPeriodWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17156,10 +13436,6 @@ labels.
 - (void)writeAttributeRmsVoltageSwellPeriodWithValue:(NSNumber * _Nonnull)value
                                               params:(MTRWriteParams * _Nullable)params
                                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageSwellPeriodWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17172,10 +13448,6 @@ labels.
 
 - (void)readAttributeAcVoltageMultiplierWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcVoltageMultiplierWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17188,10 +13460,6 @@ labels.
 
 - (void)readAttributeAcVoltageDivisorWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcVoltageDivisorWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17204,10 +13472,6 @@ labels.
 
 - (void)readAttributeAcCurrentMultiplierWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcCurrentMultiplierWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17220,10 +13484,6 @@ labels.
 
 - (void)readAttributeAcCurrentDivisorWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcCurrentDivisorWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17236,10 +13496,6 @@ labels.
 
 - (void)readAttributeAcPowerMultiplierWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcPowerMultiplierWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17252,10 +13508,6 @@ labels.
 
 - (void)readAttributeAcPowerDivisorWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcPowerDivisorWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17273,10 +13525,6 @@ labels.
 - (void)writeAttributeOverloadAlarmsMaskWithValue:(NSNumber * _Nonnull)value
                                            params:(MTRWriteParams * _Nullable)params
                                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOverloadAlarmsMaskWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17289,10 +13537,6 @@ labels.
 
 - (void)readAttributeVoltageOverloadWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeVoltageOverloadWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17305,10 +13549,6 @@ labels.
 
 - (void)readAttributeCurrentOverloadWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCurrentOverloadWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17326,10 +13566,6 @@ labels.
 - (void)writeAttributeAcOverloadAlarmsMaskWithValue:(NSNumber * _Nonnull)value
                                              params:(MTRWriteParams * _Nullable)params
                                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcOverloadAlarmsMaskWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17342,10 +13578,6 @@ labels.
 
 - (void)readAttributeAcVoltageOverloadWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcVoltageOverloadWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17358,10 +13590,6 @@ labels.
 
 - (void)readAttributeAcCurrentOverloadWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcCurrentOverloadWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17374,10 +13602,6 @@ labels.
 
 - (void)readAttributeAcActivePowerOverloadWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcActivePowerOverloadWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17390,10 +13614,6 @@ labels.
 
 - (void)readAttributeAcReactivePowerOverloadWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcReactivePowerOverloadWithParams:(MTRSubscribeParams *)params
                                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                               reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17406,10 +13626,6 @@ labels.
 
 - (void)readAttributeAverageRmsOverVoltageWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAverageRmsOverVoltageWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17422,10 +13638,6 @@ labels.
 
 - (void)readAttributeAverageRmsUnderVoltageWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAverageRmsUnderVoltageWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17438,10 +13650,6 @@ labels.
 
 - (void)readAttributeRmsExtremeOverVoltageWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsExtremeOverVoltageWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17454,10 +13662,6 @@ labels.
 
 - (void)readAttributeRmsExtremeUnderVoltageWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsExtremeUnderVoltageWithParams:(MTRSubscribeParams *)params
                                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                              reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17470,10 +13674,6 @@ labels.
 
 - (void)readAttributeRmsVoltageSagWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageSagWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17486,10 +13686,6 @@ labels.
 
 - (void)readAttributeRmsVoltageSwellWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageSwellWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17502,10 +13698,6 @@ labels.
 
 - (void)readAttributeLineCurrentPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLineCurrentPhaseBWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17518,10 +13710,6 @@ labels.
 
 - (void)readAttributeActiveCurrentPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActiveCurrentPhaseBWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17534,10 +13722,6 @@ labels.
 
 - (void)readAttributeReactiveCurrentPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeReactiveCurrentPhaseBWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17550,10 +13734,6 @@ labels.
 
 - (void)readAttributeRmsVoltagePhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltagePhaseBWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17566,10 +13746,6 @@ labels.
 
 - (void)readAttributeRmsVoltageMinPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageMinPhaseBWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17582,10 +13758,6 @@ labels.
 
 - (void)readAttributeRmsVoltageMaxPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageMaxPhaseBWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17598,10 +13770,6 @@ labels.
 
 - (void)readAttributeRmsCurrentPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsCurrentPhaseBWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17614,10 +13782,6 @@ labels.
 
 - (void)readAttributeRmsCurrentMinPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsCurrentMinPhaseBWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17630,10 +13794,6 @@ labels.
 
 - (void)readAttributeRmsCurrentMaxPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsCurrentMaxPhaseBWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17646,10 +13806,6 @@ labels.
 
 - (void)readAttributeActivePowerPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActivePowerPhaseBWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17662,10 +13818,6 @@ labels.
 
 - (void)readAttributeActivePowerMinPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActivePowerMinPhaseBWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17678,10 +13830,6 @@ labels.
 
 - (void)readAttributeActivePowerMaxPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActivePowerMaxPhaseBWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17694,10 +13842,6 @@ labels.
 
 - (void)readAttributeReactivePowerPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeReactivePowerPhaseBWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17710,10 +13854,6 @@ labels.
 
 - (void)readAttributeApparentPowerPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeApparentPowerPhaseBWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17726,10 +13866,6 @@ labels.
 
 - (void)readAttributePowerFactorPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePowerFactorPhaseBWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17742,10 +13878,6 @@ labels.
 
 - (void)readAttributeAverageRmsVoltageMeasurementPeriodPhaseBWithCompletion:
     (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAverageRmsVoltageMeasurementPeriodPhaseBWithParams:(MTRSubscribeParams *)params
                                                      subscriptionEstablished:
                                                          (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -17762,10 +13894,6 @@ labels.
 
 - (void)readAttributeAverageRmsOverVoltageCounterPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                           NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAverageRmsOverVoltageCounterPhaseBWithParams:(MTRSubscribeParams *)params
                                                subscriptionEstablished:
                                                    (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -17781,10 +13909,6 @@ labels.
 
 - (void)readAttributeAverageRmsUnderVoltageCounterPhaseBWithCompletion:
     (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAverageRmsUnderVoltageCounterPhaseBWithParams:(MTRSubscribeParams *)params
                                                 subscriptionEstablished:
                                                     (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -17800,10 +13924,6 @@ labels.
 
 - (void)readAttributeRmsExtremeOverVoltagePeriodPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                          NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsExtremeOverVoltagePeriodPhaseBWithParams:(MTRSubscribeParams *)params
                                               subscriptionEstablished:
                                                   (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -17819,10 +13939,6 @@ labels.
 
 - (void)readAttributeRmsExtremeUnderVoltagePeriodPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                           NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsExtremeUnderVoltagePeriodPhaseBWithParams:(MTRSubscribeParams *)params
                                                subscriptionEstablished:
                                                    (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -17838,10 +13954,6 @@ labels.
 
 - (void)readAttributeRmsVoltageSagPeriodPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageSagPeriodPhaseBWithParams:(MTRSubscribeParams *)params
                                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                 reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17854,10 +13966,6 @@ labels.
 
 - (void)readAttributeRmsVoltageSwellPeriodPhaseBWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                    NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageSwellPeriodPhaseBWithParams:(MTRSubscribeParams *)params
                                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                   reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17870,10 +13978,6 @@ labels.
 
 - (void)readAttributeLineCurrentPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLineCurrentPhaseCWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17886,10 +13990,6 @@ labels.
 
 - (void)readAttributeActiveCurrentPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActiveCurrentPhaseCWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17902,10 +14002,6 @@ labels.
 
 - (void)readAttributeReactiveCurrentPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeReactiveCurrentPhaseCWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17918,10 +14014,6 @@ labels.
 
 - (void)readAttributeRmsVoltagePhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltagePhaseCWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17934,10 +14026,6 @@ labels.
 
 - (void)readAttributeRmsVoltageMinPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageMinPhaseCWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17950,10 +14038,6 @@ labels.
 
 - (void)readAttributeRmsVoltageMaxPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageMaxPhaseCWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17966,10 +14050,6 @@ labels.
 
 - (void)readAttributeRmsCurrentPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsCurrentPhaseCWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -17982,10 +14062,6 @@ labels.
 
 - (void)readAttributeRmsCurrentMinPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsCurrentMinPhaseCWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -17998,10 +14074,6 @@ labels.
 
 - (void)readAttributeRmsCurrentMaxPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsCurrentMaxPhaseCWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -18014,10 +14086,6 @@ labels.
 
 - (void)readAttributeActivePowerPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActivePowerPhaseCWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18030,10 +14098,6 @@ labels.
 
 - (void)readAttributeActivePowerMinPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActivePowerMinPhaseCWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -18046,10 +14110,6 @@ labels.
 
 - (void)readAttributeActivePowerMaxPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeActivePowerMaxPhaseCWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -18062,10 +14122,6 @@ labels.
 
 - (void)readAttributeReactivePowerPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeReactivePowerPhaseCWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -18078,10 +14134,6 @@ labels.
 
 - (void)readAttributeApparentPowerPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeApparentPowerPhaseCWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -18094,10 +14146,6 @@ labels.
 
 - (void)readAttributePowerFactorPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributePowerFactorPhaseCWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18110,10 +14158,6 @@ labels.
 
 - (void)readAttributeAverageRmsVoltageMeasurementPeriodPhaseCWithCompletion:
     (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAverageRmsVoltageMeasurementPeriodPhaseCWithParams:(MTRSubscribeParams *)params
                                                      subscriptionEstablished:
                                                          (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -18130,10 +14174,6 @@ labels.
 
 - (void)readAttributeAverageRmsOverVoltageCounterPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                           NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAverageRmsOverVoltageCounterPhaseCWithParams:(MTRSubscribeParams *)params
                                                subscriptionEstablished:
                                                    (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -18149,10 +14189,6 @@ labels.
 
 - (void)readAttributeAverageRmsUnderVoltageCounterPhaseCWithCompletion:
     (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAverageRmsUnderVoltageCounterPhaseCWithParams:(MTRSubscribeParams *)params
                                                 subscriptionEstablished:
                                                     (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -18168,10 +14204,6 @@ labels.
 
 - (void)readAttributeRmsExtremeOverVoltagePeriodPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                          NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsExtremeOverVoltagePeriodPhaseCWithParams:(MTRSubscribeParams *)params
                                               subscriptionEstablished:
                                                   (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -18187,10 +14219,6 @@ labels.
 
 - (void)readAttributeRmsExtremeUnderVoltagePeriodPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                           NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsExtremeUnderVoltagePeriodPhaseCWithParams:(MTRSubscribeParams *)params
                                                subscriptionEstablished:
                                                    (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -18206,10 +14234,6 @@ labels.
 
 - (void)readAttributeRmsVoltageSagPeriodPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageSagPeriodPhaseCWithParams:(MTRSubscribeParams *)params
                                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                 reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -18222,10 +14246,6 @@ labels.
 
 - (void)readAttributeRmsVoltageSwellPeriodPhaseCWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                    NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRmsVoltageSwellPeriodPhaseCWithParams:(MTRSubscribeParams *)params
                                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                   reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -18238,10 +14258,6 @@ labels.
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -18254,10 +14270,6 @@ labels.
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -18270,10 +14282,6 @@ labels.
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18286,10 +14294,6 @@ labels.
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18302,10 +14306,6 @@ labels.
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18413,10 +14413,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeBooleanWithValue:(NSNumber * _Nonnull)value
                                 params:(MTRWriteParams * _Nullable)params
                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBooleanWithParams:(MTRSubscribeParams *)params
                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                               reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18433,10 +14429,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeBitmap8WithValue:(NSNumber * _Nonnull)value
                                 params:(MTRWriteParams * _Nullable)params
                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBitmap8WithParams:(MTRSubscribeParams *)params
                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                               reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18453,10 +14445,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeBitmap16WithValue:(NSNumber * _Nonnull)value
                                  params:(MTRWriteParams * _Nullable)params
                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBitmap16WithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18473,10 +14461,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeBitmap32WithValue:(NSNumber * _Nonnull)value
                                  params:(MTRWriteParams * _Nullable)params
                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBitmap32WithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18493,10 +14477,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeBitmap64WithValue:(NSNumber * _Nonnull)value
                                  params:(MTRWriteParams * _Nullable)params
                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeBitmap64WithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18513,10 +14493,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt8uWithValue:(NSNumber * _Nonnull)value
                               params:(MTRWriteParams * _Nullable)params
                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt8uWithParams:(MTRSubscribeParams *)params
                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                             reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18533,10 +14509,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt16uWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt16uWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18553,10 +14525,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt24uWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt24uWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18573,10 +14541,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt32uWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt32uWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18593,10 +14557,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt40uWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt40uWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18613,10 +14573,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt48uWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt48uWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18633,10 +14589,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt56uWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt56uWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18653,10 +14605,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt64uWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt64uWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18673,10 +14621,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt8sWithValue:(NSNumber * _Nonnull)value
                               params:(MTRWriteParams * _Nullable)params
                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt8sWithParams:(MTRSubscribeParams *)params
                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                             reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18693,10 +14637,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt16sWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt16sWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18713,10 +14653,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt24sWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt24sWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18733,10 +14669,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt32sWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt32sWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18753,10 +14685,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt40sWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt40sWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18773,10 +14701,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt48sWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt48sWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18793,10 +14717,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt56sWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt56sWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18813,10 +14733,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeInt64sWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeInt64sWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18833,10 +14749,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeEnum8WithValue:(NSNumber * _Nonnull)value
                               params:(MTRWriteParams * _Nullable)params
                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEnum8WithParams:(MTRSubscribeParams *)params
                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                             reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18853,10 +14765,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeEnum16WithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEnum16WithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18874,10 +14782,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeFloatSingleWithValue:(NSNumber * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFloatSingleWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18895,10 +14799,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeFloatDoubleWithValue:(NSNumber * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFloatDoubleWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18915,10 +14815,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeOctetStringWithValue:(NSData * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeOctetStringWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSData * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18935,10 +14831,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeListInt8uWithValue:(NSArray * _Nonnull)value
                                   params:(MTRWriteParams * _Nullable)params
                               completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeListInt8uWithParams:(MTRSubscribeParams *)params
                       subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                 reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18956,10 +14848,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeListOctetStringWithValue:(NSArray * _Nonnull)value
                                         params:(MTRWriteParams * _Nullable)params
                                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeListOctetStringWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -18977,10 +14865,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeListStructOctetStringWithValue:(NSArray * _Nonnull)value
                                               params:(MTRWriteParams * _Nullable)params
                                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeListStructOctetStringWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSArray * _Nullable value,
@@ -18998,10 +14882,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeLongOctetStringWithValue:(NSData * _Nonnull)value
                                         params:(MTRWriteParams * _Nullable)params
                                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLongOctetStringWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSData * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19018,10 +14898,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeCharStringWithValue:(NSString * _Nonnull)value
                                    params:(MTRWriteParams * _Nullable)params
                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeCharStringWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19039,10 +14915,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeLongCharStringWithValue:(NSString * _Nonnull)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeLongCharStringWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSString * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19059,10 +14931,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeEpochUsWithValue:(NSNumber * _Nonnull)value
                                 params:(MTRWriteParams * _Nullable)params
                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEpochUsWithParams:(MTRSubscribeParams *)params
                     subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                               reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19079,10 +14947,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeEpochSWithValue:(NSNumber * _Nonnull)value
                                params:(MTRWriteParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEpochSWithParams:(MTRSubscribeParams *)params
                    subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                              reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19099,10 +14963,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeVendorIdWithValue:(NSNumber * _Nonnull)value
                                  params:(MTRWriteParams * _Nullable)params
                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeVendorIdWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19120,10 +14980,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeListNullablesAndOptionalsStructWithValue:(NSArray * _Nonnull)value
                                                         params:(MTRWriteParams * _Nullable)params
                                                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeListNullablesAndOptionalsStructWithParams:(MTRSubscribeParams *)params
                                             subscriptionEstablished:
                                                 (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -19143,10 +14999,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeEnumAttrWithValue:(NSNumber * _Nonnull)value
                                  params:(MTRWriteParams * _Nullable)params
                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeEnumAttrWithParams:(MTRSubscribeParams *)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19164,10 +15016,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeStructAttrWithValue:(MTRUnitTestingClusterSimpleStruct * _Nonnull)value
                                    params:(MTRWriteParams * _Nullable)params
                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeStructAttrWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(MTRUnitTestingClusterSimpleStruct * _Nullable value,
@@ -19185,10 +15033,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeRangeRestrictedInt8uWithValue:(NSNumber * _Nonnull)value
                                              params:(MTRWriteParams * _Nullable)params
                                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRangeRestrictedInt8uWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -19206,10 +15050,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeRangeRestrictedInt8sWithValue:(NSNumber * _Nonnull)value
                                              params:(MTRWriteParams * _Nullable)params
                                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRangeRestrictedInt8sWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -19227,10 +15067,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeRangeRestrictedInt16uWithValue:(NSNumber * _Nonnull)value
                                               params:(MTRWriteParams * _Nullable)params
                                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRangeRestrictedInt16uWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -19248,10 +15084,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeRangeRestrictedInt16sWithValue:(NSNumber * _Nonnull)value
                                               params:(MTRWriteParams * _Nullable)params
                                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeRangeRestrictedInt16sWithParams:(MTRSubscribeParams *)params
                                   subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                             reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -19269,10 +15101,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeListLongOctetStringWithValue:(NSArray * _Nonnull)value
                                             params:(MTRWriteParams * _Nullable)params
                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeListLongOctetStringWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -19291,10 +15119,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeListFabricScopedWithValue:(NSArray * _Nonnull)value
                                          params:(MTRWriteParams * _Nullable)params
                                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeListFabricScopedWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19312,10 +15136,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeTimedWriteBooleanWithValue:(NSNumber * _Nonnull)value
                                           params:(MTRWriteParams * _Nullable)params
                                       completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeTimedWriteBooleanWithParams:(MTRSubscribeParams *)params
                               subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19333,10 +15153,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeGeneralErrorBooleanWithValue:(NSNumber * _Nonnull)value
                                             params:(MTRWriteParams * _Nullable)params
                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneralErrorBooleanWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -19354,10 +15170,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeClusterErrorBooleanWithValue:(NSNumber * _Nonnull)value
                                             params:(MTRWriteParams * _Nullable)params
                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterErrorBooleanWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -19375,10 +15187,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeUnsupportedWithValue:(NSNumber * _Nonnull)value
                                     params:(MTRWriteParams * _Nullable)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeUnsupportedWithParams:(MTRSubscribeParams *)params
                         subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                   reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19396,10 +15204,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableBooleanWithValue:(NSNumber * _Nullable)value
                                         params:(MTRWriteParams * _Nullable)params
                                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableBooleanWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19417,10 +15221,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableBitmap8WithValue:(NSNumber * _Nullable)value
                                         params:(MTRWriteParams * _Nullable)params
                                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableBitmap8WithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19438,10 +15238,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableBitmap16WithValue:(NSNumber * _Nullable)value
                                          params:(MTRWriteParams * _Nullable)params
                                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableBitmap16WithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19459,10 +15255,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableBitmap32WithValue:(NSNumber * _Nullable)value
                                          params:(MTRWriteParams * _Nullable)params
                                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableBitmap32WithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19480,10 +15272,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableBitmap64WithValue:(NSNumber * _Nullable)value
                                          params:(MTRWriteParams * _Nullable)params
                                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableBitmap64WithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19501,10 +15289,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt8uWithValue:(NSNumber * _Nullable)value
                                       params:(MTRWriteParams * _Nullable)params
                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt8uWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19522,10 +15306,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt16uWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt16uWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19543,10 +15323,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt24uWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt24uWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19564,10 +15340,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt32uWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt32uWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19585,10 +15357,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt40uWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt40uWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19606,10 +15374,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt48uWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt48uWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19627,10 +15391,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt56uWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt56uWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19648,10 +15408,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt64uWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt64uWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19669,10 +15425,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt8sWithValue:(NSNumber * _Nullable)value
                                       params:(MTRWriteParams * _Nullable)params
                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt8sWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19690,10 +15442,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt16sWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt16sWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19711,10 +15459,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt24sWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt24sWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19732,10 +15476,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt32sWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt32sWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19753,10 +15493,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt40sWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt40sWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19774,10 +15510,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt48sWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt48sWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19795,10 +15527,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt56sWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt56sWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19816,10 +15544,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableInt64sWithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableInt64sWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19837,10 +15561,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableEnum8WithValue:(NSNumber * _Nullable)value
                                       params:(MTRWriteParams * _Nullable)params
                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableEnum8WithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19858,10 +15578,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableEnum16WithValue:(NSNumber * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableEnum16WithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19879,10 +15595,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableFloatSingleWithValue:(NSNumber * _Nullable)value
                                             params:(MTRWriteParams * _Nullable)params
                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableFloatSingleWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -19900,10 +15612,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableFloatDoubleWithValue:(NSNumber * _Nullable)value
                                             params:(MTRWriteParams * _Nullable)params
                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableFloatDoubleWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSNumber * _Nullable value,
@@ -19921,10 +15629,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableOctetStringWithValue:(NSData * _Nullable)value
                                             params:(MTRWriteParams * _Nullable)params
                                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableOctetStringWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSData * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19942,10 +15646,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableCharStringWithValue:(NSString * _Nullable)value
                                            params:(MTRWriteParams * _Nullable)params
                                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableCharStringWithParams:(MTRSubscribeParams *)params
                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                          reportHandler:(void (^)(NSString * _Nullable value,
@@ -19963,10 +15663,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableEnumAttrWithValue:(NSNumber * _Nullable)value
                                          params:(MTRWriteParams * _Nullable)params
                                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableEnumAttrWithParams:(MTRSubscribeParams *)params
                              subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                        reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -19984,10 +15680,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableStructWithValue:(MTRUnitTestingClusterSimpleStruct * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableStructWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(MTRUnitTestingClusterSimpleStruct * _Nullable value,
@@ -20005,10 +15697,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableRangeRestrictedInt8uWithValue:(NSNumber * _Nullable)value
                                                      params:(MTRWriteParams * _Nullable)params
                                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableRangeRestrictedInt8uWithParams:(MTRSubscribeParams *)params
                                          subscriptionEstablished:
                                              (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -20027,10 +15715,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableRangeRestrictedInt8sWithValue:(NSNumber * _Nullable)value
                                                      params:(MTRWriteParams * _Nullable)params
                                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableRangeRestrictedInt8sWithParams:(MTRSubscribeParams *)params
                                          subscriptionEstablished:
                                              (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -20049,10 +15733,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableRangeRestrictedInt16uWithValue:(NSNumber * _Nullable)value
                                                       params:(MTRWriteParams * _Nullable)params
                                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableRangeRestrictedInt16uWithParams:(MTRSubscribeParams *)params
                                           subscriptionEstablished:
                                               (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -20071,10 +15751,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeNullableRangeRestrictedInt16sWithValue:(NSNumber * _Nullable)value
                                                       params:(MTRWriteParams * _Nullable)params
                                                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeNullableRangeRestrictedInt16sWithParams:(MTRSubscribeParams *)params
                                           subscriptionEstablished:
                                               (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
@@ -20093,10 +15769,6 @@ MTR_NEWLY_AVAILABLE
 - (void)writeAttributeWriteOnlyInt8uWithValue:(NSNumber * _Nonnull)value
                                        params:(MTRWriteParams * _Nullable)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeWriteOnlyInt8uWithParams:(MTRSubscribeParams *)params
                            subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -20109,10 +15781,6 @@ MTR_NEWLY_AVAILABLE
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                            reportHandler:(void (^)(NSArray * _Nullable value,
@@ -20125,10 +15793,6 @@ MTR_NEWLY_AVAILABLE
 
 - (void)readAttributeAcceptedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAcceptedCommandListWithParams:(MTRSubscribeParams *)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                           reportHandler:(void (^)(NSArray * _Nullable value,
@@ -20141,10 +15805,6 @@ MTR_NEWLY_AVAILABLE
 
 - (void)readAttributeAttributeListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeAttributeListWithParams:(MTRSubscribeParams *)params
                           subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                     reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
@@ -20157,10 +15817,6 @@ MTR_NEWLY_AVAILABLE
 
 - (void)readAttributeFeatureMapWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeFeatureMapWithParams:(MTRSubscribeParams *)params
                        subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                  reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
@@ -20173,10 +15829,6 @@ MTR_NEWLY_AVAILABLE
 
 - (void)readAttributeClusterRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
-/**
- * This API does not support setting resubscribeIfLost to NO in the
- * MTRSubscribeParams.
- */
 - (void)subscribeAttributeClusterRevisionWithParams:(MTRSubscribeParams *)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                       reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge.mm
@@ -35,19 +35,18 @@ void MTROctetStringAttributeCallbackBridge::OnSuccessFn(void * context, chip::By
     DispatchSuccess(context, objCValue);
 };
 
-void MTROctetStringAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROctetStringAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROctetStringAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -63,19 +62,18 @@ void MTRNullableOctetStringAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOctetStringAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableOctetStringAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableOctetStringAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -86,19 +84,18 @@ void MTRCharStringAttributeCallbackBridge::OnSuccessFn(void * context, chip::Cha
     DispatchSuccess(context, objCValue);
 };
 
-void MTRCharStringAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRCharStringAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRCharStringAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -114,19 +111,18 @@ void MTRNullableCharStringAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableCharStringAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableCharStringAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableCharStringAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -137,19 +133,18 @@ void MTRBooleanAttributeCallbackBridge::OnSuccessFn(void * context, bool value)
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBooleanAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBooleanAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBooleanAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -164,19 +159,18 @@ void MTRNullableBooleanAttributeCallbackBridge::OnSuccessFn(void * context, cons
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableBooleanAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableBooleanAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableBooleanAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -187,19 +181,18 @@ void MTRInt8uAttributeCallbackBridge::OnSuccessFn(void * context, uint8_t value)
     DispatchSuccess(context, objCValue);
 };
 
-void MTRInt8uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRInt8uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRInt8uAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -214,19 +207,18 @@ void MTRNullableInt8uAttributeCallbackBridge::OnSuccessFn(void * context, const 
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableInt8uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableInt8uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableInt8uAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -237,19 +229,18 @@ void MTRInt8sAttributeCallbackBridge::OnSuccessFn(void * context, int8_t value)
     DispatchSuccess(context, objCValue);
 };
 
-void MTRInt8sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRInt8sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRInt8sAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -264,19 +255,18 @@ void MTRNullableInt8sAttributeCallbackBridge::OnSuccessFn(void * context, const 
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableInt8sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableInt8sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableInt8sAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -287,19 +277,18 @@ void MTRInt16uAttributeCallbackBridge::OnSuccessFn(void * context, uint16_t valu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRInt16uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRInt16uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRInt16uAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -314,19 +303,18 @@ void MTRNullableInt16uAttributeCallbackBridge::OnSuccessFn(void * context, const
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableInt16uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableInt16uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableInt16uAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -337,19 +325,18 @@ void MTRInt16sAttributeCallbackBridge::OnSuccessFn(void * context, int16_t value
     DispatchSuccess(context, objCValue);
 };
 
-void MTRInt16sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRInt16sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRInt16sAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -364,19 +351,18 @@ void MTRNullableInt16sAttributeCallbackBridge::OnSuccessFn(void * context, const
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableInt16sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableInt16sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableInt16sAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -387,19 +373,18 @@ void MTRInt32uAttributeCallbackBridge::OnSuccessFn(void * context, uint32_t valu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRInt32uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRInt32uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRInt32uAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -414,19 +399,18 @@ void MTRNullableInt32uAttributeCallbackBridge::OnSuccessFn(void * context, const
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableInt32uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableInt32uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableInt32uAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -437,19 +421,18 @@ void MTRInt32sAttributeCallbackBridge::OnSuccessFn(void * context, int32_t value
     DispatchSuccess(context, objCValue);
 };
 
-void MTRInt32sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRInt32sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRInt32sAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -464,19 +447,18 @@ void MTRNullableInt32sAttributeCallbackBridge::OnSuccessFn(void * context, const
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableInt32sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableInt32sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableInt32sAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -487,19 +469,18 @@ void MTRInt64uAttributeCallbackBridge::OnSuccessFn(void * context, uint64_t valu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRInt64uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRInt64uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRInt64uAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -514,19 +495,18 @@ void MTRNullableInt64uAttributeCallbackBridge::OnSuccessFn(void * context, const
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableInt64uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableInt64uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableInt64uAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -537,19 +517,18 @@ void MTRInt64sAttributeCallbackBridge::OnSuccessFn(void * context, int64_t value
     DispatchSuccess(context, objCValue);
 };
 
-void MTRInt64sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRInt64sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRInt64sAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -564,19 +543,18 @@ void MTRNullableInt64sAttributeCallbackBridge::OnSuccessFn(void * context, const
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableInt64sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableInt64sAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableInt64sAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -587,19 +565,18 @@ void MTRFloatAttributeCallbackBridge::OnSuccessFn(void * context, float value)
     DispatchSuccess(context, objCValue);
 };
 
-void MTRFloatAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRFloatAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRFloatAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -614,19 +591,18 @@ void MTRNullableFloatAttributeCallbackBridge::OnSuccessFn(void * context, const 
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableFloatAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableFloatAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableFloatAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -637,19 +613,18 @@ void MTRDoubleAttributeCallbackBridge::OnSuccessFn(void * context, double value)
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoubleAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoubleAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoubleAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -664,19 +639,18 @@ void MTRNullableDoubleAttributeCallbackBridge::OnSuccessFn(void * context, const
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoubleAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoubleAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoubleAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -687,19 +661,18 @@ void MTRVendorIdAttributeCallbackBridge::OnSuccessFn(void * context, chip::Vendo
     DispatchSuccess(context, objCValue);
 };
 
-void MTRVendorIdAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRVendorIdAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRVendorIdAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -715,19 +688,18 @@ void MTRNullableVendorIdAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableVendorIdAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableVendorIdAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableVendorIdAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -754,19 +726,18 @@ void MTRIdentifyGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRIdentifyGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRIdentifyGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRIdentifyGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -793,19 +764,18 @@ void MTRIdentifyAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRIdentifyAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRIdentifyAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRIdentifyAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -832,19 +802,18 @@ void MTRIdentifyAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRIdentifyAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRIdentifyAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRIdentifyAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -871,19 +840,18 @@ void MTRGroupsGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGroupsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGroupsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGroupsGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -910,19 +878,18 @@ void MTRGroupsAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGroupsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGroupsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGroupsAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -949,19 +916,18 @@ void MTRGroupsAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGroupsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGroupsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGroupsAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -988,19 +954,18 @@ void MTRScenesGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRScenesGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRScenesGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRScenesGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1027,19 +992,18 @@ void MTRScenesAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRScenesAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRScenesAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRScenesAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1066,19 +1030,18 @@ void MTRScenesAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRScenesAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRScenesAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRScenesAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1105,19 +1068,18 @@ void MTROnOffGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTROnOffGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROnOffGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROnOffGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1144,19 +1106,18 @@ void MTROnOffAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTROnOffAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROnOffAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROnOffAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1183,19 +1144,18 @@ void MTROnOffAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTROnOffAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROnOffAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROnOffAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1222,20 +1182,18 @@ void MTROnOffSwitchConfigurationGeneratedCommandListListAttributeCallbackBridge:
     DispatchSuccess(context, objCValue);
 };
 
-void MTROnOffSwitchConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTROnOffSwitchConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROnOffSwitchConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1262,20 +1220,18 @@ void MTROnOffSwitchConfigurationAcceptedCommandListListAttributeCallbackBridge::
     DispatchSuccess(context, objCValue);
 };
 
-void MTROnOffSwitchConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTROnOffSwitchConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROnOffSwitchConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1302,19 +1258,18 @@ void MTROnOffSwitchConfigurationAttributeListListAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTROnOffSwitchConfigurationAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROnOffSwitchConfigurationAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROnOffSwitchConfigurationAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1341,19 +1296,18 @@ void MTRLevelControlGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRLevelControlGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRLevelControlGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRLevelControlGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1380,19 +1334,18 @@ void MTRLevelControlAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRLevelControlAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRLevelControlAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRLevelControlAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1419,19 +1372,18 @@ void MTRLevelControlAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRLevelControlAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRLevelControlAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRLevelControlAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1458,19 +1410,18 @@ void MTRBinaryInputBasicGeneratedCommandListListAttributeCallbackBridge::OnSucce
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBinaryInputBasicGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBinaryInputBasicGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBinaryInputBasicGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1497,19 +1448,18 @@ void MTRBinaryInputBasicAcceptedCommandListListAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBinaryInputBasicAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBinaryInputBasicAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBinaryInputBasicAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1536,19 +1486,18 @@ void MTRBinaryInputBasicAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBinaryInputBasicAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBinaryInputBasicAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBinaryInputBasicAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1577,19 +1526,18 @@ void MTRDescriptorDeviceTypeListListAttributeCallbackBridge::OnSuccessFn(void * 
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDescriptorDeviceTypeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDescriptorDeviceTypeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDescriptorDeviceTypeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1616,19 +1564,18 @@ void MTRDescriptorServerListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDescriptorServerListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDescriptorServerListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDescriptorServerListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1655,19 +1602,18 @@ void MTRDescriptorClientListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDescriptorClientListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDescriptorClientListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDescriptorClientListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1694,19 +1640,18 @@ void MTRDescriptorPartsListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDescriptorPartsListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDescriptorPartsListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDescriptorPartsListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1733,19 +1678,18 @@ void MTRDescriptorGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDescriptorGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDescriptorGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDescriptorGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1772,19 +1716,18 @@ void MTRDescriptorAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDescriptorAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDescriptorAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDescriptorAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1811,19 +1754,18 @@ void MTRDescriptorAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDescriptorAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDescriptorAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDescriptorAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1871,19 +1813,18 @@ void MTRBindingBindingListAttributeCallbackBridge::OnSuccessFn(void * context,
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBindingBindingListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBindingBindingListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBindingBindingListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1910,19 +1851,18 @@ void MTRBindingGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBindingGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBindingGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBindingGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1949,19 +1889,18 @@ void MTRBindingAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBindingAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBindingAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBindingAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -1988,19 +1927,18 @@ void MTRBindingAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBindingAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBindingAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBindingAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2086,19 +2024,18 @@ void MTRAccessControlAclListAttributeCallbackBridge::OnSuccessFn(void * context,
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAccessControlAclListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAccessControlAclListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAccessControlAclListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2127,19 +2064,18 @@ void MTRAccessControlExtensionListAttributeCallbackBridge::OnSuccessFn(void * co
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAccessControlExtensionListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAccessControlExtensionListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAccessControlExtensionListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2166,19 +2102,18 @@ void MTRAccessControlGeneratedCommandListListAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAccessControlGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAccessControlGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAccessControlGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2205,19 +2140,18 @@ void MTRAccessControlAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAccessControlAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAccessControlAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAccessControlAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2244,19 +2178,18 @@ void MTRAccessControlAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAccessControlAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAccessControlAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAccessControlAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2291,19 +2224,18 @@ void MTRActionsActionListListAttributeCallbackBridge::OnSuccessFn(void * context
     DispatchSuccess(context, objCValue);
 };
 
-void MTRActionsActionListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRActionsActionListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRActionsActionListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2351,19 +2283,18 @@ void MTRActionsEndpointListsListAttributeCallbackBridge::OnSuccessFn(void * cont
     DispatchSuccess(context, objCValue);
 };
 
-void MTRActionsEndpointListsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRActionsEndpointListsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRActionsEndpointListsListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2390,19 +2321,18 @@ void MTRActionsGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRActionsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRActionsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRActionsGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2429,19 +2359,18 @@ void MTRActionsAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRActionsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRActionsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRActionsAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2468,19 +2397,18 @@ void MTRActionsAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRActionsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRActionsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRActionsAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2494,19 +2422,18 @@ void MTRBasicCapabilityMinimaStructAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBasicCapabilityMinimaStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBasicCapabilityMinimaStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBasicCapabilityMinimaStructAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2533,19 +2460,18 @@ void MTRBasicGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBasicGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBasicGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBasicGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2572,19 +2498,18 @@ void MTRBasicAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBasicAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBasicAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBasicAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2611,19 +2536,18 @@ void MTRBasicAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBasicAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBasicAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBasicAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2650,20 +2574,18 @@ void MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2690,20 +2612,18 @@ void MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge:
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2730,19 +2650,18 @@ void MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2773,20 +2692,18 @@ void MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2813,20 +2730,18 @@ void MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridg
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2853,20 +2768,18 @@ void MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2893,19 +2806,18 @@ void MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2932,19 +2844,18 @@ void MTRLocalizationConfigurationSupportedLocalesListAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTRLocalizationConfigurationSupportedLocalesListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRLocalizationConfigurationSupportedLocalesListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRLocalizationConfigurationSupportedLocalesListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -2971,20 +2882,18 @@ void MTRLocalizationConfigurationGeneratedCommandListListAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTRLocalizationConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRLocalizationConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRLocalizationConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3011,20 +2920,18 @@ void MTRLocalizationConfigurationAcceptedCommandListListAttributeCallbackBridge:
     DispatchSuccess(context, objCValue);
 };
 
-void MTRLocalizationConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRLocalizationConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRLocalizationConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3051,19 +2958,18 @@ void MTRLocalizationConfigurationAttributeListListAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRLocalizationConfigurationAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRLocalizationConfigurationAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRLocalizationConfigurationAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3090,20 +2996,18 @@ void MTRTimeFormatLocalizationSupportedCalendarTypesListAttributeCallbackBridge:
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTimeFormatLocalizationSupportedCalendarTypesListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRTimeFormatLocalizationSupportedCalendarTypesListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTimeFormatLocalizationSupportedCalendarTypesListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3130,19 +3034,18 @@ void MTRTimeFormatLocalizationGeneratedCommandListListAttributeCallbackBridge::O
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTimeFormatLocalizationGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRTimeFormatLocalizationGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTimeFormatLocalizationGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3169,19 +3072,18 @@ void MTRTimeFormatLocalizationAcceptedCommandListListAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTimeFormatLocalizationAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRTimeFormatLocalizationAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTimeFormatLocalizationAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3208,19 +3110,18 @@ void MTRTimeFormatLocalizationAttributeListListAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTimeFormatLocalizationAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRTimeFormatLocalizationAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTimeFormatLocalizationAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3247,19 +3148,18 @@ void MTRUnitLocalizationGeneratedCommandListListAttributeCallbackBridge::OnSucce
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitLocalizationGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitLocalizationGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitLocalizationGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3286,19 +3186,18 @@ void MTRUnitLocalizationAcceptedCommandListListAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitLocalizationAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitLocalizationAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitLocalizationAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3325,19 +3224,18 @@ void MTRUnitLocalizationAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitLocalizationAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitLocalizationAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitLocalizationAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3364,19 +3262,18 @@ void MTRPowerSourceConfigurationSourcesListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceConfigurationSourcesListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceConfigurationSourcesListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceConfigurationSourcesListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3403,20 +3300,18 @@ void MTRPowerSourceConfigurationGeneratedCommandListListAttributeCallbackBridge:
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRPowerSourceConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3443,20 +3338,18 @@ void MTRPowerSourceConfigurationAcceptedCommandListListAttributeCallbackBridge::
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRPowerSourceConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3483,19 +3376,18 @@ void MTRPowerSourceConfigurationAttributeListListAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceConfigurationAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceConfigurationAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceConfigurationAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3522,19 +3414,18 @@ void MTRPowerSourceActiveWiredFaultsListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceActiveWiredFaultsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceActiveWiredFaultsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceActiveWiredFaultsListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3561,19 +3452,18 @@ void MTRPowerSourceActiveBatFaultsListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceActiveBatFaultsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceActiveBatFaultsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceActiveBatFaultsListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3600,19 +3490,18 @@ void MTRPowerSourceActiveBatChargeFaultsListAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceActiveBatChargeFaultsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceActiveBatChargeFaultsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceActiveBatChargeFaultsListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3639,19 +3528,18 @@ void MTRPowerSourceGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3678,19 +3566,18 @@ void MTRPowerSourceAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3717,19 +3604,18 @@ void MTRPowerSourceAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3743,20 +3629,18 @@ void MTRGeneralCommissioningBasicCommissioningInfoStructAttributeCallbackBridge:
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralCommissioningBasicCommissioningInfoStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRGeneralCommissioningBasicCommissioningInfoStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralCommissioningBasicCommissioningInfoStructAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3783,19 +3667,18 @@ void MTRGeneralCommissioningGeneratedCommandListListAttributeCallbackBridge::OnS
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralCommissioningGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralCommissioningGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralCommissioningGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3822,19 +3705,18 @@ void MTRGeneralCommissioningAcceptedCommandListListAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralCommissioningAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralCommissioningAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralCommissioningAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3861,19 +3743,18 @@ void MTRGeneralCommissioningAttributeListListAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralCommissioningAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralCommissioningAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralCommissioningAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3903,19 +3784,18 @@ void MTRNetworkCommissioningNetworksListAttributeCallbackBridge::OnSuccessFn(voi
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNetworkCommissioningNetworksListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNetworkCommissioningNetworksListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNetworkCommissioningNetworksListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3942,19 +3822,18 @@ void MTRNetworkCommissioningGeneratedCommandListListAttributeCallbackBridge::OnS
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNetworkCommissioningGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNetworkCommissioningGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNetworkCommissioningGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -3981,19 +3860,18 @@ void MTRNetworkCommissioningAcceptedCommandListListAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNetworkCommissioningAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNetworkCommissioningAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNetworkCommissioningAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4020,19 +3898,18 @@ void MTRNetworkCommissioningAttributeListListAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNetworkCommissioningAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNetworkCommissioningAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNetworkCommissioningAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4059,19 +3936,18 @@ void MTRDiagnosticLogsGeneratedCommandListListAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDiagnosticLogsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDiagnosticLogsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDiagnosticLogsGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4098,19 +3974,18 @@ void MTRDiagnosticLogsAcceptedCommandListListAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDiagnosticLogsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDiagnosticLogsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDiagnosticLogsAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4137,19 +4012,18 @@ void MTRDiagnosticLogsAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDiagnosticLogsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDiagnosticLogsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDiagnosticLogsAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4228,19 +4102,18 @@ void MTRGeneralDiagnosticsNetworkInterfacesListAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralDiagnosticsNetworkInterfacesListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralDiagnosticsNetworkInterfacesListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralDiagnosticsNetworkInterfacesListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4267,19 +4140,18 @@ void MTRGeneralDiagnosticsActiveHardwareFaultsListAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralDiagnosticsActiveHardwareFaultsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralDiagnosticsActiveHardwareFaultsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralDiagnosticsActiveHardwareFaultsListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4306,19 +4178,18 @@ void MTRGeneralDiagnosticsActiveRadioFaultsListAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralDiagnosticsActiveRadioFaultsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralDiagnosticsActiveRadioFaultsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralDiagnosticsActiveRadioFaultsListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4345,19 +4216,18 @@ void MTRGeneralDiagnosticsActiveNetworkFaultsListAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralDiagnosticsActiveNetworkFaultsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralDiagnosticsActiveNetworkFaultsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralDiagnosticsActiveNetworkFaultsListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4384,19 +4254,18 @@ void MTRGeneralDiagnosticsGeneratedCommandListListAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4423,19 +4292,18 @@ void MTRGeneralDiagnosticsAcceptedCommandListListAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4462,19 +4330,18 @@ void MTRGeneralDiagnosticsAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4525,19 +4392,18 @@ void MTRSoftwareDiagnosticsThreadMetricsListAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRSoftwareDiagnosticsThreadMetricsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRSoftwareDiagnosticsThreadMetricsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRSoftwareDiagnosticsThreadMetricsListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4564,19 +4430,18 @@ void MTRSoftwareDiagnosticsGeneratedCommandListListAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRSoftwareDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRSoftwareDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRSoftwareDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4603,19 +4468,18 @@ void MTRSoftwareDiagnosticsAcceptedCommandListListAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRSoftwareDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRSoftwareDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRSoftwareDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4642,19 +4506,18 @@ void MTRSoftwareDiagnosticsAttributeListListAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRSoftwareDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRSoftwareDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRSoftwareDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4704,19 +4567,18 @@ void MTRThreadNetworkDiagnosticsNeighborTableListListAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThreadNetworkDiagnosticsNeighborTableListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRThreadNetworkDiagnosticsNeighborTableListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThreadNetworkDiagnosticsNeighborTableListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4754,19 +4616,18 @@ void MTRThreadNetworkDiagnosticsRouteTableListListAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThreadNetworkDiagnosticsRouteTableListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRThreadNetworkDiagnosticsRouteTableListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThreadNetworkDiagnosticsRouteTableListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4785,19 +4646,18 @@ void MTRThreadNetworkDiagnosticsSecurityPolicyStructAttributeCallbackBridge::OnS
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThreadNetworkDiagnosticsSecurityPolicyStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRThreadNetworkDiagnosticsSecurityPolicyStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThreadNetworkDiagnosticsSecurityPolicyStructAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4826,21 +4686,18 @@ void MTRThreadNetworkDiagnosticsOperationalDatasetComponentsStructAttributeCallb
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThreadNetworkDiagnosticsOperationalDatasetComponentsStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRThreadNetworkDiagnosticsOperationalDatasetComponentsStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRThreadNetworkDiagnosticsOperationalDatasetComponentsStructAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4867,20 +4724,18 @@ void MTRThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeCallbackBrid
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4907,20 +4762,18 @@ void MTRThreadNetworkDiagnosticsGeneratedCommandListListAttributeCallbackBridge:
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThreadNetworkDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRThreadNetworkDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThreadNetworkDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4947,20 +4800,18 @@ void MTRThreadNetworkDiagnosticsAcceptedCommandListListAttributeCallbackBridge::
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThreadNetworkDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRThreadNetworkDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThreadNetworkDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -4987,19 +4838,18 @@ void MTRThreadNetworkDiagnosticsAttributeListListAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThreadNetworkDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRThreadNetworkDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThreadNetworkDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5026,19 +4876,18 @@ void MTRWiFiNetworkDiagnosticsGeneratedCommandListListAttributeCallbackBridge::O
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWiFiNetworkDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWiFiNetworkDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWiFiNetworkDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5065,19 +4914,18 @@ void MTRWiFiNetworkDiagnosticsAcceptedCommandListListAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWiFiNetworkDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWiFiNetworkDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWiFiNetworkDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5104,19 +4952,18 @@ void MTRWiFiNetworkDiagnosticsAttributeListListAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWiFiNetworkDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWiFiNetworkDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWiFiNetworkDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5143,20 +4990,18 @@ void MTREthernetNetworkDiagnosticsGeneratedCommandListListAttributeCallbackBridg
     DispatchSuccess(context, objCValue);
 };
 
-void MTREthernetNetworkDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTREthernetNetworkDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTREthernetNetworkDiagnosticsGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5183,20 +5028,18 @@ void MTREthernetNetworkDiagnosticsAcceptedCommandListListAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTREthernetNetworkDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTREthernetNetworkDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTREthernetNetworkDiagnosticsAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5223,19 +5066,18 @@ void MTREthernetNetworkDiagnosticsAttributeListListAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTREthernetNetworkDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTREthernetNetworkDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTREthernetNetworkDiagnosticsAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5262,19 +5104,18 @@ void MTRBridgedDeviceBasicGeneratedCommandListListAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBridgedDeviceBasicGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBridgedDeviceBasicGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBridgedDeviceBasicGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5301,19 +5142,18 @@ void MTRBridgedDeviceBasicAcceptedCommandListListAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBridgedDeviceBasicAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBridgedDeviceBasicAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBridgedDeviceBasicAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5340,19 +5180,18 @@ void MTRBridgedDeviceBasicAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBridgedDeviceBasicAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBridgedDeviceBasicAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBridgedDeviceBasicAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5379,19 +5218,18 @@ void MTRSwitchGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRSwitchGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRSwitchGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRSwitchGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5418,19 +5256,18 @@ void MTRSwitchAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRSwitchAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRSwitchAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRSwitchAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5457,19 +5294,18 @@ void MTRSwitchAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRSwitchAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRSwitchAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRSwitchAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5496,20 +5332,18 @@ void MTRAdministratorCommissioningGeneratedCommandListListAttributeCallbackBridg
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAdministratorCommissioningGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRAdministratorCommissioningGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAdministratorCommissioningGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5536,20 +5370,18 @@ void MTRAdministratorCommissioningAcceptedCommandListListAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAdministratorCommissioningAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRAdministratorCommissioningAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAdministratorCommissioningAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5576,19 +5408,18 @@ void MTRAdministratorCommissioningAttributeListListAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAdministratorCommissioningAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAdministratorCommissioningAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAdministratorCommissioningAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5623,19 +5454,18 @@ void MTROperationalCredentialsNOCsListAttributeCallbackBridge::OnSuccessFn(void 
     DispatchSuccess(context, objCValue);
 };
 
-void MTROperationalCredentialsNOCsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROperationalCredentialsNOCsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROperationalCredentialsNOCsListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5671,19 +5501,18 @@ void MTROperationalCredentialsFabricsListAttributeCallbackBridge::OnSuccessFn(vo
     DispatchSuccess(context, objCValue);
 };
 
-void MTROperationalCredentialsFabricsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROperationalCredentialsFabricsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROperationalCredentialsFabricsListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5710,20 +5539,18 @@ void MTROperationalCredentialsTrustedRootCertificatesListAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTROperationalCredentialsTrustedRootCertificatesListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTROperationalCredentialsTrustedRootCertificatesListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROperationalCredentialsTrustedRootCertificatesListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5750,19 +5577,18 @@ void MTROperationalCredentialsGeneratedCommandListListAttributeCallbackBridge::O
     DispatchSuccess(context, objCValue);
 };
 
-void MTROperationalCredentialsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROperationalCredentialsGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROperationalCredentialsGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5789,19 +5615,18 @@ void MTROperationalCredentialsAcceptedCommandListListAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTROperationalCredentialsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROperationalCredentialsAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROperationalCredentialsAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5828,19 +5653,18 @@ void MTROperationalCredentialsAttributeListListAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTROperationalCredentialsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROperationalCredentialsAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROperationalCredentialsAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5871,19 +5695,18 @@ void MTRGroupKeyManagementGroupKeyMapListAttributeCallbackBridge::OnSuccessFn(vo
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGroupKeyManagementGroupKeyMapListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGroupKeyManagementGroupKeyMapListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGroupKeyManagementGroupKeyMapListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5936,19 +5759,18 @@ void MTRGroupKeyManagementGroupTableListAttributeCallbackBridge::OnSuccessFn(voi
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGroupKeyManagementGroupTableListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGroupKeyManagementGroupTableListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGroupKeyManagementGroupTableListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -5975,19 +5797,18 @@ void MTRGroupKeyManagementGeneratedCommandListListAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGroupKeyManagementGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGroupKeyManagementGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGroupKeyManagementGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6014,19 +5835,18 @@ void MTRGroupKeyManagementAcceptedCommandListListAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGroupKeyManagementAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGroupKeyManagementAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGroupKeyManagementAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6053,19 +5873,18 @@ void MTRGroupKeyManagementAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGroupKeyManagementAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGroupKeyManagementAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGroupKeyManagementAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6098,19 +5917,18 @@ void MTRFixedLabelLabelListListAttributeCallbackBridge::OnSuccessFn(void * conte
     DispatchSuccess(context, objCValue);
 };
 
-void MTRFixedLabelLabelListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRFixedLabelLabelListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRFixedLabelLabelListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6137,19 +5955,18 @@ void MTRFixedLabelGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRFixedLabelGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRFixedLabelGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRFixedLabelGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6176,19 +5993,18 @@ void MTRFixedLabelAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRFixedLabelAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRFixedLabelAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRFixedLabelAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6215,19 +6031,18 @@ void MTRFixedLabelAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRFixedLabelAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRFixedLabelAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRFixedLabelAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6260,19 +6075,18 @@ void MTRUserLabelLabelListListAttributeCallbackBridge::OnSuccessFn(void * contex
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUserLabelLabelListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUserLabelLabelListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUserLabelLabelListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6299,19 +6113,18 @@ void MTRUserLabelGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUserLabelGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUserLabelGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUserLabelGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6338,19 +6151,18 @@ void MTRUserLabelAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUserLabelAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUserLabelAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUserLabelAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6377,19 +6189,18 @@ void MTRUserLabelAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUserLabelAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUserLabelAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUserLabelAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6416,19 +6227,18 @@ void MTRBooleanStateGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBooleanStateGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBooleanStateGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBooleanStateGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6455,19 +6265,18 @@ void MTRBooleanStateAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBooleanStateAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBooleanStateAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBooleanStateAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6494,19 +6303,18 @@ void MTRBooleanStateAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBooleanStateAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBooleanStateAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBooleanStateAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6555,19 +6363,18 @@ void MTRModeSelectSupportedModesListAttributeCallbackBridge::OnSuccessFn(void * 
     DispatchSuccess(context, objCValue);
 };
 
-void MTRModeSelectSupportedModesListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRModeSelectSupportedModesListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRModeSelectSupportedModesListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6594,19 +6401,18 @@ void MTRModeSelectGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRModeSelectGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRModeSelectGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRModeSelectGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6633,19 +6439,18 @@ void MTRModeSelectAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRModeSelectAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRModeSelectAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRModeSelectAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6672,19 +6477,18 @@ void MTRModeSelectAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRModeSelectAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRModeSelectAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRModeSelectAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6696,19 +6500,18 @@ void MTRDoorLockCredentialRulesSupportAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockCredentialRulesSupportAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockCredentialRulesSupportAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockCredentialRulesSupportAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6720,19 +6523,18 @@ void MTRDoorLockSupportedOperatingModesAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockSupportedOperatingModesAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockSupportedOperatingModesAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockSupportedOperatingModesAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6744,19 +6546,18 @@ void MTRDoorLockDefaultConfigurationRegisterAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockDefaultConfigurationRegisterAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockDefaultConfigurationRegisterAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockDefaultConfigurationRegisterAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6768,19 +6569,18 @@ void MTRDoorLockLocalProgrammingFeaturesAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockLocalProgrammingFeaturesAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockLocalProgrammingFeaturesAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockLocalProgrammingFeaturesAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6807,19 +6607,18 @@ void MTRDoorLockGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6846,19 +6645,18 @@ void MTRDoorLockAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6885,19 +6683,18 @@ void MTRDoorLockAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6909,19 +6706,18 @@ void MTRWindowCoveringConfigStatusAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWindowCoveringConfigStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWindowCoveringConfigStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWindowCoveringConfigStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6933,19 +6729,18 @@ void MTRWindowCoveringOperationalStatusAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWindowCoveringOperationalStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWindowCoveringOperationalStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWindowCoveringOperationalStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6957,19 +6752,18 @@ void MTRWindowCoveringModeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWindowCoveringModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWindowCoveringModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWindowCoveringModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -6981,19 +6775,18 @@ void MTRWindowCoveringSafetyStatusAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWindowCoveringSafetyStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWindowCoveringSafetyStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWindowCoveringSafetyStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7020,19 +6813,18 @@ void MTRWindowCoveringGeneratedCommandListListAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWindowCoveringGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWindowCoveringGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWindowCoveringGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7059,19 +6851,18 @@ void MTRWindowCoveringAcceptedCommandListListAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWindowCoveringAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWindowCoveringAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWindowCoveringAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7098,19 +6889,18 @@ void MTRWindowCoveringAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWindowCoveringAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWindowCoveringAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWindowCoveringAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7137,19 +6927,18 @@ void MTRBarrierControlGeneratedCommandListListAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBarrierControlGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBarrierControlGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBarrierControlGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7176,19 +6965,18 @@ void MTRBarrierControlAcceptedCommandListListAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBarrierControlAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBarrierControlAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBarrierControlAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7215,19 +7003,18 @@ void MTRBarrierControlAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBarrierControlAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBarrierControlAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBarrierControlAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7239,19 +7026,18 @@ void MTRPumpConfigurationAndControlPumpStatusAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPumpConfigurationAndControlPumpStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPumpConfigurationAndControlPumpStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPumpConfigurationAndControlPumpStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7278,20 +7064,18 @@ void MTRPumpConfigurationAndControlGeneratedCommandListListAttributeCallbackBrid
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPumpConfigurationAndControlGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRPumpConfigurationAndControlGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPumpConfigurationAndControlGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7318,20 +7102,18 @@ void MTRPumpConfigurationAndControlAcceptedCommandListListAttributeCallbackBridg
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPumpConfigurationAndControlAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRPumpConfigurationAndControlAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPumpConfigurationAndControlAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7358,19 +7140,18 @@ void MTRPumpConfigurationAndControlAttributeListListAttributeCallbackBridge::OnS
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPumpConfigurationAndControlAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPumpConfigurationAndControlAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPumpConfigurationAndControlAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7397,19 +7178,18 @@ void MTRThermostatGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThermostatGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRThermostatGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThermostatGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7436,19 +7216,18 @@ void MTRThermostatAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThermostatAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRThermostatAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThermostatAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7475,19 +7254,18 @@ void MTRThermostatAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThermostatAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRThermostatAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThermostatAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7514,19 +7292,18 @@ void MTRFanControlGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRFanControlGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRFanControlGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRFanControlGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7553,19 +7330,18 @@ void MTRFanControlAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRFanControlAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRFanControlAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRFanControlAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7592,19 +7368,18 @@ void MTRFanControlAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRFanControlAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRFanControlAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRFanControlAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7631,21 +7406,18 @@ void MTRThermostatUserInterfaceConfigurationGeneratedCommandListListAttributeCal
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThermostatUserInterfaceConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRThermostatUserInterfaceConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThermostatUserInterfaceConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(
-        context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7672,21 +7444,18 @@ void MTRThermostatUserInterfaceConfigurationAcceptedCommandListListAttributeCall
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThermostatUserInterfaceConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRThermostatUserInterfaceConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRThermostatUserInterfaceConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7713,21 +7482,18 @@ void MTRThermostatUserInterfaceConfigurationAttributeListListAttributeCallbackBr
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThermostatUserInterfaceConfigurationAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRThermostatUserInterfaceConfigurationAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRThermostatUserInterfaceConfigurationAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7754,19 +7520,18 @@ void MTRColorControlGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRColorControlGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRColorControlGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRColorControlGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7793,19 +7558,18 @@ void MTRColorControlAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRColorControlAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRColorControlAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRColorControlAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7832,19 +7596,18 @@ void MTRColorControlAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRColorControlAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRColorControlAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRColorControlAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7871,19 +7634,18 @@ void MTRBallastConfigurationGeneratedCommandListListAttributeCallbackBridge::OnS
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBallastConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBallastConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBallastConfigurationGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7910,19 +7672,18 @@ void MTRBallastConfigurationAcceptedCommandListListAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBallastConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBallastConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBallastConfigurationAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7949,19 +7710,18 @@ void MTRBallastConfigurationAttributeListListAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRBallastConfigurationAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRBallastConfigurationAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRBallastConfigurationAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -7988,19 +7748,18 @@ void MTRIlluminanceMeasurementGeneratedCommandListListAttributeCallbackBridge::O
     DispatchSuccess(context, objCValue);
 };
 
-void MTRIlluminanceMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRIlluminanceMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRIlluminanceMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8027,19 +7786,18 @@ void MTRIlluminanceMeasurementAcceptedCommandListListAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTRIlluminanceMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRIlluminanceMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRIlluminanceMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8066,19 +7824,18 @@ void MTRIlluminanceMeasurementAttributeListListAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRIlluminanceMeasurementAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRIlluminanceMeasurementAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRIlluminanceMeasurementAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8105,19 +7862,18 @@ void MTRTemperatureMeasurementGeneratedCommandListListAttributeCallbackBridge::O
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTemperatureMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRTemperatureMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTemperatureMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8144,19 +7900,18 @@ void MTRTemperatureMeasurementAcceptedCommandListListAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTemperatureMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRTemperatureMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTemperatureMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8183,19 +7938,18 @@ void MTRTemperatureMeasurementAttributeListListAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTemperatureMeasurementAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRTemperatureMeasurementAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTemperatureMeasurementAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8222,19 +7976,18 @@ void MTRPressureMeasurementGeneratedCommandListListAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPressureMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPressureMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPressureMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8261,19 +8014,18 @@ void MTRPressureMeasurementAcceptedCommandListListAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPressureMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPressureMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPressureMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8300,19 +8052,18 @@ void MTRPressureMeasurementAttributeListListAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPressureMeasurementAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPressureMeasurementAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPressureMeasurementAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8339,19 +8090,18 @@ void MTRFlowMeasurementGeneratedCommandListListAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRFlowMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRFlowMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRFlowMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8378,19 +8128,18 @@ void MTRFlowMeasurementAcceptedCommandListListAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, objCValue);
 };
 
-void MTRFlowMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRFlowMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRFlowMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8417,19 +8166,18 @@ void MTRFlowMeasurementAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRFlowMeasurementAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRFlowMeasurementAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRFlowMeasurementAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8456,20 +8204,18 @@ void MTRRelativeHumidityMeasurementGeneratedCommandListListAttributeCallbackBrid
     DispatchSuccess(context, objCValue);
 };
 
-void MTRRelativeHumidityMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRRelativeHumidityMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRRelativeHumidityMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8496,20 +8242,18 @@ void MTRRelativeHumidityMeasurementAcceptedCommandListListAttributeCallbackBridg
     DispatchSuccess(context, objCValue);
 };
 
-void MTRRelativeHumidityMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRRelativeHumidityMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRRelativeHumidityMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8536,19 +8280,18 @@ void MTRRelativeHumidityMeasurementAttributeListListAttributeCallbackBridge::OnS
     DispatchSuccess(context, objCValue);
 };
 
-void MTRRelativeHumidityMeasurementAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRRelativeHumidityMeasurementAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRRelativeHumidityMeasurementAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8575,19 +8318,18 @@ void MTROccupancySensingGeneratedCommandListListAttributeCallbackBridge::OnSucce
     DispatchSuccess(context, objCValue);
 };
 
-void MTROccupancySensingGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROccupancySensingGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROccupancySensingGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8614,19 +8356,18 @@ void MTROccupancySensingAcceptedCommandListListAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTROccupancySensingAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROccupancySensingAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROccupancySensingAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8653,19 +8394,18 @@ void MTROccupancySensingAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTROccupancySensingAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROccupancySensingAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROccupancySensingAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8692,19 +8432,18 @@ void MTRWakeOnLanGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWakeOnLanGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWakeOnLanGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWakeOnLanGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8731,19 +8470,18 @@ void MTRWakeOnLanAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWakeOnLanAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWakeOnLanAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWakeOnLanAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8770,19 +8508,18 @@ void MTRWakeOnLanAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWakeOnLanAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWakeOnLanAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWakeOnLanAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8832,19 +8569,18 @@ void MTRChannelChannelListListAttributeCallbackBridge::OnSuccessFn(void * contex
     DispatchSuccess(context, objCValue);
 };
 
-void MTRChannelChannelListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRChannelChannelListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRChannelChannelListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8878,19 +8614,18 @@ void MTRChannelLineupStructAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRChannelLineupStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRChannelLineupStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRChannelLineupStructAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8929,19 +8664,18 @@ void MTRChannelCurrentChannelStructAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRChannelCurrentChannelStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRChannelCurrentChannelStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRChannelCurrentChannelStructAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -8968,19 +8702,18 @@ void MTRChannelGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRChannelGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRChannelGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRChannelGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9007,19 +8740,18 @@ void MTRChannelAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRChannelAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRChannelAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRChannelAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9046,19 +8778,18 @@ void MTRChannelAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRChannelAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRChannelAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRChannelAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9089,19 +8820,18 @@ void MTRTargetNavigatorTargetListListAttributeCallbackBridge::OnSuccessFn(void *
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTargetNavigatorTargetListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRTargetNavigatorTargetListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTargetNavigatorTargetListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9128,19 +8858,18 @@ void MTRTargetNavigatorGeneratedCommandListListAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTargetNavigatorGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRTargetNavigatorGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTargetNavigatorGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9167,19 +8896,18 @@ void MTRTargetNavigatorAcceptedCommandListListAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTargetNavigatorAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRTargetNavigatorAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTargetNavigatorAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9206,19 +8934,18 @@ void MTRTargetNavigatorAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTargetNavigatorAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRTargetNavigatorAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTargetNavigatorAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9240,19 +8967,18 @@ void MTRMediaPlaybackSampledPositionStructAttributeCallbackBridge::OnSuccessFn(v
     DispatchSuccess(context, objCValue);
 };
 
-void MTRMediaPlaybackSampledPositionStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRMediaPlaybackSampledPositionStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRMediaPlaybackSampledPositionStructAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9279,19 +9005,18 @@ void MTRMediaPlaybackGeneratedCommandListListAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRMediaPlaybackGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRMediaPlaybackGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRMediaPlaybackGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9318,19 +9043,18 @@ void MTRMediaPlaybackAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRMediaPlaybackAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRMediaPlaybackAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRMediaPlaybackAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9357,19 +9081,18 @@ void MTRMediaPlaybackAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRMediaPlaybackAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRMediaPlaybackAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRMediaPlaybackAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9404,19 +9127,18 @@ void MTRMediaInputInputListListAttributeCallbackBridge::OnSuccessFn(void * conte
     DispatchSuccess(context, objCValue);
 };
 
-void MTRMediaInputInputListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRMediaInputInputListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRMediaInputInputListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9443,19 +9165,18 @@ void MTRMediaInputGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRMediaInputGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRMediaInputGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRMediaInputGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9482,19 +9203,18 @@ void MTRMediaInputAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRMediaInputAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRMediaInputAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRMediaInputAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9521,19 +9241,18 @@ void MTRMediaInputAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRMediaInputAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRMediaInputAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRMediaInputAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9560,19 +9279,18 @@ void MTRLowPowerGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRLowPowerGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRLowPowerGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRLowPowerGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9599,19 +9317,18 @@ void MTRLowPowerAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRLowPowerAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRLowPowerAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRLowPowerAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9638,19 +9355,18 @@ void MTRLowPowerAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRLowPowerAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRLowPowerAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRLowPowerAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9677,19 +9393,18 @@ void MTRKeypadInputGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRKeypadInputGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRKeypadInputGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRKeypadInputGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9716,19 +9431,18 @@ void MTRKeypadInputAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRKeypadInputAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRKeypadInputAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRKeypadInputAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9755,19 +9469,18 @@ void MTRKeypadInputAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRKeypadInputAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRKeypadInputAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRKeypadInputAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9794,19 +9507,18 @@ void MTRContentLauncherAcceptHeaderListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRContentLauncherAcceptHeaderListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRContentLauncherAcceptHeaderListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRContentLauncherAcceptHeaderListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9833,19 +9545,18 @@ void MTRContentLauncherGeneratedCommandListListAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRContentLauncherGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRContentLauncherGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRContentLauncherGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9872,19 +9583,18 @@ void MTRContentLauncherAcceptedCommandListListAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, objCValue);
 };
 
-void MTRContentLauncherAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRContentLauncherAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRContentLauncherAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9911,19 +9621,18 @@ void MTRContentLauncherAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRContentLauncherAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRContentLauncherAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRContentLauncherAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9955,19 +9664,18 @@ void MTRAudioOutputOutputListListAttributeCallbackBridge::OnSuccessFn(void * con
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAudioOutputOutputListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAudioOutputOutputListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAudioOutputOutputListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -9994,19 +9702,18 @@ void MTRAudioOutputGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAudioOutputGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAudioOutputGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAudioOutputGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10033,19 +9740,18 @@ void MTRAudioOutputAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAudioOutputAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAudioOutputAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAudioOutputAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10072,19 +9778,18 @@ void MTRAudioOutputAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAudioOutputAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAudioOutputAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAudioOutputAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10111,19 +9816,18 @@ void MTRApplicationLauncherCatalogListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRApplicationLauncherCatalogListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRApplicationLauncherCatalogListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRApplicationLauncherCatalogListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10149,19 +9853,18 @@ void MTRApplicationLauncherCurrentAppStructAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRApplicationLauncherCurrentAppStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRApplicationLauncherCurrentAppStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRApplicationLauncherCurrentAppStructAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10188,19 +9891,18 @@ void MTRApplicationLauncherGeneratedCommandListListAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRApplicationLauncherGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRApplicationLauncherGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRApplicationLauncherGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10227,19 +9929,18 @@ void MTRApplicationLauncherAcceptedCommandListListAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRApplicationLauncherAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRApplicationLauncherAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRApplicationLauncherAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10266,19 +9967,18 @@ void MTRApplicationLauncherAttributeListListAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRApplicationLauncherAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRApplicationLauncherAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRApplicationLauncherAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10294,19 +9994,18 @@ void MTRApplicationBasicApplicationStructAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRApplicationBasicApplicationStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRApplicationBasicApplicationStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRApplicationBasicApplicationStructAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10333,19 +10032,18 @@ void MTRApplicationBasicAllowedVendorListListAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRApplicationBasicAllowedVendorListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRApplicationBasicAllowedVendorListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRApplicationBasicAllowedVendorListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10372,19 +10070,18 @@ void MTRApplicationBasicGeneratedCommandListListAttributeCallbackBridge::OnSucce
     DispatchSuccess(context, objCValue);
 };
 
-void MTRApplicationBasicGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRApplicationBasicGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRApplicationBasicGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10411,19 +10108,18 @@ void MTRApplicationBasicAcceptedCommandListListAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRApplicationBasicAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRApplicationBasicAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRApplicationBasicAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10450,19 +10146,18 @@ void MTRApplicationBasicAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRApplicationBasicAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRApplicationBasicAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRApplicationBasicAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10489,19 +10184,18 @@ void MTRAccountLoginGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAccountLoginGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAccountLoginGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAccountLoginGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10528,19 +10222,18 @@ void MTRAccountLoginAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAccountLoginAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAccountLoginAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAccountLoginAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10567,19 +10260,18 @@ void MTRAccountLoginAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAccountLoginAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAccountLoginAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAccountLoginAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10606,19 +10298,18 @@ void MTRElectricalMeasurementGeneratedCommandListListAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTRElectricalMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRElectricalMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRElectricalMeasurementGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10645,19 +10336,18 @@ void MTRElectricalMeasurementAcceptedCommandListListAttributeCallbackBridge::OnS
     DispatchSuccess(context, objCValue);
 };
 
-void MTRElectricalMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRElectricalMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRElectricalMeasurementAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10684,19 +10374,18 @@ void MTRElectricalMeasurementAttributeListListAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, objCValue);
 };
 
-void MTRElectricalMeasurementAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRElectricalMeasurementAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRElectricalMeasurementAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10708,19 +10397,18 @@ void MTRUnitTestingBitmap8AttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingBitmap8AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingBitmap8AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingBitmap8AttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10732,19 +10420,18 @@ void MTRUnitTestingBitmap16AttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingBitmap16AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingBitmap16AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingBitmap16AttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10756,19 +10443,18 @@ void MTRUnitTestingBitmap32AttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingBitmap32AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingBitmap32AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingBitmap32AttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10780,19 +10466,18 @@ void MTRUnitTestingBitmap64AttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingBitmap64AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingBitmap64AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingBitmap64AttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10819,19 +10504,18 @@ void MTRUnitTestingListInt8uListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingListInt8uListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingListInt8uListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingListInt8uListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10858,19 +10542,18 @@ void MTRUnitTestingListOctetStringListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingListOctetStringListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingListOctetStringListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingListOctetStringListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -10900,19 +10583,18 @@ void MTRUnitTestingListStructOctetStringListAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingListStructOctetStringListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingListStructOctetStringListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingListStructOctetStringListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -11112,19 +10794,18 @@ void MTRUnitTestingListNullablesAndOptionalsStructListAttributeCallbackBridge::O
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingListNullablesAndOptionalsStructListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingListNullablesAndOptionalsStructListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingListNullablesAndOptionalsStructListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -11144,19 +10825,18 @@ void MTRUnitTestingStructAttrStructAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingStructAttrStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingStructAttrStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingStructAttrStructAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -11183,19 +10863,18 @@ void MTRUnitTestingListLongOctetStringListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingListLongOctetStringListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingListLongOctetStringListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingListLongOctetStringListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -11278,19 +10957,18 @@ void MTRUnitTestingListFabricScopedListAttributeCallbackBridge::OnSuccessFn(void
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingListFabricScopedListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingListFabricScopedListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingListFabricScopedListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -11306,19 +10984,18 @@ void MTRUnitTestingNullableBitmap8AttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingNullableBitmap8AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingNullableBitmap8AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingNullableBitmap8AttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -11334,19 +11011,18 @@ void MTRUnitTestingNullableBitmap16AttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingNullableBitmap16AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingNullableBitmap16AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingNullableBitmap16AttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -11362,19 +11038,18 @@ void MTRUnitTestingNullableBitmap32AttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingNullableBitmap32AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingNullableBitmap32AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingNullableBitmap32AttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -11390,19 +11065,18 @@ void MTRUnitTestingNullableBitmap64AttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingNullableBitmap64AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingNullableBitmap64AttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingNullableBitmap64AttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -11428,19 +11102,18 @@ void MTRUnitTestingNullableStructStructAttributeCallbackBridge::OnSuccessFn(void
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingNullableStructStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingNullableStructStructAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingNullableStructStructAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -11467,19 +11140,18 @@ void MTRUnitTestingGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -11506,19 +11178,18 @@ void MTRUnitTestingAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -11545,19 +11216,18 @@ void MTRUnitTestingAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingAttributeListListAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13371,19 +13041,18 @@ void MTRIdentifyClusterIdentifyEffectIdentifierAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRIdentifyClusterIdentifyEffectIdentifierAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRIdentifyClusterIdentifyEffectIdentifierAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRIdentifyClusterIdentifyEffectIdentifierAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13399,20 +13068,18 @@ void MTRNullableIdentifyClusterIdentifyEffectIdentifierAttributeCallbackBridge::
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableIdentifyClusterIdentifyEffectIdentifierAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableIdentifyClusterIdentifyEffectIdentifierAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableIdentifyClusterIdentifyEffectIdentifierAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13424,19 +13091,18 @@ void MTRIdentifyClusterIdentifyEffectVariantAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRIdentifyClusterIdentifyEffectVariantAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRIdentifyClusterIdentifyEffectVariantAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRIdentifyClusterIdentifyEffectVariantAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13452,19 +13118,18 @@ void MTRNullableIdentifyClusterIdentifyEffectVariantAttributeCallbackBridge::OnS
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableIdentifyClusterIdentifyEffectVariantAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableIdentifyClusterIdentifyEffectVariantAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableIdentifyClusterIdentifyEffectVariantAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13476,19 +13141,18 @@ void MTRIdentifyClusterIdentifyIdentifyTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRIdentifyClusterIdentifyIdentifyTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRIdentifyClusterIdentifyIdentifyTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRIdentifyClusterIdentifyIdentifyTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13504,19 +13168,18 @@ void MTRNullableIdentifyClusterIdentifyIdentifyTypeAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableIdentifyClusterIdentifyIdentifyTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableIdentifyClusterIdentifyIdentifyTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableIdentifyClusterIdentifyIdentifyTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13528,19 +13191,18 @@ void MTROnOffClusterOnOffDelayedAllOffEffectVariantAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTROnOffClusterOnOffDelayedAllOffEffectVariantAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROnOffClusterOnOffDelayedAllOffEffectVariantAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROnOffClusterOnOffDelayedAllOffEffectVariantAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13556,20 +13218,18 @@ void MTRNullableOnOffClusterOnOffDelayedAllOffEffectVariantAttributeCallbackBrid
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOnOffClusterOnOffDelayedAllOffEffectVariantAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableOnOffClusterOnOffDelayedAllOffEffectVariantAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableOnOffClusterOnOffDelayedAllOffEffectVariantAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13581,19 +13241,18 @@ void MTROnOffClusterOnOffDyingLightEffectVariantAttributeCallbackBridge::OnSucce
     DispatchSuccess(context, objCValue);
 };
 
-void MTROnOffClusterOnOffDyingLightEffectVariantAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROnOffClusterOnOffDyingLightEffectVariantAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROnOffClusterOnOffDyingLightEffectVariantAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13609,20 +13268,18 @@ void MTRNullableOnOffClusterOnOffDyingLightEffectVariantAttributeCallbackBridge:
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOnOffClusterOnOffDyingLightEffectVariantAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableOnOffClusterOnOffDyingLightEffectVariantAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableOnOffClusterOnOffDyingLightEffectVariantAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13634,19 +13291,18 @@ void MTROnOffClusterOnOffEffectIdentifierAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTROnOffClusterOnOffEffectIdentifierAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROnOffClusterOnOffEffectIdentifierAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROnOffClusterOnOffEffectIdentifierAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13662,19 +13318,18 @@ void MTRNullableOnOffClusterOnOffEffectIdentifierAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOnOffClusterOnOffEffectIdentifierAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableOnOffClusterOnOffEffectIdentifierAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableOnOffClusterOnOffEffectIdentifierAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13686,19 +13341,18 @@ void MTROnOffClusterOnOffStartUpOnOffAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTROnOffClusterOnOffStartUpOnOffAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROnOffClusterOnOffStartUpOnOffAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROnOffClusterOnOffStartUpOnOffAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13714,19 +13368,18 @@ void MTRNullableOnOffClusterOnOffStartUpOnOffAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOnOffClusterOnOffStartUpOnOffAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableOnOffClusterOnOffStartUpOnOffAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableOnOffClusterOnOffStartUpOnOffAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13738,19 +13391,18 @@ void MTRLevelControlClusterMoveModeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRLevelControlClusterMoveModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRLevelControlClusterMoveModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRLevelControlClusterMoveModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13766,19 +13418,18 @@ void MTRNullableLevelControlClusterMoveModeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableLevelControlClusterMoveModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableLevelControlClusterMoveModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableLevelControlClusterMoveModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13790,19 +13441,18 @@ void MTRLevelControlClusterStepModeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRLevelControlClusterStepModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRLevelControlClusterStepModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRLevelControlClusterStepModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13818,19 +13468,18 @@ void MTRNullableLevelControlClusterStepModeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableLevelControlClusterStepModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableLevelControlClusterStepModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableLevelControlClusterStepModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13842,19 +13491,18 @@ void MTRAccessControlClusterAuthModeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAccessControlClusterAuthModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAccessControlClusterAuthModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAccessControlClusterAuthModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13870,19 +13518,18 @@ void MTRNullableAccessControlClusterAuthModeAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableAccessControlClusterAuthModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableAccessControlClusterAuthModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableAccessControlClusterAuthModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13894,19 +13541,18 @@ void MTRAccessControlClusterChangeTypeEnumAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAccessControlClusterChangeTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAccessControlClusterChangeTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAccessControlClusterChangeTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13922,19 +13568,18 @@ void MTRNullableAccessControlClusterChangeTypeEnumAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableAccessControlClusterChangeTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableAccessControlClusterChangeTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableAccessControlClusterChangeTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13946,19 +13591,18 @@ void MTRAccessControlClusterPrivilegeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAccessControlClusterPrivilegeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAccessControlClusterPrivilegeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAccessControlClusterPrivilegeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13974,19 +13618,18 @@ void MTRNullableAccessControlClusterPrivilegeAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableAccessControlClusterPrivilegeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableAccessControlClusterPrivilegeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableAccessControlClusterPrivilegeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -13998,19 +13641,18 @@ void MTRActionsClusterActionErrorEnumAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRActionsClusterActionErrorEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRActionsClusterActionErrorEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRActionsClusterActionErrorEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14026,19 +13668,18 @@ void MTRNullableActionsClusterActionErrorEnumAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableActionsClusterActionErrorEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableActionsClusterActionErrorEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableActionsClusterActionErrorEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14050,19 +13691,18 @@ void MTRActionsClusterActionStateEnumAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRActionsClusterActionStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRActionsClusterActionStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRActionsClusterActionStateEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14078,19 +13718,18 @@ void MTRNullableActionsClusterActionStateEnumAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableActionsClusterActionStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableActionsClusterActionStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableActionsClusterActionStateEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14102,19 +13741,18 @@ void MTRActionsClusterActionTypeEnumAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRActionsClusterActionTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRActionsClusterActionTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRActionsClusterActionTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14130,19 +13768,18 @@ void MTRNullableActionsClusterActionTypeEnumAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableActionsClusterActionTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableActionsClusterActionTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableActionsClusterActionTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14154,19 +13791,18 @@ void MTRActionsClusterEndpointListTypeEnumAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRActionsClusterEndpointListTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRActionsClusterEndpointListTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRActionsClusterEndpointListTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14182,19 +13818,18 @@ void MTRNullableActionsClusterEndpointListTypeEnumAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableActionsClusterEndpointListTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableActionsClusterEndpointListTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableActionsClusterEndpointListTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14206,21 +13841,18 @@ void MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBri
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14236,21 +13868,18 @@ void MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCal
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge *>(
-        context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14262,20 +13891,18 @@ void MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBrid
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14291,21 +13918,18 @@ void MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCall
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14317,19 +13941,18 @@ void MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge::O
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14345,21 +13968,18 @@ void MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackB
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14371,21 +13991,18 @@ void MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackB
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14402,21 +14019,18 @@ void MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeC
 };
 
 void MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge::
-    OnSubscriptionEstablished(void * context)
+    OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge *>(
-            context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14428,21 +14042,18 @@ void MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBri
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14458,21 +14069,18 @@ void MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCal
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge *>(
-        context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14484,20 +14092,18 @@ void MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBrid
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14513,21 +14119,18 @@ void MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCall
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14539,19 +14142,18 @@ void MTRTimeFormatLocalizationClusterCalendarTypeAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTimeFormatLocalizationClusterCalendarTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRTimeFormatLocalizationClusterCalendarTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTimeFormatLocalizationClusterCalendarTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14567,20 +14169,18 @@ void MTRNullableTimeFormatLocalizationClusterCalendarTypeAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableTimeFormatLocalizationClusterCalendarTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableTimeFormatLocalizationClusterCalendarTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableTimeFormatLocalizationClusterCalendarTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14592,19 +14192,18 @@ void MTRTimeFormatLocalizationClusterHourFormatAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTimeFormatLocalizationClusterHourFormatAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRTimeFormatLocalizationClusterHourFormatAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTimeFormatLocalizationClusterHourFormatAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14620,20 +14219,18 @@ void MTRNullableTimeFormatLocalizationClusterHourFormatAttributeCallbackBridge::
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableTimeFormatLocalizationClusterHourFormatAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableTimeFormatLocalizationClusterHourFormatAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableTimeFormatLocalizationClusterHourFormatAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14645,19 +14242,18 @@ void MTRUnitLocalizationClusterTempUnitAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitLocalizationClusterTempUnitAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitLocalizationClusterTempUnitAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitLocalizationClusterTempUnitAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14673,19 +14269,18 @@ void MTRNullableUnitLocalizationClusterTempUnitAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableUnitLocalizationClusterTempUnitAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableUnitLocalizationClusterTempUnitAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableUnitLocalizationClusterTempUnitAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14697,19 +14292,18 @@ void MTRPowerSourceClusterBatChargeFaultAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceClusterBatChargeFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceClusterBatChargeFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceClusterBatChargeFaultAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14725,19 +14319,18 @@ void MTRNullablePowerSourceClusterBatChargeFaultAttributeCallbackBridge::OnSucce
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullablePowerSourceClusterBatChargeFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullablePowerSourceClusterBatChargeFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullablePowerSourceClusterBatChargeFaultAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14749,19 +14342,18 @@ void MTRPowerSourceClusterBatChargeLevelAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceClusterBatChargeLevelAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceClusterBatChargeLevelAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceClusterBatChargeLevelAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14777,19 +14369,18 @@ void MTRNullablePowerSourceClusterBatChargeLevelAttributeCallbackBridge::OnSucce
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullablePowerSourceClusterBatChargeLevelAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullablePowerSourceClusterBatChargeLevelAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullablePowerSourceClusterBatChargeLevelAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14801,19 +14392,18 @@ void MTRPowerSourceClusterBatChargeStateAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceClusterBatChargeStateAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceClusterBatChargeStateAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceClusterBatChargeStateAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14829,19 +14419,18 @@ void MTRNullablePowerSourceClusterBatChargeStateAttributeCallbackBridge::OnSucce
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullablePowerSourceClusterBatChargeStateAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullablePowerSourceClusterBatChargeStateAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullablePowerSourceClusterBatChargeStateAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14853,19 +14442,18 @@ void MTRPowerSourceClusterBatFaultAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceClusterBatFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceClusterBatFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceClusterBatFaultAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14881,19 +14469,18 @@ void MTRNullablePowerSourceClusterBatFaultAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullablePowerSourceClusterBatFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullablePowerSourceClusterBatFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullablePowerSourceClusterBatFaultAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14905,19 +14492,18 @@ void MTRPowerSourceClusterBatReplaceabilityAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceClusterBatReplaceabilityAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceClusterBatReplaceabilityAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceClusterBatReplaceabilityAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14933,19 +14519,18 @@ void MTRNullablePowerSourceClusterBatReplaceabilityAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullablePowerSourceClusterBatReplaceabilityAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullablePowerSourceClusterBatReplaceabilityAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullablePowerSourceClusterBatReplaceabilityAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14957,19 +14542,18 @@ void MTRPowerSourceClusterPowerSourceStatusAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceClusterPowerSourceStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceClusterPowerSourceStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceClusterPowerSourceStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -14985,19 +14569,18 @@ void MTRNullablePowerSourceClusterPowerSourceStatusAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullablePowerSourceClusterPowerSourceStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullablePowerSourceClusterPowerSourceStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullablePowerSourceClusterPowerSourceStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15009,19 +14592,18 @@ void MTRPowerSourceClusterWiredCurrentTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceClusterWiredCurrentTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceClusterWiredCurrentTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceClusterWiredCurrentTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15037,19 +14619,18 @@ void MTRNullablePowerSourceClusterWiredCurrentTypeAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullablePowerSourceClusterWiredCurrentTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullablePowerSourceClusterWiredCurrentTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullablePowerSourceClusterWiredCurrentTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15061,19 +14642,18 @@ void MTRPowerSourceClusterWiredFaultAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPowerSourceClusterWiredFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRPowerSourceClusterWiredFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPowerSourceClusterWiredFaultAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15089,19 +14669,18 @@ void MTRNullablePowerSourceClusterWiredFaultAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullablePowerSourceClusterWiredFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullablePowerSourceClusterWiredFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullablePowerSourceClusterWiredFaultAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15113,19 +14692,18 @@ void MTRGeneralCommissioningClusterCommissioningErrorAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralCommissioningClusterCommissioningErrorAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralCommissioningClusterCommissioningErrorAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralCommissioningClusterCommissioningErrorAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15141,21 +14719,18 @@ void MTRNullableGeneralCommissioningClusterCommissioningErrorAttributeCallbackBr
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableGeneralCommissioningClusterCommissioningErrorAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableGeneralCommissioningClusterCommissioningErrorAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableGeneralCommissioningClusterCommissioningErrorAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15167,20 +14742,18 @@ void MTRGeneralCommissioningClusterRegulatoryLocationTypeAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralCommissioningClusterRegulatoryLocationTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRGeneralCommissioningClusterRegulatoryLocationTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralCommissioningClusterRegulatoryLocationTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15196,21 +14769,18 @@ void MTRNullableGeneralCommissioningClusterRegulatoryLocationTypeAttributeCallba
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableGeneralCommissioningClusterRegulatoryLocationTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableGeneralCommissioningClusterRegulatoryLocationTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableGeneralCommissioningClusterRegulatoryLocationTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15222,21 +14792,18 @@ void MTRNetworkCommissioningClusterNetworkCommissioningStatusAttributeCallbackBr
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNetworkCommissioningClusterNetworkCommissioningStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNetworkCommissioningClusterNetworkCommissioningStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNetworkCommissioningClusterNetworkCommissioningStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15252,22 +14819,19 @@ void MTRNullableNetworkCommissioningClusterNetworkCommissioningStatusAttributeCa
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableNetworkCommissioningClusterNetworkCommissioningStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableNetworkCommissioningClusterNetworkCommissioningStatusAttributeCallbackSubscriptionBridge::
+    OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableNetworkCommissioningClusterNetworkCommissioningStatusAttributeCallbackSubscriptionBridge *>(
-            context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15279,19 +14843,18 @@ void MTRNetworkCommissioningClusterWiFiBandAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNetworkCommissioningClusterWiFiBandAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNetworkCommissioningClusterWiFiBandAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNetworkCommissioningClusterWiFiBandAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15307,19 +14870,18 @@ void MTRNullableNetworkCommissioningClusterWiFiBandAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableNetworkCommissioningClusterWiFiBandAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableNetworkCommissioningClusterWiFiBandAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableNetworkCommissioningClusterWiFiBandAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15331,19 +14893,18 @@ void MTRDiagnosticLogsClusterLogsIntentAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDiagnosticLogsClusterLogsIntentAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDiagnosticLogsClusterLogsIntentAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDiagnosticLogsClusterLogsIntentAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15359,19 +14920,18 @@ void MTRNullableDiagnosticLogsClusterLogsIntentAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDiagnosticLogsClusterLogsIntentAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDiagnosticLogsClusterLogsIntentAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDiagnosticLogsClusterLogsIntentAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15383,19 +14943,18 @@ void MTRDiagnosticLogsClusterLogsStatusAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDiagnosticLogsClusterLogsStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDiagnosticLogsClusterLogsStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDiagnosticLogsClusterLogsStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15411,19 +14970,18 @@ void MTRNullableDiagnosticLogsClusterLogsStatusAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDiagnosticLogsClusterLogsStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDiagnosticLogsClusterLogsStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDiagnosticLogsClusterLogsStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15435,19 +14993,18 @@ void MTRDiagnosticLogsClusterLogsTransferProtocolAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDiagnosticLogsClusterLogsTransferProtocolAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDiagnosticLogsClusterLogsTransferProtocolAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDiagnosticLogsClusterLogsTransferProtocolAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15463,20 +15020,18 @@ void MTRNullableDiagnosticLogsClusterLogsTransferProtocolAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDiagnosticLogsClusterLogsTransferProtocolAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableDiagnosticLogsClusterLogsTransferProtocolAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDiagnosticLogsClusterLogsTransferProtocolAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15488,19 +15043,18 @@ void MTRGeneralDiagnosticsClusterBootReasonTypeAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralDiagnosticsClusterBootReasonTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralDiagnosticsClusterBootReasonTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralDiagnosticsClusterBootReasonTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15516,20 +15070,18 @@ void MTRNullableGeneralDiagnosticsClusterBootReasonTypeAttributeCallbackBridge::
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableGeneralDiagnosticsClusterBootReasonTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableGeneralDiagnosticsClusterBootReasonTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableGeneralDiagnosticsClusterBootReasonTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15541,19 +15093,18 @@ void MTRGeneralDiagnosticsClusterHardwareFaultTypeAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralDiagnosticsClusterHardwareFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralDiagnosticsClusterHardwareFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralDiagnosticsClusterHardwareFaultTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15569,20 +15120,18 @@ void MTRNullableGeneralDiagnosticsClusterHardwareFaultTypeAttributeCallbackBridg
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableGeneralDiagnosticsClusterHardwareFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableGeneralDiagnosticsClusterHardwareFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableGeneralDiagnosticsClusterHardwareFaultTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15594,19 +15143,18 @@ void MTRGeneralDiagnosticsClusterInterfaceTypeAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralDiagnosticsClusterInterfaceTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralDiagnosticsClusterInterfaceTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralDiagnosticsClusterInterfaceTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15622,19 +15170,18 @@ void MTRNullableGeneralDiagnosticsClusterInterfaceTypeAttributeCallbackBridge::O
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableGeneralDiagnosticsClusterInterfaceTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableGeneralDiagnosticsClusterInterfaceTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableGeneralDiagnosticsClusterInterfaceTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15646,19 +15193,18 @@ void MTRGeneralDiagnosticsClusterNetworkFaultTypeAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralDiagnosticsClusterNetworkFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralDiagnosticsClusterNetworkFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralDiagnosticsClusterNetworkFaultTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15674,20 +15220,18 @@ void MTRNullableGeneralDiagnosticsClusterNetworkFaultTypeAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableGeneralDiagnosticsClusterNetworkFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableGeneralDiagnosticsClusterNetworkFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableGeneralDiagnosticsClusterNetworkFaultTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15699,19 +15243,18 @@ void MTRGeneralDiagnosticsClusterRadioFaultTypeAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGeneralDiagnosticsClusterRadioFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRGeneralDiagnosticsClusterRadioFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGeneralDiagnosticsClusterRadioFaultTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15727,20 +15270,18 @@ void MTRNullableGeneralDiagnosticsClusterRadioFaultTypeAttributeCallbackBridge::
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableGeneralDiagnosticsClusterRadioFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableGeneralDiagnosticsClusterRadioFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableGeneralDiagnosticsClusterRadioFaultTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15752,19 +15293,18 @@ void MTRThreadNetworkDiagnosticsClusterNetworkFaultAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThreadNetworkDiagnosticsClusterNetworkFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRThreadNetworkDiagnosticsClusterNetworkFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThreadNetworkDiagnosticsClusterNetworkFaultAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15780,20 +15320,18 @@ void MTRNullableThreadNetworkDiagnosticsClusterNetworkFaultAttributeCallbackBrid
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableThreadNetworkDiagnosticsClusterNetworkFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableThreadNetworkDiagnosticsClusterNetworkFaultAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableThreadNetworkDiagnosticsClusterNetworkFaultAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15805,19 +15343,18 @@ void MTRThreadNetworkDiagnosticsClusterRoutingRoleAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThreadNetworkDiagnosticsClusterRoutingRoleAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRThreadNetworkDiagnosticsClusterRoutingRoleAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThreadNetworkDiagnosticsClusterRoutingRoleAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15833,20 +15370,18 @@ void MTRNullableThreadNetworkDiagnosticsClusterRoutingRoleAttributeCallbackBridg
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableThreadNetworkDiagnosticsClusterRoutingRoleAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableThreadNetworkDiagnosticsClusterRoutingRoleAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableThreadNetworkDiagnosticsClusterRoutingRoleAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15858,21 +15393,18 @@ void MTRThreadNetworkDiagnosticsClusterThreadConnectionStatusAttributeCallbackBr
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThreadNetworkDiagnosticsClusterThreadConnectionStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRThreadNetworkDiagnosticsClusterThreadConnectionStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRThreadNetworkDiagnosticsClusterThreadConnectionStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15888,22 +15420,19 @@ void MTRNullableThreadNetworkDiagnosticsClusterThreadConnectionStatusAttributeCa
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableThreadNetworkDiagnosticsClusterThreadConnectionStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableThreadNetworkDiagnosticsClusterThreadConnectionStatusAttributeCallbackSubscriptionBridge::
+    OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableThreadNetworkDiagnosticsClusterThreadConnectionStatusAttributeCallbackSubscriptionBridge *>(
-            context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15915,21 +15444,18 @@ void MTRWiFiNetworkDiagnosticsClusterAssociationFailureCauseAttributeCallbackBri
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWiFiNetworkDiagnosticsClusterAssociationFailureCauseAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRWiFiNetworkDiagnosticsClusterAssociationFailureCauseAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRWiFiNetworkDiagnosticsClusterAssociationFailureCauseAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15945,21 +15471,18 @@ void MTRNullableWiFiNetworkDiagnosticsClusterAssociationFailureCauseAttributeCal
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableWiFiNetworkDiagnosticsClusterAssociationFailureCauseAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableWiFiNetworkDiagnosticsClusterAssociationFailureCauseAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableWiFiNetworkDiagnosticsClusterAssociationFailureCauseAttributeCallbackSubscriptionBridge *>(
-        context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15971,19 +15494,18 @@ void MTRWiFiNetworkDiagnosticsClusterSecurityTypeAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWiFiNetworkDiagnosticsClusterSecurityTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWiFiNetworkDiagnosticsClusterSecurityTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWiFiNetworkDiagnosticsClusterSecurityTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -15999,20 +15521,18 @@ void MTRNullableWiFiNetworkDiagnosticsClusterSecurityTypeAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableWiFiNetworkDiagnosticsClusterSecurityTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableWiFiNetworkDiagnosticsClusterSecurityTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableWiFiNetworkDiagnosticsClusterSecurityTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16024,20 +15544,18 @@ void MTRWiFiNetworkDiagnosticsClusterWiFiConnectionStatusAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWiFiNetworkDiagnosticsClusterWiFiConnectionStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRWiFiNetworkDiagnosticsClusterWiFiConnectionStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWiFiNetworkDiagnosticsClusterWiFiConnectionStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16053,21 +15571,18 @@ void MTRNullableWiFiNetworkDiagnosticsClusterWiFiConnectionStatusAttributeCallba
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableWiFiNetworkDiagnosticsClusterWiFiConnectionStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableWiFiNetworkDiagnosticsClusterWiFiConnectionStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableWiFiNetworkDiagnosticsClusterWiFiConnectionStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16079,19 +15594,18 @@ void MTRWiFiNetworkDiagnosticsClusterWiFiVersionTypeAttributeCallbackBridge::OnS
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWiFiNetworkDiagnosticsClusterWiFiVersionTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWiFiNetworkDiagnosticsClusterWiFiVersionTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWiFiNetworkDiagnosticsClusterWiFiVersionTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16107,21 +15621,18 @@ void MTRNullableWiFiNetworkDiagnosticsClusterWiFiVersionTypeAttributeCallbackBri
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableWiFiNetworkDiagnosticsClusterWiFiVersionTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableWiFiNetworkDiagnosticsClusterWiFiVersionTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableWiFiNetworkDiagnosticsClusterWiFiVersionTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16133,19 +15644,18 @@ void MTREthernetNetworkDiagnosticsClusterPHYRateTypeAttributeCallbackBridge::OnS
     DispatchSuccess(context, objCValue);
 };
 
-void MTREthernetNetworkDiagnosticsClusterPHYRateTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTREthernetNetworkDiagnosticsClusterPHYRateTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTREthernetNetworkDiagnosticsClusterPHYRateTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16161,21 +15671,18 @@ void MTRNullableEthernetNetworkDiagnosticsClusterPHYRateTypeAttributeCallbackBri
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableEthernetNetworkDiagnosticsClusterPHYRateTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableEthernetNetworkDiagnosticsClusterPHYRateTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableEthernetNetworkDiagnosticsClusterPHYRateTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16187,19 +15694,18 @@ void MTRTimeSynchronizationClusterGranularityEnumAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTimeSynchronizationClusterGranularityEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRTimeSynchronizationClusterGranularityEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTimeSynchronizationClusterGranularityEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16215,20 +15721,18 @@ void MTRNullableTimeSynchronizationClusterGranularityEnumAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableTimeSynchronizationClusterGranularityEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableTimeSynchronizationClusterGranularityEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableTimeSynchronizationClusterGranularityEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16240,19 +15744,18 @@ void MTRTimeSynchronizationClusterTimeSourceEnumAttributeCallbackBridge::OnSucce
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTimeSynchronizationClusterTimeSourceEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRTimeSynchronizationClusterTimeSourceEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTimeSynchronizationClusterTimeSourceEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16268,20 +15771,18 @@ void MTRNullableTimeSynchronizationClusterTimeSourceEnumAttributeCallbackBridge:
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableTimeSynchronizationClusterTimeSourceEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableTimeSynchronizationClusterTimeSourceEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableTimeSynchronizationClusterTimeSourceEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16293,21 +15794,18 @@ void MTRAdministratorCommissioningClusterCommissioningWindowStatusAttributeCallb
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAdministratorCommissioningClusterCommissioningWindowStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRAdministratorCommissioningClusterCommissioningWindowStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRAdministratorCommissioningClusterCommissioningWindowStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16324,21 +15822,18 @@ void MTRNullableAdministratorCommissioningClusterCommissioningWindowStatusAttrib
 };
 
 void MTRNullableAdministratorCommissioningClusterCommissioningWindowStatusAttributeCallbackSubscriptionBridge::
-    OnSubscriptionEstablished(void * context)
+    OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableAdministratorCommissioningClusterCommissioningWindowStatusAttributeCallbackSubscriptionBridge *>(
-            context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16350,19 +15845,18 @@ void MTRAdministratorCommissioningClusterStatusCodeAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAdministratorCommissioningClusterStatusCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAdministratorCommissioningClusterStatusCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAdministratorCommissioningClusterStatusCodeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16378,20 +15872,18 @@ void MTRNullableAdministratorCommissioningClusterStatusCodeAttributeCallbackBrid
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableAdministratorCommissioningClusterStatusCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableAdministratorCommissioningClusterStatusCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableAdministratorCommissioningClusterStatusCodeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16403,20 +15895,18 @@ void MTROperationalCredentialsClusterOperationalCertStatusAttributeCallbackBridg
     DispatchSuccess(context, objCValue);
 };
 
-void MTROperationalCredentialsClusterOperationalCertStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTROperationalCredentialsClusterOperationalCertStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTROperationalCredentialsClusterOperationalCertStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16432,21 +15922,18 @@ void MTRNullableOperationalCredentialsClusterOperationalCertStatusAttributeCallb
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOperationalCredentialsClusterOperationalCertStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableOperationalCredentialsClusterOperationalCertStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableOperationalCredentialsClusterOperationalCertStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16458,20 +15945,18 @@ void MTRGroupKeyManagementClusterGroupKeySecurityPolicyAttributeCallbackBridge::
     DispatchSuccess(context, objCValue);
 };
 
-void MTRGroupKeyManagementClusterGroupKeySecurityPolicyAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRGroupKeyManagementClusterGroupKeySecurityPolicyAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRGroupKeyManagementClusterGroupKeySecurityPolicyAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16487,21 +15972,18 @@ void MTRNullableGroupKeyManagementClusterGroupKeySecurityPolicyAttributeCallback
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableGroupKeyManagementClusterGroupKeySecurityPolicyAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableGroupKeyManagementClusterGroupKeySecurityPolicyAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableGroupKeyManagementClusterGroupKeySecurityPolicyAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16513,19 +15995,18 @@ void MTRDoorLockClusterDlAlarmCodeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlAlarmCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlAlarmCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlAlarmCodeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16541,19 +16022,18 @@ void MTRNullableDoorLockClusterDlAlarmCodeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlAlarmCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlAlarmCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlAlarmCodeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16565,19 +16045,18 @@ void MTRDoorLockClusterDlCredentialRuleAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlCredentialRuleAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlCredentialRuleAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlCredentialRuleAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16593,19 +16072,18 @@ void MTRNullableDoorLockClusterDlCredentialRuleAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlCredentialRuleAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlCredentialRuleAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlCredentialRuleAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16617,19 +16095,18 @@ void MTRDoorLockClusterDlCredentialTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlCredentialTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlCredentialTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlCredentialTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16645,19 +16122,18 @@ void MTRNullableDoorLockClusterDlCredentialTypeAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlCredentialTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlCredentialTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlCredentialTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16669,19 +16145,18 @@ void MTRDoorLockClusterDlDataOperationTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlDataOperationTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlDataOperationTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlDataOperationTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16697,19 +16172,18 @@ void MTRNullableDoorLockClusterDlDataOperationTypeAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlDataOperationTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlDataOperationTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlDataOperationTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16721,19 +16195,18 @@ void MTRDoorLockClusterDlDoorStateAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlDoorStateAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlDoorStateAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlDoorStateAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16749,19 +16222,18 @@ void MTRNullableDoorLockClusterDlDoorStateAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlDoorStateAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlDoorStateAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlDoorStateAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16773,19 +16245,18 @@ void MTRDoorLockClusterDlLockDataTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlLockDataTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlLockDataTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlLockDataTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16801,19 +16272,18 @@ void MTRNullableDoorLockClusterDlLockDataTypeAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlLockDataTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlLockDataTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlLockDataTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16825,19 +16295,18 @@ void MTRDoorLockClusterDlLockOperationTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlLockOperationTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlLockOperationTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlLockOperationTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16853,19 +16322,18 @@ void MTRNullableDoorLockClusterDlLockOperationTypeAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlLockOperationTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlLockOperationTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlLockOperationTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16877,19 +16345,18 @@ void MTRDoorLockClusterDlLockStateAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlLockStateAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlLockStateAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlLockStateAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16905,19 +16372,18 @@ void MTRNullableDoorLockClusterDlLockStateAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlLockStateAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlLockStateAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlLockStateAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16929,19 +16395,18 @@ void MTRDoorLockClusterDlLockTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlLockTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlLockTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlLockTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16957,19 +16422,18 @@ void MTRNullableDoorLockClusterDlLockTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlLockTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlLockTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlLockTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -16981,19 +16445,18 @@ void MTRDoorLockClusterDlOperatingModeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlOperatingModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlOperatingModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlOperatingModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17009,19 +16472,18 @@ void MTRNullableDoorLockClusterDlOperatingModeAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlOperatingModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlOperatingModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlOperatingModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17033,19 +16495,18 @@ void MTRDoorLockClusterDlOperationErrorAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlOperationErrorAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlOperationErrorAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlOperationErrorAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17061,19 +16522,18 @@ void MTRNullableDoorLockClusterDlOperationErrorAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlOperationErrorAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlOperationErrorAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlOperationErrorAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17085,19 +16545,18 @@ void MTRDoorLockClusterDlOperationSourceAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlOperationSourceAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlOperationSourceAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlOperationSourceAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17113,19 +16572,18 @@ void MTRNullableDoorLockClusterDlOperationSourceAttributeCallbackBridge::OnSucce
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlOperationSourceAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlOperationSourceAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlOperationSourceAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17136,19 +16594,18 @@ void MTRDoorLockClusterDlStatusAttributeCallbackBridge::OnSuccessFn(void * conte
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17164,19 +16621,18 @@ void MTRNullableDoorLockClusterDlStatusAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17188,19 +16644,18 @@ void MTRDoorLockClusterDlUserStatusAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlUserStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlUserStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlUserStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17216,19 +16671,18 @@ void MTRNullableDoorLockClusterDlUserStatusAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlUserStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlUserStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlUserStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17240,19 +16694,18 @@ void MTRDoorLockClusterDlUserTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDlUserTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDlUserTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDlUserTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17268,19 +16721,18 @@ void MTRNullableDoorLockClusterDlUserTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDlUserTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDlUserTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDlUserTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17292,19 +16744,18 @@ void MTRDoorLockClusterDoorLockOperationEventCodeAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDoorLockOperationEventCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDoorLockOperationEventCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDoorLockOperationEventCodeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17320,20 +16771,18 @@ void MTRNullableDoorLockClusterDoorLockOperationEventCodeAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDoorLockOperationEventCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableDoorLockClusterDoorLockOperationEventCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDoorLockOperationEventCodeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17345,19 +16794,18 @@ void MTRDoorLockClusterDoorLockProgrammingEventCodeAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDoorLockProgrammingEventCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDoorLockProgrammingEventCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDoorLockProgrammingEventCodeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17373,20 +16821,18 @@ void MTRNullableDoorLockClusterDoorLockProgrammingEventCodeAttributeCallbackBrid
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDoorLockProgrammingEventCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableDoorLockClusterDoorLockProgrammingEventCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDoorLockProgrammingEventCodeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17398,19 +16844,18 @@ void MTRDoorLockClusterDoorLockSetPinOrIdStatusAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDoorLockSetPinOrIdStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDoorLockSetPinOrIdStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDoorLockSetPinOrIdStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17426,20 +16871,18 @@ void MTRNullableDoorLockClusterDoorLockSetPinOrIdStatusAttributeCallbackBridge::
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDoorLockSetPinOrIdStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableDoorLockClusterDoorLockSetPinOrIdStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDoorLockSetPinOrIdStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17451,19 +16894,18 @@ void MTRDoorLockClusterDoorLockUserStatusAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDoorLockUserStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDoorLockUserStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDoorLockUserStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17479,19 +16921,18 @@ void MTRNullableDoorLockClusterDoorLockUserStatusAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDoorLockUserStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDoorLockUserStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDoorLockUserStatusAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17503,19 +16944,18 @@ void MTRDoorLockClusterDoorLockUserTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRDoorLockClusterDoorLockUserTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRDoorLockClusterDoorLockUserTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRDoorLockClusterDoorLockUserTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17531,19 +16971,18 @@ void MTRNullableDoorLockClusterDoorLockUserTypeAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableDoorLockClusterDoorLockUserTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableDoorLockClusterDoorLockUserTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableDoorLockClusterDoorLockUserTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17555,19 +16994,18 @@ void MTRWindowCoveringClusterEndProductTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWindowCoveringClusterEndProductTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWindowCoveringClusterEndProductTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWindowCoveringClusterEndProductTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17583,19 +17021,18 @@ void MTRNullableWindowCoveringClusterEndProductTypeAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableWindowCoveringClusterEndProductTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableWindowCoveringClusterEndProductTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableWindowCoveringClusterEndProductTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17607,19 +17044,18 @@ void MTRWindowCoveringClusterTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWindowCoveringClusterTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWindowCoveringClusterTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRWindowCoveringClusterTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17635,19 +17071,18 @@ void MTRNullableWindowCoveringClusterTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableWindowCoveringClusterTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableWindowCoveringClusterTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableWindowCoveringClusterTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17659,20 +17094,18 @@ void MTRPumpConfigurationAndControlClusterPumpControlModeAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPumpConfigurationAndControlClusterPumpControlModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRPumpConfigurationAndControlClusterPumpControlModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPumpConfigurationAndControlClusterPumpControlModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17688,21 +17121,18 @@ void MTRNullablePumpConfigurationAndControlClusterPumpControlModeAttributeCallba
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullablePumpConfigurationAndControlClusterPumpControlModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullablePumpConfigurationAndControlClusterPumpControlModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullablePumpConfigurationAndControlClusterPumpControlModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17714,20 +17144,18 @@ void MTRPumpConfigurationAndControlClusterPumpOperationModeAttributeCallbackBrid
     DispatchSuccess(context, objCValue);
 };
 
-void MTRPumpConfigurationAndControlClusterPumpOperationModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRPumpConfigurationAndControlClusterPumpOperationModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRPumpConfigurationAndControlClusterPumpOperationModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17743,21 +17171,18 @@ void MTRNullablePumpConfigurationAndControlClusterPumpOperationModeAttributeCall
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullablePumpConfigurationAndControlClusterPumpOperationModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullablePumpConfigurationAndControlClusterPumpOperationModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullablePumpConfigurationAndControlClusterPumpOperationModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17769,19 +17194,18 @@ void MTRThermostatClusterSetpointAdjustModeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThermostatClusterSetpointAdjustModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRThermostatClusterSetpointAdjustModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThermostatClusterSetpointAdjustModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17797,19 +17221,18 @@ void MTRNullableThermostatClusterSetpointAdjustModeAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableThermostatClusterSetpointAdjustModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableThermostatClusterSetpointAdjustModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableThermostatClusterSetpointAdjustModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17821,19 +17244,18 @@ void MTRThermostatClusterThermostatControlSequenceAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThermostatClusterThermostatControlSequenceAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRThermostatClusterThermostatControlSequenceAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThermostatClusterThermostatControlSequenceAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17849,20 +17271,18 @@ void MTRNullableThermostatClusterThermostatControlSequenceAttributeCallbackBridg
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableThermostatClusterThermostatControlSequenceAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableThermostatClusterThermostatControlSequenceAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableThermostatClusterThermostatControlSequenceAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17874,19 +17294,18 @@ void MTRThermostatClusterThermostatRunningModeAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThermostatClusterThermostatRunningModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRThermostatClusterThermostatRunningModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThermostatClusterThermostatRunningModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17902,19 +17321,18 @@ void MTRNullableThermostatClusterThermostatRunningModeAttributeCallbackBridge::O
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableThermostatClusterThermostatRunningModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableThermostatClusterThermostatRunningModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableThermostatClusterThermostatRunningModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17926,19 +17344,18 @@ void MTRThermostatClusterThermostatSystemModeAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRThermostatClusterThermostatSystemModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRThermostatClusterThermostatSystemModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRThermostatClusterThermostatSystemModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17954,19 +17371,18 @@ void MTRNullableThermostatClusterThermostatSystemModeAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableThermostatClusterThermostatSystemModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableThermostatClusterThermostatSystemModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableThermostatClusterThermostatSystemModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -17978,19 +17394,18 @@ void MTRFanControlClusterFanModeSequenceTypeAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRFanControlClusterFanModeSequenceTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRFanControlClusterFanModeSequenceTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRFanControlClusterFanModeSequenceTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18006,19 +17421,18 @@ void MTRNullableFanControlClusterFanModeSequenceTypeAttributeCallbackBridge::OnS
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableFanControlClusterFanModeSequenceTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableFanControlClusterFanModeSequenceTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableFanControlClusterFanModeSequenceTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18030,19 +17444,18 @@ void MTRFanControlClusterFanModeTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRFanControlClusterFanModeTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRFanControlClusterFanModeTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRFanControlClusterFanModeTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18058,19 +17471,18 @@ void MTRNullableFanControlClusterFanModeTypeAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableFanControlClusterFanModeTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableFanControlClusterFanModeTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableFanControlClusterFanModeTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18082,19 +17494,18 @@ void MTRColorControlClusterColorLoopActionAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRColorControlClusterColorLoopActionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRColorControlClusterColorLoopActionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRColorControlClusterColorLoopActionAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18110,19 +17521,18 @@ void MTRNullableColorControlClusterColorLoopActionAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableColorControlClusterColorLoopActionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableColorControlClusterColorLoopActionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableColorControlClusterColorLoopActionAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18134,19 +17544,18 @@ void MTRColorControlClusterColorLoopDirectionAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRColorControlClusterColorLoopDirectionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRColorControlClusterColorLoopDirectionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRColorControlClusterColorLoopDirectionAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18162,19 +17571,18 @@ void MTRNullableColorControlClusterColorLoopDirectionAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableColorControlClusterColorLoopDirectionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableColorControlClusterColorLoopDirectionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableColorControlClusterColorLoopDirectionAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18186,19 +17594,18 @@ void MTRColorControlClusterColorModeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRColorControlClusterColorModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRColorControlClusterColorModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRColorControlClusterColorModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18214,19 +17621,18 @@ void MTRNullableColorControlClusterColorModeAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableColorControlClusterColorModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableColorControlClusterColorModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableColorControlClusterColorModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18238,19 +17644,18 @@ void MTRColorControlClusterHueDirectionAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRColorControlClusterHueDirectionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRColorControlClusterHueDirectionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRColorControlClusterHueDirectionAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18266,19 +17671,18 @@ void MTRNullableColorControlClusterHueDirectionAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableColorControlClusterHueDirectionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableColorControlClusterHueDirectionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableColorControlClusterHueDirectionAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18290,19 +17694,18 @@ void MTRColorControlClusterHueMoveModeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRColorControlClusterHueMoveModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRColorControlClusterHueMoveModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRColorControlClusterHueMoveModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18318,19 +17721,18 @@ void MTRNullableColorControlClusterHueMoveModeAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableColorControlClusterHueMoveModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableColorControlClusterHueMoveModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableColorControlClusterHueMoveModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18342,19 +17744,18 @@ void MTRColorControlClusterHueStepModeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRColorControlClusterHueStepModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRColorControlClusterHueStepModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRColorControlClusterHueStepModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18370,19 +17771,18 @@ void MTRNullableColorControlClusterHueStepModeAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableColorControlClusterHueStepModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableColorControlClusterHueStepModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableColorControlClusterHueStepModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18394,19 +17794,18 @@ void MTRColorControlClusterSaturationMoveModeAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRColorControlClusterSaturationMoveModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRColorControlClusterSaturationMoveModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRColorControlClusterSaturationMoveModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18422,19 +17821,18 @@ void MTRNullableColorControlClusterSaturationMoveModeAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableColorControlClusterSaturationMoveModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableColorControlClusterSaturationMoveModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableColorControlClusterSaturationMoveModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18446,19 +17844,18 @@ void MTRColorControlClusterSaturationStepModeAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRColorControlClusterSaturationStepModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRColorControlClusterSaturationStepModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRColorControlClusterSaturationStepModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18474,19 +17871,18 @@ void MTRNullableColorControlClusterSaturationStepModeAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableColorControlClusterSaturationStepModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableColorControlClusterSaturationStepModeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableColorControlClusterSaturationStepModeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18498,19 +17894,18 @@ void MTRIlluminanceMeasurementClusterLightSensorTypeAttributeCallbackBridge::OnS
     DispatchSuccess(context, objCValue);
 };
 
-void MTRIlluminanceMeasurementClusterLightSensorTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRIlluminanceMeasurementClusterLightSensorTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRIlluminanceMeasurementClusterLightSensorTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18526,21 +17921,18 @@ void MTRNullableIlluminanceMeasurementClusterLightSensorTypeAttributeCallbackBri
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableIlluminanceMeasurementClusterLightSensorTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableIlluminanceMeasurementClusterLightSensorTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableIlluminanceMeasurementClusterLightSensorTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18552,19 +17944,18 @@ void MTRChannelClusterChannelStatusEnumAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRChannelClusterChannelStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRChannelClusterChannelStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRChannelClusterChannelStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18580,19 +17971,18 @@ void MTRNullableChannelClusterChannelStatusEnumAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableChannelClusterChannelStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableChannelClusterChannelStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableChannelClusterChannelStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18604,19 +17994,18 @@ void MTRChannelClusterLineupInfoTypeEnumAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRChannelClusterLineupInfoTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRChannelClusterLineupInfoTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRChannelClusterLineupInfoTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18632,19 +18021,18 @@ void MTRNullableChannelClusterLineupInfoTypeEnumAttributeCallbackBridge::OnSucce
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableChannelClusterLineupInfoTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableChannelClusterLineupInfoTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableChannelClusterLineupInfoTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18656,20 +18044,18 @@ void MTRTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge::
     DispatchSuccess(context, objCValue);
 };
 
-void MTRTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18685,21 +18071,18 @@ void MTRNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallback
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18711,19 +18094,18 @@ void MTRMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18739,20 +18121,18 @@ void MTRNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBrid
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18764,19 +18144,18 @@ void MTRMediaPlaybackClusterPlaybackStateEnumAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void MTRMediaPlaybackClusterPlaybackStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRMediaPlaybackClusterPlaybackStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRMediaPlaybackClusterPlaybackStateEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18792,19 +18171,18 @@ void MTRNullableMediaPlaybackClusterPlaybackStateEnumAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableMediaPlaybackClusterPlaybackStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableMediaPlaybackClusterPlaybackStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableMediaPlaybackClusterPlaybackStateEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18816,19 +18194,18 @@ void MTRMediaInputClusterInputTypeEnumAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRMediaInputClusterInputTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRMediaInputClusterInputTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRMediaInputClusterInputTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18844,19 +18221,18 @@ void MTRNullableMediaInputClusterInputTypeEnumAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableMediaInputClusterInputTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableMediaInputClusterInputTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableMediaInputClusterInputTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18868,19 +18244,18 @@ void MTRKeypadInputClusterCecKeyCodeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRKeypadInputClusterCecKeyCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRKeypadInputClusterCecKeyCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRKeypadInputClusterCecKeyCodeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18896,19 +18271,18 @@ void MTRNullableKeypadInputClusterCecKeyCodeAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableKeypadInputClusterCecKeyCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableKeypadInputClusterCecKeyCodeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableKeypadInputClusterCecKeyCodeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18920,19 +18294,18 @@ void MTRKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge::OnSucces
     DispatchSuccess(context, objCValue);
 };
 
-void MTRKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18948,20 +18321,18 @@ void MTRNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge::
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -18973,19 +18344,18 @@ void MTRContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void MTRContentLauncherClusterContentLaunchStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRContentLauncherClusterContentLaunchStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRContentLauncherClusterContentLaunchStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19001,21 +18371,18 @@ void MTRNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBr
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19027,19 +18394,18 @@ void MTRContentLauncherClusterMetricTypeEnumAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRContentLauncherClusterMetricTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRContentLauncherClusterMetricTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRContentLauncherClusterMetricTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19055,19 +18421,18 @@ void MTRNullableContentLauncherClusterMetricTypeEnumAttributeCallbackBridge::OnS
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableContentLauncherClusterMetricTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableContentLauncherClusterMetricTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableContentLauncherClusterMetricTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19079,19 +18444,18 @@ void MTRContentLauncherClusterParameterEnumAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRContentLauncherClusterParameterEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRContentLauncherClusterParameterEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRContentLauncherClusterParameterEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19107,19 +18471,18 @@ void MTRNullableContentLauncherClusterParameterEnumAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableContentLauncherClusterParameterEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableContentLauncherClusterParameterEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableContentLauncherClusterParameterEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19131,19 +18494,18 @@ void MTRAudioOutputClusterOutputTypeEnumAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAudioOutputClusterOutputTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAudioOutputClusterOutputTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRAudioOutputClusterOutputTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19159,19 +18521,18 @@ void MTRNullableAudioOutputClusterOutputTypeEnumAttributeCallbackBridge::OnSucce
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableAudioOutputClusterOutputTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableAudioOutputClusterOutputTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableAudioOutputClusterOutputTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19183,21 +18544,18 @@ void MTRApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallback
     DispatchSuccess(context, objCValue);
 };
 
-void MTRApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19214,21 +18572,18 @@ void MTRNullableApplicationLauncherClusterApplicationLauncherStatusEnumAttribute
 };
 
 void MTRNullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackSubscriptionBridge::
-    OnSubscriptionEstablished(void * context)
+    OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackSubscriptionBridge *>(
-            context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19240,19 +18595,18 @@ void MTRApplicationBasicClusterApplicationStatusEnumAttributeCallbackBridge::OnS
     DispatchSuccess(context, objCValue);
 };
 
-void MTRApplicationBasicClusterApplicationStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRApplicationBasicClusterApplicationStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRApplicationBasicClusterApplicationStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19268,21 +18622,18 @@ void MTRNullableApplicationBasicClusterApplicationStatusEnumAttributeCallbackBri
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableApplicationBasicClusterApplicationStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void MTRNullableApplicationBasicClusterApplicationStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self
-        = static_cast<MTRNullableApplicationBasicClusterApplicationStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19294,19 +18645,18 @@ void MTRUnitTestingClusterSimpleEnumAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRUnitTestingClusterSimpleEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRUnitTestingClusterSimpleEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRUnitTestingClusterSimpleEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19322,19 +18672,18 @@ void MTRNullableUnitTestingClusterSimpleEnumAttributeCallbackBridge::OnSuccessFn
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableUnitTestingClusterSimpleEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableUnitTestingClusterSimpleEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableUnitTestingClusterSimpleEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19346,19 +18695,18 @@ void MTRFaultInjectionClusterFaultTypeAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRFaultInjectionClusterFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRFaultInjectionClusterFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRFaultInjectionClusterFaultTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }
 
@@ -19374,18 +18722,17 @@ void MTRNullableFaultInjectionClusterFaultTypeAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableFaultInjectionClusterFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRNullableFaultInjectionClusterFaultTypeAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
 {
-    auto * self = static_cast<MTRNullableFaultInjectionClusterFaultTypeAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
+    if (!mQueue) {
         return;
     }
 
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
         // On failure, mEstablishedHandler will be cleaned up by our destructor,
         // but we can clean it up earlier on successful subscription
         // establishment.
-        self->mEstablishedHandler = nil;
+        mEstablishedHandler = nil;
     }
 }

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge_internal.h
@@ -1156,7 +1156,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROctetStringAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROctetStringAttributeCallbackBridge::OnDone;
 
@@ -1186,7 +1186,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableOctetStringAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableOctetStringAttributeCallbackBridge::OnDone;
 
@@ -1215,7 +1215,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRCharStringAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRCharStringAttributeCallbackBridge::OnDone;
 
@@ -1244,7 +1244,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableCharStringAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableCharStringAttributeCallbackBridge::OnDone;
 
@@ -1273,7 +1273,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBooleanAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBooleanAttributeCallbackBridge::OnDone;
 
@@ -1302,7 +1302,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableBooleanAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableBooleanAttributeCallbackBridge::OnDone;
 
@@ -1331,7 +1331,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRInt8uAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRInt8uAttributeCallbackBridge::OnDone;
 
@@ -1360,7 +1360,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableInt8uAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableInt8uAttributeCallbackBridge::OnDone;
 
@@ -1389,7 +1389,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRInt8sAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRInt8sAttributeCallbackBridge::OnDone;
 
@@ -1418,7 +1418,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableInt8sAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableInt8sAttributeCallbackBridge::OnDone;
 
@@ -1447,7 +1447,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRInt16uAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRInt16uAttributeCallbackBridge::OnDone;
 
@@ -1476,7 +1476,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableInt16uAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableInt16uAttributeCallbackBridge::OnDone;
 
@@ -1505,7 +1505,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRInt16sAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRInt16sAttributeCallbackBridge::OnDone;
 
@@ -1534,7 +1534,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableInt16sAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableInt16sAttributeCallbackBridge::OnDone;
 
@@ -1563,7 +1563,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRInt32uAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRInt32uAttributeCallbackBridge::OnDone;
 
@@ -1592,7 +1592,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableInt32uAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableInt32uAttributeCallbackBridge::OnDone;
 
@@ -1621,7 +1621,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRInt32sAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRInt32sAttributeCallbackBridge::OnDone;
 
@@ -1650,7 +1650,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableInt32sAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableInt32sAttributeCallbackBridge::OnDone;
 
@@ -1679,7 +1679,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRInt64uAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRInt64uAttributeCallbackBridge::OnDone;
 
@@ -1708,7 +1708,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableInt64uAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableInt64uAttributeCallbackBridge::OnDone;
 
@@ -1737,7 +1737,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRInt64sAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRInt64sAttributeCallbackBridge::OnDone;
 
@@ -1766,7 +1766,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableInt64sAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableInt64sAttributeCallbackBridge::OnDone;
 
@@ -1795,7 +1795,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRFloatAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRFloatAttributeCallbackBridge::OnDone;
 
@@ -1824,7 +1824,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableFloatAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableFloatAttributeCallbackBridge::OnDone;
 
@@ -1853,7 +1853,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoubleAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoubleAttributeCallbackBridge::OnDone;
 
@@ -1882,7 +1882,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoubleAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoubleAttributeCallbackBridge::OnDone;
 
@@ -1911,7 +1911,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRVendorIdAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRVendorIdAttributeCallbackBridge::OnDone;
 
@@ -1940,7 +1940,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableVendorIdAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableVendorIdAttributeCallbackBridge::OnDone;
 
@@ -1973,7 +1973,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRIdentifyGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRIdentifyGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2006,7 +2006,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRIdentifyAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRIdentifyAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2036,7 +2036,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRIdentifyAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRIdentifyAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -2069,7 +2069,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGroupsGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGroupsGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2102,7 +2102,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGroupsAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGroupsAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2132,7 +2132,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGroupsAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGroupsAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -2165,7 +2165,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRScenesGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRScenesGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2198,7 +2198,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRScenesAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRScenesAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2228,7 +2228,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRScenesAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRScenesAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -2261,7 +2261,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROnOffGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROnOffGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2293,7 +2293,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROnOffAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROnOffAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2323,7 +2323,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROnOffAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROnOffAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -2356,7 +2356,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROnOffSwitchConfigurationGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROnOffSwitchConfigurationGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2389,7 +2389,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROnOffSwitchConfigurationAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROnOffSwitchConfigurationAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2422,7 +2422,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROnOffSwitchConfigurationAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROnOffSwitchConfigurationAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -2455,7 +2455,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRLevelControlGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRLevelControlGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2488,7 +2488,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRLevelControlAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRLevelControlAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2521,7 +2521,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRLevelControlAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRLevelControlAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -2554,7 +2554,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBinaryInputBasicGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBinaryInputBasicGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2587,7 +2587,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBinaryInputBasicAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBinaryInputBasicAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2620,7 +2620,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBinaryInputBasicAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBinaryInputBasicAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -2655,7 +2655,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDescriptorDeviceTypeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDescriptorDeviceTypeListListAttributeCallbackBridge::OnDone;
 
@@ -2685,7 +2685,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDescriptorServerListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDescriptorServerListListAttributeCallbackBridge::OnDone;
 
@@ -2715,7 +2715,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDescriptorClientListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDescriptorClientListListAttributeCallbackBridge::OnDone;
 
@@ -2745,7 +2745,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDescriptorPartsListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDescriptorPartsListListAttributeCallbackBridge::OnDone;
 
@@ -2778,7 +2778,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDescriptorGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDescriptorGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2811,7 +2811,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDescriptorAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDescriptorAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2842,7 +2842,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDescriptorAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDescriptorAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -2873,7 +2873,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBindingBindingListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBindingBindingListAttributeCallbackBridge::OnDone;
 
@@ -2906,7 +2906,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBindingGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBindingGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2939,7 +2939,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBindingAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBindingAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -2969,7 +2969,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBindingAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBindingAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -3002,7 +3002,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAccessControlAclListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAccessControlAclListAttributeCallbackBridge::OnDone;
 
@@ -3035,7 +3035,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAccessControlExtensionListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAccessControlExtensionListAttributeCallbackBridge::OnDone;
 
@@ -3068,7 +3068,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAccessControlGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAccessControlGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3101,7 +3101,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAccessControlAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAccessControlAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3134,7 +3134,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAccessControlAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAccessControlAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -3166,7 +3166,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRActionsActionListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRActionsActionListListAttributeCallbackBridge::OnDone;
 
@@ -3199,7 +3199,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRActionsEndpointListsListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRActionsEndpointListsListAttributeCallbackBridge::OnDone;
 
@@ -3232,7 +3232,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRActionsGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRActionsGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3265,7 +3265,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRActionsAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRActionsAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3295,7 +3295,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRActionsAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRActionsAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -3327,7 +3327,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBasicCapabilityMinimaStructAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBasicCapabilityMinimaStructAttributeCallbackBridge::OnDone;
 
@@ -3360,7 +3360,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBasicGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBasicGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3392,7 +3392,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBasicAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBasicAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3422,7 +3422,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBasicAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBasicAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -3456,7 +3456,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3489,7 +3489,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3522,7 +3522,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -3558,7 +3558,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge::OnDone;
 
@@ -3592,7 +3592,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3626,7 +3626,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3659,7 +3659,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -3692,7 +3692,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRLocalizationConfigurationSupportedLocalesListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRLocalizationConfigurationSupportedLocalesListAttributeCallbackBridge::OnDone;
 
@@ -3726,7 +3726,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRLocalizationConfigurationGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRLocalizationConfigurationGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3759,7 +3759,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRLocalizationConfigurationAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRLocalizationConfigurationAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3792,7 +3792,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRLocalizationConfigurationAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRLocalizationConfigurationAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -3827,7 +3827,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTimeFormatLocalizationSupportedCalendarTypesListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTimeFormatLocalizationSupportedCalendarTypesListAttributeCallbackBridge::OnDone;
 
@@ -3860,7 +3860,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTimeFormatLocalizationGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTimeFormatLocalizationGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3893,7 +3893,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTimeFormatLocalizationAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTimeFormatLocalizationAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3926,7 +3926,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTimeFormatLocalizationAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTimeFormatLocalizationAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -3959,7 +3959,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitLocalizationGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitLocalizationGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -3992,7 +3992,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitLocalizationAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitLocalizationAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -4025,7 +4025,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitLocalizationAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitLocalizationAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -4058,7 +4058,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceConfigurationSourcesListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceConfigurationSourcesListAttributeCallbackBridge::OnDone;
 
@@ -4091,7 +4091,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceConfigurationGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceConfigurationGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -4124,7 +4124,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceConfigurationAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceConfigurationAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -4157,7 +4157,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceConfigurationAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceConfigurationAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -4191,7 +4191,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceActiveWiredFaultsListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceActiveWiredFaultsListAttributeCallbackBridge::OnDone;
 
@@ -4225,7 +4225,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceActiveBatFaultsListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceActiveBatFaultsListAttributeCallbackBridge::OnDone;
 
@@ -4259,7 +4259,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceActiveBatChargeFaultsListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceActiveBatChargeFaultsListAttributeCallbackBridge::OnDone;
 
@@ -4292,7 +4292,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -4325,7 +4325,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -4357,7 +4357,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -4392,7 +4392,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralCommissioningBasicCommissioningInfoStructAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralCommissioningBasicCommissioningInfoStructAttributeCallbackBridge::OnDone;
 
@@ -4425,7 +4425,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralCommissioningGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralCommissioningGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -4458,7 +4458,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralCommissioningAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralCommissioningAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -4491,7 +4491,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralCommissioningAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralCommissioningAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -4527,7 +4527,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNetworkCommissioningNetworksListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNetworkCommissioningNetworksListAttributeCallbackBridge::OnDone;
 
@@ -4560,7 +4560,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNetworkCommissioningGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNetworkCommissioningGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -4593,7 +4593,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNetworkCommissioningAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNetworkCommissioningAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -4626,7 +4626,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNetworkCommissioningAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNetworkCommissioningAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -4659,7 +4659,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDiagnosticLogsGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDiagnosticLogsGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -4692,7 +4692,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDiagnosticLogsAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDiagnosticLogsAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -4725,7 +4725,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDiagnosticLogsAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDiagnosticLogsAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -4760,7 +4760,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralDiagnosticsNetworkInterfacesListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralDiagnosticsNetworkInterfacesListAttributeCallbackBridge::OnDone;
 
@@ -4793,7 +4793,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralDiagnosticsActiveHardwareFaultsListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralDiagnosticsActiveHardwareFaultsListAttributeCallbackBridge::OnDone;
 
@@ -4826,7 +4826,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralDiagnosticsActiveRadioFaultsListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralDiagnosticsActiveRadioFaultsListAttributeCallbackBridge::OnDone;
 
@@ -4859,7 +4859,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralDiagnosticsActiveNetworkFaultsListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralDiagnosticsActiveNetworkFaultsListAttributeCallbackBridge::OnDone;
 
@@ -4892,7 +4892,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralDiagnosticsGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralDiagnosticsGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -4925,7 +4925,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralDiagnosticsAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralDiagnosticsAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -4958,7 +4958,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralDiagnosticsAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralDiagnosticsAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -4994,7 +4994,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRSoftwareDiagnosticsThreadMetricsListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRSoftwareDiagnosticsThreadMetricsListAttributeCallbackBridge::OnDone;
 
@@ -5027,7 +5027,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRSoftwareDiagnosticsGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRSoftwareDiagnosticsGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -5060,7 +5060,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRSoftwareDiagnosticsAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRSoftwareDiagnosticsAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -5093,7 +5093,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRSoftwareDiagnosticsAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRSoftwareDiagnosticsAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -5128,7 +5128,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThreadNetworkDiagnosticsNeighborTableListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThreadNetworkDiagnosticsNeighborTableListListAttributeCallbackBridge::OnDone;
 
@@ -5163,7 +5163,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThreadNetworkDiagnosticsRouteTableListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThreadNetworkDiagnosticsRouteTableListListAttributeCallbackBridge::OnDone;
 
@@ -5198,7 +5198,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThreadNetworkDiagnosticsSecurityPolicyStructAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThreadNetworkDiagnosticsSecurityPolicyStructAttributeCallbackBridge::OnDone;
 
@@ -5238,7 +5238,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThreadNetworkDiagnosticsOperationalDatasetComponentsStructAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThreadNetworkDiagnosticsOperationalDatasetComponentsStructAttributeCallbackBridge::OnDone;
 
@@ -5274,7 +5274,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeCallbackBridge::OnDone;
 
@@ -5307,7 +5307,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThreadNetworkDiagnosticsGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThreadNetworkDiagnosticsGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -5340,7 +5340,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThreadNetworkDiagnosticsAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThreadNetworkDiagnosticsAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -5373,7 +5373,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThreadNetworkDiagnosticsAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThreadNetworkDiagnosticsAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -5406,7 +5406,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWiFiNetworkDiagnosticsGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWiFiNetworkDiagnosticsGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -5439,7 +5439,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWiFiNetworkDiagnosticsAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWiFiNetworkDiagnosticsAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -5472,7 +5472,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWiFiNetworkDiagnosticsAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWiFiNetworkDiagnosticsAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -5506,7 +5506,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTREthernetNetworkDiagnosticsGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTREthernetNetworkDiagnosticsGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -5540,7 +5540,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTREthernetNetworkDiagnosticsAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTREthernetNetworkDiagnosticsAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -5573,7 +5573,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTREthernetNetworkDiagnosticsAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTREthernetNetworkDiagnosticsAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -5606,7 +5606,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBridgedDeviceBasicGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBridgedDeviceBasicGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -5639,7 +5639,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBridgedDeviceBasicAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBridgedDeviceBasicAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -5672,7 +5672,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBridgedDeviceBasicAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBridgedDeviceBasicAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -5705,7 +5705,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRSwitchGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRSwitchGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -5738,7 +5738,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRSwitchAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRSwitchAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -5768,7 +5768,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRSwitchAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRSwitchAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -5802,7 +5802,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAdministratorCommissioningGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAdministratorCommissioningGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -5836,7 +5836,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAdministratorCommissioningAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAdministratorCommissioningAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -5869,7 +5869,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAdministratorCommissioningAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAdministratorCommissioningAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -5905,7 +5905,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROperationalCredentialsNOCsListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROperationalCredentialsNOCsListAttributeCallbackBridge::OnDone;
 
@@ -5940,7 +5940,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROperationalCredentialsFabricsListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROperationalCredentialsFabricsListAttributeCallbackBridge::OnDone;
 
@@ -5974,7 +5974,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROperationalCredentialsTrustedRootCertificatesListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROperationalCredentialsTrustedRootCertificatesListAttributeCallbackBridge::OnDone;
 
@@ -6007,7 +6007,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROperationalCredentialsGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROperationalCredentialsGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -6040,7 +6040,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROperationalCredentialsAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROperationalCredentialsAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -6073,7 +6073,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROperationalCredentialsAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROperationalCredentialsAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -6108,7 +6108,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGroupKeyManagementGroupKeyMapListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGroupKeyManagementGroupKeyMapListAttributeCallbackBridge::OnDone;
 
@@ -6143,7 +6143,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGroupKeyManagementGroupTableListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGroupKeyManagementGroupTableListAttributeCallbackBridge::OnDone;
 
@@ -6176,7 +6176,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGroupKeyManagementGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGroupKeyManagementGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -6209,7 +6209,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGroupKeyManagementAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGroupKeyManagementAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -6242,7 +6242,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGroupKeyManagementAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGroupKeyManagementAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -6274,7 +6274,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRFixedLabelLabelListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRFixedLabelLabelListListAttributeCallbackBridge::OnDone;
 
@@ -6307,7 +6307,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRFixedLabelGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRFixedLabelGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -6340,7 +6340,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRFixedLabelAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRFixedLabelAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -6371,7 +6371,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRFixedLabelAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRFixedLabelAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -6403,7 +6403,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUserLabelLabelListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUserLabelLabelListListAttributeCallbackBridge::OnDone;
 
@@ -6436,7 +6436,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUserLabelGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUserLabelGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -6469,7 +6469,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUserLabelAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUserLabelAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -6499,7 +6499,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUserLabelAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUserLabelAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -6532,7 +6532,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBooleanStateGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBooleanStateGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -6565,7 +6565,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBooleanStateAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBooleanStateAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -6598,7 +6598,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBooleanStateAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBooleanStateAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -6633,7 +6633,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRModeSelectSupportedModesListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRModeSelectSupportedModesListAttributeCallbackBridge::OnDone;
 
@@ -6666,7 +6666,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRModeSelectGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRModeSelectGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -6699,7 +6699,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRModeSelectAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRModeSelectAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -6730,7 +6730,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRModeSelectAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRModeSelectAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -6763,7 +6763,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockCredentialRulesSupportAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockCredentialRulesSupportAttributeCallbackBridge::OnDone;
 
@@ -6796,7 +6796,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockSupportedOperatingModesAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockSupportedOperatingModesAttributeCallbackBridge::OnDone;
 
@@ -6829,7 +6829,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockDefaultConfigurationRegisterAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockDefaultConfigurationRegisterAttributeCallbackBridge::OnDone;
 
@@ -6862,7 +6862,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockLocalProgrammingFeaturesAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockLocalProgrammingFeaturesAttributeCallbackBridge::OnDone;
 
@@ -6895,7 +6895,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -6928,7 +6928,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -6958,7 +6958,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -6988,7 +6988,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWindowCoveringConfigStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWindowCoveringConfigStatusAttributeCallbackBridge::OnDone;
 
@@ -7021,7 +7021,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWindowCoveringOperationalStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWindowCoveringOperationalStatusAttributeCallbackBridge::OnDone;
 
@@ -7050,7 +7050,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWindowCoveringModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWindowCoveringModeAttributeCallbackBridge::OnDone;
 
@@ -7080,7 +7080,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWindowCoveringSafetyStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWindowCoveringSafetyStatusAttributeCallbackBridge::OnDone;
 
@@ -7113,7 +7113,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWindowCoveringGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWindowCoveringGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7146,7 +7146,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWindowCoveringAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWindowCoveringAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7179,7 +7179,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWindowCoveringAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWindowCoveringAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -7212,7 +7212,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBarrierControlGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBarrierControlGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7245,7 +7245,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBarrierControlAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBarrierControlAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7278,7 +7278,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBarrierControlAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBarrierControlAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -7311,7 +7311,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPumpConfigurationAndControlPumpStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPumpConfigurationAndControlPumpStatusAttributeCallbackBridge::OnDone;
 
@@ -7345,7 +7345,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPumpConfigurationAndControlGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPumpConfigurationAndControlGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7379,7 +7379,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPumpConfigurationAndControlAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPumpConfigurationAndControlAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7412,7 +7412,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPumpConfigurationAndControlAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPumpConfigurationAndControlAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -7445,7 +7445,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThermostatGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThermostatGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7478,7 +7478,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThermostatAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThermostatAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7509,7 +7509,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThermostatAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThermostatAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -7542,7 +7542,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRFanControlGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRFanControlGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7575,7 +7575,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRFanControlAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRFanControlAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7606,7 +7606,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRFanControlAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRFanControlAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -7643,7 +7643,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThermostatUserInterfaceConfigurationGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThermostatUserInterfaceConfigurationGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7680,7 +7680,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThermostatUserInterfaceConfigurationAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThermostatUserInterfaceConfigurationAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7715,7 +7715,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThermostatUserInterfaceConfigurationAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThermostatUserInterfaceConfigurationAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -7748,7 +7748,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRColorControlGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRColorControlGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7781,7 +7781,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRColorControlAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRColorControlAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7814,7 +7814,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRColorControlAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRColorControlAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -7847,7 +7847,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBallastConfigurationGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBallastConfigurationGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7880,7 +7880,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBallastConfigurationAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBallastConfigurationAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7913,7 +7913,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRBallastConfigurationAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRBallastConfigurationAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -7946,7 +7946,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRIlluminanceMeasurementGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRIlluminanceMeasurementGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -7979,7 +7979,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRIlluminanceMeasurementAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRIlluminanceMeasurementAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8012,7 +8012,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRIlluminanceMeasurementAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRIlluminanceMeasurementAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -8045,7 +8045,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTemperatureMeasurementGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTemperatureMeasurementGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8078,7 +8078,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTemperatureMeasurementAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTemperatureMeasurementAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8111,7 +8111,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTemperatureMeasurementAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTemperatureMeasurementAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -8144,7 +8144,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPressureMeasurementGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPressureMeasurementGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8177,7 +8177,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPressureMeasurementAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPressureMeasurementAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8210,7 +8210,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPressureMeasurementAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPressureMeasurementAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -8243,7 +8243,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRFlowMeasurementGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRFlowMeasurementGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8276,7 +8276,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRFlowMeasurementAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRFlowMeasurementAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8309,7 +8309,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRFlowMeasurementAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRFlowMeasurementAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -8343,7 +8343,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRRelativeHumidityMeasurementGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRRelativeHumidityMeasurementGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8377,7 +8377,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRRelativeHumidityMeasurementAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRRelativeHumidityMeasurementAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8410,7 +8410,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRRelativeHumidityMeasurementAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRRelativeHumidityMeasurementAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -8443,7 +8443,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROccupancySensingGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROccupancySensingGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8476,7 +8476,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROccupancySensingAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROccupancySensingAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8509,7 +8509,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROccupancySensingAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROccupancySensingAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -8542,7 +8542,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWakeOnLanGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWakeOnLanGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8575,7 +8575,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWakeOnLanAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWakeOnLanAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8605,7 +8605,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWakeOnLanAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWakeOnLanAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -8637,7 +8637,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRChannelChannelListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRChannelChannelListListAttributeCallbackBridge::OnDone;
 
@@ -8669,7 +8669,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRChannelLineupStructAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRChannelLineupStructAttributeCallbackBridge::OnDone;
 
@@ -8702,7 +8702,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRChannelCurrentChannelStructAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRChannelCurrentChannelStructAttributeCallbackBridge::OnDone;
 
@@ -8735,7 +8735,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRChannelGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRChannelGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8768,7 +8768,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRChannelAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRChannelAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8798,7 +8798,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRChannelAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRChannelAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -8834,7 +8834,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTargetNavigatorTargetListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTargetNavigatorTargetListListAttributeCallbackBridge::OnDone;
 
@@ -8867,7 +8867,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTargetNavigatorGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTargetNavigatorGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8900,7 +8900,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTargetNavigatorAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTargetNavigatorAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -8933,7 +8933,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTargetNavigatorAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTargetNavigatorAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -8968,7 +8968,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRMediaPlaybackSampledPositionStructAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRMediaPlaybackSampledPositionStructAttributeCallbackBridge::OnDone;
 
@@ -9001,7 +9001,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRMediaPlaybackGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRMediaPlaybackGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9034,7 +9034,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRMediaPlaybackAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRMediaPlaybackAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9067,7 +9067,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRMediaPlaybackAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRMediaPlaybackAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -9099,7 +9099,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRMediaInputInputListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRMediaInputInputListListAttributeCallbackBridge::OnDone;
 
@@ -9132,7 +9132,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRMediaInputGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRMediaInputGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9165,7 +9165,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRMediaInputAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRMediaInputAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9196,7 +9196,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRMediaInputAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRMediaInputAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -9229,7 +9229,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRLowPowerGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRLowPowerGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9262,7 +9262,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRLowPowerAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRLowPowerAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9292,7 +9292,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRLowPowerAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRLowPowerAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -9325,7 +9325,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRKeypadInputGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRKeypadInputGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9358,7 +9358,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRKeypadInputAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRKeypadInputAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9390,7 +9390,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRKeypadInputAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRKeypadInputAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -9423,7 +9423,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRContentLauncherAcceptHeaderListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRContentLauncherAcceptHeaderListAttributeCallbackBridge::OnDone;
 
@@ -9456,7 +9456,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRContentLauncherGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRContentLauncherGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9489,7 +9489,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRContentLauncherAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRContentLauncherAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9522,7 +9522,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRContentLauncherAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRContentLauncherAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -9554,7 +9554,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAudioOutputOutputListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAudioOutputOutputListListAttributeCallbackBridge::OnDone;
 
@@ -9587,7 +9587,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAudioOutputGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAudioOutputGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9620,7 +9620,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAudioOutputAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAudioOutputAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9652,7 +9652,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAudioOutputAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAudioOutputAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -9685,7 +9685,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRApplicationLauncherCatalogListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRApplicationLauncherCatalogListListAttributeCallbackBridge::OnDone;
 
@@ -9721,7 +9721,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRApplicationLauncherCurrentAppStructAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRApplicationLauncherCurrentAppStructAttributeCallbackBridge::OnDone;
 
@@ -9754,7 +9754,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRApplicationLauncherGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRApplicationLauncherGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9787,7 +9787,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRApplicationLauncherAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRApplicationLauncherAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9820,7 +9820,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRApplicationLauncherAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRApplicationLauncherAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -9855,7 +9855,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRApplicationBasicApplicationStructAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRApplicationBasicApplicationStructAttributeCallbackBridge::OnDone;
 
@@ -9888,7 +9888,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRApplicationBasicAllowedVendorListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRApplicationBasicAllowedVendorListListAttributeCallbackBridge::OnDone;
 
@@ -9921,7 +9921,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRApplicationBasicGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRApplicationBasicGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9954,7 +9954,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRApplicationBasicAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRApplicationBasicAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -9987,7 +9987,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRApplicationBasicAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRApplicationBasicAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -10020,7 +10020,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAccountLoginGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAccountLoginGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -10053,7 +10053,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAccountLoginAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAccountLoginAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -10086,7 +10086,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAccountLoginAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAccountLoginAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -10119,7 +10119,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRElectricalMeasurementGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRElectricalMeasurementGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -10152,7 +10152,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRElectricalMeasurementAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRElectricalMeasurementAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -10185,7 +10185,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRElectricalMeasurementAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRElectricalMeasurementAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -10214,7 +10214,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingBitmap8AttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingBitmap8AttributeCallbackBridge::OnDone;
 
@@ -10244,7 +10244,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingBitmap16AttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingBitmap16AttributeCallbackBridge::OnDone;
 
@@ -10274,7 +10274,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingBitmap32AttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingBitmap32AttributeCallbackBridge::OnDone;
 
@@ -10304,7 +10304,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingBitmap64AttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingBitmap64AttributeCallbackBridge::OnDone;
 
@@ -10334,7 +10334,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingListInt8uListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingListInt8uListAttributeCallbackBridge::OnDone;
 
@@ -10367,7 +10367,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingListOctetStringListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingListOctetStringListAttributeCallbackBridge::OnDone;
 
@@ -10403,7 +10403,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingListStructOctetStringListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingListStructOctetStringListAttributeCallbackBridge::OnDone;
 
@@ -10438,7 +10438,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingListNullablesAndOptionalsStructListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingListNullablesAndOptionalsStructListAttributeCallbackBridge::OnDone;
 
@@ -10469,7 +10469,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingStructAttrStructAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingStructAttrStructAttributeCallbackBridge::OnDone;
 
@@ -10502,7 +10502,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingListLongOctetStringListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingListLongOctetStringListAttributeCallbackBridge::OnDone;
 
@@ -10538,7 +10538,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingListFabricScopedListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingListFabricScopedListAttributeCallbackBridge::OnDone;
 
@@ -10570,7 +10570,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingNullableBitmap8AttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingNullableBitmap8AttributeCallbackBridge::OnDone;
 
@@ -10603,7 +10603,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingNullableBitmap16AttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingNullableBitmap16AttributeCallbackBridge::OnDone;
 
@@ -10636,7 +10636,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingNullableBitmap32AttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingNullableBitmap32AttributeCallbackBridge::OnDone;
 
@@ -10669,7 +10669,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingNullableBitmap64AttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingNullableBitmap64AttributeCallbackBridge::OnDone;
 
@@ -10704,7 +10704,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingNullableStructStructAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingNullableStructStructAttributeCallbackBridge::OnDone;
 
@@ -10737,7 +10737,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingGeneratedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingGeneratedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -10770,7 +10770,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingAcceptedCommandListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingAcceptedCommandListListAttributeCallbackBridge::OnDone;
 
@@ -10802,7 +10802,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingAttributeListListAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingAttributeListListAttributeCallbackBridge::OnDone;
 
@@ -11620,7 +11620,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRIdentifyClusterIdentifyEffectIdentifierAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRIdentifyClusterIdentifyEffectIdentifierAttributeCallbackBridge::OnDone;
 
@@ -11654,7 +11654,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableIdentifyClusterIdentifyEffectIdentifierAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableIdentifyClusterIdentifyEffectIdentifierAttributeCallbackBridge::OnDone;
 
@@ -11687,7 +11687,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRIdentifyClusterIdentifyEffectVariantAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRIdentifyClusterIdentifyEffectVariantAttributeCallbackBridge::OnDone;
 
@@ -11721,7 +11721,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableIdentifyClusterIdentifyEffectVariantAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableIdentifyClusterIdentifyEffectVariantAttributeCallbackBridge::OnDone;
 
@@ -11754,7 +11754,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRIdentifyClusterIdentifyIdentifyTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRIdentifyClusterIdentifyIdentifyTypeAttributeCallbackBridge::OnDone;
 
@@ -11788,7 +11788,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableIdentifyClusterIdentifyIdentifyTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableIdentifyClusterIdentifyIdentifyTypeAttributeCallbackBridge::OnDone;
 
@@ -11821,7 +11821,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROnOffClusterOnOffDelayedAllOffEffectVariantAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROnOffClusterOnOffDelayedAllOffEffectVariantAttributeCallbackBridge::OnDone;
 
@@ -11857,7 +11857,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableOnOffClusterOnOffDelayedAllOffEffectVariantAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableOnOffClusterOnOffDelayedAllOffEffectVariantAttributeCallbackBridge::OnDone;
 
@@ -11890,7 +11890,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROnOffClusterOnOffDyingLightEffectVariantAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROnOffClusterOnOffDyingLightEffectVariantAttributeCallbackBridge::OnDone;
 
@@ -11924,7 +11924,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableOnOffClusterOnOffDyingLightEffectVariantAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableOnOffClusterOnOffDyingLightEffectVariantAttributeCallbackBridge::OnDone;
 
@@ -11957,7 +11957,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROnOffClusterOnOffEffectIdentifierAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROnOffClusterOnOffEffectIdentifierAttributeCallbackBridge::OnDone;
 
@@ -11991,7 +11991,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableOnOffClusterOnOffEffectIdentifierAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableOnOffClusterOnOffEffectIdentifierAttributeCallbackBridge::OnDone;
 
@@ -12024,7 +12024,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROnOffClusterOnOffStartUpOnOffAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROnOffClusterOnOffStartUpOnOffAttributeCallbackBridge::OnDone;
 
@@ -12058,7 +12058,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableOnOffClusterOnOffStartUpOnOffAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableOnOffClusterOnOffStartUpOnOffAttributeCallbackBridge::OnDone;
 
@@ -12089,7 +12089,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRLevelControlClusterMoveModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRLevelControlClusterMoveModeAttributeCallbackBridge::OnDone;
 
@@ -12123,7 +12123,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableLevelControlClusterMoveModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableLevelControlClusterMoveModeAttributeCallbackBridge::OnDone;
 
@@ -12154,7 +12154,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRLevelControlClusterStepModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRLevelControlClusterStepModeAttributeCallbackBridge::OnDone;
 
@@ -12188,7 +12188,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableLevelControlClusterStepModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableLevelControlClusterStepModeAttributeCallbackBridge::OnDone;
 
@@ -12220,7 +12220,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAccessControlClusterAuthModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAccessControlClusterAuthModeAttributeCallbackBridge::OnDone;
 
@@ -12254,7 +12254,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableAccessControlClusterAuthModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableAccessControlClusterAuthModeAttributeCallbackBridge::OnDone;
 
@@ -12287,7 +12287,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAccessControlClusterChangeTypeEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAccessControlClusterChangeTypeEnumAttributeCallbackBridge::OnDone;
 
@@ -12321,7 +12321,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableAccessControlClusterChangeTypeEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableAccessControlClusterChangeTypeEnumAttributeCallbackBridge::OnDone;
 
@@ -12354,7 +12354,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAccessControlClusterPrivilegeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAccessControlClusterPrivilegeAttributeCallbackBridge::OnDone;
 
@@ -12388,7 +12388,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableAccessControlClusterPrivilegeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableAccessControlClusterPrivilegeAttributeCallbackBridge::OnDone;
 
@@ -12421,7 +12421,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRActionsClusterActionErrorEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRActionsClusterActionErrorEnumAttributeCallbackBridge::OnDone;
 
@@ -12455,7 +12455,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableActionsClusterActionErrorEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableActionsClusterActionErrorEnumAttributeCallbackBridge::OnDone;
 
@@ -12488,7 +12488,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRActionsClusterActionStateEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRActionsClusterActionStateEnumAttributeCallbackBridge::OnDone;
 
@@ -12522,7 +12522,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableActionsClusterActionStateEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableActionsClusterActionStateEnumAttributeCallbackBridge::OnDone;
 
@@ -12554,7 +12554,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRActionsClusterActionTypeEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRActionsClusterActionTypeEnumAttributeCallbackBridge::OnDone;
 
@@ -12588,7 +12588,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableActionsClusterActionTypeEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableActionsClusterActionTypeEnumAttributeCallbackBridge::OnDone;
 
@@ -12621,7 +12621,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRActionsClusterEndpointListTypeEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRActionsClusterEndpointListTypeEnumAttributeCallbackBridge::OnDone;
 
@@ -12655,7 +12655,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableActionsClusterEndpointListTypeEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableActionsClusterEndpointListTypeEnumAttributeCallbackBridge::OnDone;
 
@@ -12690,7 +12690,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge::OnDone;
 
@@ -12729,7 +12729,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge::OnDone;
 
@@ -12763,7 +12763,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge::OnDone;
 
@@ -12802,7 +12802,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge::OnDone;
 
@@ -12835,7 +12835,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge::OnDone;
 
@@ -12873,7 +12873,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge::OnDone;
 
@@ -12909,7 +12909,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge::OnDone;
 
@@ -12948,7 +12948,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge::OnDone;
 
@@ -12983,7 +12983,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge::OnDone;
 
@@ -13022,7 +13022,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge::OnDone;
 
@@ -13056,7 +13056,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge::OnDone;
 
@@ -13095,7 +13095,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge::OnDone;
 
@@ -13128,7 +13128,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTimeFormatLocalizationClusterCalendarTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTimeFormatLocalizationClusterCalendarTypeAttributeCallbackBridge::OnDone;
 
@@ -13164,7 +13164,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableTimeFormatLocalizationClusterCalendarTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableTimeFormatLocalizationClusterCalendarTypeAttributeCallbackBridge::OnDone;
 
@@ -13197,7 +13197,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTimeFormatLocalizationClusterHourFormatAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTimeFormatLocalizationClusterHourFormatAttributeCallbackBridge::OnDone;
 
@@ -13231,7 +13231,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableTimeFormatLocalizationClusterHourFormatAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableTimeFormatLocalizationClusterHourFormatAttributeCallbackBridge::OnDone;
 
@@ -13264,7 +13264,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitLocalizationClusterTempUnitAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitLocalizationClusterTempUnitAttributeCallbackBridge::OnDone;
 
@@ -13298,7 +13298,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableUnitLocalizationClusterTempUnitAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableUnitLocalizationClusterTempUnitAttributeCallbackBridge::OnDone;
 
@@ -13331,7 +13331,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceClusterBatChargeFaultAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceClusterBatChargeFaultAttributeCallbackBridge::OnDone;
 
@@ -13365,7 +13365,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullablePowerSourceClusterBatChargeFaultAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullablePowerSourceClusterBatChargeFaultAttributeCallbackBridge::OnDone;
 
@@ -13398,7 +13398,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceClusterBatChargeLevelAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceClusterBatChargeLevelAttributeCallbackBridge::OnDone;
 
@@ -13432,7 +13432,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullablePowerSourceClusterBatChargeLevelAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullablePowerSourceClusterBatChargeLevelAttributeCallbackBridge::OnDone;
 
@@ -13465,7 +13465,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceClusterBatChargeStateAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceClusterBatChargeStateAttributeCallbackBridge::OnDone;
 
@@ -13499,7 +13499,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullablePowerSourceClusterBatChargeStateAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullablePowerSourceClusterBatChargeStateAttributeCallbackBridge::OnDone;
 
@@ -13529,7 +13529,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceClusterBatFaultAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceClusterBatFaultAttributeCallbackBridge::OnDone;
 
@@ -13563,7 +13563,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullablePowerSourceClusterBatFaultAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullablePowerSourceClusterBatFaultAttributeCallbackBridge::OnDone;
 
@@ -13596,7 +13596,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceClusterBatReplaceabilityAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceClusterBatReplaceabilityAttributeCallbackBridge::OnDone;
 
@@ -13630,7 +13630,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullablePowerSourceClusterBatReplaceabilityAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullablePowerSourceClusterBatReplaceabilityAttributeCallbackBridge::OnDone;
 
@@ -13663,7 +13663,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceClusterPowerSourceStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceClusterPowerSourceStatusAttributeCallbackBridge::OnDone;
 
@@ -13697,7 +13697,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullablePowerSourceClusterPowerSourceStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullablePowerSourceClusterPowerSourceStatusAttributeCallbackBridge::OnDone;
 
@@ -13730,7 +13730,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceClusterWiredCurrentTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceClusterWiredCurrentTypeAttributeCallbackBridge::OnDone;
 
@@ -13764,7 +13764,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullablePowerSourceClusterWiredCurrentTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullablePowerSourceClusterWiredCurrentTypeAttributeCallbackBridge::OnDone;
 
@@ -13796,7 +13796,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPowerSourceClusterWiredFaultAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPowerSourceClusterWiredFaultAttributeCallbackBridge::OnDone;
 
@@ -13830,7 +13830,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullablePowerSourceClusterWiredFaultAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullablePowerSourceClusterWiredFaultAttributeCallbackBridge::OnDone;
 
@@ -13863,7 +13863,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralCommissioningClusterCommissioningErrorAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralCommissioningClusterCommissioningErrorAttributeCallbackBridge::OnDone;
 
@@ -13900,7 +13900,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableGeneralCommissioningClusterCommissioningErrorAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableGeneralCommissioningClusterCommissioningErrorAttributeCallbackBridge::OnDone;
 
@@ -13934,7 +13934,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralCommissioningClusterRegulatoryLocationTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralCommissioningClusterRegulatoryLocationTypeAttributeCallbackBridge::OnDone;
 
@@ -13973,7 +13973,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableGeneralCommissioningClusterRegulatoryLocationTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableGeneralCommissioningClusterRegulatoryLocationTypeAttributeCallbackBridge::OnDone;
 
@@ -14008,7 +14008,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNetworkCommissioningClusterNetworkCommissioningStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNetworkCommissioningClusterNetworkCommissioningStatusAttributeCallbackBridge::OnDone;
 
@@ -14047,7 +14047,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableNetworkCommissioningClusterNetworkCommissioningStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableNetworkCommissioningClusterNetworkCommissioningStatusAttributeCallbackBridge::OnDone;
 
@@ -14080,7 +14080,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNetworkCommissioningClusterWiFiBandAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNetworkCommissioningClusterWiFiBandAttributeCallbackBridge::OnDone;
 
@@ -14114,7 +14114,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableNetworkCommissioningClusterWiFiBandAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableNetworkCommissioningClusterWiFiBandAttributeCallbackBridge::OnDone;
 
@@ -14147,7 +14147,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDiagnosticLogsClusterLogsIntentAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDiagnosticLogsClusterLogsIntentAttributeCallbackBridge::OnDone;
 
@@ -14181,7 +14181,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDiagnosticLogsClusterLogsIntentAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDiagnosticLogsClusterLogsIntentAttributeCallbackBridge::OnDone;
 
@@ -14214,7 +14214,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDiagnosticLogsClusterLogsStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDiagnosticLogsClusterLogsStatusAttributeCallbackBridge::OnDone;
 
@@ -14248,7 +14248,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDiagnosticLogsClusterLogsStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDiagnosticLogsClusterLogsStatusAttributeCallbackBridge::OnDone;
 
@@ -14281,7 +14281,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDiagnosticLogsClusterLogsTransferProtocolAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDiagnosticLogsClusterLogsTransferProtocolAttributeCallbackBridge::OnDone;
 
@@ -14317,7 +14317,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDiagnosticLogsClusterLogsTransferProtocolAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDiagnosticLogsClusterLogsTransferProtocolAttributeCallbackBridge::OnDone;
 
@@ -14350,7 +14350,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralDiagnosticsClusterBootReasonTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralDiagnosticsClusterBootReasonTypeAttributeCallbackBridge::OnDone;
 
@@ -14384,7 +14384,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableGeneralDiagnosticsClusterBootReasonTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableGeneralDiagnosticsClusterBootReasonTypeAttributeCallbackBridge::OnDone;
 
@@ -14417,7 +14417,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralDiagnosticsClusterHardwareFaultTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralDiagnosticsClusterHardwareFaultTypeAttributeCallbackBridge::OnDone;
 
@@ -14453,7 +14453,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableGeneralDiagnosticsClusterHardwareFaultTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableGeneralDiagnosticsClusterHardwareFaultTypeAttributeCallbackBridge::OnDone;
 
@@ -14486,7 +14486,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralDiagnosticsClusterInterfaceTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralDiagnosticsClusterInterfaceTypeAttributeCallbackBridge::OnDone;
 
@@ -14520,7 +14520,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableGeneralDiagnosticsClusterInterfaceTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableGeneralDiagnosticsClusterInterfaceTypeAttributeCallbackBridge::OnDone;
 
@@ -14553,7 +14553,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralDiagnosticsClusterNetworkFaultTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralDiagnosticsClusterNetworkFaultTypeAttributeCallbackBridge::OnDone;
 
@@ -14589,7 +14589,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableGeneralDiagnosticsClusterNetworkFaultTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableGeneralDiagnosticsClusterNetworkFaultTypeAttributeCallbackBridge::OnDone;
 
@@ -14622,7 +14622,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGeneralDiagnosticsClusterRadioFaultTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGeneralDiagnosticsClusterRadioFaultTypeAttributeCallbackBridge::OnDone;
 
@@ -14656,7 +14656,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableGeneralDiagnosticsClusterRadioFaultTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableGeneralDiagnosticsClusterRadioFaultTypeAttributeCallbackBridge::OnDone;
 
@@ -14689,7 +14689,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThreadNetworkDiagnosticsClusterNetworkFaultAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThreadNetworkDiagnosticsClusterNetworkFaultAttributeCallbackBridge::OnDone;
 
@@ -14725,7 +14725,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableThreadNetworkDiagnosticsClusterNetworkFaultAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableThreadNetworkDiagnosticsClusterNetworkFaultAttributeCallbackBridge::OnDone;
 
@@ -14758,7 +14758,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThreadNetworkDiagnosticsClusterRoutingRoleAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThreadNetworkDiagnosticsClusterRoutingRoleAttributeCallbackBridge::OnDone;
 
@@ -14794,7 +14794,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableThreadNetworkDiagnosticsClusterRoutingRoleAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableThreadNetworkDiagnosticsClusterRoutingRoleAttributeCallbackBridge::OnDone;
 
@@ -14829,7 +14829,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThreadNetworkDiagnosticsClusterThreadConnectionStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThreadNetworkDiagnosticsClusterThreadConnectionStatusAttributeCallbackBridge::OnDone;
 
@@ -14868,7 +14868,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableThreadNetworkDiagnosticsClusterThreadConnectionStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableThreadNetworkDiagnosticsClusterThreadConnectionStatusAttributeCallbackBridge::OnDone;
 
@@ -14903,7 +14903,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWiFiNetworkDiagnosticsClusterAssociationFailureCauseAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWiFiNetworkDiagnosticsClusterAssociationFailureCauseAttributeCallbackBridge::OnDone;
 
@@ -14942,7 +14942,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableWiFiNetworkDiagnosticsClusterAssociationFailureCauseAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableWiFiNetworkDiagnosticsClusterAssociationFailureCauseAttributeCallbackBridge::OnDone;
 
@@ -14975,7 +14975,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWiFiNetworkDiagnosticsClusterSecurityTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWiFiNetworkDiagnosticsClusterSecurityTypeAttributeCallbackBridge::OnDone;
 
@@ -15011,7 +15011,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableWiFiNetworkDiagnosticsClusterSecurityTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableWiFiNetworkDiagnosticsClusterSecurityTypeAttributeCallbackBridge::OnDone;
 
@@ -15045,7 +15045,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWiFiNetworkDiagnosticsClusterWiFiConnectionStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWiFiNetworkDiagnosticsClusterWiFiConnectionStatusAttributeCallbackBridge::OnDone;
 
@@ -15084,7 +15084,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableWiFiNetworkDiagnosticsClusterWiFiConnectionStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableWiFiNetworkDiagnosticsClusterWiFiConnectionStatusAttributeCallbackBridge::OnDone;
 
@@ -15117,7 +15117,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWiFiNetworkDiagnosticsClusterWiFiVersionTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWiFiNetworkDiagnosticsClusterWiFiVersionTypeAttributeCallbackBridge::OnDone;
 
@@ -15154,7 +15154,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableWiFiNetworkDiagnosticsClusterWiFiVersionTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableWiFiNetworkDiagnosticsClusterWiFiVersionTypeAttributeCallbackBridge::OnDone;
 
@@ -15187,7 +15187,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTREthernetNetworkDiagnosticsClusterPHYRateTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTREthernetNetworkDiagnosticsClusterPHYRateTypeAttributeCallbackBridge::OnDone;
 
@@ -15224,7 +15224,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableEthernetNetworkDiagnosticsClusterPHYRateTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableEthernetNetworkDiagnosticsClusterPHYRateTypeAttributeCallbackBridge::OnDone;
 
@@ -15257,7 +15257,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTimeSynchronizationClusterGranularityEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTimeSynchronizationClusterGranularityEnumAttributeCallbackBridge::OnDone;
 
@@ -15293,7 +15293,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableTimeSynchronizationClusterGranularityEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableTimeSynchronizationClusterGranularityEnumAttributeCallbackBridge::OnDone;
 
@@ -15326,7 +15326,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTimeSynchronizationClusterTimeSourceEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTimeSynchronizationClusterTimeSourceEnumAttributeCallbackBridge::OnDone;
 
@@ -15360,7 +15360,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableTimeSynchronizationClusterTimeSourceEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableTimeSynchronizationClusterTimeSourceEnumAttributeCallbackBridge::OnDone;
 
@@ -15397,7 +15397,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAdministratorCommissioningClusterCommissioningWindowStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAdministratorCommissioningClusterCommissioningWindowStatusAttributeCallbackBridge::OnDone;
 
@@ -15436,7 +15436,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableAdministratorCommissioningClusterCommissioningWindowStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableAdministratorCommissioningClusterCommissioningWindowStatusAttributeCallbackBridge::OnDone;
 
@@ -15469,7 +15469,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAdministratorCommissioningClusterStatusCodeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAdministratorCommissioningClusterStatusCodeAttributeCallbackBridge::OnDone;
 
@@ -15505,7 +15505,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableAdministratorCommissioningClusterStatusCodeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableAdministratorCommissioningClusterStatusCodeAttributeCallbackBridge::OnDone;
 
@@ -15539,7 +15539,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTROperationalCredentialsClusterOperationalCertStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTROperationalCredentialsClusterOperationalCertStatusAttributeCallbackBridge::OnDone;
 
@@ -15578,7 +15578,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableOperationalCredentialsClusterOperationalCertStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableOperationalCredentialsClusterOperationalCertStatusAttributeCallbackBridge::OnDone;
 
@@ -15611,7 +15611,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRGroupKeyManagementClusterGroupKeySecurityPolicyAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRGroupKeyManagementClusterGroupKeySecurityPolicyAttributeCallbackBridge::OnDone;
 
@@ -15649,7 +15649,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableGroupKeyManagementClusterGroupKeySecurityPolicyAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableGroupKeyManagementClusterGroupKeySecurityPolicyAttributeCallbackBridge::OnDone;
 
@@ -15679,7 +15679,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlAlarmCodeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlAlarmCodeAttributeCallbackBridge::OnDone;
 
@@ -15713,7 +15713,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlAlarmCodeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlAlarmCodeAttributeCallbackBridge::OnDone;
 
@@ -15746,7 +15746,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlCredentialRuleAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlCredentialRuleAttributeCallbackBridge::OnDone;
 
@@ -15780,7 +15780,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlCredentialRuleAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlCredentialRuleAttributeCallbackBridge::OnDone;
 
@@ -15813,7 +15813,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlCredentialTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlCredentialTypeAttributeCallbackBridge::OnDone;
 
@@ -15847,7 +15847,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlCredentialTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlCredentialTypeAttributeCallbackBridge::OnDone;
 
@@ -15880,7 +15880,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlDataOperationTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlDataOperationTypeAttributeCallbackBridge::OnDone;
 
@@ -15914,7 +15914,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlDataOperationTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlDataOperationTypeAttributeCallbackBridge::OnDone;
 
@@ -15944,7 +15944,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlDoorStateAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlDoorStateAttributeCallbackBridge::OnDone;
 
@@ -15978,7 +15978,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlDoorStateAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlDoorStateAttributeCallbackBridge::OnDone;
 
@@ -16011,7 +16011,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlLockDataTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlLockDataTypeAttributeCallbackBridge::OnDone;
 
@@ -16045,7 +16045,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlLockDataTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlLockDataTypeAttributeCallbackBridge::OnDone;
 
@@ -16078,7 +16078,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlLockOperationTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlLockOperationTypeAttributeCallbackBridge::OnDone;
 
@@ -16112,7 +16112,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlLockOperationTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlLockOperationTypeAttributeCallbackBridge::OnDone;
 
@@ -16142,7 +16142,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlLockStateAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlLockStateAttributeCallbackBridge::OnDone;
 
@@ -16176,7 +16176,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlLockStateAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlLockStateAttributeCallbackBridge::OnDone;
 
@@ -16206,7 +16206,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlLockTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlLockTypeAttributeCallbackBridge::OnDone;
 
@@ -16240,7 +16240,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlLockTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlLockTypeAttributeCallbackBridge::OnDone;
 
@@ -16273,7 +16273,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlOperatingModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlOperatingModeAttributeCallbackBridge::OnDone;
 
@@ -16307,7 +16307,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlOperatingModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlOperatingModeAttributeCallbackBridge::OnDone;
 
@@ -16340,7 +16340,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlOperationErrorAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlOperationErrorAttributeCallbackBridge::OnDone;
 
@@ -16374,7 +16374,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlOperationErrorAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlOperationErrorAttributeCallbackBridge::OnDone;
 
@@ -16407,7 +16407,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlOperationSourceAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlOperationSourceAttributeCallbackBridge::OnDone;
 
@@ -16441,7 +16441,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlOperationSourceAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlOperationSourceAttributeCallbackBridge::OnDone;
 
@@ -16471,7 +16471,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlStatusAttributeCallbackBridge::OnDone;
 
@@ -16504,7 +16504,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlStatusAttributeCallbackBridge::OnDone;
 
@@ -16535,7 +16535,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlUserStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlUserStatusAttributeCallbackBridge::OnDone;
 
@@ -16569,7 +16569,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlUserStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlUserStatusAttributeCallbackBridge::OnDone;
 
@@ -16599,7 +16599,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDlUserTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDlUserTypeAttributeCallbackBridge::OnDone;
 
@@ -16633,7 +16633,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDlUserTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDlUserTypeAttributeCallbackBridge::OnDone;
 
@@ -16666,7 +16666,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDoorLockOperationEventCodeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDoorLockOperationEventCodeAttributeCallbackBridge::OnDone;
 
@@ -16702,7 +16702,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDoorLockOperationEventCodeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDoorLockOperationEventCodeAttributeCallbackBridge::OnDone;
 
@@ -16735,7 +16735,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDoorLockProgrammingEventCodeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDoorLockProgrammingEventCodeAttributeCallbackBridge::OnDone;
 
@@ -16771,7 +16771,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDoorLockProgrammingEventCodeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDoorLockProgrammingEventCodeAttributeCallbackBridge::OnDone;
 
@@ -16804,7 +16804,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDoorLockSetPinOrIdStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDoorLockSetPinOrIdStatusAttributeCallbackBridge::OnDone;
 
@@ -16838,7 +16838,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDoorLockSetPinOrIdStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDoorLockSetPinOrIdStatusAttributeCallbackBridge::OnDone;
 
@@ -16871,7 +16871,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDoorLockUserStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDoorLockUserStatusAttributeCallbackBridge::OnDone;
 
@@ -16905,7 +16905,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDoorLockUserStatusAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDoorLockUserStatusAttributeCallbackBridge::OnDone;
 
@@ -16938,7 +16938,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRDoorLockClusterDoorLockUserTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRDoorLockClusterDoorLockUserTypeAttributeCallbackBridge::OnDone;
 
@@ -16972,7 +16972,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableDoorLockClusterDoorLockUserTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableDoorLockClusterDoorLockUserTypeAttributeCallbackBridge::OnDone;
 
@@ -17005,7 +17005,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWindowCoveringClusterEndProductTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWindowCoveringClusterEndProductTypeAttributeCallbackBridge::OnDone;
 
@@ -17039,7 +17039,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableWindowCoveringClusterEndProductTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableWindowCoveringClusterEndProductTypeAttributeCallbackBridge::OnDone;
 
@@ -17069,7 +17069,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRWindowCoveringClusterTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRWindowCoveringClusterTypeAttributeCallbackBridge::OnDone;
 
@@ -17103,7 +17103,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableWindowCoveringClusterTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableWindowCoveringClusterTypeAttributeCallbackBridge::OnDone;
 
@@ -17137,7 +17137,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPumpConfigurationAndControlClusterPumpControlModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPumpConfigurationAndControlClusterPumpControlModeAttributeCallbackBridge::OnDone;
 
@@ -17176,7 +17176,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullablePumpConfigurationAndControlClusterPumpControlModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullablePumpConfigurationAndControlClusterPumpControlModeAttributeCallbackBridge::OnDone;
 
@@ -17210,7 +17210,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRPumpConfigurationAndControlClusterPumpOperationModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRPumpConfigurationAndControlClusterPumpOperationModeAttributeCallbackBridge::OnDone;
 
@@ -17249,7 +17249,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullablePumpConfigurationAndControlClusterPumpOperationModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullablePumpConfigurationAndControlClusterPumpOperationModeAttributeCallbackBridge::OnDone;
 
@@ -17282,7 +17282,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThermostatClusterSetpointAdjustModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThermostatClusterSetpointAdjustModeAttributeCallbackBridge::OnDone;
 
@@ -17316,7 +17316,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableThermostatClusterSetpointAdjustModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableThermostatClusterSetpointAdjustModeAttributeCallbackBridge::OnDone;
 
@@ -17349,7 +17349,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThermostatClusterThermostatControlSequenceAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThermostatClusterThermostatControlSequenceAttributeCallbackBridge::OnDone;
 
@@ -17385,7 +17385,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableThermostatClusterThermostatControlSequenceAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableThermostatClusterThermostatControlSequenceAttributeCallbackBridge::OnDone;
 
@@ -17418,7 +17418,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThermostatClusterThermostatRunningModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThermostatClusterThermostatRunningModeAttributeCallbackBridge::OnDone;
 
@@ -17452,7 +17452,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableThermostatClusterThermostatRunningModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableThermostatClusterThermostatRunningModeAttributeCallbackBridge::OnDone;
 
@@ -17485,7 +17485,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRThermostatClusterThermostatSystemModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRThermostatClusterThermostatSystemModeAttributeCallbackBridge::OnDone;
 
@@ -17519,7 +17519,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableThermostatClusterThermostatSystemModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableThermostatClusterThermostatSystemModeAttributeCallbackBridge::OnDone;
 
@@ -17552,7 +17552,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRFanControlClusterFanModeSequenceTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRFanControlClusterFanModeSequenceTypeAttributeCallbackBridge::OnDone;
 
@@ -17586,7 +17586,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableFanControlClusterFanModeSequenceTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableFanControlClusterFanModeSequenceTypeAttributeCallbackBridge::OnDone;
 
@@ -17618,7 +17618,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRFanControlClusterFanModeTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRFanControlClusterFanModeTypeAttributeCallbackBridge::OnDone;
 
@@ -17652,7 +17652,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableFanControlClusterFanModeTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableFanControlClusterFanModeTypeAttributeCallbackBridge::OnDone;
 
@@ -17685,7 +17685,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRColorControlClusterColorLoopActionAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRColorControlClusterColorLoopActionAttributeCallbackBridge::OnDone;
 
@@ -17719,7 +17719,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableColorControlClusterColorLoopActionAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableColorControlClusterColorLoopActionAttributeCallbackBridge::OnDone;
 
@@ -17752,7 +17752,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRColorControlClusterColorLoopDirectionAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRColorControlClusterColorLoopDirectionAttributeCallbackBridge::OnDone;
 
@@ -17786,7 +17786,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableColorControlClusterColorLoopDirectionAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableColorControlClusterColorLoopDirectionAttributeCallbackBridge::OnDone;
 
@@ -17818,7 +17818,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRColorControlClusterColorModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRColorControlClusterColorModeAttributeCallbackBridge::OnDone;
 
@@ -17852,7 +17852,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableColorControlClusterColorModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableColorControlClusterColorModeAttributeCallbackBridge::OnDone;
 
@@ -17885,7 +17885,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRColorControlClusterHueDirectionAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRColorControlClusterHueDirectionAttributeCallbackBridge::OnDone;
 
@@ -17919,7 +17919,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableColorControlClusterHueDirectionAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableColorControlClusterHueDirectionAttributeCallbackBridge::OnDone;
 
@@ -17952,7 +17952,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRColorControlClusterHueMoveModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRColorControlClusterHueMoveModeAttributeCallbackBridge::OnDone;
 
@@ -17986,7 +17986,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableColorControlClusterHueMoveModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableColorControlClusterHueMoveModeAttributeCallbackBridge::OnDone;
 
@@ -18019,7 +18019,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRColorControlClusterHueStepModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRColorControlClusterHueStepModeAttributeCallbackBridge::OnDone;
 
@@ -18053,7 +18053,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableColorControlClusterHueStepModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableColorControlClusterHueStepModeAttributeCallbackBridge::OnDone;
 
@@ -18086,7 +18086,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRColorControlClusterSaturationMoveModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRColorControlClusterSaturationMoveModeAttributeCallbackBridge::OnDone;
 
@@ -18120,7 +18120,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableColorControlClusterSaturationMoveModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableColorControlClusterSaturationMoveModeAttributeCallbackBridge::OnDone;
 
@@ -18153,7 +18153,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRColorControlClusterSaturationStepModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRColorControlClusterSaturationStepModeAttributeCallbackBridge::OnDone;
 
@@ -18187,7 +18187,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableColorControlClusterSaturationStepModeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableColorControlClusterSaturationStepModeAttributeCallbackBridge::OnDone;
 
@@ -18220,7 +18220,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRIlluminanceMeasurementClusterLightSensorTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRIlluminanceMeasurementClusterLightSensorTypeAttributeCallbackBridge::OnDone;
 
@@ -18257,7 +18257,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableIlluminanceMeasurementClusterLightSensorTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableIlluminanceMeasurementClusterLightSensorTypeAttributeCallbackBridge::OnDone;
 
@@ -18290,7 +18290,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRChannelClusterChannelStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRChannelClusterChannelStatusEnumAttributeCallbackBridge::OnDone;
 
@@ -18324,7 +18324,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableChannelClusterChannelStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableChannelClusterChannelStatusEnumAttributeCallbackBridge::OnDone;
 
@@ -18357,7 +18357,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRChannelClusterLineupInfoTypeEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRChannelClusterLineupInfoTypeEnumAttributeCallbackBridge::OnDone;
 
@@ -18391,7 +18391,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableChannelClusterLineupInfoTypeEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableChannelClusterLineupInfoTypeEnumAttributeCallbackBridge::OnDone;
 
@@ -18424,7 +18424,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge::OnDone;
 
@@ -18462,7 +18462,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge::OnDone;
 
@@ -18495,7 +18495,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge::OnDone;
 
@@ -18531,7 +18531,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge::OnDone;
 
@@ -18564,7 +18564,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRMediaPlaybackClusterPlaybackStateEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRMediaPlaybackClusterPlaybackStateEnumAttributeCallbackBridge::OnDone;
 
@@ -18598,7 +18598,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableMediaPlaybackClusterPlaybackStateEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableMediaPlaybackClusterPlaybackStateEnumAttributeCallbackBridge::OnDone;
 
@@ -18631,7 +18631,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRMediaInputClusterInputTypeEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRMediaInputClusterInputTypeEnumAttributeCallbackBridge::OnDone;
 
@@ -18665,7 +18665,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableMediaInputClusterInputTypeEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableMediaInputClusterInputTypeEnumAttributeCallbackBridge::OnDone;
 
@@ -18697,7 +18697,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRKeypadInputClusterCecKeyCodeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRKeypadInputClusterCecKeyCodeAttributeCallbackBridge::OnDone;
 
@@ -18731,7 +18731,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableKeypadInputClusterCecKeyCodeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableKeypadInputClusterCecKeyCodeAttributeCallbackBridge::OnDone;
 
@@ -18764,7 +18764,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge::OnDone;
 
@@ -18798,7 +18798,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge::OnDone;
 
@@ -18831,7 +18831,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge::OnDone;
 
@@ -18868,7 +18868,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge::OnDone;
 
@@ -18901,7 +18901,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRContentLauncherClusterMetricTypeEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRContentLauncherClusterMetricTypeEnumAttributeCallbackBridge::OnDone;
 
@@ -18935,7 +18935,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableContentLauncherClusterMetricTypeEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableContentLauncherClusterMetricTypeEnumAttributeCallbackBridge::OnDone;
 
@@ -18968,7 +18968,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRContentLauncherClusterParameterEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRContentLauncherClusterParameterEnumAttributeCallbackBridge::OnDone;
 
@@ -19002,7 +19002,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableContentLauncherClusterParameterEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableContentLauncherClusterParameterEnumAttributeCallbackBridge::OnDone;
 
@@ -19035,7 +19035,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRAudioOutputClusterOutputTypeEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRAudioOutputClusterOutputTypeEnumAttributeCallbackBridge::OnDone;
 
@@ -19069,7 +19069,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableAudioOutputClusterOutputTypeEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableAudioOutputClusterOutputTypeEnumAttributeCallbackBridge::OnDone;
 
@@ -19105,7 +19105,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackBridge::OnDone;
 
@@ -19144,7 +19144,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackBridge::OnDone;
 
@@ -19177,7 +19177,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRApplicationBasicClusterApplicationStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRApplicationBasicClusterApplicationStatusEnumAttributeCallbackBridge::OnDone;
 
@@ -19214,7 +19214,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableApplicationBasicClusterApplicationStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableApplicationBasicClusterApplicationStatusEnumAttributeCallbackBridge::OnDone;
 
@@ -19246,7 +19246,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRUnitTestingClusterSimpleEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRUnitTestingClusterSimpleEnumAttributeCallbackBridge::OnDone;
 
@@ -19280,7 +19280,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableUnitTestingClusterSimpleEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableUnitTestingClusterSimpleEnumAttributeCallbackBridge::OnDone;
 
@@ -19313,7 +19313,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRFaultInjectionClusterFaultTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRFaultInjectionClusterFaultTypeAttributeCallbackBridge::OnDone;
 
@@ -19347,7 +19347,7 @@ public:
         mEstablishedHandler(establishedHandler)
     {}
 
-    static void OnSubscriptionEstablished(void * context);
+    void OnSubscriptionEstablished();
     using MTRNullableFaultInjectionClusterFaultTypeAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableFaultInjectionClusterFaultTypeAttributeCallbackBridge::OnDone;
 

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		51E0310027EA20D20083DC9C /* MTRControllerAccessControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E030FE27EA20D20083DC9C /* MTRControllerAccessControl.h */; };
 		51E0310127EA20D20083DC9C /* MTRControllerAccessControl.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E030FF27EA20D20083DC9C /* MTRControllerAccessControl.mm */; };
 		51E24E73274E0DAC007CCF6E /* MTRErrorTestUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E24E72274E0DAC007CCF6E /* MTRErrorTestUtils.mm */; };
+		51E4D121291D0EB400C8C535 /* MTRBaseClustersCpp_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E4D120291D0EB400C8C535 /* MTRBaseClustersCpp_Internal.h */; };
 		51E51FBF282AD37A00FC978D /* MTRDeviceControllerStartupParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E51FBC282AD37A00FC978D /* MTRDeviceControllerStartupParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51E51FC0282AD37A00FC978D /* MTRDeviceControllerStartupParams_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E51FBD282AD37A00FC978D /* MTRDeviceControllerStartupParams_Internal.h */; };
 		51E51FC1282AD37A00FC978D /* MTRDeviceControllerStartupParams.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E51FBE282AD37A00FC978D /* MTRDeviceControllerStartupParams.mm */; };
@@ -207,6 +208,7 @@
 		51E030FE27EA20D20083DC9C /* MTRControllerAccessControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRControllerAccessControl.h; sourceTree = "<group>"; };
 		51E030FF27EA20D20083DC9C /* MTRControllerAccessControl.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRControllerAccessControl.mm; sourceTree = "<group>"; };
 		51E24E72274E0DAC007CCF6E /* MTRErrorTestUtils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRErrorTestUtils.mm; sourceTree = "<group>"; };
+		51E4D120291D0EB400C8C535 /* MTRBaseClustersCpp_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRBaseClustersCpp_Internal.h; sourceTree = "<group>"; };
 		51E51FBC282AD37A00FC978D /* MTRDeviceControllerStartupParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDeviceControllerStartupParams.h; sourceTree = "<group>"; };
 		51E51FBD282AD37A00FC978D /* MTRDeviceControllerStartupParams_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDeviceControllerStartupParams_Internal.h; sourceTree = "<group>"; };
 		51E51FBE282AD37A00FC978D /* MTRDeviceControllerStartupParams.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDeviceControllerStartupParams.mm; sourceTree = "<group>"; };
@@ -456,6 +458,7 @@
 				3CF134AE289D90FF0017A19E /* MTRNOCChainIssuer.h */,
 				511913FA28C100EF009235E9 /* MTRBaseSubscriptionCallback.h */,
 				511913F928C100EF009235E9 /* MTRBaseSubscriptionCallback.mm */,
+				51E4D120291D0EB400C8C535 /* MTRBaseClustersCpp_Internal.h */,
 			);
 			path = CHIP;
 			sourceTree = "<group>";
@@ -553,6 +556,7 @@
 				1EC4CE6425CC276600D7304F /* MTRBaseClusters.h in Headers */,
 				2C5EEEF6268A85C400CAE3D3 /* MTRDeviceConnectionBridge.h in Headers */,
 				2C8C8FC0253E0C2100797F05 /* MTRPersistentStorageDelegateBridge.h in Headers */,
+				51E4D121291D0EB400C8C535 /* MTRBaseClustersCpp_Internal.h in Headers */,
 				51E51FC0282AD37A00FC978D /* MTRDeviceControllerStartupParams_Internal.h in Headers */,
 				998F286F26D55EC5001846C6 /* MTRP256KeypairBridge.h in Headers */,
 				2C222ADF255C811800E446B9 /* MTRBaseDevice_Internal.h in Headers */,


### PR DESCRIPTION
This reduces Darwin build CI times from ~2 hours 30 mins to ~1 hour 20 mins.

Also includes the following fixes:

* Fix support for setting resubscribeIfLost to false in the Darwin "subscribe an
  attribute" APIs.
* Fix handling of the --autoResubscribe argument for darwin-framework-tool
  "subscribe an attribute" commands.  It used to be ignored, because the
  underlying API did not support setting it to false.
* Fix handling of fabricFiltered and keepSubscriptions in darwin-framework-tool
  YAML tests.
* Fix handling of the mKeepAlive member of Darwin callback bridges.  Before
  this, we could end up with an OnError callback, which would queue a task to
  delete the bridge, but then OnDone for a subscription would also delete the
  bridge.  This would fail any time a subscription in fact errored out.  In the
  new setup, mKeepAlive only gets set for subscriptions, and only once we have
  started the async process that will always call OnDone, so we can rely on
  deleting on error if !mKeepAlive and deleting in OnDone if mKeepAlive.
* Fix incorrect condition for whether to do an auto-resubscribe request in
  MTRBaseDevice.

@andy31415 @jtung-apple @vivien-apple 

