### PR TITLE
Fix BLE commissioning deadlock caused by 0e41b19

### DIFF
--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -70,7 +70,7 @@ public:
      * @brief Convenience method to require less casts to void pointers.
      */
     template <class T>
-    CHIP_ERROR ScheduleOnGLibMainLoopThread(int (*callback)(T *), T * userData, bool wait = false)
+    CHIP_ERROR ScheduleOnGLibMainLoopThread(gboolean (*callback)(T *), T * userData, bool wait = false)
     {
         return RunOnGLibMainLoopThread(G_SOURCE_FUNC(callback), userData, wait);
     }


### PR DESCRIPTION
### Problem

PR #23320 introduced a deadlock when commisionning with BLE.

### Changes

- do not use callback indirection when running callback from glib main event loop thread itself

### Testing

Tested manually with chip-tool (linux) and lighting-app (linux).
