### PR TITLE
Use java_binary instead of android_binary to build java-matter-contro…

### DIFF
--- a/build/chip/java/rules.gni
+++ b/build/chip/java/rules.gni
@@ -28,6 +28,8 @@ assert(android_sdk_root != "", "android_sdk_root must be specified")
 #
 #   jar_path: A path to an existing JAR. Mutually exclusive with sources.
 #
+#   deps: List of dependent .jar files needed by this library.
+#
 #   output_name: File name for the output .jar (not including extension).
 #     Defaults to the input .jar file name.
 #
@@ -183,6 +185,8 @@ template("java_library") {
 #   sources: List of .java files included in this binary. Mutually exclusive with jar_path.
 #
 #   jar_path: A path to an existing JAR. Mutually exclusive with sources.
+#
+#   deps: List of dependent .jar files needed by this binary.
 #
 #   output_name: File name for the output binary under root_build_dir/bin.
 #

--- a/examples/java-matter-controller/BUILD.gn
+++ b/examples/java-matter-controller/BUILD.gn
@@ -21,7 +21,7 @@ import("${chip_root}/build/chip/tools.gni")
 
 build_java_matter_controller = true
 
-android_binary("java-matter-controller") {
+java_binary("java-matter-controller") {
   output_name = "java-matter-controller"
   deps = [
     "${chip_root}/src/controller/java",


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/issues/23811

Currently,  we are only able to build and link Matter SDK built from Android NDK, but not able to use any functions from the Matter SDK. We need to get rid of Android toolchain completely from this project and use Linux native tool chains instead (javac/clang/gcc).

This is small step towards this direction, use java_binary instead of android_binary template to build the java-matter-controller.

**Testing on Linux:**
```
export ANDROID_HOME=~/Android/Sdk
export ANDROID_NDK_HOME=~/Android/Sdk/ndk/21.4.7075529
source scripts/bootstrap.sh
./scripts/build/build_examples.py --target android-x86-java-matter-controller build
```

Confirm the generate Java Executable still works 
```
yufengw@yufengw-SEi:~/connectedhomeip/out/android-x86-java-matter-controller/bin$ ./java-matter-controller 
Missing cluster name
Usage:
  java-matter-controller cluster_name command_name [param1 param2 ...]


  +-------------------------------------------------------------------------------------+
  | Clusters:                                                                           |
  +-------------------------------------------------------------------------------------+
  | * discover                                                                          |
  | * pairing                                                                           |
  +-------------------------------------------------------------------------------------+
```


