### PR TITLE
Stop passing passcode by mutable reference to Spake2pVerifier::Generate.

### DIFF
--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -540,7 +540,7 @@ CHIP_ERROR Spake2pVerifier::Deserialize(const ByteSpan & inSerialized)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Spake2pVerifier::Generate(uint32_t pbkdf2IterCount, const ByteSpan & salt, uint32_t & setupPin)
+CHIP_ERROR Spake2pVerifier::Generate(uint32_t pbkdf2IterCount, const ByteSpan & salt, uint32_t setupPin)
 {
     uint8_t serializedWS[kSpake2p_WS_Length * 2] = { 0 };
     ReturnErrorOnFailure(ComputeWS(pbkdf2IterCount, salt, setupPin, serializedWS, sizeof(serializedWS)));
@@ -572,7 +572,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR Spake2pVerifier::ComputeWS(uint32_t pbkdf2IterCount, const ByteSpan & salt, uint32_t & setupPin, uint8_t * ws,
+CHIP_ERROR Spake2pVerifier::ComputeWS(uint32_t pbkdf2IterCount, const ByteSpan & salt, uint32_t setupPin, uint8_t * ws,
                                       uint32_t ws_len)
 {
 #ifdef ENABLE_HSM_PBKDF2

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -1351,7 +1351,7 @@ public:
      *
      * @return CHIP_ERROR     The result of Spake2+ verifier generation
      */
-    CHIP_ERROR Generate(uint32_t pbkdf2IterCount, const ByteSpan & salt, uint32_t & setupPin);
+    CHIP_ERROR Generate(uint32_t pbkdf2IterCount, const ByteSpan & salt, uint32_t setupPin);
 
     /**
      * @brief Compute the initiator values (w0, w1) used for PAKE input.
@@ -1364,8 +1364,7 @@ public:
      *
      * @return CHIP_ERROR     The result from running PBKDF2
      */
-    static CHIP_ERROR ComputeWS(uint32_t pbkdf2IterCount, const ByteSpan & salt, uint32_t & setupPin, uint8_t * ws,
-                                uint32_t ws_len);
+    static CHIP_ERROR ComputeWS(uint32_t pbkdf2IterCount, const ByteSpan & salt, uint32_t setupPin, uint8_t * ws, uint32_t ws_len);
 };
 
 /**

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -567,10 +567,8 @@ static NSString * const kErrorSpake2pVerifierSerializationFailed = @"PASE verifi
                                                     salt:(NSData *)salt
                                                    error:(NSError * __autoreleasing *)error
 {
-    // Spake2pVerifier::Generate takes the passcode by non-const reference for some reason.
-    uint32_t unboxedSetupPasscode = [setupPasscode unsignedIntValue];
     chip::Spake2pVerifier verifier;
-    CHIP_ERROR err = verifier.Generate([iterations unsignedIntValue], AsByteSpan(salt), unboxedSetupPasscode);
+    CHIP_ERROR err = verifier.Generate(iterations.unsignedIntValue, AsByteSpan(salt), setupPasscode.unsignedIntValue);
     if ([MTRDeviceController checkForError:err logMsg:kErrorSpake2pVerifierGenerationFailed error:error]) {
         return nil;
     }


### PR DESCRIPTION
The generation bits never modify the passcode.

Fixes https://github.com/project-chip/connectedhomeip/issues/23511

