### PR TITLE
Created /opt/sdk/sdks/ folder in dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -72,6 +72,7 @@ RUN chown -R $USERNAME:$USERNAME /opt/android/sdk
 RUN chown -R $USERNAME:$USERNAME /opt/ameba/ambd_sdk_with_chip_non_NDA/
 
 # NXP uses a patch_sdk script to change SDK files
+RUN mkdir -p /opt/sdk/sdks/
 RUN chown -R $USERNAME:$USERNAME /opt/sdk/sdks/
 
 RUN chown -R $USERNAME:$USERNAME /opt/fsl-imx-xwayland/5.15-kirkstone/


### PR DESCRIPTION
Build dev container fails because it can't find the directory /opt/sdk/sdks/ 