### PR TITLE
[cloudbuild] Add build config file for code coverage

### DIFF
--- a/integrations/cloudbuild/build-coverage.yaml
+++ b/integrations/cloudbuild/build-coverage.yaml
@@ -1,0 +1,55 @@
+steps:
+    - name: gcr.io/cloud-builders/git
+      args:
+          - submodule
+          - update
+          - "--init"
+          - "--recursive"
+      id: Submodules
+
+    - name: "connectedhomeip/chip-build-vscode:0.6.06"
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
+          - "-c"
+          - source ./scripts/bootstrap.sh
+      id: Bootstrap
+      waitFor:
+          - Submodules
+      entrypoint: /usr/bin/bash
+      volumes:
+          - name: pwenv
+            path: /pwenv
+      timeout: 900s
+
+    - name: "connectedhomeip/chip-build-vscode:0.6.06"
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
+          - "-c"
+          - ./scripts/build_coverage.sh
+      id: BuildCoverage
+      waitFor:
+          - Bootstrap
+      entrypoint: /usr/bin/bash
+      volumes:
+          - name: pwenv
+            path: /pwenv
+      timeout: 900s
+
+logsBucket: matter-build-automation-build-logs
+
+# Global timeout for all steps
+timeout: 21600s
+queueTtl: 21600s
+
+artifacts:
+    objects:
+        location: "gs://matter-build-automation-artifacts/$PROJECT_ID/$COMMIT_SHA/"        
+        paths: ["/out/coverage/coverage/coverage_html.tar.gz"]
+
+# Using higher CPU machines generally speeds up builds, except bootstrap is always
+# slow.
+options:
+    machineType: "E2_HIGHCPU_32"
+    diskSizeGb: 500

--- a/scripts/build_coverage.sh
+++ b/scripts/build_coverage.sh
@@ -168,3 +168,5 @@ lcov --initial --capture --directory "$OUTPUT_ROOT/obj/src" --exclude="$PWD"/zzz
 lcov --capture --directory "$OUTPUT_ROOT/obj/src" --exclude="$PWD"/zzz_generated/* --exclude="$PWD"/third_party/* --exclude=/usr/include/* --output-file "$COVERAGE_ROOT/lcov_test.info"
 lcov --add-tracefile "$COVERAGE_ROOT/lcov_base.info" --add-tracefile "$COVERAGE_ROOT/lcov_test.info" --output-file "$COVERAGE_ROOT/lcov_final.info"
 genhtml "$COVERAGE_ROOT/lcov_final.info" --output-directory "$COVERAGE_ROOT/html"
+
+tar czvf "$COVERAGE_ROOT/coverage_html.tar.gz" -C "$COVERAGE_ROOT/html" .


### PR DESCRIPTION
Add build config file for code coverage, this build config file could be used to execute a build on google cloud, and produce the coverage report artifact.



