### PR TITLE
tv-casting-app: Synchronizing on the use of NsdManager.resolveService()

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
@@ -1,8 +1,6 @@
 package com.chip.casting.app;
 
 import android.content.Context;
-import android.net.nsd.NsdManager;
-import android.net.wifi.WifiManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -69,8 +67,6 @@ public class CommissionerDiscoveryFragment extends Fragment {
     manualCommissioningButton.setOnClickListener(manualCommissioningButtonOnClickListener);
 
     Context context = this.getContext();
-    Context applicationContext = this.getContext().getApplicationContext();
-
     SuccessCallback<DiscoveredNodeData> successCallback =
         new SuccessCallback<DiscoveredNodeData>() {
           @Override
@@ -112,11 +108,7 @@ public class CommissionerDiscoveryFragment extends Fragment {
         };
 
     tvCastingApp.discoverVideoPlayerCommissioners(
-        (WifiManager) context.getSystemService(Context.WIFI_SERVICE),
-        (NsdManager) applicationContext.getSystemService(Context.NSD_SERVICE),
-        DISCOVERY_DURATION_SECS,
-        successCallback,
-        failureCallback);
+        DISCOVERY_DURATION_SECS, successCallback, failureCallback);
   }
 
   @VisibleForTesting

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
@@ -6,15 +6,6 @@ import android.util.Log;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
-import chip.appserver.ChipAppServer;
-import chip.platform.AndroidBleManager;
-import chip.platform.AndroidChipPlatform;
-import chip.platform.ChipMdnsCallbackImpl;
-import chip.platform.DiagnosticDataProviderImpl;
-import chip.platform.NsdManagerServiceBrowser;
-import chip.platform.NsdManagerServiceResolver;
-import chip.platform.PreferencesConfigurationManager;
-import chip.platform.PreferencesKeyValueStoreManager;
 import com.chip.casting.AppParameters;
 import com.chip.casting.DACProviderStub;
 import com.chip.casting.DiscoveredNodeData;
@@ -29,7 +20,6 @@ public class MainActivity extends AppCompatActivity
 
   private static final String TAG = MainActivity.class.getSimpleName();
 
-  private ChipAppServer chipAppServer;
   private TvCastingApp tvCastingApp;
 
   @Override
@@ -79,30 +69,17 @@ public class MainActivity extends AppCompatActivity
   private void initJni() {
     tvCastingApp = new TvCastingApp();
 
-    tvCastingApp.setDACProvider(new DACProviderStub());
     Context applicationContext = this.getApplicationContext();
-    AndroidChipPlatform chipPlatform =
-        new AndroidChipPlatform(
-            new AndroidBleManager(),
-            new PreferencesKeyValueStoreManager(applicationContext),
-            new PreferencesConfigurationManager(applicationContext),
-            new NsdManagerServiceResolver(applicationContext),
-            new NsdManagerServiceBrowser(applicationContext),
-            new ChipMdnsCallbackImpl(),
-            new DiagnosticDataProviderImpl(applicationContext));
-
-    chipPlatform.updateCommissionableDataProviderData(
-        null, null, 0, GlobalCastingConstants.SetupPasscode, GlobalCastingConstants.Discriminator);
-
-    chipAppServer = new ChipAppServer();
-    chipAppServer.startApp();
 
     AppParameters appParameters = new AppParameters();
     byte[] rotatingDeviceIdUniqueId =
         new byte[AppParameters.MIN_ROTATING_DEVICE_ID_UNIQUE_ID_LENGTH];
     new Random().nextBytes(rotatingDeviceIdUniqueId);
     appParameters.setRotatingDeviceIdUniqueId(rotatingDeviceIdUniqueId);
-    tvCastingApp.init(appParameters);
+    appParameters.setDacProvider(new DACProviderStub());
+    appParameters.setSetupPasscode(GlobalCastingConstants.SetupPasscode);
+    appParameters.setDiscriminator(GlobalCastingConstants.Discriminator);
+    tvCastingApp.initApp(applicationContext, appParameters);
   }
 
   private void showFragment(Fragment fragment, boolean showOnBack) {

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/util/GlobalCastingConstants.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/util/GlobalCastingConstants.java
@@ -1,12 +1,8 @@
 package com.chip.casting.util;
 
-import java.util.Arrays;
-import java.util.List;
-
 public class GlobalCastingConstants {
   public static final String CommissionerServiceType = "_matterd._udp.";
   public static final int CommissioningWindowDurationSecs = 3 * 60;
-  public static int SetupPasscode = 20202021;
-  public static int Discriminator = 0xF00;
-  public static List<Long> CommissionerDeviceTypeFilter = Arrays.asList(35L); // Video player = 35
+  public static final int SetupPasscode = 20202021;
+  public static final int Discriminator = 0xF00;
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/AppParameters.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/AppParameters.java
@@ -19,8 +19,14 @@ package com.chip.casting;
 
 public class AppParameters {
   public static final int MIN_ROTATING_DEVICE_ID_UNIQUE_ID_LENGTH = 16;
+  private static final int TEST_SETUP_PASSCODE = 20202021;
+  private static final int TEST_DISCRIMINATOR = 0xF00;
+  private DACProvider TEST_DAC_PROVIDER = new DACProviderStub();
 
   private byte[] rotatingDeviceIdUniqueId;
+  private DACProvider dacProvider = TEST_DAC_PROVIDER;
+  private int setupPasscode = TEST_SETUP_PASSCODE;
+  public int discriminator = TEST_DISCRIMINATOR;
 
   public void setRotatingDeviceIdUniqueId(byte[] rotatingDeviceIdUniqueId) {
     this.rotatingDeviceIdUniqueId = rotatingDeviceIdUniqueId;
@@ -28,5 +34,29 @@ public class AppParameters {
 
   public byte[] getRotatingDeviceIdUniqueId() {
     return rotatingDeviceIdUniqueId;
+  }
+
+  public DACProvider getDacProvider() {
+    return dacProvider;
+  }
+
+  public void setDacProvider(DACProvider dacProvider) {
+    this.dacProvider = dacProvider;
+  }
+
+  public int getSetupPasscode() {
+    return setupPasscode;
+  }
+
+  public void setSetupPasscode(int setupPasscode) {
+    this.setupPasscode = setupPasscode;
+  }
+
+  public int getDiscriminator() {
+    return discriminator;
+  }
+
+  public void setDiscriminator(int discriminator) {
+    this.discriminator = discriminator;
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/AppParameters.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/AppParameters.java
@@ -26,7 +26,7 @@ public class AppParameters {
   private byte[] rotatingDeviceIdUniqueId;
   private DACProvider dacProvider = TEST_DAC_PROVIDER;
   private int setupPasscode = TEST_SETUP_PASSCODE;
-  public int discriminator = TEST_DISCRIMINATOR;
+  private int discriminator = TEST_DISCRIMINATOR;
 
   public void setRotatingDeviceIdUniqueId(byte[] rotatingDeviceIdUniqueId) {
     this.rotatingDeviceIdUniqueId = rotatingDeviceIdUniqueId;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.h
@@ -181,7 +181,7 @@ class TargetListSuccessHandlerJNI
     : public SuccessHandlerJNI<chip::app::Clusters::TargetNavigator::Attributes::TargetList::TypeInfo::DecodableArgType>
 {
 public:
-    TargetListSuccessHandlerJNI() : SuccessHandlerJNI("(Ljava/util/ArrayList;)V") {}
+    TargetListSuccessHandlerJNI() : SuccessHandlerJNI("(Ljava/lang/Object;)V") {}
     jobject ConvertToJObject(chip::app::Clusters::TargetNavigator::Attributes::TargetList::TypeInfo::DecodableArgType responseData);
 };
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -52,10 +52,10 @@ void JNI_OnUnload(JavaVM * jvm, void * reserved)
     return AndroidAppServerJNI_OnUnload(jvm, reserved);
 }
 
-JNI_METHOD(jboolean, init)(JNIEnv *, jobject, jobject jAppParameters)
+JNI_METHOD(jboolean, initJni)(JNIEnv *, jobject, jobject jAppParameters)
 {
     chip::DeviceLayer::StackLock lock;
-    ChipLogProgress(AppServer, "JNI_METHOD init called");
+    ChipLogProgress(AppServer, "JNI_METHOD initJni called");
 
     CHIP_ERROR err = CHIP_NO_ERROR;
     if (jAppParameters == nullptr)

--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -53,6 +53,8 @@ android_library("java") {
 
   deps = [
     ":android",
+    "${chip_root}/src/app/server/java",
+    "${chip_root}/src/platform/android:java",
     "${chip_root}/third_party/android_deps:annotation",
   ]
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
@@ -480,7 +480,7 @@
  @param requestSentHandler Handler to call on sending the request
  */
 - (void)mediaPlayback_seek:(ContentApp * _Nonnull)contentApp
-                  position:(uint8_t)position
+                  position:(uint64_t)position
           responseCallback:(void (^_Nonnull)(bool))responseCallback
                clientQueue:(dispatch_queue_t _Nonnull)clientQueue
         requestSentHandler:(void (^_Nonnull)(bool))requestSentHandler;


### PR DESCRIPTION
Related to https://github.com/project-chip/connectedhomeip/issues/23514 

#### Problem
1. A pre-commissioned Android tv-casting-app fails to resolve Matter TVs with the FAILURE_ALREADY_ACTIVE error.
2. Also, Seek command and Read API not working with the iOS tv-casting-app

#### Change summary
1. Used the NsdManagerServiceResolver's NsdManagerResolverAvailState to synchronize on the use of the NsdManager resolver.
2. Also, Made the necessary change in data types for the seek command request param and initialized the dictionaries that hold the readAttributeHandlers (previously nil)

#### Testing
Tested with the tv-casting-apps running on Android and iOS, against the Linux tv-app