### PR TITLE
Fix use of string-typed config values in YAML expected value checks.

### DIFF
--- a/examples/chip-tool/templates/tests/partials/value_equals.zapt
+++ b/examples/chip-tool/templates/tests/partials/value_equals.zapt
@@ -56,11 +56,19 @@
   {{else}}
     VerifyOrReturn(CheckValue{{#if (isString type)}}AsString{{/if}}("{{label}}", {{actual}}, 
       {{~#if (chip_tests_variables_has expected)}}{{expected}}
+      {{else if (chip_tests_config_has expected)}}
+        m{{asUpperCamelCase expected}}.HasValue() ? m{{asUpperCamelCase expected}}.Value() :
+        {{#if (isCharString type)}}
+          chip::Span<const char>("{{chip_tests_config_get_default_value expected}}", {{utf8StringLength (chip_tests_config_get_default_value expected)}})
+        {{else if (isOctetString type)}}
+          {{> octetStringValue value=(chip_tests_config_get_default_value expected)}}
+        {{else}}
+          {{asTypedExpression (chip_tests_config_get_default_value expected) type}}
+        {{/if}}
       {{else if keepAsExpected}}{{expected}}
       {{else if (isOctetString type)}}
         {{> octetStringValue value=expected}}
       {{else if (isCharString type)}}chip::CharSpan("{{expected}}", {{utf8StringLength expected}})
-      {{else if (chip_tests_config_has expected)}}m{{asUpperCamelCase expected}}.HasValue() ? m{{asUpperCamelCase expected}}.Value() : {{asTypedLiteral (chip_tests_config_get_default_value expected) (chip_tests_config_get_type expected)}}
       {{else}}{{asTypedExpression expected type}}
       {{/if}}
     ));

--- a/examples/darwin-framework-tool/templates/tests/partials/check_test_value.zapt
+++ b/examples/darwin-framework-tool/templates/tests/partials/check_test_value.zapt
@@ -36,12 +36,20 @@
     {{! Maybe we should add a check for properties in the expected object (other
         than "global") that are not present in the struct ? }}
   {{else}}
-    VerifyOrReturn(CheckValue{{#if (isString type)}}AsString{{/if}}("{{label}}", {{actual}}, 
+    VerifyOrReturn(CheckValue{{#if (isString type)}}AsString{{/if}}("{{label}}", {{actual}},
       {{~#if (chip_tests_variables_has expected)}}{{expected}}
+      {{~else if (chip_tests_config_has expected)}}
+        m{{asUpperCamelCase expected}}.HasValue() ?
+        {{#if (isCharString type)}}
+          [[NSString alloc] initWithBytes:m{{asUpperCamelCase expected}}.Value().data() length:m{{asUpperCamelCase expected}}.Value().size() encoding:NSUTF8StringEncoding] : @"{{chip_tests_config_get_default_value expected}}"
+        {{else if (isOctetString type)}}
+          [NSData dataWithBytes:m{{asUpperCamelCase expected}}.Value().data() length:m{{asUpperCamelCase expected}}.Value().size()] : {{> octetStringValue value=(chip_tests_config_get_default_value expected)}}
+        {{else}}
+          m{{asUpperCamelCase expected}}.Value() : {{asTypedExpressionFromObjectiveC (chip_tests_config_get_default_value expected) type}}
+        {{/if}}
       {{~else if (isOctetString type)}}
         {{> octetStringValue value=expected}}
       {{~else if (isCharString type)}}@"{{expected}}"
-      {{else if (chip_tests_config_has expected)}}m{{asUpperCamelCase expected}}.HasValue() ? m{{asUpperCamelCase expected}}.Value() : {{asTypedLiteral (chip_tests_config_get_default_value expected) (chip_tests_config_get_type expected)}}
       {{~else}}{{asTypedExpressionFromObjectiveC expected type}}
       {{~/if}}));
   {{/if_is_struct}}

--- a/examples/darwin-framework-tool/templates/tests/partials/test_value.zapt
+++ b/examples/darwin-framework-tool/templates/tests/partials/test_value.zapt
@@ -35,9 +35,9 @@
     {{else if (chip_tests_config_has definedValue)}}
       m{{asUpperCamelCase definedValue}}.HasValue() ?
       {{#if (isCharString type)}}
-        m{{asUpperCamelCase definedValue}}.Value() : @"{{chip_tests_config_get_default_value definedValue}}";
+        [[NSString alloc] initWithBytes:m{{asUpperCamelCase definedValue}}.Value().data() length:m{{asUpperCamelCase definedValue}}.Value().size() encoding:NSUTF8StringEncoding] : @"{{chip_tests_config_get_default_value definedValue}}";
       {{else if (isOctetString type)}}
-        {{> octetStringValue value=(chip_tests_config_get_default_value definedValue)}};
+        [NSData dataWithBytes:m{{asUpperCamelCase definedValue}}.Value().data() length:m{{asUpperCamelCase definedValue}}.Value().size()] : {{> octetStringValue value=(chip_tests_config_get_default_value definedValue)}};
       {{else}}
         [NSNumber numberWith{{asObjectiveCNumberType definedValue type false}}:m{{asUpperCamelCase definedValue}}.Value()] :
         [NSNumber numberWith{{asObjectiveCNumberType definedValue type false}}:{{asTypedExpressionFromObjectiveC (chip_tests_config_get_default_value definedValue) type}}];


### PR DESCRIPTION
We were never looking at the config if the type was string.

Fixes https://github.com/project-chip/connectedhomeip/issues/23508

