### PR TITLE
[cloudbuild] Fix TestInetEndPoint failure in GCP cloudbuild

### DIFF
--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -265,6 +265,13 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_IN_USE(System::Stats::kInetLayer_NumUDPEps, 1));
 
     err = InterfaceId::Null().GetLinkLocalAddr(&addr);
+
+    // We should skip the following checks if the interface does not have the Link local address
+    if (err == INET_ERROR_ADDRESS_NOT_FOUND)
+    {
+        return;
+    }
+
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     intId = InterfaceId::FromIPAddress(addr);
     NL_TEST_ASSERT(inSuite, intId.IsPresent());


### PR DESCRIPTION
TestInetEndPoint test failed in GCP cloudbuild.

```
INF Test 1/1: [ RUN] TestInetEndPoint
ERR ../../third_party/pigweed/repo/targets/host/run_test exited with status 255
OUT [7918]
'#0:','inet-endpoint'
'#2:','Setup                          ','PASSED'
'#3:','InetEndPoint::PreTest          ','PASSED'
'#3:','InetEndPoint::TestInetError    ','PASSED'
    Interfaces:
     interface id: 0x1, interface name: lo, interface state: UP, no multicast, no broadcast addr
     interface id: 0x13, interface name: eth0, interface state: UP, supports multicast, has broadcast addr
    Addresses:
     127.0.0.1/8, interface id: 0x1, interface name: lo, interface state: UP, no multicast, no broadcast addr
     192.168.10.2/24, interface id: 0x13, interface name: eth0, interface state: UP, supports multicast, has broadcast addr
'#3:','InetEndPoint::TestInetInterface','PASSED'
../../src/inet/tests/TestInetEndPoint.cpp:273: assertion failed: "err == CHIP_NO_ERROR"
../../src/inet/tests/TestInetEndPoint.cpp:275: assertion failed: "intId.IsPresent()"
'#3:','InetEndPoint::TestInetEndPoint ','FAILED'
'#4:','Teardown                       ','PASSED'
'#6:','1','4'
'#7:','2','74'
INF Test 1/1: [FAIL] TestInetEndPoint
```
It looks certain interfaces on cloudbuild docker does not have local address, we should skip the following local address checks for those interfaces if the local address is not available on the platform.

