### PR TITLE
spake2p: generate verifier sets with specified PIN codes in a file

### DIFF
--- a/src/tools/spake2p/Cmd_GenVerifier.cpp
+++ b/src/tools/spake2p/Cmd_GenVerifier.cpp
@@ -149,20 +149,21 @@ uint8_t gSalt[BASE64_MAX_DECODED_LEN(BASE64_ENCODED_LEN(chip::kSpake2p_Max_PBKDF
 uint8_t gSaltDecodedLen   = 0;
 uint8_t gSaltLen          = 0;
 const char * gOutFileName = nullptr;
-FILE *gPinCodeFile        = nullptr;
+FILE * gPinCodeFile       = nullptr;
 
 static uint32_t GetNextPinCode()
 {
-    if (!gPinCodeFile) {
+    if (!gPinCodeFile)
+    {
         return chip::kSetupPINCodeUndefinedValue;
     }
-    char pinCodeStr[9] = {0};
+    char pinCodeStr[9] = { 0 };
     if (fgets(pinCodeStr, 8, gPinCodeFile) != nullptr)
     {
         uint32_t pinCode = atoi(pinCodeStr);
-        if (pinCode == 11111111 || pinCode == 22222222 || pinCode == 33333333 || pinCode == 44444444 ||
-            pinCode == 55555555 || pinCode == 66666666 || pinCode == 77777777 || pinCode == 88888888 ||
-            pinCode == 99999999 || pinCode == 12345678 || pinCode == 87654321)
+        if (pinCode == 11111111 || pinCode == 22222222 || pinCode == 33333333 || pinCode == 44444444 || pinCode == 55555555 ||
+            pinCode == 66666666 || pinCode == 77777777 || pinCode == 88888888 || pinCode == 99999999 || pinCode == 12345678 ||
+            pinCode == 87654321)
         {
             return chip::kSetupPINCodeUndefinedValue;
         }

--- a/src/tools/spake2p/README.md
+++ b/src/tools/spake2p/README.md
@@ -31,3 +31,11 @@ random Salts and corresponding Verifiers):
 ```
 ./spake2p gen-verifier --count 100 --iteration-count 15000 --salt-len 32 --out spake2p-provisioning-data.csv
 ```
+
+Example command that generates 100 sets of spake2p parameters (Specific PIN Codes,
+random Salts and corresponding Verifiers):
+
+```
+./spake2p gen-verifier --count 100 --pin-code-file pincodes.txt --iteration-count 15000 --salt-len 32 --out spake2p-provisioning-data.csv
+```
+Notes: Each line of the `pincodes.txt` should be a valid PIN code.

--- a/src/tools/spake2p/README.md
+++ b/src/tools/spake2p/README.md
@@ -32,10 +32,11 @@ random Salts and corresponding Verifiers):
 ./spake2p gen-verifier --count 100 --iteration-count 15000 --salt-len 32 --out spake2p-provisioning-data.csv
 ```
 
-Example command that generates 100 sets of spake2p parameters (Specific PIN Codes,
-random Salts and corresponding Verifiers):
+Example command that generates 100 sets of spake2p parameters (Specific PIN
+Codes, random Salts and corresponding Verifiers):
 
 ```
 ./spake2p gen-verifier --count 100 --pin-code-file pincodes.txt --iteration-count 15000 --salt-len 32 --out spake2p-provisioning-data.csv
 ```
+
 Notes: Each line of the `pincodes.txt` should be a valid PIN code.

--- a/src/tools/spake2p/README.md
+++ b/src/tools/spake2p/README.md
@@ -36,7 +36,8 @@ Example command that generates 100 sets of spake2p parameters (Specific PIN
 Codes, random Salts and corresponding Verifiers):
 
 ```
-./spake2p gen-verifier --count 100 --pin-code-file pincodes.txt --iteration-count 15000 --salt-len 32 --out spake2p-provisioning-data.csv
+./spake2p gen-verifier --count 100 --pin-code-file pincodes.csv --iteration-count 15000 --salt-len 32 --out spake2p-provisioning-data.csv
 ```
 
-Notes: Each line of the `pincodes.txt` should be a valid PIN code.
+Notes: Each line of the `pincodes.csv` should be a valid PIN code. You can use
+`spake2p --help` to get the example content of the file.


### PR DESCRIPTION
### Problems
Currently we cannot generate spake2+ verifier sets with specified PIN codes. Only the first set will use the specified PIN code value. And others will be randomly generated.

### Changes
Add an option `--pin-code-file` for `spake2p` tool. The PIN codes in the file will be used to generate spake2+ verifier.

### Test
Tested with following command:
```
$ cat testpincode.txt 
1234
2345
3456
4567
5678

$ ./spake2p gen-verifier --count 5 --iteration-count 10000 --salt-len 32 --out - -f testpincode.txt
Index,PIN Code,Iteration Count,Salt,Verifier
0,00001234,10000,ZO5QNNKszXQkS4SX4tVUX4uQa4U8ajqGMFj+UlErmfM=,iPz/xTyRAehwVOnl7D+ehRzRnhoyH6GI7h8rsIbivAsEM/8EAKKUw/xtGLYaGcZGydqnItI2WkcYzcayzLIQhMHfILnCVkcjMaoBlyJgOzvjewoQwDZy7XZBiQQK67CQFg==
1,00002345,10000,VvDV/hIqSfv2rzuCAltM+Itt1iEtbAO6+/oV8Y5VXeY=,nD5I8kQJjTP1vP7feutIJ0P6s9uIaNBNXeF2DCdqXc0EgvZy/TYbIwv3T/ZWFbjlNOi3TYOTTy+N614AmXEzzkICvTezCDnDw2162UDk/1d6zjrUdOmQoGRSE9eD+sAFQQ==
2,00003456,10000,BE0lga34mDKngPsTdyz//S9apLuleV6T4Q95cMVCSrA=,O3hzwG6oDivOkpB2IhYorS97X/gve/T37gr2un5W9NsEkHx5rfSKIOmeBXePcsZf+bXM2/1N1bq0nzd8JblNuJnmT4VkMiHQUbAMpXhGeO2MTK/u1zA2b//b89w88h4Vhw==
3,00004567,10000,TjQ8JYXxldV4tUVgrLH/lzaRrkt7hBXCBaAsCgVkL10=,ruGXJi6RA41I8Nzaob+lMUQFg82dzKQ3fXF838MLN+wE9uWUQOXO5AByIrqoq0H7d1u95BbuxQnrRRukunw99cl6I6KDi5/ObGwVNGyatalQZeAY9dGnIthw46y15yHnVg==
4,00005678,10000,Xian6nXcSqMrd904q1w/xl4Lo3LELhwhxoFUGqjCEE8=,QdHt7AfQccmp50bYgbLmBJ7t0SELHMSuSxpRcCsPmsYEYGPgqt5OOYalc6r+xKoD9hnPfYs+SKMIM8pxCthVG0o9iDOT4UUN6Zvj2RFb+Yd2ZlrZf0peY9X5WCWQtJSnZQ==
```
