### PR TITLE
[EFR32] 70A board bring up configuration changes

### DIFF
--- a/examples/platform/efr32/rs911x/hal/rsi_board_configuration.h
+++ b/examples/platform/efr32/rs911x/hal/rsi_board_configuration.h
@@ -28,7 +28,8 @@ typedef struct
     (rsi_pin_t) { .port = gpioPort##port_id, .pin = pin_id }
 
 #if defined(EFR32MG12_BRD4161A) || defined(BRD4161A) || defined(EFR32MG12_BRD4162A) || defined(BRD4162A) ||                        \
-    defined(EFR32MG12_BRD4163A) || defined(BRD4163A) || defined(EFR32MG12_BRD4164A) || defined(BRD4164A) || defined(EFR32MG12_BRD4170A) || defined(BRD4170A)
+    defined(EFR32MG12_BRD4163A) || defined(BRD4163A) || defined(EFR32MG12_BRD4164A) || defined(BRD4164A) ||                        \
+    defined(EFR32MG12_BRD4170A) || defined(BRD4170A)
 // BRD4161-63-64 are pin to pin compatible for SPI
 #include "brd4161a.h"
 #elif defined(EFR32MG24_BRD4186C) || defined(BRD4186C)

--- a/examples/platform/efr32/rs911x/hal/rsi_board_configuration.h
+++ b/examples/platform/efr32/rs911x/hal/rsi_board_configuration.h
@@ -28,7 +28,7 @@ typedef struct
     (rsi_pin_t) { .port = gpioPort##port_id, .pin = pin_id }
 
 #if defined(EFR32MG12_BRD4161A) || defined(BRD4161A) || defined(EFR32MG12_BRD4162A) || defined(BRD4162A) ||                        \
-    defined(EFR32MG12_BRD4163A) || defined(BRD4163A) || defined(EFR32MG12_BRD4164A) || defined(BRD4164A)
+    defined(EFR32MG12_BRD4163A) || defined(BRD4163A) || defined(EFR32MG12_BRD4164A) || defined(BRD4164A) || defined(EFR32MG12_BRD4170A) || defined(BRD4170A)
 // BRD4161-63-64 are pin to pin compatible for SPI
 #include "brd4161a.h"
 #elif defined(EFR32MG24_BRD4186C) || defined(BRD4186C)

--- a/examples/platform/efr32/wf200/sl_wfx_board.h
+++ b/examples/platform/efr32/wf200/sl_wfx_board.h
@@ -21,7 +21,8 @@
  * Pull in the right board PINS
  */
 #if defined(EFR32MG12_BRD4161A) || defined(BRD4161A) || defined(EFR32MG12_BRD4162A) || defined(BRD4162A) ||                        \
-    defined(EFR32MG12_BRD4163A) || defined(BRD4163A) || defined(EFR32MG12_BRD4164A) || defined(BRD4164A) || defined(EFR32MG12_BRD4170A) || defined(BRD4170A)
+    defined(EFR32MG12_BRD4163A) || defined(BRD4163A) || defined(EFR32MG12_BRD4164A) || defined(BRD4164A) ||                        \
+    defined(EFR32MG12_BRD4170A) || defined(BRD4170A)
 #include "brd4161a.h"
 #elif defined(EFR32MG24_BRD4186C) || defined(BRD4186C) || defined(EFR32MG24_BRD4186A) || defined(BRD4186A)
 #include "brd4186c.h"

--- a/examples/platform/efr32/wf200/sl_wfx_board.h
+++ b/examples/platform/efr32/wf200/sl_wfx_board.h
@@ -21,7 +21,7 @@
  * Pull in the right board PINS
  */
 #if defined(EFR32MG12_BRD4161A) || defined(BRD4161A) || defined(EFR32MG12_BRD4162A) || defined(BRD4162A) ||                        \
-    defined(EFR32MG12_BRD4163A) || defined(BRD4163A) || defined(EFR32MG12_BRD4164A) || defined(BRD4164A)
+    defined(EFR32MG12_BRD4163A) || defined(BRD4163A) || defined(EFR32MG12_BRD4164A) || defined(BRD4164A) || defined(EFR32MG12_BRD4170A) || defined(BRD4170A)
 #include "brd4161a.h"
 #elif defined(EFR32MG24_BRD4186C) || defined(BRD4186C) || defined(EFR32MG24_BRD4186A) || defined(BRD4186A)
 #include "brd4186c.h"


### PR DESCRIPTION
Problem / Feature
What is being fixed? 
70A board bring up

What is the feature being added? Examples:
This PR adds 70A board configuration changes for WF200 and RS911x.

How was this tested?
Manually Tested below scenario's

- Build is successful.
- Commissioning is successful
- Sanity completed with MG12-70A with RS9116 and WF200 on one application (Lighting App).