### PR TITLE
Fix Logging When Trying to Log Nullptr To Strings

### DIFF
--- a/src/app/tests/suites/credentials/TestHarnessDACProvider.cpp
+++ b/src/app/tests/suites/credentials/TestHarnessDACProvider.cpp
@@ -147,7 +147,7 @@ void TestHarnessDACProvider::Init(const char * filepath)
     std::ifstream json(filepath, std::ifstream::binary);
     if (!json)
     {
-        ChipLogError(AppServer, "Error opening json file: %s", filepath);
+        ChipLogError(AppServer, "Error opening json file: %s", StringOrNullMarker(filepath));
         return;
     }
 
@@ -155,7 +155,7 @@ void TestHarnessDACProvider::Init(const char * filepath)
     Json::Value root;
     if (!reader.parse(json, root))
     {
-        ChipLogError(AppServer, "Error parsing json file: %s", filepath);
+        ChipLogError(AppServer, "Error parsing json file: %s", StringOrNullMarker(filepath));
         return;
     }
 

--- a/src/app/tests/suites/include/ConstraintsChecker.h
+++ b/src/app/tests/suites/include/ConstraintsChecker.h
@@ -46,7 +46,8 @@ protected:
 
     bool CheckConstraintFormat(const char * itemName, const char * current, const char * expected)
     {
-        ChipLogError(chipTool, "Warning: %s format checking is not implemented yet. Expected format: '%s'", itemName, expected);
+        ChipLogError(chipTool, "Warning: %s format checking is not implemented yet. Expected format: '%s'",
+                     StringOrNullMarker(itemName), StringOrNullMarker(expected));
         return true;
     }
 

--- a/src/app/tests/suites/include/PICSChecker.h
+++ b/src/app/tests/suites/include/PICSChecker.h
@@ -40,7 +40,7 @@ public:
         bool shouldSkip = !PICSBooleanExpressionParser::Eval(expression, pics);
         if (shouldSkip)
         {
-            ChipLogProgress(chipTool, " **** Skipping: %s == false\n", expression);
+            ChipLogProgress(chipTool, " **** Skipping: %s == false\n", StringOrNullMarker(expression));
         }
         return shouldSkip;
     }

--- a/src/app/tests/suites/include/TestRunner.h
+++ b/src/app/tests/suites/include/TestRunner.h
@@ -30,11 +30,11 @@ public:
     TestRunner(const char * name, uint16_t testCount) : mTestName(name), mTestCount(testCount), mTestIndex(0) {}
     virtual ~TestRunner(){};
 
-    void LogStart() { ChipLogProgress(chipTool, " ***** Test Start : %s\n", mTestName); }
+    void LogStart() { ChipLogProgress(chipTool, " ***** Test Start : %s\n", StringOrNullMarker(mTestName)); }
 
     void LogStep(uint32_t stepNumber, const char * stepName)
     {
-        ChipLogProgress(chipTool, " ***** Test Step %u : %s\n", stepNumber, stepName);
+        ChipLogProgress(chipTool, " ***** Test Step %u : %s\n", stepNumber, StringOrNullMarker(stepName));
     }
 
     void LogEnd(std::string message, CHIP_ERROR err)

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -649,7 +649,7 @@ void AndroidDeviceControllerWrapper::OnScanNetworksFailure(CHIP_ERROR error)
 
 CHIP_ERROR AndroidDeviceControllerWrapper::SyncGetKeyValue(const char * key, void * value, uint16_t & size)
 {
-    ChipLogProgress(chipTool, "KVS: Getting key %s", key);
+    ChipLogProgress(chipTool, "KVS: Getting key %s", StringOrNullMarker(key));
 
     size_t read_size = 0;
 
@@ -662,12 +662,12 @@ CHIP_ERROR AndroidDeviceControllerWrapper::SyncGetKeyValue(const char * key, voi
 
 CHIP_ERROR AndroidDeviceControllerWrapper::SyncSetKeyValue(const char * key, const void * value, uint16_t size)
 {
-    ChipLogProgress(chipTool, "KVS: Setting key %s", key);
+    ChipLogProgress(chipTool, "KVS: Setting key %s", StringOrNullMarker(key));
     return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Put(key, value, size);
 }
 
 CHIP_ERROR AndroidDeviceControllerWrapper::SyncDeleteKeyValue(const char * key)
 {
-    ChipLogProgress(chipTool, "KVS: Deleting key %s", key);
+    ChipLogProgress(chipTool, "KVS: Deleting key %s", StringOrNullMarker(key));
     return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key);
 }

--- a/src/controller/python/ChipDeviceController-StorageDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.cpp
@@ -1,7 +1,6 @@
-
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,7 +57,7 @@ CHIP_ERROR PythonPersistentStorageDelegate::SyncGetKeyValue(const char * key, vo
 CHIP_ERROR PythonPersistentStorageDelegate::SyncSetKeyValue(const char * key, const void * value, uint16_t size)
 {
     mStorage[key] = std::string(static_cast<const char *>(value), size);
-    ChipLogDetail(Controller, "SyncSetKeyValue on %s", key);
+    ChipLogDetail(Controller, "SyncSetKeyValue on %s", StringOrNullMarker(key));
 
     return CHIP_NO_ERROR;
 }
@@ -79,7 +78,7 @@ namespace Python {
 
 CHIP_ERROR StorageAdapter::SyncGetKeyValue(const char * key, void * value, uint16_t & size)
 {
-    ChipLogDetail(Controller, "StorageAdapter::GetKeyValue: Key = %s, Value = %p (%u)", key, value, size);
+    ChipLogDetail(Controller, "StorageAdapter::GetKeyValue: Key = %s, Value = %p (%u)", StringOrNullMarker(key), value, size);
     if ((value == nullptr) && (size != 0))
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -109,7 +108,7 @@ CHIP_ERROR StorageAdapter::SyncGetKeyValue(const char * key, void * value, uint1
 CHIP_ERROR StorageAdapter::SyncSetKeyValue(const char * key, const void * value, uint16_t size)
 {
     ReturnErrorCodeIf(((value == nullptr) && (size != 0)), CHIP_ERROR_INVALID_ARGUMENT);
-    ChipLogDetail(Controller, "StorageAdapter::SetKeyValue: Key = %s, Value = %p (%u)", key, value, size);
+    ChipLogDetail(Controller, "StorageAdapter::SetKeyValue: Key = %s, Value = %p (%u)", StringOrNullMarker(key), value, size);
     mSetKeyCb(mContext, key, value, size);
     return CHIP_NO_ERROR;
 }
@@ -124,7 +123,7 @@ CHIP_ERROR StorageAdapter::SyncDeleteKeyValue(const char * key)
         return err;
     }
 
-    ChipLogDetail(Controller, "StorageAdapter::DeleteKeyValue: Key = %s", key);
+    ChipLogDetail(Controller, "StorageAdapter::DeleteKeyValue: Key = %s", StringOrNullMarker(key));
     mDeleteKeyCb(mContext, key);
     return CHIP_NO_ERROR;
 }

--- a/src/credentials/LastKnownGoodTime.cpp
+++ b/src/credentials/LastKnownGoodTime.cpp
@@ -44,7 +44,7 @@ void LastKnownGoodTime::LogTime(const char * msg, System::Clock::Seconds32 chipE
     uint8_t second;
     ChipEpochToCalendarTime(chipEpochTime.count(), year, month, day, hour, minute, second);
     snprintf(buf, sizeof(buf), "%04u-%02u-%02uT%02u:%02u:%02u", year, month, day, hour, minute, second);
-    ChipLogProgress(TimeService, "%s%s", msg, buf);
+    ChipLogProgress(TimeService, "%s%s", StringOrNullMarker(msg), buf);
 }
 
 CHIP_ERROR LastKnownGoodTime::LoadLastKnownGoodChipEpochTime(System::Clock::Seconds32 & lastKnownGoodChipEpochTime) const

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -115,7 +115,8 @@ static void _logSSLError()
         const char * err_str_reason  = ERR_reason_error_string(static_cast<libssl_err_type>(ssl_err_code));
         if (err_str_lib)
         {
-            ChipLogError(Crypto, " ssl err  %s %s %s\n", err_str_lib, err_str_routine, err_str_reason);
+            ChipLogError(Crypto, " ssl err  %s %s %s\n", StringOrNullMarker(err_str_lib), StringOrNullMarker(err_str_routine),
+                         StringOrNullMarker(err_str_reason));
         }
 #endif // CHIP_ERROR_LOGGING
         ssl_err_code = ERR_get_error();

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -531,7 +531,8 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
 
     AdvertiseRecords(BroadcastAdvertiseType::kStarted);
 
-    ChipLogProgress(Discovery, "mDNS service published: %s.%s", instanceName.names[1], instanceName.names[2]);
+    ChipLogProgress(Discovery, "mDNS service published: %s.%s", StringOrNullMarker(instanceName.names[1]),
+                    StringOrNullMarker(instanceName.names[2]));
 
     return CHIP_NO_ERROR;
 }
@@ -725,17 +726,18 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const CommissionAdvertisingParameters & 
     if (params.GetCommissionAdvertiseMode() == CommssionAdvertiseMode::kCommissionableNode)
     {
         ChipLogProgress(Discovery, "CHIP minimal mDNS configured as 'Commissionable node device'; instance name: %s.",
-                        instanceName.names[0]);
+                        StringOrNullMarker(instanceName.names[0]));
     }
     else
     {
         ChipLogProgress(Discovery, "CHIP minimal mDNS configured as 'Commissioner device'; instance name: %s.",
-                        instanceName.names[0]);
+                        StringOrNullMarker(instanceName.names[0]));
     }
 
     AdvertiseRecords(BroadcastAdvertiseType::kStarted);
 
-    ChipLogProgress(Discovery, "mDNS service published: %s.%s", instanceName.names[1], instanceName.names[2]);
+    ChipLogProgress(Discovery, "mDNS service published: %s.%s", StringOrNullMarker(instanceName.names[1]),
+                    StringOrNullMarker(instanceName.names[2]));
 
     return CHIP_NO_ERROR;
 }

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -466,7 +466,8 @@ void DiscoveryImplPlatform::HandleDnssdPublish(void * context, const char * type
 {
     if (CHIP_NO_ERROR == error)
     {
-        ChipLogProgress(Discovery, "mDNS service published: %s; instance name: %s", type, instanceName);
+        ChipLogProgress(Discovery, "mDNS service published: %s; instance name: %s", StringOrNullMarker(type),
+                        StringOrNullMarker(instanceName));
     }
     else
     {
@@ -520,12 +521,13 @@ CHIP_ERROR DiscoveryImplPlatform::PublishService(const char * serviceType, TextE
 
     for (size_t i = 0; i < textEntrySize; i++)
     {
-        printf(" entry [%u] : %s %s\n", static_cast<unsigned int>(i), textEntries[i].mKey, (char *) (textEntries[i].mData));
+        printf(" entry [%u] : %s %s\n", static_cast<unsigned int>(i), StringOrNullMarker(textEntries[i].mKey),
+               StringOrNullMarker((char *) (textEntries[i].mData)));
     }
 
     for (size_t i = 0; i < subTypeSize; i++)
     {
-        printf(" type [%u] : %s\n", static_cast<unsigned int>(i), subTypes[i]);
+        printf(" type [%u] : %s\n", static_cast<unsigned int>(i), StringOrNullMarker(subTypes[i]));
     }
 #endif
 

--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -145,7 +145,7 @@ void JniReferences::ReportError(JNIEnv * env, CHIP_ERROR cbErr, const char * fun
 {
     if (cbErr == CHIP_JNI_ERROR_EXCEPTION_THROWN)
     {
-        ChipLogError(Support, "Java exception thrown in %s", functName);
+        ChipLogError(Support, "Java exception thrown in %s", StringOrNullMarker(functName));
         env->ExceptionDescribe();
     }
     else
@@ -166,7 +166,7 @@ void JniReferences::ReportError(JNIEnv * env, CHIP_ERROR cbErr, const char * fun
             errStr = ErrorStr(cbErr);
             break;
         }
-        ChipLogError(Support, "Error in %s : %s", functName, errStr);
+        ChipLogError(Support, "Error in %s : %s", StringOrNullMarker(functName), errStr);
     }
 }
 

--- a/src/lib/support/TestPersistentStorageDelegate.h
+++ b/src/lib/support/TestPersistentStorageDelegate.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,7 +57,7 @@ public:
     {
         if (mLoggingLevel >= LoggingLevel::kLogMutationAndReads)
         {
-            ChipLogDetail(Test, "TestPersistentStorageDelegate::SyncGetKeyValue: Get key '%s'", key);
+            ChipLogDetail(Test, "TestPersistentStorageDelegate::SyncGetKeyValue: Get key '%s'", StringOrNullMarker(key));
         }
 
         CHIP_ERROR err = SyncGetKeyValueInternal(key, buffer, size);
@@ -66,11 +66,13 @@ public:
         {
             if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
             {
-                ChipLogDetail(Test, "--> TestPersistentStorageDelegate::SyncGetKeyValue: Key '%s' not found", key);
+                ChipLogDetail(Test, "--> TestPersistentStorageDelegate::SyncGetKeyValue: Key '%s' not found",
+                              StringOrNullMarker(key));
             }
             else if (err == CHIP_ERROR_PERSISTED_STORAGE_FAILED)
             {
-                ChipLogDetail(Test, "--> TestPersistentStorageDelegate::SyncGetKeyValue: Key '%s' is a poison key", key);
+                ChipLogDetail(Test, "--> TestPersistentStorageDelegate::SyncGetKeyValue: Key '%s' is a poison key",
+                              StringOrNullMarker(key));
             }
         }
 
@@ -91,7 +93,8 @@ public:
         {
             if (err == CHIP_ERROR_PERSISTED_STORAGE_FAILED)
             {
-                ChipLogDetail(Test, "--> TestPersistentStorageDelegate::SyncSetKeyValue: Key '%s' is a poison key", key);
+                ChipLogDetail(Test, "--> TestPersistentStorageDelegate::SyncSetKeyValue: Key '%s' is a poison key",
+                              StringOrNullMarker(key));
             }
         }
 
@@ -102,7 +105,7 @@ public:
     {
         if (mLoggingLevel >= LoggingLevel::kLogMutation)
         {
-            ChipLogDetail(Test, "TestPersistentStorageDelegate::SyncDeleteKeyValue, Delete key '%s'", key);
+            ChipLogDetail(Test, "TestPersistentStorageDelegate::SyncDeleteKeyValue, Delete key '%s'", StringOrNullMarker(key));
         }
         CHIP_ERROR err = SyncDeleteKeyValueInternal(key);
 
@@ -110,11 +113,13 @@ public:
         {
             if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
             {
-                ChipLogDetail(Test, "--> TestPersistentStorageDelegate::SyncDeleteKeyValue: Key '%s' not found", key);
+                ChipLogDetail(Test, "--> TestPersistentStorageDelegate::SyncDeleteKeyValue: Key '%s' not found",
+                              StringOrNullMarker(key));
             }
             else if (err == CHIP_ERROR_PERSISTED_STORAGE_FAILED)
             {
-                ChipLogDetail(Test, "--> TestPersistentStorageDelegate::SyncDeleteKeyValue: Key '%s' is a poison key", key);
+                ChipLogDetail(Test, "--> TestPersistentStorageDelegate::SyncDeleteKeyValue: Key '%s' is a poison key",
+                              StringOrNullMarker(key));
             }
         }
 

--- a/src/platform/Ameba/AmebaConfig.cpp
+++ b/src/platform/Ameba/AmebaConfig.cpp
@@ -104,7 +104,8 @@ CHIP_ERROR AmebaConfig::ReadConfigValue(Key key, bool & val)
 
     success = getPref_bool_new(key.Namespace, key.Name, &intVal);
     if (success != 0)
-        ChipLogProgress(DeviceLayer, "getPref_bool_new: %s/%s failed\n", key.Namespace, key.Name);
+        ChipLogProgress(DeviceLayer, "getPref_bool_new: %s/%s failed\n", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name));
 
     val = (intVal != 0);
 
@@ -120,7 +121,8 @@ CHIP_ERROR AmebaConfig::ReadConfigValue(Key key, uint32_t & val)
 
     success = getPref_u32_new(key.Namespace, key.Name, &val);
     if (success != 0)
-        ChipLogProgress(DeviceLayer, "getPref_u32_new: %s/%s failed\n", key.Namespace, key.Name);
+        ChipLogProgress(DeviceLayer, "getPref_u32_new: %s/%s failed\n", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name));
 
     if (success == 0)
         return CHIP_NO_ERROR;
@@ -134,7 +136,8 @@ CHIP_ERROR AmebaConfig::ReadConfigValue(Key key, uint64_t & val)
 
     success = getPref_u64_new(key.Namespace, key.Name, &val);
     if (success != 0)
-        ChipLogProgress(DeviceLayer, "getPref_u32_new: %s/%s failed\n", key.Namespace, key.Name);
+        ChipLogProgress(DeviceLayer, "getPref_u32_new: %s/%s failed\n", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name));
 
     if (success == 0)
         return CHIP_NO_ERROR;
@@ -148,7 +151,8 @@ CHIP_ERROR AmebaConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, 
 
     success = getPref_str_new(key.Namespace, key.Name, buf, bufSize, &outLen);
     if (success != 0)
-        ChipLogProgress(DeviceLayer, "getPref_str_new: %s/%s failed\n", key.Namespace, key.Name);
+        ChipLogProgress(DeviceLayer, "getPref_str_new: %s/%s failed\n", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name));
 
     if (success == 0)
     {
@@ -168,7 +172,8 @@ CHIP_ERROR AmebaConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSiz
 
     success = getPref_bin_new(key.Namespace, key.Name, buf, bufSize, &outLen);
     if (success != 0)
-        ChipLogProgress(DeviceLayer, "getPref_bin_new: %s/%s failed\n", key.Namespace, key.Name);
+        ChipLogProgress(DeviceLayer, "getPref_bin_new: %s/%s failed\n", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name));
 
     if (success == 0)
     {
@@ -192,9 +197,11 @@ CHIP_ERROR AmebaConfig::WriteConfigValue(Key key, bool val)
         value = 0;
     success = setPref_new(key.Namespace, key.Name, &value, 1);
     if (!success)
-        ChipLogError(DeviceLayer, "setPref: %s/%s = %s failed\n", key.Namespace, key.Name, value ? "true" : "false");
+        ChipLogError(DeviceLayer, "setPref: %s/%s = %s failed\n", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name),
+                     value ? "true" : "false");
     else
-        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %s", key.Namespace, key.Name, val ? "true" : "false");
+        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %s", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name),
+                        val ? "true" : "false");
 
     return CHIP_NO_ERROR;
 }
@@ -205,9 +212,11 @@ CHIP_ERROR AmebaConfig::WriteConfigValue(Key key, uint32_t val)
 
     success = setPref_new(key.Namespace, key.Name, (uint8_t *) &val, sizeof(uint32_t));
     if (!success)
-        ChipLogError(DeviceLayer, "setPref: %s/%s = %d(0x%x) failed\n", key.Namespace, key.Name, val, val);
+        ChipLogError(DeviceLayer, "setPref: %s/%s = %d(0x%x) failed\n", StringOrNullMarker(key.Namespace),
+                     StringOrNullMarker(key.Name), val, val);
     else
-        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu32 " (0x%" PRIX32 ")", key.Namespace, key.Name, val, val);
+        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu32 " (0x%" PRIX32 ")", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name), val, val);
 
     return CHIP_NO_ERROR;
 }
@@ -218,9 +227,11 @@ CHIP_ERROR AmebaConfig::WriteConfigValue(Key key, uint64_t val)
 
     success = setPref_new(key.Namespace, key.Name, (uint8_t *) &val, sizeof(uint64_t));
     if (!success)
-        ChipLogError(DeviceLayer, "setPref: %s/%s = %d(0x%x) failed\n", key.Namespace, key.Name, val, val);
+        ChipLogError(DeviceLayer, "setPref: %s/%s = %d(0x%x) failed\n", StringOrNullMarker(key.Namespace),
+                     StringOrNullMarker(key.Name), val, val);
     else
-        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu64 " (0x%" PRIX64 ")", key.Namespace, key.Name, val, val);
+        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu64 " (0x%" PRIX64 ")", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name), val, val);
 
     return CHIP_NO_ERROR;
 }
@@ -231,9 +242,11 @@ CHIP_ERROR AmebaConfig::WriteConfigValueStr(Key key, const char * str)
 
     success = setPref_new(key.Namespace, key.Name, (uint8_t *) str, strlen(str) + 1);
     if (!success)
-        ChipLogError(DeviceLayer, "setPref: %s/%s = %s failed\n", key.Namespace, key.Name, str);
+        ChipLogError(DeviceLayer, "setPref: %s/%s = %s failed\n", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name),
+                     StringOrNullMarker(str));
     else
-        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = \"%s\"", key.Namespace, key.Name, str);
+        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = \"%s\"", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name),
+                        StringOrNullMarker(str));
     return CHIP_NO_ERROR;
 }
 
@@ -259,9 +272,10 @@ CHIP_ERROR AmebaConfig::WriteConfigValueBin(Key key, const uint8_t * data, size_
 
     success = setPref_new(key.Namespace, key.Name, (uint8_t *) data, dataLen);
     if (!success)
-        ChipLogError(DeviceLayer, "setPref: %s/%s failed\n", key.Namespace, key.Name);
+        ChipLogError(DeviceLayer, "setPref: %s/%s failed\n", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name));
     else
-        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = (blob length %" PRId32 ")", key.Namespace, key.Name, dataLen);
+        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = (blob length %" PRId32 ")", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name), dataLen);
 
     return CHIP_NO_ERROR;
 }
@@ -272,9 +286,10 @@ CHIP_ERROR AmebaConfig::ClearConfigValue(Key key)
 
     success = deleteKey(key.Namespace, key.Name);
     if (!success)
-        ChipLogProgress(DeviceLayer, "%s : %s/%s failed\n", __FUNCTION__, key.Namespace, key.Name);
+        ChipLogProgress(DeviceLayer, "%s : %s/%s failed\n", __FUNCTION__, StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name));
     else
-        ChipLogProgress(DeviceLayer, "NVS erase: %s/%s", key.Namespace, key.Name);
+        ChipLogProgress(DeviceLayer, "NVS erase: %s/%s", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name));
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Beken/BekenConfig.cpp
+++ b/src/platform/Beken/BekenConfig.cpp
@@ -94,7 +94,8 @@ CHIP_ERROR BekenConfig::ReadConfigValue(Key key, bool & val)
     success             = bk_read_data(key.Namespace, key.Name, (char *) &intval, 1, &out_length);
 
     if (kNoErr != success)
-        ChipLogProgress(DeviceLayer, "bk_read_data: %s  %s failed\n", (char *) key.Namespace, (char *) key.Name);
+        ChipLogProgress(DeviceLayer, "bk_read_data: %s  %s failed\n", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name));
 
     val = (intval != 0);
     if (kNoErr == success)
@@ -112,7 +113,8 @@ CHIP_ERROR BekenConfig::ReadConfigValue(Key key, uint32_t & val)
     success = bk_read_data(key.Namespace, key.Name, (char *) &temp_data, sizeof(uint32_t), &out_length);
 
     if (kNoErr != success)
-        ChipLogProgress(DeviceLayer, "bk_read_data: %s  %s failed\n", (char *) key.Namespace, (char *) key.Name);
+        ChipLogProgress(DeviceLayer, "bk_read_data: %s  %s failed\n", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name));
     val = temp_data;
 
     if (kNoErr == success)
@@ -130,7 +132,8 @@ CHIP_ERROR BekenConfig::ReadConfigValue(Key key, uint64_t & val)
     success = bk_read_data(key.Namespace, key.Name, (char *) &temp_data, sizeof(uint64_t), &out_length);
 
     if (kNoErr != success)
-        ChipLogProgress(DeviceLayer, "bk_read_data: %s  %s failed\n", (char *) key.Namespace, (char *) key.Name);
+        ChipLogProgress(DeviceLayer, "bk_read_data: %s  %s failed\n", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name));
     val = temp_data;
 
     if (kNoErr == success)
@@ -148,7 +151,8 @@ CHIP_ERROR BekenConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, 
     outLen  = out_length;
 
     if (kNoErr != success)
-        ChipLogProgress(DeviceLayer, "bk_read_data: %s  %s failed\n", (char *) key.Namespace, (char *) key.Name);
+        ChipLogProgress(DeviceLayer, "bk_read_data: %s  %s failed\n", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name));
 
     if (kNoErr == success)
     {
@@ -170,7 +174,8 @@ CHIP_ERROR BekenConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSiz
     outLen  = out_length;
 
     if (kNoErr != success)
-        ChipLogProgress(DeviceLayer, "bk_read_data: %s  %s failed\n", (char *) key.Namespace, (char *) key.Name);
+        ChipLogProgress(DeviceLayer, "bk_read_data: %s  %s failed\n", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name));
 
     if (kNoErr == success)
     {
@@ -199,8 +204,8 @@ CHIP_ERROR BekenConfig::WriteConfigValue(Key key, bool val)
 
     success = bk_write_data(key.Namespace, key.Name, (char *) &value, 1);
     if (kNoErr != success)
-        ChipLogError(DeviceLayer, "bk_write_data: %s  %s  %s failed\n", (char *) key.Namespace, (char *) key.Name,
-                     value ? "true" : "false");
+        ChipLogError(DeviceLayer, "bk_write_data: %s  %s  %s failed\n", StringOrNullMarker(key.Namespace),
+                     StringOrNullMarker(key.Name), value ? "true" : "false");
 
     return CHIP_NO_ERROR;
 }
@@ -211,8 +216,8 @@ CHIP_ERROR BekenConfig::WriteConfigValue(Key key, uint32_t val)
 
     success = bk_write_data(key.Namespace, key.Name, (char *) &val, sizeof(val));
     if (kNoErr != success)
-        ChipLogError(DeviceLayer, "bk_write_data: %s  %s = %lu(0x%lx) failed\n", (char *) key.Namespace, (char *) key.Name, val,
-                     val);
+        ChipLogError(DeviceLayer, "bk_write_data: %s  %s = %lu(0x%lx) failed\n", StringOrNullMarker(key.Namespace),
+                     StringOrNullMarker(key.Name), val, val);
 
     return CHIP_NO_ERROR;
 }
@@ -223,8 +228,8 @@ CHIP_ERROR BekenConfig::WriteConfigValue(Key key, uint64_t val)
 
     success = bk_write_data(key.Namespace, key.Name, (char *) &val, sizeof(val));
     if (kNoErr != success)
-        ChipLogError(DeviceLayer, "bk_write_data: %s  %s = %llu(0x%llx) failed\n", (char *) key.Namespace, (char *) key.Name, val,
-                     val);
+        ChipLogError(DeviceLayer, "bk_write_data: %s  %s = %llu(0x%llx) failed\n", StringOrNullMarker(key.Namespace),
+                     StringOrNullMarker(key.Name), val, val);
 
     return CHIP_NO_ERROR;
 }
@@ -235,7 +240,8 @@ CHIP_ERROR BekenConfig::WriteConfigValueStr(Key key, const char * str)
 
     success = bk_write_data(key.Namespace, key.Name, (char *) str, strlen(str));
     if (kNoErr != success)
-        ChipLogError(DeviceLayer, "bk_write_data: %s %s %s failed\n", (char *) key.Namespace, (char *) key.Name, (char *) str);
+        ChipLogError(DeviceLayer, "bk_write_data: %s %s %s failed\n", StringOrNullMarker(key.Namespace),
+                     StringOrNullMarker(key.Name), StringOrNullMarker(str));
 
     return CHIP_NO_ERROR;
 }
@@ -247,7 +253,8 @@ CHIP_ERROR BekenConfig::WriteConfigValueStr(Key key, const char * str, size_t st
 
     success = bk_write_data(key.Namespace, key.Name, (char *) str, strLen);
     if (kNoErr != success)
-        ChipLogError(DeviceLayer, "bk_write_data: %s %s %s failed\n", (char *) key.Namespace, (char *) key.Name, (char *) str);
+        ChipLogError(DeviceLayer, "bk_write_data: %s %s %s failed\n", StringOrNullMarker(key.Namespace),
+                     StringOrNullMarker(key.Name), StringOrNullMarker(str));
 
     return CHIP_NO_ERROR;
 }
@@ -258,7 +265,8 @@ CHIP_ERROR BekenConfig::WriteConfigValueBin(Key key, const uint8_t * data, size_
 
     success = bk_write_data(key.Namespace, key.Name, (char *) data, dataLen);
     if (kNoErr != success)
-        ChipLogError(DeviceLayer, "bk_write_data: %s  %s failed \r\n", key.Namespace, key.Name);
+        ChipLogError(DeviceLayer, "bk_write_data: %s  %s failed \r\n", StringOrNullMarker(key.Namespace),
+                     StringOrNullMarker(key.Name));
 
     return CHIP_NO_ERROR;
 }
@@ -269,7 +277,8 @@ CHIP_ERROR BekenConfig::ClearConfigValue(Key key)
 
     success = bk_clean_data(key.Namespace, key.Name);
     if (kNoErr != success)
-        ChipLogProgress(DeviceLayer, "%s : %s  %s failed\n", __FUNCTION__, key.Namespace, key.Name);
+        ChipLogProgress(DeviceLayer, "%s : %s  %s failed\n", __FUNCTION__, StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name));
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/Beken/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Beken/NetworkCommissioningWiFiDriver.cpp
@@ -147,7 +147,7 @@ Status BekenWiFiDriver::ReorderNetwork(ByteSpan networkId, uint8_t index, Mutabl
 
 CHIP_ERROR BekenWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, const char * key, uint8_t keyLen)
 {
-    ChipLogProgress(NetworkProvisioning, "BekenWiFiDriver::ConnectWiFiNetwork....ssid:%s", ssid);
+    ChipLogProgress(NetworkProvisioning, "BekenWiFiDriver::ConnectWiFiNetwork....ssid:%s", StringOrNullMarker(ssid));
     ReturnErrorOnFailure(ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Disabled));
 
     wifi_sta_config_t sta_config;

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ void LogOnFailure(const char * name, DNSServiceErrorType err)
 {
     if (kDNSServiceErr_NoError != err)
     {
-        ChipLogError(Discovery, "%s (%s)", name, Error::ToString(err));
+        ChipLogError(Discovery, "%s (%s)", StringOrNullMarker(name), Error::ToString(err));
     }
 }
 
@@ -171,7 +171,8 @@ namespace {
 static void OnRegister(DNSServiceRef sdRef, DNSServiceFlags flags, DNSServiceErrorType err, const char * name, const char * type,
                        const char * domain, void * context)
 {
-    ChipLogDetail(Discovery, "Mdns: %s name: %s, type: %s, domain: %s, flags: %d", __func__, name, type, domain, flags);
+    ChipLogDetail(Discovery, "Mdns: %s name: %s, type: %s, domain: %s, flags: %d", __func__, StringOrNullMarker(name),
+                  StringOrNullMarker(type), StringOrNullMarker(domain), flags);
 
     auto sdCtx = reinterpret_cast<RegisterContext *>(context);
     sdCtx->Finalize(err);
@@ -180,8 +181,8 @@ static void OnRegister(DNSServiceRef sdRef, DNSServiceFlags flags, DNSServiceErr
 CHIP_ERROR Register(void * context, DnssdPublishCallback callback, uint32_t interfaceId, const char * type, const char * name,
                     uint16_t port, ScopedTXTRecord & record, Inet::IPAddressType addressType, const char * hostname)
 {
-    ChipLogDetail(Discovery, "Registering service %s on host %s with port %u and type: %s on interface id: %" PRIu32, name,
-                  hostname, port, type, interfaceId);
+    ChipLogDetail(Discovery, "Registering service %s on host %s with port %u and type: %s on interface id: %" PRIu32,
+                  StringOrNullMarker(name), StringOrNullMarker(hostname), port, StringOrNullMarker(type), interfaceId);
 
     RegisterContext * sdCtx = nullptr;
     if (CHIP_NO_ERROR == MdnsContexts::GetInstance().GetRegisterContextOfType(type, &sdCtx))
@@ -206,8 +207,8 @@ CHIP_ERROR Register(void * context, DnssdPublishCallback callback, uint32_t inte
 
 void OnBrowseAdd(BrowseContext * context, const char * name, const char * type, const char * domain, uint32_t interfaceId)
 {
-    ChipLogDetail(Discovery, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %" PRIu32, __func__, name, type, domain,
-                  interfaceId);
+    ChipLogDetail(Discovery, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %" PRIu32, __func__, StringOrNullMarker(name),
+                  StringOrNullMarker(type), StringOrNullMarker(domain), interfaceId);
 
     VerifyOrReturn(strcmp(kLocalDot, domain) == 0);
 
@@ -233,9 +234,10 @@ void OnBrowseAdd(BrowseContext * context, const char * name, const char * type, 
 
 void OnBrowseRemove(BrowseContext * context, const char * name, const char * type, const char * domain, uint32_t interfaceId)
 {
-    ChipLogDetail(Discovery, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %" PRIu32, __func__, name, type, domain,
-                  interfaceId);
+    ChipLogDetail(Discovery, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %" PRIu32, __func__, StringOrNullMarker(name),
+                  StringOrNullMarker(type), StringOrNullMarker(domain), interfaceId);
 
+    VerifyOrReturn(name != nullptr);
     VerifyOrReturn(strcmp(kLocalDot, domain) == 0);
 
     context->services.erase(std::remove_if(context->services.begin(), context->services.end(),
@@ -267,7 +269,7 @@ CHIP_ERROR Browse(void * context, DnssdBrowseCallback callback, uint32_t interfa
     auto sdCtx = chip::Platform::New<BrowseContext>(context, callback, protocol);
     VerifyOrReturnError(nullptr != sdCtx, CHIP_ERROR_NO_MEMORY);
 
-    ChipLogProgress(Discovery, "Browsing for: %s", type);
+    ChipLogProgress(Discovery, "Browsing for: %s", StringOrNullMarker(type));
     DNSServiceRef sdRef;
     auto err = DNSServiceBrowse(&sdRef, kBrowseFlags, interfaceId, type, kLocalDot, OnBrowse, sdCtx);
     VerifyOrReturnError(kDNSServiceErr_NoError == err, sdCtx->Finalize(err));
@@ -339,7 +341,8 @@ static void OnResolve(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t inter
 static CHIP_ERROR Resolve(void * context, DnssdResolveCallback callback, uint32_t interfaceId,
                           chip::Inet::IPAddressType addressType, const char * type, const char * name)
 {
-    ChipLogDetail(Discovery, "Resolve type=%s name=%s interface=%" PRIu32, type, name, interfaceId);
+    ChipLogDetail(Discovery, "Resolve type=%s name=%s interface=%" PRIu32, StringOrNullMarker(type), StringOrNullMarker(name),
+                  interfaceId);
 
     auto sdCtx = chip::Platform::New<ResolveContext>(context, callback, addressType);
     VerifyOrReturnError(nullptr != sdCtx, CHIP_ERROR_NO_MEMORY);

--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -250,7 +250,8 @@ CHIP_ERROR ESP32Config::WriteConfigValue(Key key, bool val)
     // Commit the value to the persistent store.
     ReturnMappedErrorOnFailure(nvs_commit(handle));
 
-    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %s", key.Namespace, key.Name, val ? "true" : "false");
+    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %s", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name),
+                    val ? "true" : "false");
     return CHIP_NO_ERROR;
 }
 
@@ -264,7 +265,8 @@ CHIP_ERROR ESP32Config::WriteConfigValue(Key key, uint32_t val)
     // Commit the value to the persistent store.
     ReturnMappedErrorOnFailure(nvs_commit(handle));
 
-    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu32 " (0x%" PRIX32 ")", key.Namespace, key.Name, val, val);
+    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu32 " (0x%" PRIX32 ")", StringOrNullMarker(key.Namespace),
+                    StringOrNullMarker(key.Name), val, val);
     return CHIP_NO_ERROR;
 }
 
@@ -278,7 +280,8 @@ CHIP_ERROR ESP32Config::WriteConfigValue(Key key, uint64_t val)
     // Commit the value to the persistent store.
     ReturnMappedErrorOnFailure(nvs_commit(handle));
 
-    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu64 " (0x%" PRIX64 ")", key.Namespace, key.Name, val, val);
+    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu64 " (0x%" PRIX64 ")", StringOrNullMarker(key.Namespace),
+                    StringOrNullMarker(key.Name), val, val);
     return CHIP_NO_ERROR;
 }
 
@@ -294,7 +297,8 @@ CHIP_ERROR ESP32Config::WriteConfigValueStr(Key key, const char * str)
         // Commit the value to the persistent store.
         ReturnMappedErrorOnFailure(nvs_commit(handle));
 
-        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = \"%s\"", key.Namespace, key.Name, str);
+        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = \"%s\"", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name),
+                        str);
         return CHIP_NO_ERROR;
     }
 
@@ -326,7 +330,8 @@ CHIP_ERROR ESP32Config::WriteConfigValueBin(Key key, const uint8_t * data, size_
         // Commit the value to the persistent store.
         ReturnMappedErrorOnFailure(nvs_commit(handle));
 
-        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = (blob length %" PRId32 ")", key.Namespace, key.Name, dataLen);
+        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = (blob length %" PRId32 ")", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name), dataLen);
         return CHIP_NO_ERROR;
     }
 
@@ -349,7 +354,7 @@ CHIP_ERROR ESP32Config::ClearConfigValue(Key key)
     // Commit the value to the persistent store.
     ReturnMappedErrorOnFailure(nvs_commit(handle));
 
-    ChipLogProgress(DeviceLayer, "NVS erase: %s/%s", key.Namespace, key.Name);
+    ChipLogProgress(DeviceLayer, "NVS erase: %s/%s", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name));
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/ESP32/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/ESP32/KeyValueStoreManagerImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,7 +58,7 @@ bool HashIfLongKey(const char * key, char * keyHash)
     Encoding::BytesToHex(hashBuffer, NVS_KEY_NAME_MAX_SIZE / 2, keyHash, NVS_KEY_NAME_MAX_SIZE, flags);
     keyHash[NVS_KEY_NAME_MAX_SIZE - 1] = 0;
 
-    ChipLogDetail(DeviceLayer, "Using hash:%s for nvs key:%s", keyHash, key);
+    ChipLogDetail(DeviceLayer, "Using hash:%s for nvs key:%s", keyHash, StringOrNullMarker(key));
     return true;
 }
 } // namespace

--- a/src/platform/Linux/CHIPLinuxStorage.cpp
+++ b/src/platform/Linux/CHIPLinuxStorage.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,10 +53,11 @@ CHIP_ERROR ChipLinuxStorage::Init(const char * configFile)
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;
 
-    ChipLogDetail(DeviceLayer, "ChipLinuxStorage::Init: Using KVS config file: %s", configFile);
+    ChipLogDetail(DeviceLayer, "ChipLinuxStorage::Init: Using KVS config file: %s", StringOrNullMarker(configFile));
     if (mInitialized)
     {
-        ChipLogError(DeviceLayer, "ChipLinuxStorage::Init: Attempt to re-initialize with KVS config file: %s", configFile);
+        ChipLogError(DeviceLayer, "ChipLinuxStorage::Init: Attempt to re-initialize with KVS config file: %s",
+                     StringOrNullMarker(configFile));
         return CHIP_NO_ERROR;
     }
 

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -390,7 +390,8 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
         {
             gchar * value_str;
             value_str = g_variant_print(value, TRUE);
-            ChipLogProgress(DeviceLayer, "wpa_supplicant:PropertiesChanged:key:%s -> %s", key, value_str);
+            ChipLogProgress(DeviceLayer, "wpa_supplicant:PropertiesChanged:key:%s -> %s", StringOrNullMarker(key),
+                            StringOrNullMarker(value_str));
 
             if (g_strcmp0(key, "State") == 0)
             {
@@ -665,7 +666,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * pr
 
     if (g_strcmp0(mWpaSupplicant.interfacePath, path) == 0)
     {
-        ChipLogProgress(DeviceLayer, "wpa_supplicant: WiFi interface removed: %s", path);
+        ChipLogProgress(DeviceLayer, "wpa_supplicant: WiFi interface removed: %s", StringOrNullMarker(path));
 
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_NO_INTERFACE_PATH;
 
@@ -1199,7 +1200,7 @@ CHIP_ERROR ConnectivityManagerImpl::GetWiFiSecurityType(uint8_t & securityType)
     }
 
     mode = wpa_fi_w1_wpa_supplicant1_interface_get_current_auth_mode(mWpaSupplicant.iface);
-    ChipLogProgress(DeviceLayer, "wpa_supplicant: current Wi-Fi security type: %s", mode);
+    ChipLogProgress(DeviceLayer, "wpa_supplicant: current Wi-Fi security type: %s", StringOrNullMarker(mode));
 
     if (strncmp(mode, "WPA-PSK", 7) == 0)
     {
@@ -1292,7 +1293,7 @@ CHIP_ERROR ConnectivityManagerImpl::GetConfiguredNetwork(NetworkCommissioning::N
     // TODO: wpa_supplicant will return ssid with quotes! We should have a better way to get the actual ssid in bytes.
     gsize length_actual = length - 2;
     VerifyOrReturnError(length_actual <= sizeof(network.networkID), CHIP_ERROR_INTERNAL);
-    ChipLogDetail(DeviceLayer, "Current connected network: %s", ssidStr);
+    ChipLogDetail(DeviceLayer, "Current connected network: %s", StringOrNullMarker(ssidStr));
     memcpy(network.networkID, ssidStr + 1, length_actual);
     network.networkIDLen = length_actual;
     return CHIP_NO_ERROR;
@@ -1461,7 +1462,7 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
     // may be gone when we try to get the properties.
     if (ssid == nullptr || bssid == nullptr)
     {
-        ChipLogDetail(DeviceLayer, "wpa_supplicant: BSS not found: %s", bssPath);
+        ChipLogDetail(DeviceLayer, "wpa_supplicant: BSS not found: %s", StringOrNullMarker(bssPath));
         return false;
     }
 
@@ -1486,7 +1487,8 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
         bssidLen = 0;
         ChipLogError(DeviceLayer, "Got a network with bssid not equals to 6");
     }
-    ChipLogDetail(DeviceLayer, "Network Found: %.*s (%s) Signal:%d", int(ssidLen), ssidStr, bssidStr, signal);
+    ChipLogDetail(DeviceLayer, "Network Found: %.*s (%s) Signal:%d", int(ssidLen), StringOrNullMarker((const gchar *) ssidStr),
+                  bssidStr, signal);
 
     // A flag for enterprise encryption option to avoid returning open for these networks by mistake
     // TODO: The following code will mistakenly recognize WEP encryption as OPEN network, this should be fixed by reading

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -93,7 +93,7 @@ CHIP_ERROR GetEthernetStatsCount(EthernetStatsCountType type, uint64_t & count)
         {
             if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::EMBER_ZCL_INTERFACE_TYPE_ETHERNET)
             {
-                ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", ifa->ifa_name);
+                ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;
             }
         }
@@ -157,7 +157,7 @@ CHIP_ERROR GetWiFiStatsCount(WiFiStatsCountType type, uint64_t & count)
         {
             if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::EMBER_ZCL_INTERFACE_TYPE_WI_FI)
             {
-                ChipLogProgress(DeviceLayer, "Found the primary WiFi interface:%s", ifa->ifa_name);
+                ChipLogProgress(DeviceLayer, "Found the primary WiFi interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;
             }
         }
@@ -615,7 +615,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetEthNetworkDiagnosticsCounts()
         {
             if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::EMBER_ZCL_INTERFACE_TYPE_ETHERNET)
             {
-                ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", ifa->ifa_name);
+                ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;
             }
         }
@@ -780,7 +780,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
         {
             if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::EMBER_ZCL_INTERFACE_TYPE_WI_FI)
             {
-                ChipLogProgress(DeviceLayer, "Found the primary WiFi interface:%s", ifa->ifa_name);
+                ChipLogProgress(DeviceLayer, "Found the primary WiFi interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;
             }
         }

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -572,7 +572,7 @@ DnssdServiceProtocol GetProtocolInType(const char * type)
 
     if (deliminator == nullptr)
     {
-        ChipLogError(Discovery, "Failed to find protocol in type: %s", type);
+        ChipLogError(Discovery, "Failed to find protocol in type: %s", StringOrNullMarker(type));
         return DnssdServiceProtocol::kDnssdProtocolUnknown;
     }
 
@@ -585,7 +585,7 @@ DnssdServiceProtocol GetProtocolInType(const char * type)
         return DnssdServiceProtocol::kDnssdProtocolUdp;
     }
 
-    ChipLogError(Discovery, "Unknown protocol in type: %s", type);
+    ChipLogError(Discovery, "Unknown protocol in type: %s", StringOrNullMarker(type));
     return DnssdServiceProtocol::kDnssdProtocolUnknown;
 }
 

--- a/src/platform/Linux/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Linux/NetworkCommissioningWiFiDriver.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -156,7 +156,8 @@ void LinuxWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callb
 
     VerifyOrExit(NetworkMatch(mStagingNetwork, networkId), networkingStatus = Status::kNetworkIDNotFound);
 
-    ChipLogProgress(NetworkProvisioning, "LinuxNetworkCommissioningDelegate: SSID: %s", networkId.data());
+    ChipLogProgress(NetworkProvisioning, "LinuxNetworkCommissioningDelegate: SSID: %s",
+                    StringOrNullMarker((char *) networkId.data()));
 
     err = ConnectivityMgrImpl().ConnectWiFiNetworkAsync(ByteSpan(mStagingNetwork.ssid, mStagingNetwork.ssidLen),
                                                         ByteSpan(mStagingNetwork.credentials, mStagingNetwork.credentialsLen),

--- a/src/platform/Linux/PosixConfig.cpp
+++ b/src/platform/Linux/PosixConfig.cpp
@@ -259,7 +259,8 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, bool val)
     err = storage->Commit();
     SuccessOrExit(err);
 
-    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %s", key.Namespace, key.Name, val ? "true" : "false");
+    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %s", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name),
+                    val ? "true" : "false");
 
 exit:
     return err;
@@ -280,7 +281,8 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint16_t val)
     err = storage->Commit();
     SuccessOrExit(err);
 
-    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %u (0x%X)", key.Namespace, key.Name, val, val);
+    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %u (0x%X)", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name), val,
+                    val);
 
 exit:
     return err;
@@ -301,7 +303,8 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint32_t val)
     err = storage->Commit();
     SuccessOrExit(err);
 
-    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu32 " (0x%" PRIX32 ")", key.Namespace, key.Name, val, val);
+    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu32 " (0x%" PRIX32 ")", StringOrNullMarker(key.Namespace),
+                    StringOrNullMarker(key.Name), val, val);
 
 exit:
     return err;
@@ -322,7 +325,8 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint64_t val)
     err = storage->Commit();
     SuccessOrExit(err);
 
-    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu64 " (0x%" PRIX64 ")", key.Namespace, key.Name, val, val);
+    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu64 " (0x%" PRIX64 ")", StringOrNullMarker(key.Namespace),
+                    StringOrNullMarker(key.Name), val, val);
 
 exit:
     return err;
@@ -345,7 +349,8 @@ CHIP_ERROR PosixConfig::WriteConfigValueStr(Key key, const char * str)
         err = storage->Commit();
         SuccessOrExit(err);
 
-        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = \"%s\"", key.Namespace, key.Name, str);
+        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = \"%s\"", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name),
+                        str);
     }
 
     else
@@ -400,8 +405,8 @@ CHIP_ERROR PosixConfig::WriteConfigValueBin(Key key, const uint8_t * data, size_
         err = storage->Commit();
         SuccessOrExit(err);
 
-        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = (blob length %u)", key.Namespace, key.Name,
-                        static_cast<unsigned int>(dataLen));
+        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = (blob length %u)", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name), static_cast<unsigned int>(dataLen));
     }
     else
     {
@@ -432,7 +437,7 @@ CHIP_ERROR PosixConfig::ClearConfigValue(Key key)
     err = storage->Commit();
     SuccessOrExit(err);
 
-    ChipLogProgress(DeviceLayer, "NVS erase: %s/%s", key.Namespace, key.Name);
+    ChipLogProgress(DeviceLayer, "NVS erase: %s/%s", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name));
 
 exit:
     return err;

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ void ThreadStackManagerImpl::OnDbusPropertiesChanged(OpenthreadIoOpenthreadBorde
                 const gchar * value_str = g_variant_get_string(value, nullptr);
                 if (value_str == nullptr)
                     continue;
-                ChipLogProgress(DeviceLayer, "Thread role changed to: %s", value_str);
+                ChipLogProgress(DeviceLayer, "Thread role changed to: %s", StringOrNullMarker(value_str));
                 me->ThreadDevcieRoleChangedHandler(value_str);
             }
         }

--- a/src/platform/Linux/bluez/AdapterIterator.cpp
+++ b/src/platform/Linux/bluez/AdapterIterator.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ bool AdapterIterator::Advance()
 
         if (sscanf(path, BLUEZ_PATH "/hci%u", &index) != 1)
         {
-            ChipLogError(DeviceLayer, "Failed to extract HCI index from '%s'", path);
+            ChipLogError(DeviceLayer, "Failed to extract HCI index from '%s'", StringOrNullMarker(path));
             index = 0;
         }
 

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -259,7 +259,7 @@ void ChipDeviceScanner::RemoveDevice(BluezDevice1 * device)
 
     if (!bluez_adapter1_call_remove_device_sync(mAdapter, devicePath, nullptr, &error))
     {
-        ChipLogDetail(Ble, "Failed to remove device %s: %s", devicePath, error->message);
+        ChipLogDetail(Ble, "Failed to remove device %s: %s", StringOrNullMarker(devicePath), error->message);
         g_error_free(error);
     }
 }

--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -155,7 +155,7 @@ static BluezLEAdvertisement1 * BluezAdvertisingCreate(BluezEndpoint * apEndpoint
     serviceUUID = g_variant_builder_end(&serviceUUIDsBuilder);
 
     debugStr = g_variant_print(serviceData, TRUE);
-    ChipLogDetail(DeviceLayer, "SET service data to %s", debugStr);
+    ChipLogDetail(DeviceLayer, "SET service data to %s", StringOrNullMarker(debugStr));
     g_free(debugStr);
 
     bluez_leadvertisement1_set_type_(adv, (apEndpoint->mType & BLUEZ_ADV_TYPE_CONNECTABLE) ? "peripheral" : "broadcast");
@@ -463,7 +463,7 @@ static gboolean BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar
 #if CHIP_ERROR_LOGGING
         errStr = strerror(errno);
 #endif // CHIP_ERROR_LOGGING
-        ChipLogError(DeviceLayer, "FAIL: socketpair: %s in %s", errStr, __func__);
+        ChipLogError(DeviceLayer, "FAIL: socketpair: %s in %s", StringOrNullMarker(errStr), __func__);
         g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "FD creation failed");
         goto exit;
     }
@@ -544,7 +544,7 @@ static gboolean BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aCha
 #if CHIP_ERROR_LOGGING
         errStr = strerror(errno);
 #endif // CHIP_ERROR_LOGGING
-        ChipLogError(DeviceLayer, "FAIL: socketpair: %s in %s", errStr, __func__);
+        ChipLogError(DeviceLayer, "FAIL: socketpair: %s in %s", StringOrNullMarker(errStr), __func__);
         g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "FD creation failed");
         goto exit;
     }

--- a/src/platform/LockTracker.cpp
+++ b/src/platform/LockTracker.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ void AssertChipStackLockedByCurrentThread(const char * file, int line)
 {
     if (!chip::DeviceLayer::PlatformMgr().IsChipStackLockedByCurrentThread())
     {
-        ChipLogError(DeviceLayer, "Chip stack locking error at '%s:%d'. Code is unsafe/racy", file, line);
+        ChipLogError(DeviceLayer, "Chip stack locking error at '%s:%d'. Code is unsafe/racy", StringOrNullMarker(file), line);
 #if CHIP_STACK_LOCK_TRACKING_ERROR_FATAL
         chipDie();
 #endif

--- a/src/platform/OpenThread/DnssdImpl.cpp
+++ b/src/platform/OpenThread/DnssdImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@ CHIP_ERROR ChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, Ine
         return CHIP_ERROR_INVALID_ARGUMENT;
 
     char serviceType[Dnssd::kDnssdFullTypeAndProtocolMaxSize + 1]; // +1 for null-terminator
-    snprintf(serviceType, sizeof(serviceType), "%s.%s", type, GetProtocolString(protocol));
+    snprintf(serviceType, sizeof(serviceType), "%s.%s", StringOrNullMarker(type), GetProtocolString(protocol));
 
     *browseIdentifier = reinterpret_cast<intptr_t>(nullptr);
     return ThreadStackMgr().DnsBrowse(serviceType, callback, context);

--- a/src/platform/OpenThread/OpenThreadUtils.cpp
+++ b/src/platform/OpenThread/OpenThreadUtils.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *    Copyright (c) 2019 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -237,13 +237,13 @@ void LogOpenThreadPacket(const char * titleStr, otMessage * pkt)
             snprintf(destStr + strlen(destStr), 13, ", port %u", Encoding::BigEndian::Get16(IPv6_DestPort));
         }
 
-        ChipLogDetail(DeviceLayer, "%s: %s, len %u", titleStr, type, pktLen);
+        ChipLogDetail(DeviceLayer, "%s: %s, len %u", StringOrNullMarker(titleStr), type, pktLen);
         ChipLogDetail(DeviceLayer, "    src  %s", srcStr);
         ChipLogDetail(DeviceLayer, "    dest %s", destStr);
     }
     else
     {
-        ChipLogDetail(DeviceLayer, "%s: %s, len %u", titleStr, "(decode error)", pktLen);
+        ChipLogDetail(DeviceLayer, "%s: %s, len %u", StringOrNullMarker(titleStr), "(decode error)", pktLen);
     }
 
 #endif // CHIP_DETAIL_LOGGING

--- a/src/platform/Tizen/AppPreference.cpp
+++ b/src/platform/Tizen/AppPreference.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ CHIP_ERROR GetData(const char * key, void * data, size_t dataSize, size_t * getD
     }
     if (err != PREFERENCE_ERROR_NONE)
     {
-        ChipLogError(DeviceLayer, "Failed to get preference [%s]: %s", key, get_error_message(err));
+        ChipLogError(DeviceLayer, "Failed to get preference [%s]: %s", StringOrNullMarker(key), get_error_message(err));
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
@@ -96,7 +96,7 @@ CHIP_ERROR SaveData(const char * key, const void * data, size_t dataSize)
     }
     if (err != PREFERENCE_ERROR_NONE)
     {
-        ChipLogError(DeviceLayer, "Failed to set preference [%s]: %s", key, get_error_message(err));
+        ChipLogError(DeviceLayer, "Failed to set preference [%s]: %s", StringOrNullMarker(key), get_error_message(err));
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
@@ -113,7 +113,7 @@ CHIP_ERROR RemoveData(const char * key)
     }
     if (err != PREFERENCE_ERROR_NONE)
     {
-        ChipLogError(DeviceLayer, "Failed to remove preference [%s]: %s", key, get_error_message(err));
+        ChipLogError(DeviceLayer, "Failed to remove preference [%s]: %s", StringOrNullMarker(key), get_error_message(err));
         return CHIP_ERROR_INCORRECT_STATE;
     }
 

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -136,7 +136,8 @@ gboolean OnBrowseTimeout(void * userData)
 
 void OnBrowseAdd(BrowseContext * context, const char * type, const char * name, uint32_t interfaceId)
 {
-    ChipLogDetail(DeviceLayer, "DNSsd %s: name: %s, type: %s, interfaceId: %u", __func__, name, type, interfaceId);
+    ChipLogDetail(DeviceLayer, "DNSsd %s: name: %s, type: %s, interfaceId: %u", __func__, StringOrNullMarker(name),
+                  StringOrNullMarker(type), interfaceId);
 
     char * tokens  = strdup(type);
     char * regtype = strtok(tokens, ".");
@@ -154,7 +155,8 @@ void OnBrowseAdd(BrowseContext * context, const char * type, const char * name, 
 
 void OnBrowseRemove(BrowseContext * context, const char * type, const char * name, uint32_t interfaceId)
 {
-    ChipLogDetail(DeviceLayer, "DNSsd %s: name: %s, type: %s, interfaceId: %u", __func__, name, type, interfaceId);
+    ChipLogDetail(DeviceLayer, "DNSsd %s: name: %s, type: %s, interfaceId: %u", __func__, StringOrNullMarker(name),
+                  StringOrNullMarker(type), interfaceId);
     context->mServices.erase(std::remove_if(
         context->mServices.begin(), context->mServices.end(), [name, type, interfaceId](const DnssdService & service) {
             return strcmp(name, service.mName) == 0 && type == GetFullType(service.mType, service.mProtocol) &&
@@ -343,7 +345,8 @@ void OnResolve(dnssd_error_e result, dnssd_service_h service, void * data)
     }
 #endif
 
-    ChipLogDetail(DeviceLayer, "DNSsd %s: IPv4: %s, IPv6: %s, ret: %d", __func__, ipv4, ipv6, ret);
+    ChipLogDetail(DeviceLayer, "DNSsd %s: IPv4: %s, IPv6: %s, ret: %d", __func__, StringOrNullMarker(ipv4),
+                  StringOrNullMarker(ipv6), ret);
 
     g_free(ipv4);
     g_free(ipv6);

--- a/src/platform/Zephyr/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Zephyr/KeyValueStoreManagerImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -131,7 +131,7 @@ int DeleteSubtreeCallback(const char * name, size_t /* entrySize */, settings_re
     char fullKey[SETTINGS_MAX_NAME_LEN + 1];
 
     // name comes from Zephyr settings subsystem so it is guaranteed to fit in the buffer.
-    (void) snprintf(fullKey, sizeof(fullKey), CHIP_DEVICE_CONFIG_SETTINGS_KEY "/%s", name);
+    (void) snprintf(fullKey, sizeof(fullKey), CHIP_DEVICE_CONFIG_SETTINGS_KEY "/%s", StringOrNullMarker(name));
     const int result = settings_delete(fullKey);
 
     // Return the first error, but continue removing remaining keys anyway.

--- a/src/platform/bouffalolab/BL602/BL602Config.cpp
+++ b/src/platform/bouffalolab/BL602/BL602Config.cpp
@@ -216,7 +216,7 @@ CHIP_ERROR BL602Config::WriteConfigValue(Key key, uint64_t val)
     EfErrCode ret = ef_set_env_blob(key.name, &val, sizeof(val));
     if (ret != EF_NO_ERR)
     {
-        log_error("WriteConfigValue() failed. key: %s, ret: %d\r\n", key.name, ret);
+        log_error("WriteConfigValue() failed. key: %s, ret: %d\r\n", StringOrNullMarker(key.name), ret);
         err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
     }
     SuccessOrExit(err);
@@ -339,7 +339,7 @@ CHIP_ERROR BL602Config::ClearConfigValue(Key key)
 
     SuccessOrExit(err);
 
-    ChipLogProgress(DeviceLayer, "Easyflash erase: %s", key.name);
+    ChipLogProgress(DeviceLayer, "Easyflash erase: %s", StringOrNullMarker(key.name));
 
 exit:
     return err;

--- a/src/platform/bouffalolab/BL602/BLEManagerImpl.cpp
+++ b/src/platform/bouffalolab/BL602/BLEManagerImpl.cpp
@@ -384,7 +384,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
 
-    ChipLogDetail(DeviceLayer, "Device name set to: %s", deviceName);
+    ChipLogDetail(DeviceLayer, "Device name set to: %s", StringOrNullMarker(deviceName));
     return MapErrorZephyr(bt_set_name(deviceName));
 }
 

--- a/src/platform/mt793x/DnssdImpl.cpp
+++ b/src/platform/mt793x/DnssdImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ static TXTRecordRef PublishTxtRecord;
 
 void ChipDnssdMdnsLog(const char * level, const char * msg)
 {
-    ChipLogProgress(ServiceProvisioning, "%s %s", level, msg);
+    ChipLogProgress(ServiceProvisioning, "%s %s", StringOrNullMarker(level), StringOrNullMarker(msg));
 }
 
 /**
@@ -225,7 +225,7 @@ void ChipDNSServiceBrowseReply(DNSServiceRef sdRef, DNSServiceFlags flags, uint3
     DnssdBrowseCallback ChipBrowseHandler = (DnssdBrowseCallback) context;
     DnssdService service;
 
-    ChipLogProgress(ServiceProvisioning, "ChipDNSServiceBrowseReply %s", serviceName);
+    ChipLogProgress(ServiceProvisioning, "ChipDNSServiceBrowseReply %s", StringOrNullMarker(serviceName));
     strcpy(service.mName, serviceName);
 
     ChipBrowseHandler(NULL, &service, 1, true, CHIP_NO_ERROR);
@@ -240,7 +240,7 @@ CHIP_ERROR ChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, chi
     char ServiceType[kDnssdTypeMaxSize + 10] = { 0 };
 
     (void) addressType;
-    ChipLogProgress(ServiceProvisioning, "ChipDnssdBrowse %s", type);
+    ChipLogProgress(ServiceProvisioning, "ChipDnssdBrowse %s", StringOrNullMarker(type));
     strcpy(ServiceType, type);
     strcat(ServiceType, ".");
     strcat(ServiceType, GetProtocolString(protocol));

--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -774,7 +774,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * devName)
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
 
-    if (devName == NULL && devName[0] == 0)
+    if (devName == NULL || devName[0] == 0)
     {
         ChipLogError(DeviceLayer, "Invalid name");
 

--- a/src/platform/webos/CHIPWebOSStorage.cpp
+++ b/src/platform/webos/CHIPWebOSStorage.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,10 +53,11 @@ CHIP_ERROR ChipLinuxStorage::Init(const char * configFile)
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;
 
-    ChipLogDetail(DeviceLayer, "ChipLinuxStorage::Init: Using KVS config file: %s", configFile);
+    ChipLogDetail(DeviceLayer, "ChipLinuxStorage::Init: Using KVS config file: %s", StringOrNullMarker(configFile));
     if (mInitialized)
     {
-        ChipLogError(DeviceLayer, "ChipLinuxStorage::Init: Attempt to re-initialize with KVS config file: %s", configFile);
+        ChipLogError(DeviceLayer, "ChipLinuxStorage::Init: Attempt to re-initialize with KVS config file: %s",
+                     StringOrNullMarker(configFile));
         return CHIP_NO_ERROR;
     }
 

--- a/src/platform/webos/ConnectivityManagerImpl.cpp
+++ b/src/platform/webos/ConnectivityManagerImpl.cpp
@@ -386,7 +386,8 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
         {
             gchar * value_str;
             value_str = g_variant_print(value, TRUE);
-            ChipLogProgress(DeviceLayer, "wpa_supplicant:PropertiesChanged:key:%s -> %s", key, value_str);
+            ChipLogProgress(DeviceLayer, "wpa_supplicant:PropertiesChanged:key:%s -> %s", StringOrNullMarker(key),
+                            StringOrNullMarker(value_str));
 
             if (g_strcmp0(key, "State") == 0)
             {
@@ -638,7 +639,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * pr
 
     if (g_strcmp0(mWpaSupplicant.interfacePath, path) == 0)
     {
-        ChipLogProgress(DeviceLayer, "wpa_supplicant: WiFi interface removed: %s", path);
+        ChipLogProgress(DeviceLayer, "wpa_supplicant: WiFi interface removed: %s", StringOrNullMarker(path));
 
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_NO_INTERFACE_PATH;
 
@@ -1161,7 +1162,7 @@ CHIP_ERROR ConnectivityManagerImpl::GetWiFiSecurityType(uint8_t & securityType)
     }
 
     mode = wpa_fi_w1_wpa_supplicant1_interface_get_current_auth_mode(mWpaSupplicant.iface);
-    ChipLogProgress(DeviceLayer, "wpa_supplicant: current Wi-Fi security type: %s", mode);
+    ChipLogProgress(DeviceLayer, "wpa_supplicant: current Wi-Fi security type: %s", StringOrNullMarker(mode));
 
     if (strncmp(mode, "WPA-PSK", 7) == 0)
     {
@@ -1413,7 +1414,7 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
     // may be gone when we try to get the properties.
     if (ssid == nullptr || bssid == nullptr)
     {
-        ChipLogDetail(DeviceLayer, "wpa_supplicant: BSS not found: %s", bssPath);
+        ChipLogDetail(DeviceLayer, "wpa_supplicant: BSS not found: %s", StringOrNullMarker(bssPath));
         return false;
     }
 
@@ -1438,7 +1439,8 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
         bssidLen = 0;
         ChipLogError(DeviceLayer, "Got a network with bssid not equals to 6");
     }
-    ChipLogDetail(DeviceLayer, "Network Found: %.*s (%s) Signal:%d", int(ssidLen), ssidStr, bssidStr, signal);
+    ChipLogDetail(DeviceLayer, "Network Found: %.*s (%s) Signal:%d", int(ssidLen), StringOrNullMarker((const gchar *) ssidStr),
+                  bssidStr, signal);
 
     // A flag for enterprise encryption option to avoid returning open for these networks by mistake
     // TODO: The following code will mistakenly recognize WEP encryption as OPEN network, this should be fixed by reading

--- a/src/platform/webos/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/webos/DiagnosticDataProviderImpl.cpp
@@ -90,7 +90,7 @@ CHIP_ERROR GetEthernetStatsCount(EthernetStatsCountType type, uint64_t & count)
         {
             if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::EMBER_ZCL_INTERFACE_TYPE_ETHERNET)
             {
-                ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", ifa->ifa_name);
+                ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;
             }
         }
@@ -154,7 +154,7 @@ CHIP_ERROR GetWiFiStatsCount(WiFiStatsCountType type, uint64_t & count)
         {
             if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::EMBER_ZCL_INTERFACE_TYPE_WI_FI)
             {
-                ChipLogProgress(DeviceLayer, "Found the primary WiFi interface:%s", ifa->ifa_name);
+                ChipLogProgress(DeviceLayer, "Found the primary WiFi interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;
             }
         }
@@ -584,7 +584,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetEthNetworkDiagnosticsCounts()
         {
             if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::EMBER_ZCL_INTERFACE_TYPE_ETHERNET)
             {
-                ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", ifa->ifa_name);
+                ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;
             }
         }
@@ -749,7 +749,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
         {
             if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::EMBER_ZCL_INTERFACE_TYPE_WI_FI)
             {
-                ChipLogProgress(DeviceLayer, "Found the primary WiFi interface:%s", ifa->ifa_name);
+                ChipLogProgress(DeviceLayer, "Found the primary WiFi interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;
             }
         }

--- a/src/platform/webos/DnssdImpl.cpp
+++ b/src/platform/webos/DnssdImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -570,7 +570,7 @@ DnssdServiceProtocol GetProtocolInType(const char * type)
 
     if (deliminator == nullptr)
     {
-        ChipLogError(Discovery, "Failed to find protocol in type: %s", type);
+        ChipLogError(Discovery, "Failed to find protocol in type: %s", StringOrNullMarker(type));
         return DnssdServiceProtocol::kDnssdProtocolUnknown;
     }
 
@@ -583,7 +583,7 @@ DnssdServiceProtocol GetProtocolInType(const char * type)
         return DnssdServiceProtocol::kDnssdProtocolUdp;
     }
 
-    ChipLogError(Discovery, "Unknown protocol in type: %s", type);
+    ChipLogError(Discovery, "Unknown protocol in type: %s", StringOrNullMarker(type));
     return DnssdServiceProtocol::kDnssdProtocolUnknown;
 }
 

--- a/src/platform/webos/PosixConfig.cpp
+++ b/src/platform/webos/PosixConfig.cpp
@@ -266,7 +266,8 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, bool val)
     err = storage->Commit();
     SuccessOrExit(err);
 
-    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %s", key.Namespace, key.Name, val ? "true" : "false");
+    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %s", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name),
+                    val ? "true" : "false");
 
 exit:
     return err;
@@ -287,7 +288,8 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint16_t val)
     err = storage->Commit();
     SuccessOrExit(err);
 
-    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %u (0x%X)", key.Namespace, key.Name, val, val);
+    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %u (0x%X)", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name), val,
+                    val);
 
 exit:
     return err;
@@ -308,7 +310,8 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint32_t val)
     err = storage->Commit();
     SuccessOrExit(err);
 
-    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu32 " (0x%" PRIX32 ")", key.Namespace, key.Name, val, val);
+    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu32 " (0x%" PRIX32 ")", StringOrNullMarker(key.Namespace),
+                    StringOrNullMarker(key.Name), val, val);
 
 exit:
     return err;
@@ -329,7 +332,8 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint64_t val)
     err = storage->Commit();
     SuccessOrExit(err);
 
-    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu64 " (0x%" PRIX64 ")", key.Namespace, key.Name, val, val);
+    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu64 " (0x%" PRIX64 ")", StringOrNullMarker(key.Namespace),
+                    StringOrNullMarker(key.Name), val, val);
 
 exit:
     return err;
@@ -352,7 +356,8 @@ CHIP_ERROR PosixConfig::WriteConfigValueStr(Key key, const char * str)
         err = storage->Commit();
         SuccessOrExit(err);
 
-        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = \"%s\"", key.Namespace, key.Name, str);
+        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = \"%s\"", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name),
+                        str);
     }
 
     else
@@ -407,8 +412,8 @@ CHIP_ERROR PosixConfig::WriteConfigValueBin(Key key, const uint8_t * data, size_
         err = storage->Commit();
         SuccessOrExit(err);
 
-        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = (blob length %u)", key.Namespace, key.Name,
-                        static_cast<unsigned int>(dataLen));
+        ChipLogProgress(DeviceLayer, "NVS set: %s/%s = (blob length %u)", StringOrNullMarker(key.Namespace),
+                        StringOrNullMarker(key.Name), static_cast<unsigned int>(dataLen));
     }
     else
     {
@@ -439,7 +444,7 @@ CHIP_ERROR PosixConfig::ClearConfigValue(Key key)
     err = storage->Commit();
     SuccessOrExit(err);
 
-    ChipLogProgress(DeviceLayer, "NVS erase: %s/%s", key.Namespace, key.Name);
+    ChipLogProgress(DeviceLayer, "NVS erase: %s/%s", StringOrNullMarker(key.Namespace), StringOrNullMarker(key.Name));
 
 exit:
     return err;

--- a/src/platform/webos/ThreadStackManagerImpl.cpp
+++ b/src/platform/webos/ThreadStackManagerImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ void ThreadStackManagerImpl::OnDbusPropertiesChanged(OpenthreadIoOpenthreadBorde
                 const gchar * value_str = g_variant_get_string(value, nullptr);
                 if (value_str == nullptr)
                     continue;
-                ChipLogProgress(DeviceLayer, "Thread role changed to: %s", value_str);
+                ChipLogProgress(DeviceLayer, "Thread role changed to: %s", StringOrNullMarker(value_str));
                 me->ThreadDevcieRoleChangedHandler(value_str);
             }
         }
@@ -632,7 +632,7 @@ void ThreadStackManagerImpl::_OnNetworkScanFinished(GAsyncResult * res)
             ChipLogProgress(DeviceLayer,
                             "Thread Network: %s (%016" PRIx64 ") ExtPanId(%016" PRIx64 ") RSSI %u LQI %u"
                             " Version %u",
-                            network_name, ext_address, ext_panid, rssi, lqi, version);
+                            StringOrNullMarker(network_name), ext_address, ext_panid, rssi, lqi, version);
             NetworkCommissioning::ThreadScanResponse networkScanned;
             networkScanned.panId         = panid;
             networkScanned.extendedPanId = ext_panid;

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -98,7 +98,7 @@ void UserDirectedCommissioningServer::SetUDCClientProcessingState(char * instanc
         }
     }
 
-    ChipLogDetail(AppServer, "SetUDCClientProcessingState instance=%s new state=%d", instanceName, (int) state);
+    ChipLogDetail(AppServer, "SetUDCClientProcessingState instance=%s new state=%d", StringOrNullMarker(instanceName), (int) state);
 
     client->SetUDCClientProcessingState(state);
 

--- a/src/qrcodetool/qrcodetool.cpp
+++ b/src/qrcodetool/qrcodetool.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 #include <stdio.h>
@@ -43,7 +44,7 @@ static int usage(const char * prog_name)
     ChipLogDetail(chipTool,
                   "Usage: %s [-h] [command] [opt ...]\n"
                   "%s commands are:\n",
-                  prog_name, prog_name);
+                  StringOrNullMarker(prog_name), StringOrNullMarker(prog_name));
     help(0, nullptr);
     return 2;
 }

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *    Copyright (c) 2016-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -137,8 +137,8 @@ public:
 
     static void PrintHandle(const char * tag, const PacketBuffer * buffer)
     {
-        printf("%s %p ref=%u len=%-4u next=%p\n", tag, buffer, buffer ? buffer->ref : 0, buffer ? buffer->len : 0,
-               buffer ? buffer->next : nullptr);
+        printf("%s %p ref=%u len=%-4u next=%p\n", StringOrNullMarker(tag), buffer, buffer ? buffer->ref : 0,
+               buffer ? buffer->len : 0, buffer ? buffer->next : nullptr);
     }
     static void PrintHandle(const char * tag, const PacketBufferHandle & handle) { PrintHandle(tag, handle.mBuffer); }
 
@@ -163,8 +163,8 @@ private:
     static void PrintHandle(const char * tag, const BufferConfiguration & config) { PrintHandle(tag, config.handle); }
     static void PrintConfig(const char * tag, const BufferConfiguration & config)
     {
-        printf("%s pay=%-4zu len=%-4u res=%-4u:", tag, config.payload_ptr - config.start_buffer, config.init_len,
-               config.reserved_size);
+        printf("%s pay=%-4zu len=%-4u res=%-4u:", StringOrNullMarker(tag), config.payload_ptr - config.start_buffer,
+               config.init_len, config.reserved_size);
         PrintHandle("", config.handle);
     }
 


### PR DESCRIPTION
This PR attempts to identify all cases where %s specifiers in the logging APIs (ChipLogError(), ChipLogProgress(), ChipLogDetail()) don't have a guaranteed non-null string parameter.

In all identified cases the issue is fixed using StringOrNullMarker() helper method to guarantee it doesn't happen.

Fixes #23603