### PR TITLE
remove unused python-dbus

### DIFF
--- a/scripts/constraints.txt
+++ b/scripts/constraints.txt
@@ -61,9 +61,7 @@ cryptography==3.4.7
     # via
     #   -c constraints.esp32.txt
     #   -r requirements.txt
-cxxfilt==0.2.2
-    # via -r requirements.txt
-dbus-python==1.2.18 ; sys_platform == "linux"
+cxxfilt==0.2.2 ; sys_platform == "linux"
     # via -r requirements.txt
 decorator==5.0.9
     # via ipython

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -21,8 +21,7 @@ virtualenv
 requests>=2.24.0
 
 # device controller wheel package
-wheel
-dbus-python==1.2.18; sys_platform == 'linux'
+wheel; sys_platform == 'linux'
 pgi; sys_platform == 'linux'
 pyobjc-core; sys_platform == 'darwin'
 pyobjc-framework-cocoa; sys_platform == 'darwin'

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -299,7 +299,6 @@ chip_python_wheel_action("chip-core") {
     py_package_reqs += [ "pyobjc-framework-corebluetooth" ]
   } else if (current_os == "linux") {
     py_package_reqs += [
-      "dbus-python==1.2.18",
       "pygobject",
     ]
   }

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -298,9 +298,7 @@ chip_python_wheel_action("chip-core") {
   if (current_os == "mac") {
     py_package_reqs += [ "pyobjc-framework-corebluetooth" ]
   } else if (current_os == "linux") {
-    py_package_reqs += [
-      "pygobject",
-    ]
+    py_package_reqs += [ "pygobject" ]
   }
 
   if (current_cpu == "x64") {

--- a/src/pybindings/pycontroller/build-chip-wheel.py
+++ b/src/pybindings/pycontroller/build-chip-wheel.py
@@ -123,7 +123,6 @@ try:
         requiredPackages.append('pyobjc-framework-corebluetooth')
 
     if platform.system() == 'Linux':
-        requiredPackages.append('dbus-python==1.2.18')
         requiredPackages.append('pygobject')
 
     #


### PR DESCRIPTION
python-dbus was used when we do python controller with python bluez implementation, now we have switched to c++ bluez implemenation, so we can remove this python-dbus

