### PR TITLE
Add chip_external_mbedtls flag to src/crypto

### DIFF
--- a/config/nrfconnect/chip-gn/args.gni
+++ b/config/nrfconnect/chip-gn/args.gni
@@ -14,6 +14,8 @@
 
 import("//build_overrides/chip.gni")
 
+import("${chip_root}/src/crypto/crypto.gni")
+
 chip_device_platform = "nrfconnect"
 
 chip_build_tests = false
@@ -21,6 +23,9 @@ chip_build_tests = false
 chip_project_config_include = ""
 chip_system_project_config_include = ""
 chip_ble_project_config_include = ""
+
+chip_crypto = "mbedtls"
+chip_external_mbedtls = true
 
 custom_toolchain = "${chip_root}/config/nrfconnect/chip-gn/toolchain:zephyr"
 

--- a/config/telink/chip-gn/args.gni
+++ b/config/telink/chip-gn/args.gni
@@ -14,6 +14,8 @@
 
 import("//build_overrides/chip.gni")
 
+import("${chip_root}/src/crypto/crypto.gni")
+
 chip_device_platform = "telink"
 
 chip_build_tests = false
@@ -21,6 +23,9 @@ chip_build_tests = false
 chip_project_config_include = ""
 chip_system_project_config_include = ""
 chip_ble_project_config_include = ""
+
+chip_crypto = "mbedtls"
+chip_external_mbedtls = true
 
 custom_toolchain = "${chip_root}/config/telink/chip-gn/toolchain:zephyr"
 

--- a/config/zephyr/chip-gn/args.gni
+++ b/config/zephyr/chip-gn/args.gni
@@ -14,6 +14,8 @@
 
 import("//build_overrides/chip.gni")
 
+import("${chip_root}/src/crypto/crypto.gni")
+
 chip_device_platform = "zephyr"
 
 chip_build_tests = false
@@ -21,6 +23,9 @@ chip_build_tests = false
 chip_project_config_include = ""
 chip_system_project_config_include = ""
 chip_ble_project_config_include = ""
+
+chip_crypto = "mbedtls"
+chip_external_mbedtls = true
 
 custom_toolchain = "${chip_root}/config/zephyr/chip-gn/toolchain:zephyr"
 

--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -107,9 +107,7 @@ if (chip_crypto == "openssl") {
     sources = [ "CHIPCryptoPALmbedTLS.cpp" ]
     public_deps = [ ":public_headers" ]
 
-    external_mbedtls = current_os == "zephyr"
-
-    if (!external_mbedtls) {
+    if (!chip_external_mbedtls) {
       public_deps += [ "${mbedtls_root}:mbedtls" ]
     }
   }

--- a/src/crypto/crypto.gni
+++ b/src/crypto/crypto.gni
@@ -16,4 +16,10 @@ declare_args() {
   # Crypto implementation: mbedtls, openssl, tinycrypt, boringssl, platform.
   chip_crypto = ""
   chip_with_se05x = 0
+
+  # Compile mbedtls externally. Only used if chip_crypto == "mbedtls"
+  chip_external_mbedtls = false
 }
+
+assert(!chip_external_mbedtls || chip_crypto == "mbedtls",
+       "Use of external mbedtls requires the mbedtls crypto impl")


### PR DESCRIPTION
This allows mbedtls to be compiled outside of the Matter gn build routine, for build targets that wish to share mbedtls symbols.

Currently the zephyr target avoids building mbedtls. Expose this flag so that any target can set this for the Matter crypto library. The default value is false unless using the zephyr os, so this should not introduce any change to existing targets in the SDK.