### PR TITLE
Update the RegulatoryLocation and LocationCapability get and set logic

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -227,7 +227,7 @@ menu "CHIP Device Layer"
             default 25
             help
                 The maximum number of events that can be held in the CHIP Platform event queue.
-        
+
         config ENABLE_EXTENDED_DISCOVERY
             bool "Enable Extended discovery Support"
             default n
@@ -474,7 +474,7 @@ menu "CHIP Device Layer"
         config USE_BLE_ONLY_FOR_COMMISSIONING
 	    bool "Use BLE only for commissioning"
 	    default y
-	    help 
+	    help
             Disable this flag if BLE is used for any other purpose than commissioning.
             When enabled, it deinitialized the BLE on successful commissioning, and on
             bootup do not initialize the BLE if device is already provisioned with Wi-Fi/Thread credentials.
@@ -656,6 +656,13 @@ menu "CHIP Device Layer"
                 Use ESP32 Device Info Provider to get device instance info from factory partition.
                 Details like Supported calendar types, supported locales, and fixed labels will be read from factory
                 partition.
+
+        config ENABLE_ESP32_LOCATIONCAPABILITY
+            depends on ENABLE_ESP32_FACTORY_DATA_PROVIDER
+            bool "Enable ESP32 Device LocationCapability "
+            default n
+            help
+                Enable ESP32 Device LocationCapability
 
     endmenu
 
@@ -850,7 +857,7 @@ menu "CHIP Device Layer"
             default "nvs"
             help
                 Label of the partition to store key-values in the "chip-counters" namespace.
-        
+
         config CHIP_KVS_NAMESPACE_PARTITION_LABEL
             string "chip-kvs namespace partition label"
             default "nvs"

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -423,7 +423,22 @@ void GenericConfigurationManagerImpl<ImplClass>::NotifyOfAdvertisementStart()
 template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetRegulatoryLocation(uint8_t & location)
 {
-    return GetLocationCapability(location);
+    uint32_t value;
+    if (CHIP_NO_ERROR != ReadConfigValue(ConfigClass::kConfigKey_RegulatoryLocation, value))
+    {
+        ReturnErrorOnFailure(GetLocationCapability(location));
+
+        if (CHIP_NO_ERROR != StoreRegulatoryLocation(location))
+        {
+            ChipLogError(DeviceLayer, "Failed to store RegulatoryLocation");
+        }
+    }
+    else
+    {
+        location = static_cast<uint8_t>(value);
+    }
+
+    return CHIP_NO_ERROR;
 }
 
 template <class ConfigClass>

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -159,6 +159,20 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     // TODO: Initialize the global GroupKeyStore object here (#1266)
 
+     if (!ESP32Config::ConfigValueExists(ESP32Config::kConfigKey_RegulatoryLocation))
+    {
+        uint32_t location = to_underlying(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoor);
+        err = WriteConfigValue(ESP32Config::kConfigKey_RegulatoryLocation, location);
+        SuccessOrExit(err);
+    }
+
+    if (!ESP32Config::ConfigValueExists(ESP32Config::kConfigKey_LocationCapability))
+    {
+        uint32_t location = to_underlying(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoor);
+        err = WriteConfigValue(ESP32Config::kConfigKey_LocationCapability, location);
+        SuccessOrExit(err);
+    }
+
     err = CHIP_NO_ERROR;
 
 exit:
@@ -199,6 +213,40 @@ CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersion(uint32_t & softwareVer)
 {
     softwareVer = CHIP_CONFIG_SOFTWARE_VERSION_NUMBER;
     return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetRegulatoryLocation(uint8_t & location)
+{
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
+    uint32_t value = 0;
+
+    CHIP_ERROR err = ReadConfigValue(ESP32Config::kConfigKey_RegulatoryLocation, value);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(value <= UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        location = static_cast<uint8_t>(value);
+    }
+
+    return err;
+#endif // CHIP_DISABLE_PLATFORM_KVS
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetLocationCapability(uint8_t & location)
+{
+    uint32_t value = 0;
+
+    CHIP_ERROR err = ReadConfigValue(ESP32Config::kConfigKey_LocationCapability, value);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(value <= UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        location = static_cast<uint8_t>(value);
+    }
+
+    return err;
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -159,20 +159,6 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     // TODO: Initialize the global GroupKeyStore object here (#1266)
 
-     if (!ESP32Config::ConfigValueExists(ESP32Config::kConfigKey_RegulatoryLocation))
-    {
-        uint32_t location = to_underlying(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoor);
-        err = WriteConfigValue(ESP32Config::kConfigKey_RegulatoryLocation, location);
-        SuccessOrExit(err);
-    }
-
-    if (!ESP32Config::ConfigValueExists(ESP32Config::kConfigKey_LocationCapability))
-    {
-        uint32_t location = to_underlying(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoor);
-        err = WriteConfigValue(ESP32Config::kConfigKey_LocationCapability, location);
-        SuccessOrExit(err);
-    }
-
     err = CHIP_NO_ERROR;
 
 exit:
@@ -215,29 +201,10 @@ CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersion(uint32_t & softwareVer)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::GetRegulatoryLocation(uint8_t & location)
-{
-#if CHIP_DISABLE_PLATFORM_KVS
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#else  // CHIP_DISABLE_PLATFORM_KVS
-    uint32_t value = 0;
-
-    CHIP_ERROR err = ReadConfigValue(ESP32Config::kConfigKey_RegulatoryLocation, value);
-
-    if (err == CHIP_NO_ERROR)
-    {
-        VerifyOrReturnError(value <= UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
-        location = static_cast<uint8_t>(value);
-    }
-
-    return err;
-#endif // CHIP_DISABLE_PLATFORM_KVS
-}
-
 CHIP_ERROR ConfigurationManagerImpl::GetLocationCapability(uint8_t & location)
 {
+#if CONFIG_ENABLE_ESP32_LOCATIONCAPABILITY
     uint32_t value = 0;
-
     CHIP_ERROR err = ReadConfigValue(ESP32Config::kConfigKey_LocationCapability, value);
 
     if (err == CHIP_NO_ERROR)
@@ -247,6 +214,10 @@ CHIP_ERROR ConfigurationManagerImpl::GetLocationCapability(uint8_t & location)
     }
 
     return err;
+#else
+    location = static_cast<uint8_t>(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoor);
+    return CHIP_NO_ERROR;
+#endif
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -55,6 +55,8 @@ public:
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override;
     CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize);
     CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override;
+    CHIP_ERROR GetRegulatoryLocation(uint8_t & location) override;
+    CHIP_ERROR GetLocationCapability(uint8_t & location) override;
     static ConfigurationManagerImpl & GetDefaultInstance();
 
 private:

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -55,7 +55,6 @@ public:
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override;
     CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize);
     CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override;
-    CHIP_ERROR GetRegulatoryLocation(uint8_t & location) override;
     CHIP_ERROR GetLocationCapability(uint8_t & location) override;
     static ConfigurationManagerImpl & GetDefaultInstance();
 

--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -77,6 +77,7 @@ const ESP32Config::Key ESP32Config::kConfigKey_ProductURL            = { kConfig
 const ESP32Config::Key ESP32Config::kConfigKey_SupportedCalTypes     = { kConfigNamespace_ChipFactory, "cal-types" };
 const ESP32Config::Key ESP32Config::kConfigKey_SupportedLocaleSize   = { kConfigNamespace_ChipFactory, "locale-sz" };
 const ESP32Config::Key ESP32Config::kConfigKey_RotatingDevIdUniqueId = { kConfigNamespace_ChipFactory, "rd-id-uid" };
+const ESP32Config::Key ESP32Config::kConfigKey_LocationCapability    = { kConfigNamespace_ChipFactory, "loc-capability" };
 
 // Keys stored in the chip-config namespace
 const ESP32Config::Key ESP32Config::kConfigKey_ServiceConfig      = { kConfigNamespace_ChipConfig, "service-config" };
@@ -86,7 +87,6 @@ const ESP32Config::Key ESP32Config::kConfigKey_LastUsedEpochKeyId = { kConfigNam
 const ESP32Config::Key ESP32Config::kConfigKey_FailSafeArmed      = { kConfigNamespace_ChipConfig, "fail-safe-armed" };
 const ESP32Config::Key ESP32Config::kConfigKey_WiFiStationSecType = { kConfigNamespace_ChipConfig, "sta-sec-type" };
 const ESP32Config::Key ESP32Config::kConfigKey_RegulatoryLocation = { kConfigNamespace_ChipConfig, "reg-location" };
-const ESP32Config::Key ESP32Config::kConfigKey_LocationCapability = { kConfigNamespace_ChipConfig, "loc-capability"};
 const ESP32Config::Key ESP32Config::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const ESP32Config::Key ESP32Config::kConfigKey_UniqueId           = { kConfigNamespace_ChipConfig, "unique-id" };
 

--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -86,6 +86,7 @@ const ESP32Config::Key ESP32Config::kConfigKey_LastUsedEpochKeyId = { kConfigNam
 const ESP32Config::Key ESP32Config::kConfigKey_FailSafeArmed      = { kConfigNamespace_ChipConfig, "fail-safe-armed" };
 const ESP32Config::Key ESP32Config::kConfigKey_WiFiStationSecType = { kConfigNamespace_ChipConfig, "sta-sec-type" };
 const ESP32Config::Key ESP32Config::kConfigKey_RegulatoryLocation = { kConfigNamespace_ChipConfig, "reg-location" };
+const ESP32Config::Key ESP32Config::kConfigKey_LocationCapability = { kConfigNamespace_ChipConfig, "loc-capability"};
 const ESP32Config::Key ESP32Config::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const ESP32Config::Key ESP32Config::kConfigKey_UniqueId           = { kConfigNamespace_ChipConfig, "unique-id" };
 

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -88,6 +88,7 @@ public:
     static const Key kConfigKey_FailSafeArmed;
     static const Key kConfigKey_WiFiStationSecType;
     static const Key kConfigKey_RegulatoryLocation;
+    static const Key kConfigKey_LocationCapability;
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_UniqueId;
 

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -79,6 +79,7 @@ public:
     static const Key kConfigKey_SupportedCalTypes;
     static const Key kConfigKey_SupportedLocaleSize;
     static const Key kConfigKey_RotatingDevIdUniqueId;
+    static const Key kConfigKey_LocationCapability;
 
     // CHIP Config keys
     static const Key kConfigKey_ServiceConfig;
@@ -88,7 +89,6 @@ public:
     static const Key kConfigKey_FailSafeArmed;
     static const Key kConfigKey_WiFiStationSecType;
     static const Key kConfigKey_RegulatoryLocation;
-    static const Key kConfigKey_LocationCapability;
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_UniqueId;
 


### PR DESCRIPTION
Currently interfaces for get and set RegulatoryLocation,   LocationCapability are uncorrectly, the value we read out is not what we write but a fixed value, so I changed the logic according to spec.

In this PR
1. Add macro CONFIG_ENABLE_ESP32_LOCATIONCAPABILITY to enable or disable read LocationCapability from flash.
2. Add kConfigKey_LocationCapability defination into ChipFactory namespace.
3. Get RegulatoryLocation from flash instead of fixed  value.

fix  #23580: 

