### PR TITLE
[linux]: Use LocationCapability if GetRegulatoryLocation fail

### DIFF
--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -369,17 +369,19 @@ CHIP_ERROR ConfigurationManagerImpl::StoreBootReason(uint32_t bootReason)
 
 CHIP_ERROR ConfigurationManagerImpl::GetRegulatoryLocation(uint8_t & location)
 {
-    uint32_t value = 0;
+    uint32_t value;
 
-    CHIP_ERROR err = ReadConfigValue(PosixConfig::kConfigKey_RegulatoryLocation, value);
-
-    if (err == CHIP_NO_ERROR)
+    if (CHIP_NO_ERROR != ReadConfigValue(ConfigClass::kConfigKey_RegulatoryLocation, value))
     {
-        VerifyOrReturnError(value <= UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        ReturnErrorOnFailure(GetLocationCapability(location));
+        StoreRegulatoryLocation(location);
+    }
+    else
+    {
         location = static_cast<uint8_t>(value);
     }
 
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetLocationCapability(uint8_t & location)

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -371,10 +371,14 @@ CHIP_ERROR ConfigurationManagerImpl::GetRegulatoryLocation(uint8_t & location)
 {
     uint32_t value;
 
-    if (CHIP_NO_ERROR != ReadConfigValue(ConfigClass::kConfigKey_RegulatoryLocation, value))
+    if (CHIP_NO_ERROR != ReadConfigValue(PosixConfig::kConfigKey_RegulatoryLocation, value))
     {
         ReturnErrorOnFailure(GetLocationCapability(location));
-        StoreRegulatoryLocation(location);
+
+        if (CHIP_NO_ERROR != StoreRegulatoryLocation(location))
+        {
+            ChipLogError(DeviceLayer, "Failed to store RegulatoryLocation");
+        }
     }
     else
     {


### PR DESCRIPTION
See https://github.com/project-chip/connectedhomeip/pull/23579, this is similar change for Linux platform, per spec, we should use the value of LocationCapability as RegulatoryLocation if GetRegulatoryLocation fail.
