### PR TITLE
examples/Tv Casting library: Checking for defunct session and returning error

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MediaPlaybackFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MediaPlaybackFragment.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 import com.chip.casting.ContentApp;
 import com.chip.casting.FailureCallback;
 import com.chip.casting.MatterError;
@@ -68,16 +69,18 @@ public class MediaPlaybackFragment extends Fragment {
                       TAG,
                       "handle() called on SuccessCallback<MediaPlaybackResponseTypes.PlaybackStateEnum> with "
                           + playbackStateEnum);
-                  getActivity()
-                      .runOnUiThread(
-                          new Runnable() {
-                            @Override
-                            public void run() {
-                              if (playbackStateEnum != null) {
-                                currentStateValue.setText(playbackStateEnum.toString());
-                              }
+                  FragmentActivity fragmentActivity = getActivity();
+                  if (fragmentActivity != null) {
+                    fragmentActivity.runOnUiThread(
+                        new Runnable() {
+                          @Override
+                          public void run() {
+                            if (playbackStateEnum != null) {
+                              currentStateValue.setText(playbackStateEnum.toString());
                             }
-                          });
+                          }
+                        });
+                  }
                 };
 
             FailureCallback failureCallback =
@@ -85,14 +88,16 @@ public class MediaPlaybackFragment extends Fragment {
                   @Override
                   public void handle(MatterError matterError) {
                     Log.d(TAG, "handle() called on FailureCallback with " + matterError);
-                    getActivity()
-                        .runOnUiThread(
-                            new Runnable() {
-                              @Override
-                              public void run() {
-                                currentStateValue.setText("Error!");
-                              }
-                            });
+                    FragmentActivity fragmentActivity = getActivity();
+                    if (fragmentActivity != null) {
+                      fragmentActivity.runOnUiThread(
+                          new Runnable() {
+                            @Override
+                            public void run() {
+                              currentStateValue.setText("Error!");
+                            }
+                          });
+                    }
                   }
                 };
 
@@ -100,14 +105,16 @@ public class MediaPlaybackFragment extends Fragment {
                 (SubscriptionEstablishedCallback)
                     () -> {
                       Log.d(TAG, "handle() called on SubscriptionEstablishedCallback");
-                      getActivity()
-                          .runOnUiThread(
-                              new Runnable() {
-                                @Override
-                                public void run() {
-                                  subscriptionStatus.setText("Subscription established!");
-                                }
-                              });
+                      FragmentActivity fragmentActivity = getActivity();
+                      if (fragmentActivity != null) {
+                        fragmentActivity.runOnUiThread(
+                            new Runnable() {
+                              @Override
+                              public void run() {
+                                subscriptionStatus.setText("Subscription established!");
+                              }
+                            });
+                      }
                     };
 
             boolean retVal =

--- a/examples/tv-casting-app/tv-casting-common/include/MediaCommandBase.h
+++ b/examples/tv-casting-app/tv-casting-common/include/MediaCommandBase.h
@@ -29,10 +29,14 @@ public:
 
     CHIP_ERROR Invoke(RequestType request, std::function<void(CHIP_ERROR)> responseCallback)
     {
-        VerifyOrDieWithMsg(mTargetVideoPlayerInfo != nullptr, AppServer, "Target unknown");
+        ReturnErrorCodeIf(mTargetVideoPlayerInfo == nullptr, CHIP_ERROR_PEER_NODE_NOT_FOUND);
 
         auto deviceProxy = mTargetVideoPlayerInfo->GetOperationalDeviceProxy();
         ReturnErrorCodeIf(deviceProxy == nullptr || !deviceProxy->ConnectionReady(), CHIP_ERROR_PEER_NODE_NOT_FOUND);
+        ReturnErrorCodeIf(!deviceProxy->GetSecureSession().HasValue(), CHIP_ERROR_MISSING_SECURE_SESSION);
+        const chip::SessionHandle & sessionHandle = deviceProxy->GetSecureSession().Value();
+        ReturnErrorCodeIf(!sessionHandle->IsSecureSession(), CHIP_ERROR_MISSING_SECURE_SESSION);
+        ReturnErrorCodeIf(sessionHandle->AsSecureSession()->IsDefunct(), CHIP_ERROR_CONNECTION_CLOSED_UNEXPECTEDLY);
 
         sResponseCallback = responseCallback;
 

--- a/examples/tv-casting-app/tv-casting-common/include/MediaReadBase.h
+++ b/examples/tv-casting-app/tv-casting-common/include/MediaReadBase.h
@@ -29,10 +29,14 @@ public:
                              chip::Controller::ReadResponseSuccessCallback<typename TypeInfo::DecodableArgType> successFn,
                              chip::Controller::ReadResponseFailureCallback failureFn)
     {
-        VerifyOrDieWithMsg(mTargetVideoPlayerInfo != nullptr, AppServer, "Target unknown");
+        ReturnErrorCodeIf(mTargetVideoPlayerInfo == nullptr, CHIP_ERROR_PEER_NODE_NOT_FOUND);
 
         auto deviceProxy = mTargetVideoPlayerInfo->GetOperationalDeviceProxy();
         ReturnErrorCodeIf(deviceProxy == nullptr || !deviceProxy->ConnectionReady(), CHIP_ERROR_PEER_NODE_NOT_FOUND);
+        ReturnErrorCodeIf(!deviceProxy->GetSecureSession().HasValue(), CHIP_ERROR_MISSING_SECURE_SESSION);
+        const chip::SessionHandle & sessionHandle = deviceProxy->GetSecureSession().Value();
+        ReturnErrorCodeIf(!sessionHandle->IsSecureSession(), CHIP_ERROR_MISSING_SECURE_SESSION);
+        ReturnErrorCodeIf(sessionHandle->AsSecureSession()->IsDefunct(), CHIP_ERROR_CONNECTION_CLOSED_UNEXPECTEDLY);
 
         MediaClusterBase cluster(*deviceProxy->GetExchangeManager(), deviceProxy->GetSecureSession().Value(), mClusterId,
                                  mTvEndpoint);

--- a/examples/tv-casting-app/tv-casting-common/include/MediaSubscriptionBase.h
+++ b/examples/tv-casting-app/tv-casting-common/include/MediaSubscriptionBase.h
@@ -30,10 +30,14 @@ public:
                                   chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval,
                                   uint16_t maxInterval, chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished)
     {
-        VerifyOrDieWithMsg(mTargetVideoPlayerInfo != nullptr, AppServer, "Target unknown");
+        ReturnErrorCodeIf(mTargetVideoPlayerInfo == nullptr, CHIP_ERROR_PEER_NODE_NOT_FOUND);
 
         auto deviceProxy = mTargetVideoPlayerInfo->GetOperationalDeviceProxy();
         ReturnErrorCodeIf(deviceProxy == nullptr || !deviceProxy->ConnectionReady(), CHIP_ERROR_PEER_NODE_NOT_FOUND);
+        ReturnErrorCodeIf(!deviceProxy->GetSecureSession().HasValue(), CHIP_ERROR_MISSING_SECURE_SESSION);
+        const chip::SessionHandle & sessionHandle = deviceProxy->GetSecureSession().Value();
+        ReturnErrorCodeIf(!sessionHandle->IsSecureSession(), CHIP_ERROR_MISSING_SECURE_SESSION);
+        ReturnErrorCodeIf(sessionHandle->AsSecureSession()->IsDefunct(), CHIP_ERROR_CONNECTION_CLOSED_UNEXPECTEDLY);
 
         MediaClusterBase cluster(*deviceProxy->GetExchangeManager(), deviceProxy->GetSecureSession().Value(), mClusterId,
                                  mTvEndpoint);


### PR DESCRIPTION
Fixes #23576

#### Problem
1. Connect Android/iOS/Linux tv-casting-app with a TV
2. Subscribe to any attribute on the TV
3. If the above subscription leads to the current session being marked as Defunct, send a command (play/pause/etc) from the tv-casting-app to the TV

Actual: tv-casting-app will crash. 
Expected: It should show an error to the user.

#### Change summary
Added conditions before attempting to send a command/read/subscription request to check if the session is defunct or non-existent and return an error as appropriate.

#### Testing
Tested with the Android tv-casting-app running against the Linux tv-app.