### PR TITLE
[ESP32] Update ESP-IDF in CHIP to v4.4.3 release

### DIFF
--- a/docs/guides/esp32/setup_idf_chip.md
+++ b/docs/guides/esp32/setup_idf_chip.md
@@ -13,27 +13,27 @@ step.
 
 ### Install Prerequisites
 
--   [Linux](https://docs.espressif.com/projects/esp-idf/en/v4.4.2/esp32/get-started/linux-setup.html)
--   [macOS](https://docs.espressif.com/projects/esp-idf/en/v4.4.2/esp32/get-started/macos-setup.html)
+-   [Linux](https://docs.espressif.com/projects/esp-idf/en/v4.4.3/esp32/get-started/linux-setup.html)
+-   [macOS](https://docs.espressif.com/projects/esp-idf/en/v4.4.3/esp32/get-started/macos-setup.html)
 
-### Get IDF v4.4.2
+### Get IDF v4.4.3
 
 -   Clone ESP-IDF
-    [v4.4.2 release](https://github.com/espressif/esp-idf/releases/tag/v4.4.2)
+    [v4.4.3 release](https://github.com/espressif/esp-idf/releases/tag/v4.4.3)
 
     ```
-    $ git clone -b v4.4.2 --recursive https://github.com/espressif/esp-idf.git
+    $ git clone -b v4.4.3 --recursive https://github.com/espressif/esp-idf.git
     $ cd esp-idf
     $ ./install.sh
     ```
 
--   To update an existing esp-idf toolchain to v4.4.2:
+-   To update an existing esp-idf toolchain to v4.4.3:
 
     ```
     $ cd path/to/esp-idf
     $ git fetch origin
-    $ git checkout v4.4.2
-    $ git reset --hard origin/v4.4.2
+    $ git checkout v4.4.3
+    $ git reset --hard origin/v4.4.3
     $ git submodule update --recursive --init
     $ git clean -fdx
     $ ./install.sh

--- a/integrations/docker/images/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32/Dockerfile
@@ -10,7 +10,7 @@ RUN set -x \
     && : # last line
 
 RUN set -x \
-    && git clone --recursive -b v4.4.2 --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git /tmp/esp-idf \
+    && git clone --recursive -b v4.4.3 --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git /tmp/esp-idf \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.07 Version bump reason: Build glib-2.0 libs with TSAN
+0.6.08 Version bump reason: Update ESP-IDF to v4.4.3 release


### PR DESCRIPTION
Problem

> CHIP uses ESP-IDF v4.4.2. [ESP-IDF v4.4.3](https://github.com/espressif/esp-idf/releases/tag/v4.4.3) is released, so need to update to use that.

Change overview

> Update the documentation to use v4.4.3 release tag
> Update docker to use v4.4.3

Testing

> Compilation of esp32/all-clusters-app with ESP32 and ESP32-C3
> Commissioning and cluster control with ESP32 and ESP32-C3

