### PR TITLE
Add Darwin backwards-compat shims for the TestCluster rename.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
@@ -237,18 +237,32 @@ reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value
 {{/chip_server_cluster_attributes}}
 
 @end
+{{#if (isStrEqual (asUpperCamelCase name) "UnitTesting")}}
 
-@implementation MTRBaseCluster{{asUpperCamelCase name}} (Deprecated)
+@implementation MTRBaseClusterTestCluster
+@end
+{{/if}}
+
+@implementation MTRBaseCluster{{compatClusterNameRemapping name}} (Deprecated)
 
 {{#chip_cluster_commands}}
-- (void){{asLowerCamelCase name}}WithParams:(MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completionHandler:({{>command_completion_type command=.}})completionHandler
+- (void){{asLowerCamelCase name}}WithParams:(MTR{{compatClusterNameRemapping parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completionHandler:({{>command_completion_type command=. compatRemapClusterName=true}})completionHandler
 {
-  [self {{asLowerCamelCase name}}WithParams:params completion:completionHandler];
+  [self {{asLowerCamelCase name}}WithParams:params completion:
+    {{#if hasSpecificResponse}}
+    ^(MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}Params * _Nullable data, NSError * _Nullable error) {
+      // Cast is safe because subclass does not add any selectors.
+      completionHandler(static_cast<MTR{{compatClusterNameRemapping parent.name}}Cluster{{asUpperCamelCase responseName}}Params *>(data), error);
+    }
+    {{else}}
+    completionHandler
+    {{/if}}
+    ];
 }
 {{#unless (hasArguments)}}
-- (void){{asLowerCamelCase name}}WithCompletionHandler:({{>command_completion_type command=.}})completionHandler
+- (void){{asLowerCamelCase name}}WithCompletionHandler:({{>command_completion_type command=. compatRemapClusterName=true}})completionHandler
 {
-  [self {{asLowerCamelCase name}}WithParams:nil completion:completionHandler];
+  [self {{asLowerCamelCase name}}WithParams:nil completionHandler:completionHandler];
 }
 {{/unless}}
 {{/chip_cluster_commands}}
@@ -263,16 +277,20 @@ reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value
 {{~else~}}
   CompletionHandler:
 {{~/if_is_fabric_scoped_struct~}}
-(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))completionHandler
+(void (^)({{asObjectiveCClass type parent.name compatRemapClusterName=true}} * _Nullable value, NSError * _Nullable error))completionHandler
 {
-  [self readAttribute{{asUpperCamelCase name}}With{{#if_is_fabric_scoped_struct type}}Params:params completion:{{else}}Completion:{{/if_is_fabric_scoped_struct}}completionHandler];
+  [self readAttribute{{asUpperCamelCase name}}With{{#if_is_fabric_scoped_struct type}}Params:params completion:{{else}}Completion:{{/if_is_fabric_scoped_struct}}
+      ^({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error) {
+        // Cast is safe because subclass does not add any selectors.
+        completionHandler(static_cast<{{asObjectiveCClass type parent.name compatRemapClusterName=true}} *>(value), error);
+      }];
 }
 {{#if isWritableAttribute}}
-- (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name}})value completionHandler:(MTRStatusCompletion)completionHandler
+- (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name compatRemapClusterName=true}})value completionHandler:(MTRStatusCompletion)completionHandler
 {
   [self writeAttribute{{asUpperCamelCase name}}WithValue:value params:nil completion:completionHandler];
 }
-- (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name}})value params:(MTRWriteParams * _Nullable)params completionHandler:(MTRStatusCompletion)completionHandler
+- (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name compatRemapClusterName=true}})value params:(MTRWriteParams * _Nullable)params completionHandler:(MTRStatusCompletion)completionHandler
 {
   [self writeAttribute{{asUpperCamelCase name}}WithValue:value params:params completion:completionHandler];
 }
@@ -280,7 +298,7 @@ reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value
 {{#if isReportableAttribute}}
 - (void) subscribe{{>attribute}}WithMinInterval:(NSNumber * _Nonnull)minInterval  maxInterval:(NSNumber * _Nonnull)maxInterval
        params:(MTRSubscribeParams * _Nullable)params
-subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))reportHandler
+subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler reportHandler:(void (^)({{asObjectiveCClass type parent.name compatRemapClusterName=true}} * _Nullable value, NSError * _Nullable error))reportHandler
 {
   MTRSubscribeParams * _Nullable subscribeParams = [params copy];
   if (subscribeParams == nil) {
@@ -289,11 +307,19 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
       subscribeParams.minInterval = minInterval;
       subscribeParams.maxInterval = maxInterval;
   }
-  [self subscribeAttribute{{asUpperCamelCase name}}WithParams:subscribeParams subscriptionEstablished:subscriptionEstablishedHandler reportHandler:reportHandler];
+  [self subscribeAttribute{{asUpperCamelCase name}}WithParams:subscribeParams subscriptionEstablished:subscriptionEstablishedHandler reportHandler:
+     ^({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error) {
+       // Cast is safe because subclass does not add any selectors.
+       reportHandler(static_cast<{{asObjectiveCClass type parent.name compatRemapClusterName=true}} *>(value), error)     ;
+     }];
 }
-+ (void) read{{>attribute}}WithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue completionHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))completionHandler
++ (void) read{{>attribute}}WithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue completionHandler:(void (^)({{asObjectiveCClass type parent.name compatRemapClusterName=true}} * _Nullable value, NSError * _Nullable error))completionHandler
 {
-  [self readAttribute{{asUpperCamelCase name}}WithAttributeCache:attributeCacheContainer endpoint:endpoint queue:queue completion:completionHandler];
+  [self readAttribute{{asUpperCamelCase name}}WithAttributeCache:attributeCacheContainer endpoint:endpoint queue:queue completion:
+      ^({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error) {
+        // Cast is safe because subclass does not add any selectors.
+        completionHandler(static_cast<{{asObjectiveCClass type parent.name compatRemapClusterName=true}} *>(value), error);
+      }];
 }
 {{/if}}
 {{/chip_server_cluster_attributes}}
@@ -308,4 +334,5 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 @end
 
 {{/chip_client_clusters}}
+
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -16,6 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
  * Cluster {{name}}
  *    {{description}}
  */
+{{#if (isStrEqual (asUpperCamelCase name) "UnitTesting")}}
+MTR_NEWLY_AVAILABLE
+{{/if}}
 @interface MTRBaseCluster{{asUpperCamelCase name}} : MTRCluster
 
 - (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
@@ -60,19 +63,37 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 
 {{/chip_client_clusters}}
 
+MTR_NEWLY_DEPRECATED("Please use MTRBaseClusterUnitTesting")
+@interface MTRBaseClusterTestCluster : MTRBaseClusterUnitTesting
+@end
+
 {{#zcl_clusters}}
 {{#zcl_enums}}
-typedef NS_ENUM({{asUnderlyingZclType name}}, {{objCEnumName ../name label}}) {
+{{#*inline "enumDef"}}
+typedef NS_ENUM({{asUnderlyingZclType name}}, {{objCEnumName clusterName label}}) {
    {{#zcl_enum_items}}
-   {{objCEnumName ../../name ../label}}{{objCEnumItemLabel label}} = {{asHex value 2}},
+   {{objCEnumName ../clusterName ../label}}{{objCEnumItemLabel label}} = {{asHex value 2}},
    {{/zcl_enum_items}}
-};
+}
+{{#if (isStrEqual (asUpperCamelCase clusterName) "UnitTesting")}}
+MTR_NEWLY_AVAILABLE
+{{else if (isStrEqual (asUpperCamelCase clusterName) "TestCluster")}}
+MTR_NEWLY_DEPRECATED("Please use {{objCEnumName "UnitTesting" label}}")
+{{/if}}
+;
+{{/inline}}
+{{> enumDef name=name clusterName=../name label=label}}
 
+{{#if (isStrEqual (asUpperCamelCase ../name) "UnitTesting")}}
+{{> enumDef name=name clusterName="TestCluster" label=label}}
+
+{{/if}}
 {{/zcl_enums}}
 {{#zcl_bitmaps}}
-typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName ../name label}}) {
+{{#*inline "bitmapDef"}}
+typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName label}}) {
    {{#zcl_bitmap_items}}
-   {{objCEnumName ../../name ../label}}{{objCEnumItemLabel label}} = {{asHex mask}},
+   {{objCEnumName ../clusterName ../label}}{{objCEnumItemLabel label}} = {{asHex mask}},
    {{/zcl_bitmap_items}}
 }
 {{! TODO: We need a better setup for the API_AVALABLE annotations here; this does not scale at all sanely. }}
@@ -86,23 +107,34 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 {{/if}}
 {{/if}}
+{{#if (isStrEqual (asUpperCamelCase clusterName) "UnitTesting")}}
+MTR_NEWLY_AVAILABLE
+{{else if (isStrEqual (asUpperCamelCase clusterName) "TestCluster")}}
+MTR_NEWLY_DEPRECATED("Please use {{objCEnumName "UnitTesting" label}}")
+{{/if}}
 ;
+{{/inline}}
+{{> bitmapDef name=name clusterName=../name label=label}}
 
+{{#if (isStrEqual (asUpperCamelCase ../name) "UnitTesting")}}
+{{> bitmapDef name=name clusterName="TestCluster" label=label}}
+
+{{/if}}
 {{/zcl_bitmaps}}
 {{/zcl_clusters}}
 
 {{#chip_client_clusters includeAll=true}}
-@interface MTRBaseCluster{{asUpperCamelCase name}} (Deprecated)
+@interface MTRBaseCluster{{compatClusterNameRemapping name}} (Deprecated)
 
 - (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
                                endpoint:(uint16_t)endpoint
                                   queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 {{#chip_cluster_commands}}
-- (void){{asLowerCamelCase name}}WithParams:(MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completionHandler:({{>command_completion_type command=.}})completionHandler
+- (void){{asLowerCamelCase name}}WithParams:(MTR{{compatClusterNameRemapping parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completionHandler:({{>command_completion_type command=. compatRemapClusterName=true}})completionHandler
   MTR_NEWLY_DEPRECATED("Please use {{asLowerCamelCase name}}WithParams:completion:");
 {{#unless (hasArguments)}}
-- (void){{asLowerCamelCase name}}WithCompletionHandler:({{>command_completion_type command=.}})completionHandler
+- (void){{asLowerCamelCase name}}WithCompletionHandler:({{>command_completion_type command=. compatRemapClusterName=true}})completionHandler
   MTR_NEWLY_DEPRECATED("Please use {{asLowerCamelCase name}}WithCompletion:");
 {{/unless}}
 {{/chip_cluster_commands}}
@@ -117,21 +149,21 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 {{~else~}}
   CompletionHandler:
 {{~/if_is_fabric_scoped_struct~}}
-(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))completionHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "TestCluster")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
+(void (^)({{asObjectiveCClass type parent.name compatRemapClusterName=true}} * _Nullable value, NSError * _Nullable error))completionHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
   MTR_NEWLY_DEPRECATED("Please use read{{>attribute}}With{{#if_is_fabric_scoped_struct type}}Params:completion:{{else}}Completion:{{/if_is_fabric_scoped_struct}}");
 {{#if isWritableAttribute}}
-- (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name}})value completionHandler:(MTRStatusCompletion)completionHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "TestCluster")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
+- (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name compatRemapClusterName=true}})value completionHandler:(MTRStatusCompletion)completionHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
   MTR_NEWLY_DEPRECATED("Please use write{{>attribute}}WithValue:completion:");
-- (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name}})value params:(MTRWriteParams * _Nullable)params completionHandler:(MTRStatusCompletion)completionHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "TestCluster")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
+- (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name compatRemapClusterName=true}})value params:(MTRWriteParams * _Nullable)params completionHandler:(MTRStatusCompletion)completionHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
   MTR_NEWLY_DEPRECATED("Please use write{{>attribute}}WithValue:params:completion:");
 {{/if}}
 {{#if isReportableAttribute}}
 {{! TODO: We need a better setup for the API_AVALABLE annotations here; this does not scale at all sanely. }}
 - (void) subscribe{{>attribute}}WithMinInterval:(NSNumber * _Nonnull)minInterval  maxInterval:(NSNumber * _Nonnull)maxInterval
        params:(MTRSubscribeParams * _Nullable)params
-subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))reportHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "TestCluster")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
+subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler reportHandler:(void (^)({{asObjectiveCClass type parent.name compatRemapClusterName=true}} * _Nullable value, NSError * _Nullable error))reportHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
   MTR_NEWLY_DEPRECATED("Please use subscribe{{>attribute}}WithParams:subscriptionEstablished:");
-+ (void) read{{>attribute}}WithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue completionHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))completionHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "TestCluster")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
++ (void) read{{>attribute}}WithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue completionHandler:(void (^)({{asObjectiveCClass type parent.name compatRemapClusterName=true}} * _Nullable value, NSError * _Nullable error))completionHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
   MTR_NEWLY_DEPRECATED("Please use read{{>attribute}}WithAttributeCache:endpoint:queue:completion:");
 {{/if}}
 {{/chip_server_cluster_attributes}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusterConstants.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterConstants.zapt
@@ -7,7 +7,10 @@
 
 typedef NS_ENUM(uint32_t, MTRClusterIDType) {
 {{#zcl_clusters}}
-MTRCluster{{asUpperCamelCase label}}ID = {{asMEI manufacturerCode code}},
+MTRCluster{{asUpperCamelCase label}}ID {{#if (isStrEqual (asUpperCamelCase label) "UnitTesting")}}MTR_NEWLY_AVAILABLE{{/if}}= {{asMEI manufacturerCode code}},
+{{#if (isStrEqual (asUpperCamelCase label) "UnitTesting")}}
+MTRClusterTestClusterID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingID") = {{asMEI manufacturerCode code}},
+{{/if}}
 {{/zcl_clusters}}
 };
 
@@ -22,26 +25,44 @@ MTRClusterGlobalAttribute{{asUpperCamelCase label}}ID = {{asMEI manufacturerCode
 {{/zcl_attributes_server}}
 
 {{#zcl_clusters}}
+{{#*inline "attributeIDs"}}
 {{#zcl_attributes_server}}
 {{#first}}
-// Cluster {{asUpperCamelCase parent.label}} attributes
+// Cluster {{asUpperCamelCase ../clusterName}} attributes
 {{/first}}
 {{#if clusterRef}}
 {{! TODO: We need a better setup for the API_AVALABLE annotations here; this does not scale at all sanely. }}
-MTRCluster{{asUpperCamelCase parent.label}}Attribute{{asUpperCamelCase label}}ID {{#if (isStrEqual (asUpperCamelCase parent.label) "Descriptor")}} {{#if (isStrEqual (asUpperCamelCase label) "DeviceTypeList")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}} = {{asMEI manufacturerCode code}},
+MTRCluster{{asUpperCamelCase ../clusterName}}Attribute{{asUpperCamelCase label}}ID
+{{#if (isStrEqual (asUpperCamelCase ../clusterName) "Descriptor")}}
+{{#if (isStrEqual (asUpperCamelCase label) "DeviceTypeList")}}
+API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
+{{/if}}
+{{else if (isStrEqual (asUpperCamelCase ../clusterName) "TestCluster")}}
+MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttribute{{asUpperCamelCase label}}ID")
+{{else if (isStrEqual (asUpperCamelCase ../clusterName) "UnitTesting")}}
+MTR_NEWLY_AVAILABLE
+{{/if}}
+= {{asMEI manufacturerCode code}},
 {{!Backwards compat for now: DeviceList as an alias for DeviceTypeList}}
-{{#if (isStrEqual (asUpperCamelCase parent.label) "Descriptor")}}
+{{#if (isStrEqual (asUpperCamelCase ../clusterName) "Descriptor")}}
 {{#if (isStrEqual (asUpperCamelCase label) "DeviceTypeList")}}
 MTRClusterDescriptorAttributeDeviceListID = {{asMEI manufacturerCode code}},
 {{/if}}
 {{/if}}
 {{else}}
-MTRCluster{{asUpperCamelCase parent.label}}Attribute{{asUpperCamelCase label}}ID = MTRClusterGlobalAttribute{{asUpperCamelCase label}}ID,
+MTRCluster{{asUpperCamelCase ../clusterName}}Attribute{{asUpperCamelCase label}}ID = MTRClusterGlobalAttribute{{asUpperCamelCase label}}ID,
 {{/if}}
 {{#last}}
 
 {{/last}}
 {{/zcl_attributes_server}}
+{{/inline}}
+
+{{> attributeIDs clusterName=label}}
+{{#if (isStrEqual (asUpperCamelCase label) "UnitTesting")}}
+
+{{> attributeIDs clusterName="TestCluster"}}
+{{/if}}
 {{/zcl_clusters}}
 };
 
@@ -49,15 +70,29 @@ MTRCluster{{asUpperCamelCase parent.label}}Attribute{{asUpperCamelCase label}}ID
 
 typedef NS_ENUM(uint32_t, MTRClusterCommandIDType) {
 {{#zcl_clusters}}
+{{#*inline "commandIDs"}}
 {{#zcl_commands}}
 {{#first}}
-// Cluster {{asUpperCamelCase parent.label}} commands
+// Cluster {{asUpperCamelCase ../clusterName}} commands
 {{/first}}
-MTRCluster{{asUpperCamelCase parent.label}}Command{{asUpperCamelCase label}}ID = {{asMEI manufacturerCode code}},
+MTRCluster{{asUpperCamelCase ../clusterName}}Command{{asUpperCamelCase label}}ID
+{{#if (isStrEqual (asUpperCamelCase ../clusterName) "TestCluster")}}
+MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingCommand{{asUpperCamelCase label}}ID")
+{{else if (isStrEqual (asUpperCamelCase ../clusterName) "UnitTesting")}}
+MTR_NEWLY_AVAILABLE
+{{/if}}
+= {{asMEI manufacturerCode code}},
 {{#last}}
 
 {{/last}}
 {{/zcl_commands}}
+{{/inline}}
+
+{{> commandIDs clusterName=label}}
+{{#if (isStrEqual (asUpperCamelCase label) "UnitTesting")}}
+
+{{> commandIDs clusterName="TestCluster"}}
+{{/if}}
 {{/zcl_clusters}}
 };
 
@@ -65,14 +100,28 @@ MTRCluster{{asUpperCamelCase parent.label}}Command{{asUpperCamelCase label}}ID =
 
 typedef NS_ENUM(uint32_t, MTRClusterEventIDType) {
 {{#zcl_clusters}}
+{{#*inline "eventIDs"}}
 {{#zcl_events}}
 {{#first}}
-// Cluster {{asUpperCamelCase parent.label}} events
+// Cluster {{asUpperCamelCase ../clusterName}} events
 {{/first}}
-MTRCluster{{asUpperCamelCase parent.label}}Event{{asUpperCamelCase name}}ID = {{asMEI manufacturerCode code}},
+MTRCluster{{asUpperCamelCase ../clusterName}}Event{{asUpperCamelCase name}}ID
+{{#if (isStrEqual (asUpperCamelCase ../clusterName) "TestCluster")}}
+MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingEvent{{asUpperCamelCase name}}ID")
+{{else if (isStrEqual (asUpperCamelCase ../clusterName) "UnitTesting")}}
+MTR_NEWLY_AVAILABLE
+{{/if}}
+= {{asMEI manufacturerCode code}},
 {{#last}}
 
 {{/last}}
 {{/zcl_events}}
+{{/inline}}
+
+{{> eventIDs clusterName=label}}
+{{#if (isStrEqual (asUpperCamelCase label) "UnitTesting")}}
+
+{{> eventIDs clusterName="TestCluster"}}
+{{/if}}
 {{/zcl_clusters}}
 };

--- a/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
@@ -151,8 +151,13 @@ using chip::SessionHandle;
 {{/chip_server_cluster_attributes}}
 
 @end
+{{#if (isStrEqual (asUpperCamelCase name) "UnitTesting")}}
 
-@implementation MTRCluster{{asUpperCamelCase name}} (Deprecated)
+@implementation MTRClusterTestCluster
+@end
+{{/if}}
+
+@implementation MTRCluster{{compatClusterNameRemapping name}} (Deprecated)
 
 - (instancetype)initWithDevice:(MTRDevice *)device endpoint:(uint16_t)endpoint queue:(dispatch_queue_t)queue
 {
@@ -160,18 +165,28 @@ using chip::SessionHandle;
 }
 
 {{#chip_cluster_commands}}
-- (void){{asLowerCamelCase name}}WithParams:(MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completionHandler:({{>command_completion_type command=.}})completionHandler
+- (void){{asLowerCamelCase name}}WithParams:(MTR{{compatClusterNameRemapping parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completionHandler:({{>command_completion_type command=. compatRemapClusterName=true}})completionHandler
 {
-  [self {{asLowerCamelCase name}}WithParams:params expectedValues:expectedDataValueDictionaries expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+  [self {{asLowerCamelCase name}}WithParams:params expectedValues:expectedDataValueDictionaries expectedValueInterval:expectedValueIntervalMs completion:
+      {{#if hasSpecificResponse}}
+    ^(MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}Params * _Nullable data, NSError * _Nullable error) {
+      // Cast is safe because subclass does not add any selectors.
+      completionHandler(static_cast<MTR{{compatClusterNameRemapping parent.name}}Cluster{{asUpperCamelCase responseName}}Params *>(data), error);
+    }
+    {{else}}
+    completionHandler
+    {{/if}}
+    ];
 }
 {{#unless (hasArguments)}}
-- (void){{asLowerCamelCase name}}WithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completionHandler:({{>command_completion_type command=.}})completionHandler
+- (void){{asLowerCamelCase name}}WithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completionHandler:({{>command_completion_type command=. compatRemapClusterName=true}})completionHandler
 {
-  [self {{asLowerCamelCase name}}WithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+  [self {{asLowerCamelCase name}}WithParams:nil expectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completionHandler:completionHandler];
 }
 {{/unless}}
 {{/chip_cluster_commands}}
 @end
 
 {{/chip_client_clusters}}
+
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)

--- a/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
@@ -18,6 +18,9 @@ NS_ASSUME_NONNULL_BEGIN
  * Cluster {{name}}
  *    {{description}}
  */
+{{#if (isStrEqual (asUpperCamelCase name) "UnitTesting")}}
+MTR_NEWLY_AVAILABLE
+{{/if}}
 @interface MTRCluster{{asUpperCamelCase name}} : MTRCluster
 
 - (instancetype _Nullable)initWithDevice:(MTRDevice *)device
@@ -35,10 +38,10 @@ NS_ASSUME_NONNULL_BEGIN
 {{!Backwards compat for now: Treat DeviceTypeList as DeviceList.  Ideally we would have both, not just DeviceList. }}
 {{#*inline "attribute"}}Attribute{{#if (isStrEqual (asUpperCamelCase parent.name) "Descriptor")}}{{#if (isStrEqual (asUpperCamelCase name) "DeviceTypeList")}}DeviceList{{else}}{{asUpperCamelCase name}}{{/if}}{{else}}{{asUpperCamelCase name}}{{/if}}{{/inline}}
 {{! TODO: We need a better setup for the API_AVALABLE annotations here; this does not scale at all sanely. }}
-- (NSDictionary<NSString *, id> *)read{{>attribute}}WithParams:(MTRReadParams * _Nullable)params {{#if (isStrEqual (asUpperCamelCase parent.name) "TestCluster")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}};
+- (NSDictionary<NSString *, id> *)read{{>attribute}}WithParams:(MTRReadParams * _Nullable)params {{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}};
 {{#if isWritableAttribute}}
-- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs {{#if (isStrEqual (asUpperCamelCase parent.name) "TestCluster")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}};
-- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs params:(MTRWriteParams * _Nullable)params {{#if (isStrEqual (asUpperCamelCase parent.name) "TestCluster")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}};
+- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs {{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}};
+- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs params:(MTRWriteParams * _Nullable)params {{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}};
 {{/if}}
 {{/chip_server_cluster_attributes}}
 
@@ -49,17 +52,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{/chip_client_clusters}}
 
+MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTesting")
+@interface MTRClusterTestCluster : MTRClusterUnitTesting
+@end
+
 {{#chip_client_clusters includeAll=true}}
-@interface MTRCluster{{asUpperCamelCase name}} (Deprecated)
+@interface MTRCluster{{compatClusterNameRemapping name}} (Deprecated)
 
 - (nullable instancetype)initWithDevice:(MTRDevice *)device
                                endpoint:(uint16_t)endpoint
                                   queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 {{#chip_cluster_commands}}
-- (void){{asLowerCamelCase name}}WithParams:(MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completionHandler:({{>command_completion_type command=.}})completionHandler MTR_NEWLY_DEPRECATED("Please use {{asLowerCamelCase name}}WithParams:expectedValues:expectedValueIntervalMs:completion:");
+- (void){{asLowerCamelCase name}}WithParams:(MTR{{compatClusterNameRemapping parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completionHandler:({{>command_completion_type command=. compatRemapClusterName=true}})completionHandler MTR_NEWLY_DEPRECATED("Please use {{asLowerCamelCase name}}WithParams:expectedValues:expectedValueIntervalMs:completion:");
 {{#unless (hasArguments)}}
-- (void){{asLowerCamelCase name}}WithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completionHandler:({{>command_completion_type command=.}})completionHandler MTR_NEWLY_DEPRECATED("Please use {{asLowerCamelCase name}}WithExpectedValues:expectedValueIntervalMs:completion:");
+- (void){{asLowerCamelCase name}}WithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completionHandler:({{>command_completion_type command=. compatRemapClusterName=true}})completionHandler MTR_NEWLY_DEPRECATED("Please use {{asLowerCamelCase name}}WithExpectedValues:expectedValueIntervalMs:completion:");
 {{/unless}}
 {{/chip_cluster_commands}}
 @end

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
@@ -38,6 +38,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+{{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}
+
+@implementation MTRTestClusterCluster{{asUpperCamelCase name}}Params
+@end
+{{/if}}
 {{/zcl_commands}}
 {{/zcl_clusters}}
 

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
@@ -7,6 +7,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{#zcl_clusters}}
 {{#zcl_commands}}
+{{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}
+MTR_NEWLY_AVAILABLE
+{{/if}}
 @interface MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params : NSObject <NSCopying>
 {{#zcl_command_arguments}}
 
@@ -33,6 +36,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+{{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingCluster{{asUpperCamelCase name}}Params")
+@interface MTRTestClusterCluster{{asUpperCamelCase name}}Params : MTRUnitTestingCluster{{asUpperCamelCase name}}Params
+@end
+
+{{/if}}
 {{/zcl_commands}}
 {{/zcl_clusters}}
 

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
@@ -45,6 +45,9 @@ NS_ASSUME_NONNULL_BEGIN
 {{#if (isStrEqual (asUpperCamelCase name) "DeviceTypeStruct")}}
 {{> interfaceImpl interfaceName="MTRDescriptorClusterDeviceType"}}
 {{/if}}
+{{else if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}
+@implementation MTRTestClusterCluster{{asUpperCamelCase name}} : MTRUnitTestingCluster{{asUpperCamelCase name}}
+@end
 {{/if}}
 
 {{/zcl_structs}}
@@ -79,6 +82,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+{{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}
+
+@implementation MTRTestClusterCluster{{asUpperCamelCase name}}Event : MTRUnitTestingCluster{{asUpperCamelCase name}}Event
+@end
+{{/if}}
 
 {{/zcl_events}}
 

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
@@ -21,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 {{#if (isStrEqual (asUpperCamelCase name) "DeviceTypeStruct")}}
 API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 {{/if}}
+{{else if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}
+MTR_NEWLY_AVAILABLE
 {{/if}}
 @interface MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}} : NSObject <NSCopying>
 {{> interfaceDecl}}
@@ -33,10 +35,17 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 {{> interfaceDecl}}
 @end
 {{/if}}
+{{else if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingCluster{{asUpperCamelCase name}}")
+@interface MTRTestClusterCluster{{asUpperCamelCase name}} : MTRUnitTestingCluster{{asUpperCamelCase name}}
+@end
 {{/if}}
 {{/zcl_structs}}
 
 {{#zcl_events}}
+{{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}
+MTR_NEWLY_AVAILABLE
+{{/if}}
 @interface MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event : NSObject <NSCopying>
 {{#zcl_event_fields}}
 @property (nonatomic, copy{{#unless (isStrEqual (asGetterName name) (asStructPropertyName name))}}, getter={{asGetterName name}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName name}};
@@ -45,6 +54,12 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+{{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingCluster{{asUpperCamelCase name}}Event")
+@interface MTRTestClusterCluster{{asUpperCamelCase name}}Event : MTRUnitTestingCluster{{asUpperCamelCase name}}Event
+@end
+{{/if}}
 
 {{/zcl_events}}
 

--- a/src/darwin/Framework/CHIP/templates/partials/command_completion_type.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/command_completion_type.zapt
@@ -1,5 +1,12 @@
 {{#if command.hasSpecificResponse}}
-void (^)(MTR{{asUpperCamelCase command.parent.name}}Cluster{{asUpperCamelCase command.responseName}}Params * _Nullable data, NSError * _Nullable error)
+{{#*inline "clusterName"}}
+{{~#if compatRemapClusterName~}}
+{{compatClusterNameRemapping command.parent.name}}
+{{~else~}}
+{{asUpperCamelCase command.parent.name}}
+{{~/if~}}
+{{/inline}}
+void (^)(MTR{{> clusterName}}Cluster{{asUpperCamelCase command.responseName}}Params * _Nullable data, NSError * _Nullable error)
 {{else}}
 MTRStatusCompletion
 {{/if}}

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -18325,6 +18325,7 @@ labels.
  * Cluster Unit Testing
  *    The Test Cluster is meant to validate the generated code
  */
+MTR_NEWLY_AVAILABLE
 @interface MTRBaseClusterUnitTesting : MTRCluster
 
 - (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
@@ -20191,6 +20192,10 @@ labels.
 
 @end
 
+MTR_NEWLY_DEPRECATED("Please use MTRBaseClusterUnitTesting")
+@interface MTRBaseClusterTestCluster : MTRBaseClusterUnitTesting
+@end
+
 typedef NS_ENUM(uint8_t, MTRIdentifyEffectIdentifier) {
     MTRIdentifyEffectIdentifierBlink = 0x00,
     MTRIdentifyEffectIdentifierBreathe = 0x01,
@@ -21595,41 +21600,82 @@ typedef NS_ENUM(uint8_t, MTRUnitTestingSimple) {
     MTRUnitTestingSimpleValueA = 0x01,
     MTRUnitTestingSimpleValueB = 0x02,
     MTRUnitTestingSimpleValueC = 0x03,
-};
+} MTR_NEWLY_AVAILABLE;
+
+typedef NS_ENUM(uint8_t, MTRTestClusterSimple) {
+    MTRTestClusterSimpleUnspecified = 0x00,
+    MTRTestClusterSimpleValueA = 0x01,
+    MTRTestClusterSimpleValueB = 0x02,
+    MTRTestClusterSimpleValueC = 0x03,
+} MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingSimple");
 
 typedef NS_OPTIONS(uint16_t, MTRUnitTestingBitmap16MaskMap) {
     MTRUnitTestingBitmap16MaskMapMaskVal1 = 0x1,
     MTRUnitTestingBitmap16MaskMapMaskVal2 = 0x2,
     MTRUnitTestingBitmap16MaskMapMaskVal3 = 0x4,
     MTRUnitTestingBitmap16MaskMapMaskVal4 = 0x4000,
-};
+} MTR_NEWLY_AVAILABLE;
+
+typedef NS_OPTIONS(uint16_t, MTRTestClusterBitmap16MaskMap) {
+    MTRTestClusterBitmap16MaskMapMaskVal1 = 0x1,
+    MTRTestClusterBitmap16MaskMapMaskVal2 = 0x2,
+    MTRTestClusterBitmap16MaskMapMaskVal3 = 0x4,
+    MTRTestClusterBitmap16MaskMapMaskVal4 = 0x4000,
+} MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingBitmap16MaskMap");
 
 typedef NS_OPTIONS(uint32_t, MTRUnitTestingBitmap32MaskMap) {
     MTRUnitTestingBitmap32MaskMapMaskVal1 = 0x1,
     MTRUnitTestingBitmap32MaskMapMaskVal2 = 0x2,
     MTRUnitTestingBitmap32MaskMapMaskVal3 = 0x4,
     MTRUnitTestingBitmap32MaskMapMaskVal4 = 0x40000000,
-};
+} MTR_NEWLY_AVAILABLE;
+
+typedef NS_OPTIONS(uint32_t, MTRTestClusterBitmap32MaskMap) {
+    MTRTestClusterBitmap32MaskMapMaskVal1 = 0x1,
+    MTRTestClusterBitmap32MaskMapMaskVal2 = 0x2,
+    MTRTestClusterBitmap32MaskMapMaskVal3 = 0x4,
+    MTRTestClusterBitmap32MaskMapMaskVal4 = 0x40000000,
+} MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingBitmap32MaskMap");
 
 typedef NS_OPTIONS(uint64_t, MTRUnitTestingBitmap64MaskMap) {
     MTRUnitTestingBitmap64MaskMapMaskVal1 = 0x1,
     MTRUnitTestingBitmap64MaskMapMaskVal2 = 0x2,
     MTRUnitTestingBitmap64MaskMapMaskVal3 = 0x4,
     MTRUnitTestingBitmap64MaskMapMaskVal4 = 0x4000000000000000,
-};
+} MTR_NEWLY_AVAILABLE;
+
+typedef NS_OPTIONS(uint64_t, MTRTestClusterBitmap64MaskMap) {
+    MTRTestClusterBitmap64MaskMapMaskVal1 = 0x1,
+    MTRTestClusterBitmap64MaskMapMaskVal2 = 0x2,
+    MTRTestClusterBitmap64MaskMapMaskVal3 = 0x4,
+    MTRTestClusterBitmap64MaskMapMaskVal4 = 0x4000000000000000,
+} MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingBitmap64MaskMap");
 
 typedef NS_OPTIONS(uint8_t, MTRUnitTestingBitmap8MaskMap) {
     MTRUnitTestingBitmap8MaskMapMaskVal1 = 0x1,
     MTRUnitTestingBitmap8MaskMapMaskVal2 = 0x2,
     MTRUnitTestingBitmap8MaskMapMaskVal3 = 0x4,
     MTRUnitTestingBitmap8MaskMapMaskVal4 = 0x40,
-};
+} MTR_NEWLY_AVAILABLE;
+
+typedef NS_OPTIONS(uint8_t, MTRTestClusterBitmap8MaskMap) {
+    MTRTestClusterBitmap8MaskMapMaskVal1 = 0x1,
+    MTRTestClusterBitmap8MaskMapMaskVal2 = 0x2,
+    MTRTestClusterBitmap8MaskMapMaskVal3 = 0x4,
+    MTRTestClusterBitmap8MaskMapMaskVal4 = 0x40,
+} MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingBitmap8MaskMap");
 
 typedef NS_OPTIONS(uint8_t, MTRUnitTestingSimpleBitmap) {
     MTRUnitTestingSimpleBitmapValueA = 0x1,
     MTRUnitTestingSimpleBitmapValueB = 0x2,
     MTRUnitTestingSimpleBitmapValueC = 0x4,
-};
+} MTR_NEWLY_AVAILABLE;
+
+typedef NS_OPTIONS(uint8_t, MTRTestClusterSimpleBitmap) {
+    MTRTestClusterSimpleBitmapValueA = 0x1,
+    MTRTestClusterSimpleBitmapValueB = 0x2,
+    MTRTestClusterSimpleBitmapValueC = 0x4,
+} MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingSimpleBitmap");
 
 typedef NS_ENUM(uint8_t, MTRFaultInjectionFaultType) {
     MTRFaultInjectionFaultTypeUnspecified = 0x00,
@@ -40685,107 +40731,107 @@ typedef NS_ENUM(uint8_t, MTRFaultInjectionFaultType) {
 
 @end
 
-@interface MTRBaseClusterUnitTesting (Deprecated)
+@interface MTRBaseClusterTestCluster (Deprecated)
 
 - (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
                                endpoint:(uint16_t)endpoint
                                   queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
-- (void)testWithParams:(MTRUnitTestingClusterTestParams * _Nullable)params
+- (void)testWithParams:(MTRTestClusterClusterTestParams * _Nullable)params
      completionHandler:(MTRStatusCompletion)completionHandler MTR_NEWLY_DEPRECATED("Please use testWithParams:completion:");
 - (void)testWithCompletionHandler:(MTRStatusCompletion)completionHandler MTR_NEWLY_DEPRECATED("Please use testWithCompletion:");
-- (void)testNotHandledWithParams:(MTRUnitTestingClusterTestNotHandledParams * _Nullable)params
+- (void)testNotHandledWithParams:(MTRTestClusterClusterTestNotHandledParams * _Nullable)params
                completionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use testNotHandledWithParams:completion:");
 - (void)testNotHandledWithCompletionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use testNotHandledWithCompletion:");
-- (void)testSpecificWithParams:(MTRUnitTestingClusterTestSpecificParams * _Nullable)params
-             completionHandler:(void (^)(MTRUnitTestingClusterTestSpecificResponseParams * _Nullable data,
+- (void)testSpecificWithParams:(MTRTestClusterClusterTestSpecificParams * _Nullable)params
+             completionHandler:(void (^)(MTRTestClusterClusterTestSpecificResponseParams * _Nullable data,
                                    NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testSpecificWithParams:completion:");
 - (void)testSpecificWithCompletionHandler:
-    (void (^)(MTRUnitTestingClusterTestSpecificResponseParams * _Nullable data, NSError * _Nullable error))completionHandler
+    (void (^)(MTRTestClusterClusterTestSpecificResponseParams * _Nullable data, NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testSpecificWithCompletion:");
-- (void)testUnknownCommandWithParams:(MTRUnitTestingClusterTestUnknownCommandParams * _Nullable)params
+- (void)testUnknownCommandWithParams:(MTRTestClusterClusterTestUnknownCommandParams * _Nullable)params
                    completionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use testUnknownCommandWithParams:completion:");
 - (void)testUnknownCommandWithCompletionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use testUnknownCommandWithCompletion:");
-- (void)testAddArgumentsWithParams:(MTRUnitTestingClusterTestAddArgumentsParams *)params
-                 completionHandler:(void (^)(MTRUnitTestingClusterTestAddArgumentsResponseParams * _Nullable data,
+- (void)testAddArgumentsWithParams:(MTRTestClusterClusterTestAddArgumentsParams *)params
+                 completionHandler:(void (^)(MTRTestClusterClusterTestAddArgumentsResponseParams * _Nullable data,
                                        NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testAddArgumentsWithParams:completion:");
-- (void)testSimpleArgumentRequestWithParams:(MTRUnitTestingClusterTestSimpleArgumentRequestParams *)params
-                          completionHandler:(void (^)(MTRUnitTestingClusterTestSimpleArgumentResponseParams * _Nullable data,
+- (void)testSimpleArgumentRequestWithParams:(MTRTestClusterClusterTestSimpleArgumentRequestParams *)params
+                          completionHandler:(void (^)(MTRTestClusterClusterTestSimpleArgumentResponseParams * _Nullable data,
                                                 NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testSimpleArgumentRequestWithParams:completion:");
-- (void)testStructArrayArgumentRequestWithParams:(MTRUnitTestingClusterTestStructArrayArgumentRequestParams *)params
+- (void)testStructArrayArgumentRequestWithParams:(MTRTestClusterClusterTestStructArrayArgumentRequestParams *)params
                                completionHandler:
-                                   (void (^)(MTRUnitTestingClusterTestStructArrayArgumentResponseParams * _Nullable data,
+                                   (void (^)(MTRTestClusterClusterTestStructArrayArgumentResponseParams * _Nullable data,
                                        NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testStructArrayArgumentRequestWithParams:completion:");
-- (void)testStructArgumentRequestWithParams:(MTRUnitTestingClusterTestStructArgumentRequestParams *)params
-                          completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+- (void)testStructArgumentRequestWithParams:(MTRTestClusterClusterTestStructArgumentRequestParams *)params
+                          completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                 NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testStructArgumentRequestWithParams:completion:");
-- (void)testNestedStructArgumentRequestWithParams:(MTRUnitTestingClusterTestNestedStructArgumentRequestParams *)params
-                                completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+- (void)testNestedStructArgumentRequestWithParams:(MTRTestClusterClusterTestNestedStructArgumentRequestParams *)params
+                                completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                       NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testNestedStructArgumentRequestWithParams:completion:");
-- (void)testListStructArgumentRequestWithParams:(MTRUnitTestingClusterTestListStructArgumentRequestParams *)params
-                              completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+- (void)testListStructArgumentRequestWithParams:(MTRTestClusterClusterTestListStructArgumentRequestParams *)params
+                              completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                     NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testListStructArgumentRequestWithParams:completion:");
-- (void)testListInt8UArgumentRequestWithParams:(MTRUnitTestingClusterTestListInt8UArgumentRequestParams *)params
-                             completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+- (void)testListInt8UArgumentRequestWithParams:(MTRTestClusterClusterTestListInt8UArgumentRequestParams *)params
+                             completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                    NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testListInt8UArgumentRequestWithParams:completion:");
-- (void)testNestedStructListArgumentRequestWithParams:(MTRUnitTestingClusterTestNestedStructListArgumentRequestParams *)params
-                                    completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+- (void)testNestedStructListArgumentRequestWithParams:(MTRTestClusterClusterTestNestedStructListArgumentRequestParams *)params
+                                    completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                           NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testNestedStructListArgumentRequestWithParams:completion:");
 - (void)testListNestedStructListArgumentRequestWithParams:
-            (MTRUnitTestingClusterTestListNestedStructListArgumentRequestParams *)params
-                                        completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+            (MTRTestClusterClusterTestListNestedStructListArgumentRequestParams *)params
+                                        completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                               NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testListNestedStructListArgumentRequestWithParams:completion:");
-- (void)testListInt8UReverseRequestWithParams:(MTRUnitTestingClusterTestListInt8UReverseRequestParams *)params
-                            completionHandler:(void (^)(MTRUnitTestingClusterTestListInt8UReverseResponseParams * _Nullable data,
+- (void)testListInt8UReverseRequestWithParams:(MTRTestClusterClusterTestListInt8UReverseRequestParams *)params
+                            completionHandler:(void (^)(MTRTestClusterClusterTestListInt8UReverseResponseParams * _Nullable data,
                                                   NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testListInt8UReverseRequestWithParams:completion:");
-- (void)testEnumsRequestWithParams:(MTRUnitTestingClusterTestEnumsRequestParams *)params
-                 completionHandler:(void (^)(MTRUnitTestingClusterTestEnumsResponseParams * _Nullable data,
+- (void)testEnumsRequestWithParams:(MTRTestClusterClusterTestEnumsRequestParams *)params
+                 completionHandler:(void (^)(MTRTestClusterClusterTestEnumsResponseParams * _Nullable data,
                                        NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testEnumsRequestWithParams:completion:");
-- (void)testNullableOptionalRequestWithParams:(MTRUnitTestingClusterTestNullableOptionalRequestParams * _Nullable)params
-                            completionHandler:(void (^)(MTRUnitTestingClusterTestNullableOptionalResponseParams * _Nullable data,
+- (void)testNullableOptionalRequestWithParams:(MTRTestClusterClusterTestNullableOptionalRequestParams * _Nullable)params
+                            completionHandler:(void (^)(MTRTestClusterClusterTestNullableOptionalResponseParams * _Nullable data,
                                                   NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testNullableOptionalRequestWithParams:completion:");
-- (void)testComplexNullableOptionalRequestWithParams:(MTRUnitTestingClusterTestComplexNullableOptionalRequestParams *)params
+- (void)testComplexNullableOptionalRequestWithParams:(MTRTestClusterClusterTestComplexNullableOptionalRequestParams *)params
                                    completionHandler:
-                                       (void (^)(MTRUnitTestingClusterTestComplexNullableOptionalResponseParams * _Nullable data,
+                                       (void (^)(MTRTestClusterClusterTestComplexNullableOptionalResponseParams * _Nullable data,
                                            NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testComplexNullableOptionalRequestWithParams:completion:");
-- (void)simpleStructEchoRequestWithParams:(MTRUnitTestingClusterSimpleStructEchoRequestParams *)params
-                        completionHandler:(void (^)(MTRUnitTestingClusterSimpleStructResponseParams * _Nullable data,
+- (void)simpleStructEchoRequestWithParams:(MTRTestClusterClusterSimpleStructEchoRequestParams *)params
+                        completionHandler:(void (^)(MTRTestClusterClusterSimpleStructResponseParams * _Nullable data,
                                               NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use simpleStructEchoRequestWithParams:completion:");
-- (void)timedInvokeRequestWithParams:(MTRUnitTestingClusterTimedInvokeRequestParams * _Nullable)params
+- (void)timedInvokeRequestWithParams:(MTRTestClusterClusterTimedInvokeRequestParams * _Nullable)params
                    completionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use timedInvokeRequestWithParams:completion:");
 - (void)timedInvokeRequestWithCompletionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use timedInvokeRequestWithCompletion:");
-- (void)testSimpleOptionalArgumentRequestWithParams:(MTRUnitTestingClusterTestSimpleOptionalArgumentRequestParams * _Nullable)params
+- (void)testSimpleOptionalArgumentRequestWithParams:(MTRTestClusterClusterTestSimpleOptionalArgumentRequestParams * _Nullable)params
                                   completionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use testSimpleOptionalArgumentRequestWithParams:completion:");
-- (void)testEmitTestEventRequestWithParams:(MTRUnitTestingClusterTestEmitTestEventRequestParams *)params
-                         completionHandler:(void (^)(MTRUnitTestingClusterTestEmitTestEventResponseParams * _Nullable data,
+- (void)testEmitTestEventRequestWithParams:(MTRTestClusterClusterTestEmitTestEventRequestParams *)params
+                         completionHandler:(void (^)(MTRTestClusterClusterTestEmitTestEventResponseParams * _Nullable data,
                                                NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testEmitTestEventRequestWithParams:completion:");
-- (void)testEmitTestFabricScopedEventRequestWithParams:(MTRUnitTestingClusterTestEmitTestFabricScopedEventRequestParams *)params
+- (void)testEmitTestFabricScopedEventRequestWithParams:(MTRTestClusterClusterTestEmitTestFabricScopedEventRequestParams *)params
                                      completionHandler:
                                          (void (^)(
-                                             MTRUnitTestingClusterTestEmitTestFabricScopedEventResponseParams * _Nullable data,
+                                             MTRTestClusterClusterTestEmitTestFabricScopedEventResponseParams * _Nullable data,
                                              NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testEmitTestFabricScopedEventRequestWithParams:completion:");
 
@@ -41596,12 +41642,12 @@ typedef NS_ENUM(uint8_t, MTRFaultInjectionFaultType) {
     MTR_NEWLY_DEPRECATED("Please use readAttributeEnumAttrWithAttributeCache:endpoint:queue:completion:");
 
 - (void)readAttributeStructAttrWithCompletionHandler:
-    (void (^)(MTRUnitTestingClusterSimpleStruct * _Nullable value, NSError * _Nullable error))completionHandler
+    (void (^)(MTRTestClusterClusterSimpleStruct * _Nullable value, NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use readAttributeStructAttrWithCompletion:");
-- (void)writeAttributeStructAttrWithValue:(MTRUnitTestingClusterSimpleStruct * _Nonnull)value
+- (void)writeAttributeStructAttrWithValue:(MTRTestClusterClusterSimpleStruct * _Nonnull)value
                         completionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use writeAttributeStructAttrWithValue:completion:");
-- (void)writeAttributeStructAttrWithValue:(MTRUnitTestingClusterSimpleStruct * _Nonnull)value
+- (void)writeAttributeStructAttrWithValue:(MTRTestClusterClusterSimpleStruct * _Nonnull)value
                                    params:(MTRWriteParams * _Nullable)params
                         completionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use writeAttributeStructAttrWithValue:params:completion:");
@@ -41609,13 +41655,13 @@ typedef NS_ENUM(uint8_t, MTRFaultInjectionFaultType) {
                                         maxInterval:(NSNumber * _Nonnull)maxInterval
                                              params:(MTRSubscribeParams * _Nullable)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
-                                      reportHandler:(void (^)(MTRUnitTestingClusterSimpleStruct * _Nullable value,
+                                      reportHandler:(void (^)(MTRTestClusterClusterSimpleStruct * _Nullable value,
                                                         NSError * _Nullable error))reportHandler
     MTR_NEWLY_DEPRECATED("Please use subscribeAttributeStructAttrWithParams:subscriptionEstablished:");
 + (void)readAttributeStructAttrWithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer
                                          endpoint:(NSNumber *)endpoint
                                             queue:(dispatch_queue_t)queue
-                                completionHandler:(void (^)(MTRUnitTestingClusterSimpleStruct * _Nullable value,
+                                completionHandler:(void (^)(MTRTestClusterClusterSimpleStruct * _Nullable value,
                                                       NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use readAttributeStructAttrWithAttributeCache:endpoint:queue:completion:");
 
@@ -42543,12 +42589,12 @@ typedef NS_ENUM(uint8_t, MTRFaultInjectionFaultType) {
     MTR_NEWLY_DEPRECATED("Please use readAttributeNullableEnumAttrWithAttributeCache:endpoint:queue:completion:");
 
 - (void)readAttributeNullableStructWithCompletionHandler:
-    (void (^)(MTRUnitTestingClusterSimpleStruct * _Nullable value, NSError * _Nullable error))completionHandler
+    (void (^)(MTRTestClusterClusterSimpleStruct * _Nullable value, NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use readAttributeNullableStructWithCompletion:");
-- (void)writeAttributeNullableStructWithValue:(MTRUnitTestingClusterSimpleStruct * _Nullable)value
+- (void)writeAttributeNullableStructWithValue:(MTRTestClusterClusterSimpleStruct * _Nullable)value
                             completionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use writeAttributeNullableStructWithValue:completion:");
-- (void)writeAttributeNullableStructWithValue:(MTRUnitTestingClusterSimpleStruct * _Nullable)value
+- (void)writeAttributeNullableStructWithValue:(MTRTestClusterClusterSimpleStruct * _Nullable)value
                                        params:(MTRWriteParams * _Nullable)params
                             completionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use writeAttributeNullableStructWithValue:params:completion:");
@@ -42556,13 +42602,13 @@ typedef NS_ENUM(uint8_t, MTRFaultInjectionFaultType) {
                                             maxInterval:(NSNumber * _Nonnull)maxInterval
                                                  params:(MTRSubscribeParams * _Nullable)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
-                                          reportHandler:(void (^)(MTRUnitTestingClusterSimpleStruct * _Nullable value,
+                                          reportHandler:(void (^)(MTRTestClusterClusterSimpleStruct * _Nullable value,
                                                             NSError * _Nullable error))reportHandler
     MTR_NEWLY_DEPRECATED("Please use subscribeAttributeNullableStructWithParams:subscriptionEstablished:");
 + (void)readAttributeNullableStructWithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer
                                              endpoint:(NSNumber *)endpoint
                                                 queue:(dispatch_queue_t)queue
-                                    completionHandler:(void (^)(MTRUnitTestingClusterSimpleStruct * _Nullable value,
+                                    completionHandler:(void (^)(MTRTestClusterClusterSimpleStruct * _Nullable value,
                                                           NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use readAttributeNullableStructWithAttributeCache:endpoint:queue:completion:");
 
@@ -42668,27 +42714,32 @@ typedef NS_ENUM(uint8_t, MTRFaultInjectionFaultType) {
 
 - (void)readAttributeWriteOnlyInt8uWithCompletionHandler:
     (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completionHandler
-    MTR_NEWLY_DEPRECATED("Please use readAttributeWriteOnlyInt8uWithCompletion:");
+    API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
+        MTR_NEWLY_DEPRECATED("Please use readAttributeWriteOnlyInt8uWithCompletion:");
 - (void)writeAttributeWriteOnlyInt8uWithValue:(NSNumber * _Nonnull)value
                             completionHandler:(MTRStatusCompletion)completionHandler
-    MTR_NEWLY_DEPRECATED("Please use writeAttributeWriteOnlyInt8uWithValue:completion:");
+    API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
+        MTR_NEWLY_DEPRECATED("Please use writeAttributeWriteOnlyInt8uWithValue:completion:");
 - (void)writeAttributeWriteOnlyInt8uWithValue:(NSNumber * _Nonnull)value
                                        params:(MTRWriteParams * _Nullable)params
                             completionHandler:(MTRStatusCompletion)completionHandler
-    MTR_NEWLY_DEPRECATED("Please use writeAttributeWriteOnlyInt8uWithValue:params:completion:");
+    API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
+        MTR_NEWLY_DEPRECATED("Please use writeAttributeWriteOnlyInt8uWithValue:params:completion:");
 - (void)subscribeAttributeWriteOnlyInt8uWithMinInterval:(NSNumber * _Nonnull)minInterval
                                             maxInterval:(NSNumber * _Nonnull)maxInterval
                                                  params:(MTRSubscribeParams * _Nullable)params
                                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
                                           reportHandler:
                                               (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
-    MTR_NEWLY_DEPRECATED("Please use subscribeAttributeWriteOnlyInt8uWithParams:subscriptionEstablished:");
+    API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
+        MTR_NEWLY_DEPRECATED("Please use subscribeAttributeWriteOnlyInt8uWithParams:subscriptionEstablished:");
 + (void)readAttributeWriteOnlyInt8uWithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer
                                              endpoint:(NSNumber *)endpoint
                                                 queue:(dispatch_queue_t)queue
                                     completionHandler:
                                         (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completionHandler
-    MTR_NEWLY_DEPRECATED("Please use readAttributeWriteOnlyInt8uWithAttributeCache:endpoint:queue:completion:");
+    API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
+        MTR_NEWLY_DEPRECATED("Please use readAttributeWriteOnlyInt8uWithAttributeCache:endpoint:queue:completion:");
 
 - (void)readAttributeGeneratedCommandListWithCompletionHandler:
     (void (^)(NSArray * _Nullable value, NSError * _Nullable error))completionHandler

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
@@ -90,7 +90,8 @@ typedef NS_ENUM(uint32_t, MTRClusterIDType) {
     MTRClusterApplicationBasicID = 0x0000050D,
     MTRClusterAccountLoginID = 0x0000050E,
     MTRClusterElectricalMeasurementID = 0x00000B04,
-    MTRClusterUnitTestingID = 0xFFF1FC05,
+    MTRClusterUnitTestingID MTR_NEWLY_AVAILABLE = 0xFFF1FC05,
+    MTRClusterTestClusterID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingID") = 0xFFF1FC05,
     MTRClusterFaultInjectionID = 0xFFF1FC06,
 };
 
@@ -1279,93 +1280,269 @@ typedef NS_ENUM(uint32_t, MTRClusterAttributeIDType) {
     MTRClusterElectricalMeasurementAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster UnitTesting attributes
-    MTRClusterUnitTestingAttributeBooleanID = 0x00000000,
-    MTRClusterUnitTestingAttributeBitmap8ID = 0x00000001,
-    MTRClusterUnitTestingAttributeBitmap16ID = 0x00000002,
-    MTRClusterUnitTestingAttributeBitmap32ID = 0x00000003,
-    MTRClusterUnitTestingAttributeBitmap64ID = 0x00000004,
-    MTRClusterUnitTestingAttributeInt8uID = 0x00000005,
-    MTRClusterUnitTestingAttributeInt16uID = 0x00000006,
-    MTRClusterUnitTestingAttributeInt24uID = 0x00000007,
-    MTRClusterUnitTestingAttributeInt32uID = 0x00000008,
-    MTRClusterUnitTestingAttributeInt40uID = 0x00000009,
-    MTRClusterUnitTestingAttributeInt48uID = 0x0000000A,
-    MTRClusterUnitTestingAttributeInt56uID = 0x0000000B,
-    MTRClusterUnitTestingAttributeInt64uID = 0x0000000C,
-    MTRClusterUnitTestingAttributeInt8sID = 0x0000000D,
-    MTRClusterUnitTestingAttributeInt16sID = 0x0000000E,
-    MTRClusterUnitTestingAttributeInt24sID = 0x0000000F,
-    MTRClusterUnitTestingAttributeInt32sID = 0x00000010,
-    MTRClusterUnitTestingAttributeInt40sID = 0x00000011,
-    MTRClusterUnitTestingAttributeInt48sID = 0x00000012,
-    MTRClusterUnitTestingAttributeInt56sID = 0x00000013,
-    MTRClusterUnitTestingAttributeInt64sID = 0x00000014,
-    MTRClusterUnitTestingAttributeEnum8ID = 0x00000015,
-    MTRClusterUnitTestingAttributeEnum16ID = 0x00000016,
-    MTRClusterUnitTestingAttributeFloatSingleID = 0x00000017,
-    MTRClusterUnitTestingAttributeFloatDoubleID = 0x00000018,
-    MTRClusterUnitTestingAttributeOctetStringID = 0x00000019,
-    MTRClusterUnitTestingAttributeListInt8uID = 0x0000001A,
-    MTRClusterUnitTestingAttributeListOctetStringID = 0x0000001B,
-    MTRClusterUnitTestingAttributeListStructOctetStringID = 0x0000001C,
-    MTRClusterUnitTestingAttributeLongOctetStringID = 0x0000001D,
-    MTRClusterUnitTestingAttributeCharStringID = 0x0000001E,
-    MTRClusterUnitTestingAttributeLongCharStringID = 0x0000001F,
-    MTRClusterUnitTestingAttributeEpochUsID = 0x00000020,
-    MTRClusterUnitTestingAttributeEpochSID = 0x00000021,
-    MTRClusterUnitTestingAttributeVendorIdID = 0x00000022,
-    MTRClusterUnitTestingAttributeListNullablesAndOptionalsStructID = 0x00000023,
-    MTRClusterUnitTestingAttributeEnumAttrID = 0x00000024,
-    MTRClusterUnitTestingAttributeStructAttrID = 0x00000025,
-    MTRClusterUnitTestingAttributeRangeRestrictedInt8uID = 0x00000026,
-    MTRClusterUnitTestingAttributeRangeRestrictedInt8sID = 0x00000027,
-    MTRClusterUnitTestingAttributeRangeRestrictedInt16uID = 0x00000028,
-    MTRClusterUnitTestingAttributeRangeRestrictedInt16sID = 0x00000029,
-    MTRClusterUnitTestingAttributeListLongOctetStringID = 0x0000002A,
-    MTRClusterUnitTestingAttributeListFabricScopedID = 0x0000002B,
-    MTRClusterUnitTestingAttributeTimedWriteBooleanID = 0x00000030,
-    MTRClusterUnitTestingAttributeGeneralErrorBooleanID = 0x00000031,
-    MTRClusterUnitTestingAttributeClusterErrorBooleanID = 0x00000032,
-    MTRClusterUnitTestingAttributeUnsupportedID = 0x000000FF,
-    MTRClusterUnitTestingAttributeNullableBooleanID = 0x00004000,
-    MTRClusterUnitTestingAttributeNullableBitmap8ID = 0x00004001,
-    MTRClusterUnitTestingAttributeNullableBitmap16ID = 0x00004002,
-    MTRClusterUnitTestingAttributeNullableBitmap32ID = 0x00004003,
-    MTRClusterUnitTestingAttributeNullableBitmap64ID = 0x00004004,
-    MTRClusterUnitTestingAttributeNullableInt8uID = 0x00004005,
-    MTRClusterUnitTestingAttributeNullableInt16uID = 0x00004006,
-    MTRClusterUnitTestingAttributeNullableInt24uID = 0x00004007,
-    MTRClusterUnitTestingAttributeNullableInt32uID = 0x00004008,
-    MTRClusterUnitTestingAttributeNullableInt40uID = 0x00004009,
-    MTRClusterUnitTestingAttributeNullableInt48uID = 0x0000400A,
-    MTRClusterUnitTestingAttributeNullableInt56uID = 0x0000400B,
-    MTRClusterUnitTestingAttributeNullableInt64uID = 0x0000400C,
-    MTRClusterUnitTestingAttributeNullableInt8sID = 0x0000400D,
-    MTRClusterUnitTestingAttributeNullableInt16sID = 0x0000400E,
-    MTRClusterUnitTestingAttributeNullableInt24sID = 0x0000400F,
-    MTRClusterUnitTestingAttributeNullableInt32sID = 0x00004010,
-    MTRClusterUnitTestingAttributeNullableInt40sID = 0x00004011,
-    MTRClusterUnitTestingAttributeNullableInt48sID = 0x00004012,
-    MTRClusterUnitTestingAttributeNullableInt56sID = 0x00004013,
-    MTRClusterUnitTestingAttributeNullableInt64sID = 0x00004014,
-    MTRClusterUnitTestingAttributeNullableEnum8ID = 0x00004015,
-    MTRClusterUnitTestingAttributeNullableEnum16ID = 0x00004016,
-    MTRClusterUnitTestingAttributeNullableFloatSingleID = 0x00004017,
-    MTRClusterUnitTestingAttributeNullableFloatDoubleID = 0x00004018,
-    MTRClusterUnitTestingAttributeNullableOctetStringID = 0x00004019,
-    MTRClusterUnitTestingAttributeNullableCharStringID = 0x0000401E,
-    MTRClusterUnitTestingAttributeNullableEnumAttrID = 0x00004024,
-    MTRClusterUnitTestingAttributeNullableStructID = 0x00004025,
-    MTRClusterUnitTestingAttributeNullableRangeRestrictedInt8uID = 0x00004026,
-    MTRClusterUnitTestingAttributeNullableRangeRestrictedInt8sID = 0x00004027,
-    MTRClusterUnitTestingAttributeNullableRangeRestrictedInt16uID = 0x00004028,
-    MTRClusterUnitTestingAttributeNullableRangeRestrictedInt16sID = 0x00004029,
-    MTRClusterUnitTestingAttributeWriteOnlyInt8uID = 0x0000402A,
+    MTRClusterUnitTestingAttributeBooleanID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRClusterUnitTestingAttributeBitmap8ID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRClusterUnitTestingAttributeBitmap16ID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRClusterUnitTestingAttributeBitmap32ID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRClusterUnitTestingAttributeBitmap64ID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRClusterUnitTestingAttributeInt8uID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRClusterUnitTestingAttributeInt16uID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRClusterUnitTestingAttributeInt24uID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRClusterUnitTestingAttributeInt32uID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRClusterUnitTestingAttributeInt40uID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRClusterUnitTestingAttributeInt48uID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRClusterUnitTestingAttributeInt56uID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTRClusterUnitTestingAttributeInt64uID MTR_NEWLY_AVAILABLE = 0x0000000C,
+    MTRClusterUnitTestingAttributeInt8sID MTR_NEWLY_AVAILABLE = 0x0000000D,
+    MTRClusterUnitTestingAttributeInt16sID MTR_NEWLY_AVAILABLE = 0x0000000E,
+    MTRClusterUnitTestingAttributeInt24sID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTRClusterUnitTestingAttributeInt32sID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRClusterUnitTestingAttributeInt40sID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRClusterUnitTestingAttributeInt48sID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRClusterUnitTestingAttributeInt56sID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRClusterUnitTestingAttributeInt64sID MTR_NEWLY_AVAILABLE = 0x00000014,
+    MTRClusterUnitTestingAttributeEnum8ID MTR_NEWLY_AVAILABLE = 0x00000015,
+    MTRClusterUnitTestingAttributeEnum16ID MTR_NEWLY_AVAILABLE = 0x00000016,
+    MTRClusterUnitTestingAttributeFloatSingleID MTR_NEWLY_AVAILABLE = 0x00000017,
+    MTRClusterUnitTestingAttributeFloatDoubleID MTR_NEWLY_AVAILABLE = 0x00000018,
+    MTRClusterUnitTestingAttributeOctetStringID MTR_NEWLY_AVAILABLE = 0x00000019,
+    MTRClusterUnitTestingAttributeListInt8uID MTR_NEWLY_AVAILABLE = 0x0000001A,
+    MTRClusterUnitTestingAttributeListOctetStringID MTR_NEWLY_AVAILABLE = 0x0000001B,
+    MTRClusterUnitTestingAttributeListStructOctetStringID MTR_NEWLY_AVAILABLE = 0x0000001C,
+    MTRClusterUnitTestingAttributeLongOctetStringID MTR_NEWLY_AVAILABLE = 0x0000001D,
+    MTRClusterUnitTestingAttributeCharStringID MTR_NEWLY_AVAILABLE = 0x0000001E,
+    MTRClusterUnitTestingAttributeLongCharStringID MTR_NEWLY_AVAILABLE = 0x0000001F,
+    MTRClusterUnitTestingAttributeEpochUsID MTR_NEWLY_AVAILABLE = 0x00000020,
+    MTRClusterUnitTestingAttributeEpochSID MTR_NEWLY_AVAILABLE = 0x00000021,
+    MTRClusterUnitTestingAttributeVendorIdID MTR_NEWLY_AVAILABLE = 0x00000022,
+    MTRClusterUnitTestingAttributeListNullablesAndOptionalsStructID MTR_NEWLY_AVAILABLE = 0x00000023,
+    MTRClusterUnitTestingAttributeEnumAttrID MTR_NEWLY_AVAILABLE = 0x00000024,
+    MTRClusterUnitTestingAttributeStructAttrID MTR_NEWLY_AVAILABLE = 0x00000025,
+    MTRClusterUnitTestingAttributeRangeRestrictedInt8uID MTR_NEWLY_AVAILABLE = 0x00000026,
+    MTRClusterUnitTestingAttributeRangeRestrictedInt8sID MTR_NEWLY_AVAILABLE = 0x00000027,
+    MTRClusterUnitTestingAttributeRangeRestrictedInt16uID MTR_NEWLY_AVAILABLE = 0x00000028,
+    MTRClusterUnitTestingAttributeRangeRestrictedInt16sID MTR_NEWLY_AVAILABLE = 0x00000029,
+    MTRClusterUnitTestingAttributeListLongOctetStringID MTR_NEWLY_AVAILABLE = 0x0000002A,
+    MTRClusterUnitTestingAttributeListFabricScopedID MTR_NEWLY_AVAILABLE = 0x0000002B,
+    MTRClusterUnitTestingAttributeTimedWriteBooleanID MTR_NEWLY_AVAILABLE = 0x00000030,
+    MTRClusterUnitTestingAttributeGeneralErrorBooleanID MTR_NEWLY_AVAILABLE = 0x00000031,
+    MTRClusterUnitTestingAttributeClusterErrorBooleanID MTR_NEWLY_AVAILABLE = 0x00000032,
+    MTRClusterUnitTestingAttributeUnsupportedID MTR_NEWLY_AVAILABLE = 0x000000FF,
+    MTRClusterUnitTestingAttributeNullableBooleanID MTR_NEWLY_AVAILABLE = 0x00004000,
+    MTRClusterUnitTestingAttributeNullableBitmap8ID MTR_NEWLY_AVAILABLE = 0x00004001,
+    MTRClusterUnitTestingAttributeNullableBitmap16ID MTR_NEWLY_AVAILABLE = 0x00004002,
+    MTRClusterUnitTestingAttributeNullableBitmap32ID MTR_NEWLY_AVAILABLE = 0x00004003,
+    MTRClusterUnitTestingAttributeNullableBitmap64ID MTR_NEWLY_AVAILABLE = 0x00004004,
+    MTRClusterUnitTestingAttributeNullableInt8uID MTR_NEWLY_AVAILABLE = 0x00004005,
+    MTRClusterUnitTestingAttributeNullableInt16uID MTR_NEWLY_AVAILABLE = 0x00004006,
+    MTRClusterUnitTestingAttributeNullableInt24uID MTR_NEWLY_AVAILABLE = 0x00004007,
+    MTRClusterUnitTestingAttributeNullableInt32uID MTR_NEWLY_AVAILABLE = 0x00004008,
+    MTRClusterUnitTestingAttributeNullableInt40uID MTR_NEWLY_AVAILABLE = 0x00004009,
+    MTRClusterUnitTestingAttributeNullableInt48uID MTR_NEWLY_AVAILABLE = 0x0000400A,
+    MTRClusterUnitTestingAttributeNullableInt56uID MTR_NEWLY_AVAILABLE = 0x0000400B,
+    MTRClusterUnitTestingAttributeNullableInt64uID MTR_NEWLY_AVAILABLE = 0x0000400C,
+    MTRClusterUnitTestingAttributeNullableInt8sID MTR_NEWLY_AVAILABLE = 0x0000400D,
+    MTRClusterUnitTestingAttributeNullableInt16sID MTR_NEWLY_AVAILABLE = 0x0000400E,
+    MTRClusterUnitTestingAttributeNullableInt24sID MTR_NEWLY_AVAILABLE = 0x0000400F,
+    MTRClusterUnitTestingAttributeNullableInt32sID MTR_NEWLY_AVAILABLE = 0x00004010,
+    MTRClusterUnitTestingAttributeNullableInt40sID MTR_NEWLY_AVAILABLE = 0x00004011,
+    MTRClusterUnitTestingAttributeNullableInt48sID MTR_NEWLY_AVAILABLE = 0x00004012,
+    MTRClusterUnitTestingAttributeNullableInt56sID MTR_NEWLY_AVAILABLE = 0x00004013,
+    MTRClusterUnitTestingAttributeNullableInt64sID MTR_NEWLY_AVAILABLE = 0x00004014,
+    MTRClusterUnitTestingAttributeNullableEnum8ID MTR_NEWLY_AVAILABLE = 0x00004015,
+    MTRClusterUnitTestingAttributeNullableEnum16ID MTR_NEWLY_AVAILABLE = 0x00004016,
+    MTRClusterUnitTestingAttributeNullableFloatSingleID MTR_NEWLY_AVAILABLE = 0x00004017,
+    MTRClusterUnitTestingAttributeNullableFloatDoubleID MTR_NEWLY_AVAILABLE = 0x00004018,
+    MTRClusterUnitTestingAttributeNullableOctetStringID MTR_NEWLY_AVAILABLE = 0x00004019,
+    MTRClusterUnitTestingAttributeNullableCharStringID MTR_NEWLY_AVAILABLE = 0x0000401E,
+    MTRClusterUnitTestingAttributeNullableEnumAttrID MTR_NEWLY_AVAILABLE = 0x00004024,
+    MTRClusterUnitTestingAttributeNullableStructID MTR_NEWLY_AVAILABLE = 0x00004025,
+    MTRClusterUnitTestingAttributeNullableRangeRestrictedInt8uID MTR_NEWLY_AVAILABLE = 0x00004026,
+    MTRClusterUnitTestingAttributeNullableRangeRestrictedInt8sID MTR_NEWLY_AVAILABLE = 0x00004027,
+    MTRClusterUnitTestingAttributeNullableRangeRestrictedInt16uID MTR_NEWLY_AVAILABLE = 0x00004028,
+    MTRClusterUnitTestingAttributeNullableRangeRestrictedInt16sID MTR_NEWLY_AVAILABLE = 0x00004029,
+    MTRClusterUnitTestingAttributeWriteOnlyInt8uID MTR_NEWLY_AVAILABLE = 0x0000402A,
     MTRClusterUnitTestingAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
     MTRClusterUnitTestingAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
     MTRClusterUnitTestingAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
     MTRClusterUnitTestingAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
     MTRClusterUnitTestingAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+
+    // Cluster TestCluster attributes
+    MTRClusterTestClusterAttributeBooleanID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeBooleanID") = 0x00000000,
+    MTRClusterTestClusterAttributeBitmap8ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeBitmap8ID") = 0x00000001,
+    MTRClusterTestClusterAttributeBitmap16ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeBitmap16ID")
+    = 0x00000002,
+    MTRClusterTestClusterAttributeBitmap32ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeBitmap32ID")
+    = 0x00000003,
+    MTRClusterTestClusterAttributeBitmap64ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeBitmap64ID")
+    = 0x00000004,
+    MTRClusterTestClusterAttributeInt8uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt8uID") = 0x00000005,
+    MTRClusterTestClusterAttributeInt16uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt16uID") = 0x00000006,
+    MTRClusterTestClusterAttributeInt24uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt24uID") = 0x00000007,
+    MTRClusterTestClusterAttributeInt32uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt32uID") = 0x00000008,
+    MTRClusterTestClusterAttributeInt40uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt40uID") = 0x00000009,
+    MTRClusterTestClusterAttributeInt48uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt48uID") = 0x0000000A,
+    MTRClusterTestClusterAttributeInt56uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt56uID") = 0x0000000B,
+    MTRClusterTestClusterAttributeInt64uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt64uID") = 0x0000000C,
+    MTRClusterTestClusterAttributeInt8sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt8sID") = 0x0000000D,
+    MTRClusterTestClusterAttributeInt16sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt16sID") = 0x0000000E,
+    MTRClusterTestClusterAttributeInt24sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt24sID") = 0x0000000F,
+    MTRClusterTestClusterAttributeInt32sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt32sID") = 0x00000010,
+    MTRClusterTestClusterAttributeInt40sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt40sID") = 0x00000011,
+    MTRClusterTestClusterAttributeInt48sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt48sID") = 0x00000012,
+    MTRClusterTestClusterAttributeInt56sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt56sID") = 0x00000013,
+    MTRClusterTestClusterAttributeInt64sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt64sID") = 0x00000014,
+    MTRClusterTestClusterAttributeEnum8ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeEnum8ID") = 0x00000015,
+    MTRClusterTestClusterAttributeEnum16ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeEnum16ID") = 0x00000016,
+    MTRClusterTestClusterAttributeFloatSingleID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeFloatSingleID")
+    = 0x00000017,
+    MTRClusterTestClusterAttributeFloatDoubleID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeFloatDoubleID")
+    = 0x00000018,
+    MTRClusterTestClusterAttributeOctetStringID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeOctetStringID")
+    = 0x00000019,
+    MTRClusterTestClusterAttributeListInt8uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeListInt8uID")
+    = 0x0000001A,
+    MTRClusterTestClusterAttributeListOctetStringID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeListOctetStringID")
+    = 0x0000001B,
+    MTRClusterTestClusterAttributeListStructOctetStringID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeListStructOctetStringID")
+    = 0x0000001C,
+    MTRClusterTestClusterAttributeLongOctetStringID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeLongOctetStringID")
+    = 0x0000001D,
+    MTRClusterTestClusterAttributeCharStringID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeCharStringID")
+    = 0x0000001E,
+    MTRClusterTestClusterAttributeLongCharStringID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeLongCharStringID")
+    = 0x0000001F,
+    MTRClusterTestClusterAttributeEpochUsID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeEpochUsID") = 0x00000020,
+    MTRClusterTestClusterAttributeEpochSID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeEpochSID") = 0x00000021,
+    MTRClusterTestClusterAttributeVendorIdID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeVendorIdID")
+    = 0x00000022,
+    MTRClusterTestClusterAttributeListNullablesAndOptionalsStructID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeListNullablesAndOptionalsStructID")
+    = 0x00000023,
+    MTRClusterTestClusterAttributeEnumAttrID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeEnumAttrID")
+    = 0x00000024,
+    MTRClusterTestClusterAttributeStructAttrID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeStructAttrID")
+    = 0x00000025,
+    MTRClusterTestClusterAttributeRangeRestrictedInt8uID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeRangeRestrictedInt8uID")
+    = 0x00000026,
+    MTRClusterTestClusterAttributeRangeRestrictedInt8sID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeRangeRestrictedInt8sID")
+    = 0x00000027,
+    MTRClusterTestClusterAttributeRangeRestrictedInt16uID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeRangeRestrictedInt16uID")
+    = 0x00000028,
+    MTRClusterTestClusterAttributeRangeRestrictedInt16sID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeRangeRestrictedInt16sID")
+    = 0x00000029,
+    MTRClusterTestClusterAttributeListLongOctetStringID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeListLongOctetStringID")
+    = 0x0000002A,
+    MTRClusterTestClusterAttributeListFabricScopedID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeListFabricScopedID")
+    = 0x0000002B,
+    MTRClusterTestClusterAttributeTimedWriteBooleanID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeTimedWriteBooleanID")
+    = 0x00000030,
+    MTRClusterTestClusterAttributeGeneralErrorBooleanID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeGeneralErrorBooleanID")
+    = 0x00000031,
+    MTRClusterTestClusterAttributeClusterErrorBooleanID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeClusterErrorBooleanID")
+    = 0x00000032,
+    MTRClusterTestClusterAttributeUnsupportedID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeUnsupportedID")
+    = 0x000000FF,
+    MTRClusterTestClusterAttributeNullableBooleanID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeNullableBooleanID")
+    = 0x00004000,
+    MTRClusterTestClusterAttributeNullableBitmap8ID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeNullableBitmap8ID")
+    = 0x00004001,
+    MTRClusterTestClusterAttributeNullableBitmap16ID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeNullableBitmap16ID")
+    = 0x00004002,
+    MTRClusterTestClusterAttributeNullableBitmap32ID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeNullableBitmap32ID")
+    = 0x00004003,
+    MTRClusterTestClusterAttributeNullableBitmap64ID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeNullableBitmap64ID")
+    = 0x00004004,
+    MTRClusterTestClusterAttributeNullableInt8uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt8uID")
+    = 0x00004005,
+    MTRClusterTestClusterAttributeNullableInt16uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt16uID")
+    = 0x00004006,
+    MTRClusterTestClusterAttributeNullableInt24uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt24uID")
+    = 0x00004007,
+    MTRClusterTestClusterAttributeNullableInt32uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt32uID")
+    = 0x00004008,
+    MTRClusterTestClusterAttributeNullableInt40uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt40uID")
+    = 0x00004009,
+    MTRClusterTestClusterAttributeNullableInt48uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt48uID")
+    = 0x0000400A,
+    MTRClusterTestClusterAttributeNullableInt56uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt56uID")
+    = 0x0000400B,
+    MTRClusterTestClusterAttributeNullableInt64uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt64uID")
+    = 0x0000400C,
+    MTRClusterTestClusterAttributeNullableInt8sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt8sID")
+    = 0x0000400D,
+    MTRClusterTestClusterAttributeNullableInt16sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt16sID")
+    = 0x0000400E,
+    MTRClusterTestClusterAttributeNullableInt24sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt24sID")
+    = 0x0000400F,
+    MTRClusterTestClusterAttributeNullableInt32sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt32sID")
+    = 0x00004010,
+    MTRClusterTestClusterAttributeNullableInt40sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt40sID")
+    = 0x00004011,
+    MTRClusterTestClusterAttributeNullableInt48sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt48sID")
+    = 0x00004012,
+    MTRClusterTestClusterAttributeNullableInt56sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt56sID")
+    = 0x00004013,
+    MTRClusterTestClusterAttributeNullableInt64sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt64sID")
+    = 0x00004014,
+    MTRClusterTestClusterAttributeNullableEnum8ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableEnum8ID")
+    = 0x00004015,
+    MTRClusterTestClusterAttributeNullableEnum16ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableEnum16ID")
+    = 0x00004016,
+    MTRClusterTestClusterAttributeNullableFloatSingleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeNullableFloatSingleID")
+    = 0x00004017,
+    MTRClusterTestClusterAttributeNullableFloatDoubleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeNullableFloatDoubleID")
+    = 0x00004018,
+    MTRClusterTestClusterAttributeNullableOctetStringID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeNullableOctetStringID")
+    = 0x00004019,
+    MTRClusterTestClusterAttributeNullableCharStringID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeNullableCharStringID")
+    = 0x0000401E,
+    MTRClusterTestClusterAttributeNullableEnumAttrID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeNullableEnumAttrID")
+    = 0x00004024,
+    MTRClusterTestClusterAttributeNullableStructID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableStructID")
+    = 0x00004025,
+    MTRClusterTestClusterAttributeNullableRangeRestrictedInt8uID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeNullableRangeRestrictedInt8uID")
+    = 0x00004026,
+    MTRClusterTestClusterAttributeNullableRangeRestrictedInt8sID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeNullableRangeRestrictedInt8sID")
+    = 0x00004027,
+    MTRClusterTestClusterAttributeNullableRangeRestrictedInt16uID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeNullableRangeRestrictedInt16uID")
+    = 0x00004028,
+    MTRClusterTestClusterAttributeNullableRangeRestrictedInt16sID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingAttributeNullableRangeRestrictedInt16sID")
+    = 0x00004029,
+    MTRClusterTestClusterAttributeWriteOnlyInt8uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeWriteOnlyInt8uID")
+    = 0x0000402A,
+    MTRClusterTestClusterAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterTestClusterAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterTestClusterAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterTestClusterAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterTestClusterAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster FaultInjection attributes
     MTRClusterFaultInjectionAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
@@ -1379,6 +1556,7 @@ typedef NS_ENUM(uint32_t, MTRClusterAttributeIDType) {
 #pragma mark - Commands IDs
 
 typedef NS_ENUM(uint32_t, MTRClusterCommandIDType) {
+
     // Cluster Identify commands
     MTRClusterIdentifyCommandIdentifyID = 0x00000000,
     MTRClusterIdentifyCommandTriggerEffectID = 0x00000040,
@@ -1665,40 +1843,137 @@ typedef NS_ENUM(uint32_t, MTRClusterCommandIDType) {
     MTRClusterElectricalMeasurementCommandGetMeasurementProfileCommandID = 0x00000001,
 
     // Cluster UnitTesting commands
-    MTRClusterUnitTestingCommandTestID = 0x00000000,
-    MTRClusterUnitTestingCommandTestSpecificResponseID = 0x00000000,
-    MTRClusterUnitTestingCommandTestNotHandledID = 0x00000001,
-    MTRClusterUnitTestingCommandTestAddArgumentsResponseID = 0x00000001,
-    MTRClusterUnitTestingCommandTestSpecificID = 0x00000002,
-    MTRClusterUnitTestingCommandTestSimpleArgumentResponseID = 0x00000002,
-    MTRClusterUnitTestingCommandTestUnknownCommandID = 0x00000003,
-    MTRClusterUnitTestingCommandTestStructArrayArgumentResponseID = 0x00000003,
-    MTRClusterUnitTestingCommandTestAddArgumentsID = 0x00000004,
-    MTRClusterUnitTestingCommandTestListInt8UReverseResponseID = 0x00000004,
-    MTRClusterUnitTestingCommandTestSimpleArgumentRequestID = 0x00000005,
-    MTRClusterUnitTestingCommandTestEnumsResponseID = 0x00000005,
-    MTRClusterUnitTestingCommandTestStructArrayArgumentRequestID = 0x00000006,
-    MTRClusterUnitTestingCommandTestNullableOptionalResponseID = 0x00000006,
-    MTRClusterUnitTestingCommandTestStructArgumentRequestID = 0x00000007,
-    MTRClusterUnitTestingCommandTestComplexNullableOptionalResponseID = 0x00000007,
-    MTRClusterUnitTestingCommandTestNestedStructArgumentRequestID = 0x00000008,
-    MTRClusterUnitTestingCommandBooleanResponseID = 0x00000008,
-    MTRClusterUnitTestingCommandTestListStructArgumentRequestID = 0x00000009,
-    MTRClusterUnitTestingCommandSimpleStructResponseID = 0x00000009,
-    MTRClusterUnitTestingCommandTestListInt8UArgumentRequestID = 0x0000000A,
-    MTRClusterUnitTestingCommandTestEmitTestEventResponseID = 0x0000000A,
-    MTRClusterUnitTestingCommandTestNestedStructListArgumentRequestID = 0x0000000B,
-    MTRClusterUnitTestingCommandTestEmitTestFabricScopedEventResponseID = 0x0000000B,
-    MTRClusterUnitTestingCommandTestListNestedStructListArgumentRequestID = 0x0000000C,
-    MTRClusterUnitTestingCommandTestListInt8UReverseRequestID = 0x0000000D,
-    MTRClusterUnitTestingCommandTestEnumsRequestID = 0x0000000E,
-    MTRClusterUnitTestingCommandTestNullableOptionalRequestID = 0x0000000F,
-    MTRClusterUnitTestingCommandTestComplexNullableOptionalRequestID = 0x00000010,
-    MTRClusterUnitTestingCommandSimpleStructEchoRequestID = 0x00000011,
-    MTRClusterUnitTestingCommandTimedInvokeRequestID = 0x00000012,
-    MTRClusterUnitTestingCommandTestSimpleOptionalArgumentRequestID = 0x00000013,
-    MTRClusterUnitTestingCommandTestEmitTestEventRequestID = 0x00000014,
-    MTRClusterUnitTestingCommandTestEmitTestFabricScopedEventRequestID = 0x00000015,
+    MTRClusterUnitTestingCommandTestID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRClusterUnitTestingCommandTestSpecificResponseID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRClusterUnitTestingCommandTestNotHandledID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRClusterUnitTestingCommandTestAddArgumentsResponseID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRClusterUnitTestingCommandTestSpecificID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRClusterUnitTestingCommandTestSimpleArgumentResponseID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRClusterUnitTestingCommandTestUnknownCommandID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRClusterUnitTestingCommandTestStructArrayArgumentResponseID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRClusterUnitTestingCommandTestAddArgumentsID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRClusterUnitTestingCommandTestListInt8UReverseResponseID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRClusterUnitTestingCommandTestSimpleArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRClusterUnitTestingCommandTestEnumsResponseID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRClusterUnitTestingCommandTestStructArrayArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRClusterUnitTestingCommandTestNullableOptionalResponseID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRClusterUnitTestingCommandTestStructArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRClusterUnitTestingCommandTestComplexNullableOptionalResponseID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRClusterUnitTestingCommandTestNestedStructArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRClusterUnitTestingCommandBooleanResponseID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRClusterUnitTestingCommandTestListStructArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRClusterUnitTestingCommandSimpleStructResponseID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRClusterUnitTestingCommandTestListInt8UArgumentRequestID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRClusterUnitTestingCommandTestEmitTestEventResponseID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRClusterUnitTestingCommandTestNestedStructListArgumentRequestID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTRClusterUnitTestingCommandTestEmitTestFabricScopedEventResponseID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTRClusterUnitTestingCommandTestListNestedStructListArgumentRequestID MTR_NEWLY_AVAILABLE = 0x0000000C,
+    MTRClusterUnitTestingCommandTestListInt8UReverseRequestID MTR_NEWLY_AVAILABLE = 0x0000000D,
+    MTRClusterUnitTestingCommandTestEnumsRequestID MTR_NEWLY_AVAILABLE = 0x0000000E,
+    MTRClusterUnitTestingCommandTestNullableOptionalRequestID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTRClusterUnitTestingCommandTestComplexNullableOptionalRequestID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRClusterUnitTestingCommandSimpleStructEchoRequestID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRClusterUnitTestingCommandTimedInvokeRequestID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRClusterUnitTestingCommandTestSimpleOptionalArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRClusterUnitTestingCommandTestEmitTestEventRequestID MTR_NEWLY_AVAILABLE = 0x00000014,
+    MTRClusterUnitTestingCommandTestEmitTestFabricScopedEventRequestID MTR_NEWLY_AVAILABLE = 0x00000015,
+
+    // Cluster TestCluster commands
+    MTRClusterTestClusterCommandTestID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingCommandTestID") = 0x00000000,
+    MTRClusterTestClusterCommandTestSpecificResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestSpecificResponseID")
+    = 0x00000000,
+    MTRClusterTestClusterCommandTestNotHandledID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingCommandTestNotHandledID")
+    = 0x00000001,
+    MTRClusterTestClusterCommandTestAddArgumentsResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestAddArgumentsResponseID")
+    = 0x00000001,
+    MTRClusterTestClusterCommandTestSpecificID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingCommandTestSpecificID")
+    = 0x00000002,
+    MTRClusterTestClusterCommandTestSimpleArgumentResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestSimpleArgumentResponseID")
+    = 0x00000002,
+    MTRClusterTestClusterCommandTestUnknownCommandID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestUnknownCommandID")
+    = 0x00000003,
+    MTRClusterTestClusterCommandTestStructArrayArgumentResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestStructArrayArgumentResponseID")
+    = 0x00000003,
+    MTRClusterTestClusterCommandTestAddArgumentsID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingCommandTestAddArgumentsID")
+    = 0x00000004,
+    MTRClusterTestClusterCommandTestListInt8UReverseResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestListInt8UReverseResponseID")
+    = 0x00000004,
+    MTRClusterTestClusterCommandTestSimpleArgumentRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestSimpleArgumentRequestID")
+    = 0x00000005,
+    MTRClusterTestClusterCommandTestEnumsResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestEnumsResponseID")
+    = 0x00000005,
+    MTRClusterTestClusterCommandTestStructArrayArgumentRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestStructArrayArgumentRequestID")
+    = 0x00000006,
+    MTRClusterTestClusterCommandTestNullableOptionalResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestNullableOptionalResponseID")
+    = 0x00000006,
+    MTRClusterTestClusterCommandTestStructArgumentRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestStructArgumentRequestID")
+    = 0x00000007,
+    MTRClusterTestClusterCommandTestComplexNullableOptionalResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestComplexNullableOptionalResponseID")
+    = 0x00000007,
+    MTRClusterTestClusterCommandTestNestedStructArgumentRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestNestedStructArgumentRequestID")
+    = 0x00000008,
+    MTRClusterTestClusterCommandBooleanResponseID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingCommandBooleanResponseID")
+    = 0x00000008,
+    MTRClusterTestClusterCommandTestListStructArgumentRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestListStructArgumentRequestID")
+    = 0x00000009,
+    MTRClusterTestClusterCommandSimpleStructResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandSimpleStructResponseID")
+    = 0x00000009,
+    MTRClusterTestClusterCommandTestListInt8UArgumentRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestListInt8UArgumentRequestID")
+    = 0x0000000A,
+    MTRClusterTestClusterCommandTestEmitTestEventResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestEmitTestEventResponseID")
+    = 0x0000000A,
+    MTRClusterTestClusterCommandTestNestedStructListArgumentRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestNestedStructListArgumentRequestID")
+    = 0x0000000B,
+    MTRClusterTestClusterCommandTestEmitTestFabricScopedEventResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestEmitTestFabricScopedEventResponseID")
+    = 0x0000000B,
+    MTRClusterTestClusterCommandTestListNestedStructListArgumentRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestListNestedStructListArgumentRequestID")
+    = 0x0000000C,
+    MTRClusterTestClusterCommandTestListInt8UReverseRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestListInt8UReverseRequestID")
+    = 0x0000000D,
+    MTRClusterTestClusterCommandTestEnumsRequestID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingCommandTestEnumsRequestID")
+    = 0x0000000E,
+    MTRClusterTestClusterCommandTestNullableOptionalRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestNullableOptionalRequestID")
+    = 0x0000000F,
+    MTRClusterTestClusterCommandTestComplexNullableOptionalRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestComplexNullableOptionalRequestID")
+    = 0x00000010,
+    MTRClusterTestClusterCommandSimpleStructEchoRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandSimpleStructEchoRequestID")
+    = 0x00000011,
+    MTRClusterTestClusterCommandTimedInvokeRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTimedInvokeRequestID")
+    = 0x00000012,
+    MTRClusterTestClusterCommandTestSimpleOptionalArgumentRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestSimpleOptionalArgumentRequestID")
+    = 0x00000013,
+    MTRClusterTestClusterCommandTestEmitTestEventRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestEmitTestEventRequestID")
+    = 0x00000014,
+    MTRClusterTestClusterCommandTestEmitTestFabricScopedEventRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingCommandTestEmitTestFabricScopedEventRequestID")
+    = 0x00000015,
 
     // Cluster FaultInjection commands
     MTRClusterFaultInjectionCommandFailAtFaultID = 0x00000000,
@@ -1709,6 +1984,7 @@ typedef NS_ENUM(uint32_t, MTRClusterCommandIDType) {
 #pragma mark - Events IDs
 
 typedef NS_ENUM(uint32_t, MTRClusterEventIDType) {
+
     // Cluster AccessControl events
     MTRClusterAccessControlEventAccessControlEntryChangedID = 0x00000000,
     MTRClusterAccessControlEventAccessControlExtensionChangedID = 0x00000001,
@@ -1791,7 +2067,13 @@ typedef NS_ENUM(uint32_t, MTRClusterEventIDType) {
     MTRClusterPumpConfigurationAndControlEventTurbineOperationID = 0x00000010,
 
     // Cluster UnitTesting events
-    MTRClusterUnitTestingEventTestEventID = 0x00000001,
-    MTRClusterUnitTestingEventTestFabricScopedEventID = 0x00000002,
+    MTRClusterUnitTestingEventTestEventID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRClusterUnitTestingEventTestFabricScopedEventID MTR_NEWLY_AVAILABLE = 0x00000002,
+
+    // Cluster TestCluster events
+    MTRClusterTestClusterEventTestEventID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingEventTestEventID") = 0x00000001,
+    MTRClusterTestClusterEventTestFabricScopedEventID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterUnitTestingEventTestFabricScopedEventID")
+    = 0x00000002,
 
 };

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
@@ -4598,6 +4598,7 @@ labels.
  * Cluster Unit Testing
  *    The Test Cluster is meant to validate the generated code
  */
+MTR_NEWLY_AVAILABLE
 @interface MTRClusterUnitTesting : MTRCluster
 
 - (instancetype _Nullable)initWithDevice:(MTRDevice *)device
@@ -5304,12 +5305,15 @@ labels.
                                        expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                                                       params:(MTRWriteParams * _Nullable)params;
 
-- (NSDictionary<NSString *, id> *)readAttributeWriteOnlyInt8uWithParams:(MTRReadParams * _Nullable)params;
-- (void)writeAttributeWriteOnlyInt8uWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
-                        expectedValueInterval:(NSNumber *)expectedValueIntervalMs;
+- (NSDictionary<NSString *, id> *)readAttributeWriteOnlyInt8uWithParams:(MTRReadParams * _Nullable)params
+    API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2));
 - (void)writeAttributeWriteOnlyInt8uWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
                         expectedValueInterval:(NSNumber *)expectedValueIntervalMs
-                                       params:(MTRWriteParams * _Nullable)params;
+    API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2));
+- (void)writeAttributeWriteOnlyInt8uWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+                        expectedValueInterval:(NSNumber *)expectedValueIntervalMs
+                                       params:(MTRWriteParams * _Nullable)params
+    API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2));
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params;
 
@@ -5324,6 +5328,10 @@ labels.
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
+@end
+
+MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTesting")
+@interface MTRClusterTestCluster : MTRClusterUnitTesting
 @end
 
 @interface MTRClusterIdentify (Deprecated)
@@ -6850,13 +6858,13 @@ labels.
     MTR_NEWLY_DEPRECATED("Please use getMeasurementProfileCommandWithParams:expectedValues:expectedValueIntervalMs:completion:");
 @end
 
-@interface MTRClusterUnitTesting (Deprecated)
+@interface MTRClusterTestCluster (Deprecated)
 
 - (nullable instancetype)initWithDevice:(MTRDevice *)device
                                endpoint:(uint16_t)endpoint
                                   queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
-- (void)testWithParams:(MTRUnitTestingClusterTestParams * _Nullable)params
+- (void)testWithParams:(MTRTestClusterClusterTestParams * _Nullable)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
     expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
         completionHandler:(MTRStatusCompletion)completionHandler
@@ -6865,7 +6873,7 @@ labels.
          expectedValueInterval:(NSNumber *)expectedValueIntervalMs
              completionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use testWithExpectedValues:expectedValueIntervalMs:completion:");
-- (void)testNotHandledWithParams:(MTRUnitTestingClusterTestNotHandledParams * _Nullable)params
+- (void)testNotHandledWithParams:(MTRTestClusterClusterTestNotHandledParams * _Nullable)params
                   expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
            expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                completionHandler:(MTRStatusCompletion)completionHandler
@@ -6874,18 +6882,18 @@ labels.
                    expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                        completionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use testNotHandledWithExpectedValues:expectedValueIntervalMs:completion:");
-- (void)testSpecificWithParams:(MTRUnitTestingClusterTestSpecificParams * _Nullable)params
+- (void)testSpecificWithParams:(MTRTestClusterClusterTestSpecificParams * _Nullable)params
                 expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
          expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-             completionHandler:(void (^)(MTRUnitTestingClusterTestSpecificResponseParams * _Nullable data,
+             completionHandler:(void (^)(MTRTestClusterClusterTestSpecificResponseParams * _Nullable data,
                                    NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testSpecificWithParams:expectedValues:expectedValueIntervalMs:completion:");
 - (void)testSpecificWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
                  expectedValueInterval:(NSNumber *)expectedValueIntervalMs
-                     completionHandler:(void (^)(MTRUnitTestingClusterTestSpecificResponseParams * _Nullable data,
+                     completionHandler:(void (^)(MTRTestClusterClusterTestSpecificResponseParams * _Nullable data,
                                            NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testSpecificWithExpectedValues:expectedValueIntervalMs:completion:");
-- (void)testUnknownCommandWithParams:(MTRUnitTestingClusterTestUnknownCommandParams * _Nullable)params
+- (void)testUnknownCommandWithParams:(MTRTestClusterClusterTestUnknownCommandParams * _Nullable)params
                       expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                    completionHandler:(MTRStatusCompletion)completionHandler
@@ -6894,100 +6902,100 @@ labels.
                        expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                            completionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use testUnknownCommandWithExpectedValues:expectedValueIntervalMs:completion:");
-- (void)testAddArgumentsWithParams:(MTRUnitTestingClusterTestAddArgumentsParams *)params
+- (void)testAddArgumentsWithParams:(MTRTestClusterClusterTestAddArgumentsParams *)params
                     expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
              expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                 completionHandler:(void (^)(MTRUnitTestingClusterTestAddArgumentsResponseParams * _Nullable data,
+                 completionHandler:(void (^)(MTRTestClusterClusterTestAddArgumentsResponseParams * _Nullable data,
                                        NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testAddArgumentsWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)testSimpleArgumentRequestWithParams:(MTRUnitTestingClusterTestSimpleArgumentRequestParams *)params
+- (void)testSimpleArgumentRequestWithParams:(MTRTestClusterClusterTestSimpleArgumentRequestParams *)params
                              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                       expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                          completionHandler:(void (^)(MTRUnitTestingClusterTestSimpleArgumentResponseParams * _Nullable data,
+                          completionHandler:(void (^)(MTRTestClusterClusterTestSimpleArgumentResponseParams * _Nullable data,
                                                 NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testSimpleArgumentRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)testStructArrayArgumentRequestWithParams:(MTRUnitTestingClusterTestStructArrayArgumentRequestParams *)params
+- (void)testStructArrayArgumentRequestWithParams:(MTRTestClusterClusterTestStructArrayArgumentRequestParams *)params
                                   expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                            expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                                completionHandler:
-                                   (void (^)(MTRUnitTestingClusterTestStructArrayArgumentResponseParams * _Nullable data,
+                                   (void (^)(MTRTestClusterClusterTestStructArrayArgumentResponseParams * _Nullable data,
                                        NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testStructArrayArgumentRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)testStructArgumentRequestWithParams:(MTRUnitTestingClusterTestStructArgumentRequestParams *)params
+- (void)testStructArgumentRequestWithParams:(MTRTestClusterClusterTestStructArgumentRequestParams *)params
                              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                       expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                          completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                          completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                 NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testStructArgumentRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)testNestedStructArgumentRequestWithParams:(MTRUnitTestingClusterTestNestedStructArgumentRequestParams *)params
+- (void)testNestedStructArgumentRequestWithParams:(MTRTestClusterClusterTestNestedStructArgumentRequestParams *)params
                                    expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                             expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                                completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                                completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                       NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testNestedStructArgumentRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)testListStructArgumentRequestWithParams:(MTRUnitTestingClusterTestListStructArgumentRequestParams *)params
+- (void)testListStructArgumentRequestWithParams:(MTRTestClusterClusterTestListStructArgumentRequestParams *)params
                                  expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                           expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                              completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                              completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                     NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testListStructArgumentRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)testListInt8UArgumentRequestWithParams:(MTRUnitTestingClusterTestListInt8UArgumentRequestParams *)params
+- (void)testListInt8UArgumentRequestWithParams:(MTRTestClusterClusterTestListInt8UArgumentRequestParams *)params
                                 expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                          expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                             completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                             completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                    NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testListInt8UArgumentRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)testNestedStructListArgumentRequestWithParams:(MTRUnitTestingClusterTestNestedStructListArgumentRequestParams *)params
+- (void)testNestedStructListArgumentRequestWithParams:(MTRTestClusterClusterTestNestedStructListArgumentRequestParams *)params
                                        expectedValues:
                                            (NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                                 expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                                    completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                                    completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                           NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED(
         "Please use testNestedStructListArgumentRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
 - (void)testListNestedStructListArgumentRequestWithParams:
-            (MTRUnitTestingClusterTestListNestedStructListArgumentRequestParams *)params
+            (MTRTestClusterClusterTestListNestedStructListArgumentRequestParams *)params
                                            expectedValues:
                                                (NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                                     expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                                        completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                                        completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                               NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED(
         "Please use testListNestedStructListArgumentRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)testListInt8UReverseRequestWithParams:(MTRUnitTestingClusterTestListInt8UReverseRequestParams *)params
+- (void)testListInt8UReverseRequestWithParams:(MTRTestClusterClusterTestListInt8UReverseRequestParams *)params
                                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                         expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                            completionHandler:(void (^)(MTRUnitTestingClusterTestListInt8UReverseResponseParams * _Nullable data,
+                            completionHandler:(void (^)(MTRTestClusterClusterTestListInt8UReverseResponseParams * _Nullable data,
                                                   NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testListInt8UReverseRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)testEnumsRequestWithParams:(MTRUnitTestingClusterTestEnumsRequestParams *)params
+- (void)testEnumsRequestWithParams:(MTRTestClusterClusterTestEnumsRequestParams *)params
                     expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
              expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                 completionHandler:(void (^)(MTRUnitTestingClusterTestEnumsResponseParams * _Nullable data,
+                 completionHandler:(void (^)(MTRTestClusterClusterTestEnumsResponseParams * _Nullable data,
                                        NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testEnumsRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)testNullableOptionalRequestWithParams:(MTRUnitTestingClusterTestNullableOptionalRequestParams * _Nullable)params
+- (void)testNullableOptionalRequestWithParams:(MTRTestClusterClusterTestNullableOptionalRequestParams * _Nullable)params
                                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                         expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                            completionHandler:(void (^)(MTRUnitTestingClusterTestNullableOptionalResponseParams * _Nullable data,
+                            completionHandler:(void (^)(MTRTestClusterClusterTestNullableOptionalResponseParams * _Nullable data,
                                                   NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testNullableOptionalRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)testComplexNullableOptionalRequestWithParams:(MTRUnitTestingClusterTestComplexNullableOptionalRequestParams *)params
+- (void)testComplexNullableOptionalRequestWithParams:(MTRTestClusterClusterTestComplexNullableOptionalRequestParams *)params
                                       expectedValues:
                                           (NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                                expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                                    completionHandler:
-                                       (void (^)(MTRUnitTestingClusterTestComplexNullableOptionalResponseParams * _Nullable data,
+                                       (void (^)(MTRTestClusterClusterTestComplexNullableOptionalResponseParams * _Nullable data,
                                            NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED(
         "Please use testComplexNullableOptionalRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)simpleStructEchoRequestWithParams:(MTRUnitTestingClusterSimpleStructEchoRequestParams *)params
+- (void)simpleStructEchoRequestWithParams:(MTRTestClusterClusterSimpleStructEchoRequestParams *)params
                            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                     expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                        completionHandler:(void (^)(MTRUnitTestingClusterSimpleStructResponseParams * _Nullable data,
+                        completionHandler:(void (^)(MTRTestClusterClusterSimpleStructResponseParams * _Nullable data,
                                               NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use simpleStructEchoRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)timedInvokeRequestWithParams:(MTRUnitTestingClusterTimedInvokeRequestParams * _Nullable)params
+- (void)timedInvokeRequestWithParams:(MTRTestClusterClusterTimedInvokeRequestParams * _Nullable)params
                       expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                    completionHandler:(MTRStatusCompletion)completionHandler
@@ -6996,26 +7004,26 @@ labels.
                        expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                            completionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED("Please use timedInvokeRequestWithExpectedValues:expectedValueIntervalMs:completion:");
-- (void)testSimpleOptionalArgumentRequestWithParams:(MTRUnitTestingClusterTestSimpleOptionalArgumentRequestParams * _Nullable)params
+- (void)testSimpleOptionalArgumentRequestWithParams:(MTRTestClusterClusterTestSimpleOptionalArgumentRequestParams * _Nullable)params
                                      expectedValues:
                                          (NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                               expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                                   completionHandler:(MTRStatusCompletion)completionHandler
     MTR_NEWLY_DEPRECATED(
         "Please use testSimpleOptionalArgumentRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)testEmitTestEventRequestWithParams:(MTRUnitTestingClusterTestEmitTestEventRequestParams *)params
+- (void)testEmitTestEventRequestWithParams:(MTRTestClusterClusterTestEmitTestEventRequestParams *)params
                             expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                      expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                         completionHandler:(void (^)(MTRUnitTestingClusterTestEmitTestEventResponseParams * _Nullable data,
+                         completionHandler:(void (^)(MTRTestClusterClusterTestEmitTestEventResponseParams * _Nullable data,
                                                NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED("Please use testEmitTestEventRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");
-- (void)testEmitTestFabricScopedEventRequestWithParams:(MTRUnitTestingClusterTestEmitTestFabricScopedEventRequestParams *)params
+- (void)testEmitTestFabricScopedEventRequestWithParams:(MTRTestClusterClusterTestEmitTestFabricScopedEventRequestParams *)params
                                         expectedValues:
                                             (NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                                  expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                                      completionHandler:
                                          (void (^)(
-                                             MTRUnitTestingClusterTestEmitTestFabricScopedEventResponseParams * _Nullable data,
+                                             MTRTestClusterClusterTestEmitTestFabricScopedEventResponseParams * _Nullable data,
                                              NSError * _Nullable error))completionHandler
     MTR_NEWLY_DEPRECATED(
         "Please use testEmitTestFabricScopedEventRequestWithParams:expectedValues:expectedValueIntervalMs:completion:");

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
@@ -653,7 +653,10 @@ using chip::SessionHandle;
     [self addGroupWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRGroupsClusterAddGroupResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRGroupsClusterAddGroupResponseParams *>(data), error);
+                   }];
 }
 - (void)viewGroupWithParams:(MTRGroupsClusterViewGroupParams *)params
              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -664,7 +667,10 @@ using chip::SessionHandle;
     [self viewGroupWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRGroupsClusterViewGroupResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRGroupsClusterViewGroupResponseParams *>(data), error);
+                   }];
 }
 - (void)getGroupMembershipWithParams:(MTRGroupsClusterGetGroupMembershipParams *)params
                       expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -675,7 +681,11 @@ using chip::SessionHandle;
     [self getGroupMembershipWithParams:params
                         expectedValues:expectedDataValueDictionaries
                  expectedValueInterval:expectedValueIntervalMs
-                            completion:completionHandler];
+                            completion:^(
+                                MTRGroupsClusterGetGroupMembershipResponseParams * _Nullable data, NSError * _Nullable error) {
+                                // Cast is safe because subclass does not add any selectors.
+                                completionHandler(static_cast<MTRGroupsClusterGetGroupMembershipResponseParams *>(data), error);
+                            }];
 }
 - (void)removeGroupWithParams:(MTRGroupsClusterRemoveGroupParams *)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -686,7 +696,10 @@ using chip::SessionHandle;
     [self removeGroupWithParams:params
                  expectedValues:expectedDataValueDictionaries
           expectedValueInterval:expectedValueIntervalMs
-                     completion:completionHandler];
+                     completion:^(MTRGroupsClusterRemoveGroupResponseParams * _Nullable data, NSError * _Nullable error) {
+                         // Cast is safe because subclass does not add any selectors.
+                         completionHandler(static_cast<MTRGroupsClusterRemoveGroupResponseParams *>(data), error);
+                     }];
 }
 - (void)removeAllGroupsWithParams:(MTRGroupsClusterRemoveAllGroupsParams * _Nullable)params
                    expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -702,9 +715,10 @@ using chip::SessionHandle;
                     expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                         completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self removeAllGroupsWithExpectedValues:expectedValues
-                      expectedValueInterval:expectedValueIntervalMs
-                                 completion:completionHandler];
+    [self removeAllGroupsWithParams:nil
+                     expectedValues:expectedValues
+              expectedValueInterval:expectedValueIntervalMs
+                  completionHandler:completionHandler];
 }
 - (void)addGroupIfIdentifyingWithParams:(MTRGroupsClusterAddGroupIfIdentifyingParams *)params
                          expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1469,7 +1483,10 @@ using chip::SessionHandle;
     [self addSceneWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRScenesClusterAddSceneResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRScenesClusterAddSceneResponseParams *>(data), error);
+                   }];
 }
 - (void)viewSceneWithParams:(MTRScenesClusterViewSceneParams *)params
              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1480,7 +1497,10 @@ using chip::SessionHandle;
     [self viewSceneWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRScenesClusterViewSceneResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRScenesClusterViewSceneResponseParams *>(data), error);
+                   }];
 }
 - (void)removeSceneWithParams:(MTRScenesClusterRemoveSceneParams *)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1491,7 +1511,10 @@ using chip::SessionHandle;
     [self removeSceneWithParams:params
                  expectedValues:expectedDataValueDictionaries
           expectedValueInterval:expectedValueIntervalMs
-                     completion:completionHandler];
+                     completion:^(MTRScenesClusterRemoveSceneResponseParams * _Nullable data, NSError * _Nullable error) {
+                         // Cast is safe because subclass does not add any selectors.
+                         completionHandler(static_cast<MTRScenesClusterRemoveSceneResponseParams *>(data), error);
+                     }];
 }
 - (void)removeAllScenesWithParams:(MTRScenesClusterRemoveAllScenesParams *)params
                    expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1502,7 +1525,10 @@ using chip::SessionHandle;
     [self removeAllScenesWithParams:params
                      expectedValues:expectedDataValueDictionaries
               expectedValueInterval:expectedValueIntervalMs
-                         completion:completionHandler];
+                         completion:^(MTRScenesClusterRemoveAllScenesResponseParams * _Nullable data, NSError * _Nullable error) {
+                             // Cast is safe because subclass does not add any selectors.
+                             completionHandler(static_cast<MTRScenesClusterRemoveAllScenesResponseParams *>(data), error);
+                         }];
 }
 - (void)storeSceneWithParams:(MTRScenesClusterStoreSceneParams *)params
               expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1513,7 +1539,10 @@ using chip::SessionHandle;
     [self storeSceneWithParams:params
                 expectedValues:expectedDataValueDictionaries
          expectedValueInterval:expectedValueIntervalMs
-                    completion:completionHandler];
+                    completion:^(MTRScenesClusterStoreSceneResponseParams * _Nullable data, NSError * _Nullable error) {
+                        // Cast is safe because subclass does not add any selectors.
+                        completionHandler(static_cast<MTRScenesClusterStoreSceneResponseParams *>(data), error);
+                    }];
 }
 - (void)recallSceneWithParams:(MTRScenesClusterRecallSceneParams *)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1534,7 +1563,11 @@ using chip::SessionHandle;
     [self getSceneMembershipWithParams:params
                         expectedValues:expectedDataValueDictionaries
                  expectedValueInterval:expectedValueIntervalMs
-                            completion:completionHandler];
+                            completion:^(
+                                MTRScenesClusterGetSceneMembershipResponseParams * _Nullable data, NSError * _Nullable error) {
+                                // Cast is safe because subclass does not add any selectors.
+                                completionHandler(static_cast<MTRScenesClusterGetSceneMembershipResponseParams *>(data), error);
+                            }];
 }
 - (void)enhancedAddSceneWithParams:(MTRScenesClusterEnhancedAddSceneParams *)params
                     expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1545,7 +1578,10 @@ using chip::SessionHandle;
     [self enhancedAddSceneWithParams:params
                       expectedValues:expectedDataValueDictionaries
                expectedValueInterval:expectedValueIntervalMs
-                          completion:completionHandler];
+                          completion:^(MTRScenesClusterEnhancedAddSceneResponseParams * _Nullable data, NSError * _Nullable error) {
+                              // Cast is safe because subclass does not add any selectors.
+                              completionHandler(static_cast<MTRScenesClusterEnhancedAddSceneResponseParams *>(data), error);
+                          }];
 }
 - (void)enhancedViewSceneWithParams:(MTRScenesClusterEnhancedViewSceneParams *)params
                      expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1553,10 +1589,14 @@ using chip::SessionHandle;
                   completionHandler:(void (^)(MTRScenesClusterEnhancedViewSceneResponseParams * _Nullable data,
                                         NSError * _Nullable error))completionHandler
 {
-    [self enhancedViewSceneWithParams:params
-                       expectedValues:expectedDataValueDictionaries
-                expectedValueInterval:expectedValueIntervalMs
-                           completion:completionHandler];
+    [self
+        enhancedViewSceneWithParams:params
+                     expectedValues:expectedDataValueDictionaries
+              expectedValueInterval:expectedValueIntervalMs
+                         completion:^(MTRScenesClusterEnhancedViewSceneResponseParams * _Nullable data, NSError * _Nullable error) {
+                             // Cast is safe because subclass does not add any selectors.
+                             completionHandler(static_cast<MTRScenesClusterEnhancedViewSceneResponseParams *>(data), error);
+                         }];
 }
 - (void)copySceneWithParams:(MTRScenesClusterCopySceneParams *)params
              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -1567,7 +1607,10 @@ using chip::SessionHandle;
     [self copySceneWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRScenesClusterCopySceneResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRScenesClusterCopySceneResponseParams *>(data), error);
+                   }];
 }
 @end
 
@@ -2069,7 +2112,10 @@ using chip::SessionHandle;
         expectedValueInterval:(NSNumber *)expectedValueIntervalMs
             completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self offWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self offWithParams:nil
+               expectedValues:expectedValues
+        expectedValueInterval:expectedValueIntervalMs
+            completionHandler:completionHandler];
 }
 - (void)onWithParams:(MTROnOffClusterOnParams * _Nullable)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -2085,7 +2131,10 @@ using chip::SessionHandle;
        expectedValueInterval:(NSNumber *)expectedValueIntervalMs
            completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self onWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self onWithParams:nil
+               expectedValues:expectedValues
+        expectedValueInterval:expectedValueIntervalMs
+            completionHandler:completionHandler];
 }
 - (void)toggleWithParams:(MTROnOffClusterToggleParams * _Nullable)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -2101,7 +2150,10 @@ using chip::SessionHandle;
            expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self toggleWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self toggleWithParams:nil
+               expectedValues:expectedValues
+        expectedValueInterval:expectedValueIntervalMs
+            completionHandler:completionHandler];
 }
 - (void)offWithEffectWithParams:(MTROnOffClusterOffWithEffectParams *)params
                  expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -2127,9 +2179,10 @@ using chip::SessionHandle;
                             expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                                 completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self onWithRecallGlobalSceneWithExpectedValues:expectedValues
-                              expectedValueInterval:expectedValueIntervalMs
-                                         completion:completionHandler];
+    [self onWithRecallGlobalSceneWithParams:nil
+                             expectedValues:expectedValues
+                      expectedValueInterval:expectedValueIntervalMs
+                          completionHandler:completionHandler];
 }
 - (void)onWithTimedOffWithParams:(MTROnOffClusterOnWithTimedOffParams *)params
                   expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -4932,9 +4985,10 @@ using chip::SessionHandle;
                     expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                         completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self mfgSpecificPingWithExpectedValues:expectedValues
-                      expectedValueInterval:expectedValueIntervalMs
-                                 completion:completionHandler];
+    [self mfgSpecificPingWithParams:nil
+                     expectedValues:expectedValues
+              expectedValueInterval:expectedValueIntervalMs
+                  completionHandler:completionHandler];
 }
 @end
 
@@ -5196,7 +5250,11 @@ using chip::SessionHandle;
     [self queryImageWithParams:params
                 expectedValues:expectedDataValueDictionaries
          expectedValueInterval:expectedValueIntervalMs
-                    completion:completionHandler];
+                    completion:^(
+                        MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data, NSError * _Nullable error) {
+                        // Cast is safe because subclass does not add any selectors.
+                        completionHandler(static_cast<MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams *>(data), error);
+                    }];
 }
 - (void)applyUpdateRequestWithParams:(MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
                       expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -5207,7 +5265,12 @@ using chip::SessionHandle;
     [self applyUpdateRequestWithParams:params
                         expectedValues:expectedDataValueDictionaries
                  expectedValueInterval:expectedValueIntervalMs
-                            completion:completionHandler];
+                            completion:^(MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
+                                NSError * _Nullable error) {
+                                // Cast is safe because subclass does not add any selectors.
+                                completionHandler(
+                                    static_cast<MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams *>(data), error);
+                            }];
 }
 - (void)notifyUpdateAppliedWithParams:(MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
                        expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -6403,7 +6466,11 @@ using chip::SessionHandle;
     [self armFailSafeWithParams:params
                  expectedValues:expectedDataValueDictionaries
           expectedValueInterval:expectedValueIntervalMs
-                     completion:completionHandler];
+                     completion:^(
+                         MTRGeneralCommissioningClusterArmFailSafeResponseParams * _Nullable data, NSError * _Nullable error) {
+                         // Cast is safe because subclass does not add any selectors.
+                         completionHandler(static_cast<MTRGeneralCommissioningClusterArmFailSafeResponseParams *>(data), error);
+                     }];
 }
 - (void)setRegulatoryConfigWithParams:(MTRGeneralCommissioningClusterSetRegulatoryConfigParams *)params
                        expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -6414,7 +6481,12 @@ using chip::SessionHandle;
     [self setRegulatoryConfigWithParams:params
                          expectedValues:expectedDataValueDictionaries
                   expectedValueInterval:expectedValueIntervalMs
-                             completion:completionHandler];
+                             completion:^(MTRGeneralCommissioningClusterSetRegulatoryConfigResponseParams * _Nullable data,
+                                 NSError * _Nullable error) {
+                                 // Cast is safe because subclass does not add any selectors.
+                                 completionHandler(
+                                     static_cast<MTRGeneralCommissioningClusterSetRegulatoryConfigResponseParams *>(data), error);
+                             }];
 }
 - (void)commissioningCompleteWithParams:(MTRGeneralCommissioningClusterCommissioningCompleteParams * _Nullable)params
                          expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -6423,10 +6495,16 @@ using chip::SessionHandle;
                           (void (^)(MTRGeneralCommissioningClusterCommissioningCompleteResponseParams * _Nullable data,
                               NSError * _Nullable error))completionHandler
 {
-    [self commissioningCompleteWithParams:params
-                           expectedValues:expectedDataValueDictionaries
-                    expectedValueInterval:expectedValueIntervalMs
-                               completion:completionHandler];
+    [self
+        commissioningCompleteWithParams:params
+                         expectedValues:expectedDataValueDictionaries
+                  expectedValueInterval:expectedValueIntervalMs
+                             completion:^(MTRGeneralCommissioningClusterCommissioningCompleteResponseParams * _Nullable data,
+                                 NSError * _Nullable error) {
+                                 // Cast is safe because subclass does not add any selectors.
+                                 completionHandler(
+                                     static_cast<MTRGeneralCommissioningClusterCommissioningCompleteResponseParams *>(data), error);
+                             }];
 }
 - (void)commissioningCompleteWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
                           expectedValueInterval:(NSNumber *)expectedValueIntervalMs
@@ -6434,9 +6512,10 @@ using chip::SessionHandle;
                                   (void (^)(MTRGeneralCommissioningClusterCommissioningCompleteResponseParams * _Nullable data,
                                       NSError * _Nullable error))completionHandler
 {
-    [self commissioningCompleteWithExpectedValues:expectedValues
-                            expectedValueInterval:expectedValueIntervalMs
-                                       completion:completionHandler];
+    [self commissioningCompleteWithParams:nil
+                           expectedValues:expectedValues
+                    expectedValueInterval:expectedValueIntervalMs
+                        completionHandler:completionHandler];
 }
 @end
 
@@ -6908,7 +6987,11 @@ using chip::SessionHandle;
     [self scanNetworksWithParams:params
                   expectedValues:expectedDataValueDictionaries
            expectedValueInterval:expectedValueIntervalMs
-                      completion:completionHandler];
+                      completion:^(
+                          MTRNetworkCommissioningClusterScanNetworksResponseParams * _Nullable data, NSError * _Nullable error) {
+                          // Cast is safe because subclass does not add any selectors.
+                          completionHandler(static_cast<MTRNetworkCommissioningClusterScanNetworksResponseParams *>(data), error);
+                      }];
 }
 - (void)addOrUpdateWiFiNetworkWithParams:(MTRNetworkCommissioningClusterAddOrUpdateWiFiNetworkParams *)params
                           expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -6919,7 +7002,12 @@ using chip::SessionHandle;
     [self addOrUpdateWiFiNetworkWithParams:params
                             expectedValues:expectedDataValueDictionaries
                      expectedValueInterval:expectedValueIntervalMs
-                                completion:completionHandler];
+                                completion:^(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
+                                    NSError * _Nullable error) {
+                                    // Cast is safe because subclass does not add any selectors.
+                                    completionHandler(
+                                        static_cast<MTRNetworkCommissioningClusterNetworkConfigResponseParams *>(data), error);
+                                }];
 }
 - (void)addOrUpdateThreadNetworkWithParams:(MTRNetworkCommissioningClusterAddOrUpdateThreadNetworkParams *)params
                             expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -6930,7 +7018,12 @@ using chip::SessionHandle;
     [self addOrUpdateThreadNetworkWithParams:params
                               expectedValues:expectedDataValueDictionaries
                        expectedValueInterval:expectedValueIntervalMs
-                                  completion:completionHandler];
+                                  completion:^(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
+                                      NSError * _Nullable error) {
+                                      // Cast is safe because subclass does not add any selectors.
+                                      completionHandler(
+                                          static_cast<MTRNetworkCommissioningClusterNetworkConfigResponseParams *>(data), error);
+                                  }];
 }
 - (void)removeNetworkWithParams:(MTRNetworkCommissioningClusterRemoveNetworkParams *)params
                  expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -6941,7 +7034,11 @@ using chip::SessionHandle;
     [self removeNetworkWithParams:params
                    expectedValues:expectedDataValueDictionaries
             expectedValueInterval:expectedValueIntervalMs
-                       completion:completionHandler];
+                       completion:^(
+                           MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data, NSError * _Nullable error) {
+                           // Cast is safe because subclass does not add any selectors.
+                           completionHandler(static_cast<MTRNetworkCommissioningClusterNetworkConfigResponseParams *>(data), error);
+                       }];
 }
 - (void)connectNetworkWithParams:(MTRNetworkCommissioningClusterConnectNetworkParams *)params
                   expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -6949,10 +7046,15 @@ using chip::SessionHandle;
                completionHandler:(void (^)(MTRNetworkCommissioningClusterConnectNetworkResponseParams * _Nullable data,
                                      NSError * _Nullable error))completionHandler
 {
-    [self connectNetworkWithParams:params
-                    expectedValues:expectedDataValueDictionaries
-             expectedValueInterval:expectedValueIntervalMs
-                        completion:completionHandler];
+    [self
+        connectNetworkWithParams:params
+                  expectedValues:expectedDataValueDictionaries
+           expectedValueInterval:expectedValueIntervalMs
+                      completion:^(
+                          MTRNetworkCommissioningClusterConnectNetworkResponseParams * _Nullable data, NSError * _Nullable error) {
+                          // Cast is safe because subclass does not add any selectors.
+                          completionHandler(static_cast<MTRNetworkCommissioningClusterConnectNetworkResponseParams *>(data), error);
+                      }];
 }
 - (void)reorderNetworkWithParams:(MTRNetworkCommissioningClusterReorderNetworkParams *)params
                   expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -6960,10 +7062,15 @@ using chip::SessionHandle;
                completionHandler:(void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
                                      NSError * _Nullable error))completionHandler
 {
-    [self reorderNetworkWithParams:params
-                    expectedValues:expectedDataValueDictionaries
-             expectedValueInterval:expectedValueIntervalMs
-                        completion:completionHandler];
+    [self
+        reorderNetworkWithParams:params
+                  expectedValues:expectedDataValueDictionaries
+           expectedValueInterval:expectedValueIntervalMs
+                      completion:^(
+                          MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data, NSError * _Nullable error) {
+                          // Cast is safe because subclass does not add any selectors.
+                          completionHandler(static_cast<MTRNetworkCommissioningClusterNetworkConfigResponseParams *>(data), error);
+                      }];
 }
 @end
 
@@ -7089,7 +7196,11 @@ using chip::SessionHandle;
     [self retrieveLogsRequestWithParams:params
                          expectedValues:expectedDataValueDictionaries
                   expectedValueInterval:expectedValueIntervalMs
-                             completion:completionHandler];
+                             completion:^(
+                                 MTRDiagnosticLogsClusterRetrieveLogsResponseParams * _Nullable data, NSError * _Nullable error) {
+                                 // Cast is safe because subclass does not add any selectors.
+                                 completionHandler(static_cast<MTRDiagnosticLogsClusterRetrieveLogsResponseParams *>(data), error);
+                             }];
 }
 @end
 
@@ -7458,9 +7569,10 @@ using chip::SessionHandle;
                     expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                         completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self resetWatermarksWithExpectedValues:expectedValues
-                      expectedValueInterval:expectedValueIntervalMs
-                                 completion:completionHandler];
+    [self resetWatermarksWithParams:nil
+                     expectedValues:expectedValues
+              expectedValueInterval:expectedValueIntervalMs
+                  completionHandler:completionHandler];
 }
 @end
 
@@ -8104,7 +8216,10 @@ using chip::SessionHandle;
                 expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                     completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self resetCountsWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self resetCountsWithParams:nil
+                 expectedValues:expectedValues
+          expectedValueInterval:expectedValueIntervalMs
+              completionHandler:completionHandler];
 }
 @end
 
@@ -8347,7 +8462,10 @@ using chip::SessionHandle;
                 expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                     completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self resetCountsWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self resetCountsWithParams:nil
+                 expectedValues:expectedValues
+          expectedValueInterval:expectedValueIntervalMs
+              completionHandler:completionHandler];
 }
 @end
 
@@ -8558,7 +8676,10 @@ using chip::SessionHandle;
                 expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                     completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self resetCountsWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self resetCountsWithParams:nil
+                 expectedValues:expectedValues
+          expectedValueInterval:expectedValueIntervalMs
+              completionHandler:completionHandler];
 }
 @end
 
@@ -9147,9 +9268,10 @@ using chip::SessionHandle;
                         expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                             completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self revokeCommissioningWithExpectedValues:expectedValues
-                          expectedValueInterval:expectedValueIntervalMs
-                                     completion:completionHandler];
+    [self revokeCommissioningWithParams:nil
+                         expectedValues:expectedValues
+                  expectedValueInterval:expectedValueIntervalMs
+                      completionHandler:completionHandler];
 }
 @end
 
@@ -9661,7 +9783,12 @@ using chip::SessionHandle;
     [self attestationRequestWithParams:params
                         expectedValues:expectedDataValueDictionaries
                  expectedValueInterval:expectedValueIntervalMs
-                            completion:completionHandler];
+                            completion:^(MTROperationalCredentialsClusterAttestationResponseParams * _Nullable data,
+                                NSError * _Nullable error) {
+                                // Cast is safe because subclass does not add any selectors.
+                                completionHandler(
+                                    static_cast<MTROperationalCredentialsClusterAttestationResponseParams *>(data), error);
+                            }];
 }
 - (void)certificateChainRequestWithParams:(MTROperationalCredentialsClusterCertificateChainRequestParams *)params
                            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -9669,10 +9796,16 @@ using chip::SessionHandle;
                         completionHandler:(void (^)(MTROperationalCredentialsClusterCertificateChainResponseParams * _Nullable data,
                                               NSError * _Nullable error))completionHandler
 {
-    [self certificateChainRequestWithParams:params
-                             expectedValues:expectedDataValueDictionaries
-                      expectedValueInterval:expectedValueIntervalMs
-                                 completion:completionHandler];
+    [self
+        certificateChainRequestWithParams:params
+                           expectedValues:expectedDataValueDictionaries
+                    expectedValueInterval:expectedValueIntervalMs
+                               completion:^(MTROperationalCredentialsClusterCertificateChainResponseParams * _Nullable data,
+                                   NSError * _Nullable error) {
+                                   // Cast is safe because subclass does not add any selectors.
+                                   completionHandler(
+                                       static_cast<MTROperationalCredentialsClusterCertificateChainResponseParams *>(data), error);
+                               }];
 }
 - (void)CSRRequestWithParams:(MTROperationalCredentialsClusterCSRRequestParams *)params
               expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -9683,7 +9816,10 @@ using chip::SessionHandle;
     [self CSRRequestWithParams:params
                 expectedValues:expectedDataValueDictionaries
          expectedValueInterval:expectedValueIntervalMs
-                    completion:completionHandler];
+                    completion:^(MTROperationalCredentialsClusterCSRResponseParams * _Nullable data, NSError * _Nullable error) {
+                        // Cast is safe because subclass does not add any selectors.
+                        completionHandler(static_cast<MTROperationalCredentialsClusterCSRResponseParams *>(data), error);
+                    }];
 }
 - (void)addNOCWithParams:(MTROperationalCredentialsClusterAddNOCParams *)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -9694,7 +9830,10 @@ using chip::SessionHandle;
     [self addNOCWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTROperationalCredentialsClusterNOCResponseParams *>(data), error);
+                   }];
 }
 - (void)updateNOCWithParams:(MTROperationalCredentialsClusterUpdateNOCParams *)params
              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -9705,7 +9844,10 @@ using chip::SessionHandle;
     [self updateNOCWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTROperationalCredentialsClusterNOCResponseParams *>(data), error);
+                   }];
 }
 - (void)updateFabricLabelWithParams:(MTROperationalCredentialsClusterUpdateFabricLabelParams *)params
                      expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -9716,7 +9858,11 @@ using chip::SessionHandle;
     [self updateFabricLabelWithParams:params
                        expectedValues:expectedDataValueDictionaries
                 expectedValueInterval:expectedValueIntervalMs
-                           completion:completionHandler];
+                           completion:^(
+                               MTROperationalCredentialsClusterNOCResponseParams * _Nullable data, NSError * _Nullable error) {
+                               // Cast is safe because subclass does not add any selectors.
+                               completionHandler(static_cast<MTROperationalCredentialsClusterNOCResponseParams *>(data), error);
+                           }];
 }
 - (void)removeFabricWithParams:(MTROperationalCredentialsClusterRemoveFabricParams *)params
                 expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -9727,7 +9873,10 @@ using chip::SessionHandle;
     [self removeFabricWithParams:params
                   expectedValues:expectedDataValueDictionaries
            expectedValueInterval:expectedValueIntervalMs
-                      completion:completionHandler];
+                      completion:^(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data, NSError * _Nullable error) {
+                          // Cast is safe because subclass does not add any selectors.
+                          completionHandler(static_cast<MTROperationalCredentialsClusterNOCResponseParams *>(data), error);
+                      }];
 }
 - (void)addTrustedRootCertificateWithParams:(MTROperationalCredentialsClusterAddTrustedRootCertificateParams *)params
                              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -10125,7 +10274,10 @@ using chip::SessionHandle;
     [self keySetReadWithParams:params
                 expectedValues:expectedDataValueDictionaries
          expectedValueInterval:expectedValueIntervalMs
-                    completion:completionHandler];
+                    completion:^(MTRGroupKeyManagementClusterKeySetReadResponseParams * _Nullable data, NSError * _Nullable error) {
+                        // Cast is safe because subclass does not add any selectors.
+                        completionHandler(static_cast<MTRGroupKeyManagementClusterKeySetReadResponseParams *>(data), error);
+                    }];
 }
 - (void)keySetRemoveWithParams:(MTRGroupKeyManagementClusterKeySetRemoveParams *)params
                 expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -10146,7 +10298,12 @@ using chip::SessionHandle;
     [self keySetReadAllIndicesWithParams:params
                           expectedValues:expectedDataValueDictionaries
                    expectedValueInterval:expectedValueIntervalMs
-                              completion:completionHandler];
+                              completion:^(MTRGroupKeyManagementClusterKeySetReadAllIndicesResponseParams * _Nullable data,
+                                  NSError * _Nullable error) {
+                                  // Cast is safe because subclass does not add any selectors.
+                                  completionHandler(
+                                      static_cast<MTRGroupKeyManagementClusterKeySetReadAllIndicesResponseParams *>(data), error);
+                              }];
 }
 @end
 
@@ -12345,7 +12502,11 @@ using chip::SessionHandle;
     [self getWeekDayScheduleWithParams:params
                         expectedValues:expectedDataValueDictionaries
                  expectedValueInterval:expectedValueIntervalMs
-                            completion:completionHandler];
+                            completion:^(
+                                MTRDoorLockClusterGetWeekDayScheduleResponseParams * _Nullable data, NSError * _Nullable error) {
+                                // Cast is safe because subclass does not add any selectors.
+                                completionHandler(static_cast<MTRDoorLockClusterGetWeekDayScheduleResponseParams *>(data), error);
+                            }];
 }
 - (void)clearWeekDayScheduleWithParams:(MTRDoorLockClusterClearWeekDayScheduleParams *)params
                         expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -12376,7 +12537,11 @@ using chip::SessionHandle;
     [self getYearDayScheduleWithParams:params
                         expectedValues:expectedDataValueDictionaries
                  expectedValueInterval:expectedValueIntervalMs
-                            completion:completionHandler];
+                            completion:^(
+                                MTRDoorLockClusterGetYearDayScheduleResponseParams * _Nullable data, NSError * _Nullable error) {
+                                // Cast is safe because subclass does not add any selectors.
+                                completionHandler(static_cast<MTRDoorLockClusterGetYearDayScheduleResponseParams *>(data), error);
+                            }];
 }
 - (void)clearYearDayScheduleWithParams:(MTRDoorLockClusterClearYearDayScheduleParams *)params
                         expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -12407,7 +12572,11 @@ using chip::SessionHandle;
     [self getHolidayScheduleWithParams:params
                         expectedValues:expectedDataValueDictionaries
                  expectedValueInterval:expectedValueIntervalMs
-                            completion:completionHandler];
+                            completion:^(
+                                MTRDoorLockClusterGetHolidayScheduleResponseParams * _Nullable data, NSError * _Nullable error) {
+                                // Cast is safe because subclass does not add any selectors.
+                                completionHandler(static_cast<MTRDoorLockClusterGetHolidayScheduleResponseParams *>(data), error);
+                            }];
 }
 - (void)clearHolidayScheduleWithParams:(MTRDoorLockClusterClearHolidayScheduleParams *)params
                         expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -12438,7 +12607,10 @@ using chip::SessionHandle;
     [self getUserWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRDoorLockClusterGetUserResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRDoorLockClusterGetUserResponseParams *>(data), error);
+                   }];
 }
 - (void)clearUserWithParams:(MTRDoorLockClusterClearUserParams *)params
              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -12459,7 +12631,10 @@ using chip::SessionHandle;
     [self setCredentialWithParams:params
                    expectedValues:expectedDataValueDictionaries
             expectedValueInterval:expectedValueIntervalMs
-                       completion:completionHandler];
+                       completion:^(MTRDoorLockClusterSetCredentialResponseParams * _Nullable data, NSError * _Nullable error) {
+                           // Cast is safe because subclass does not add any selectors.
+                           completionHandler(static_cast<MTRDoorLockClusterSetCredentialResponseParams *>(data), error);
+                       }];
 }
 - (void)getCredentialStatusWithParams:(MTRDoorLockClusterGetCredentialStatusParams *)params
                        expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -12470,7 +12645,11 @@ using chip::SessionHandle;
     [self getCredentialStatusWithParams:params
                          expectedValues:expectedDataValueDictionaries
                   expectedValueInterval:expectedValueIntervalMs
-                             completion:completionHandler];
+                             completion:^(
+                                 MTRDoorLockClusterGetCredentialStatusResponseParams * _Nullable data, NSError * _Nullable error) {
+                                 // Cast is safe because subclass does not add any selectors.
+                                 completionHandler(static_cast<MTRDoorLockClusterGetCredentialStatusResponseParams *>(data), error);
+                             }];
 }
 - (void)clearCredentialWithParams:(MTRDoorLockClusterClearCredentialParams *)params
                    expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -13121,7 +13300,10 @@ using chip::SessionHandle;
              expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                  completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self upOrOpenWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self upOrOpenWithParams:nil
+               expectedValues:expectedValues
+        expectedValueInterval:expectedValueIntervalMs
+            completionHandler:completionHandler];
 }
 - (void)downOrCloseWithParams:(MTRWindowCoveringClusterDownOrCloseParams * _Nullable)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -13137,7 +13319,10 @@ using chip::SessionHandle;
                 expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                     completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self downOrCloseWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self downOrCloseWithParams:nil
+                 expectedValues:expectedValues
+          expectedValueInterval:expectedValueIntervalMs
+              completionHandler:completionHandler];
 }
 - (void)stopMotionWithParams:(MTRWindowCoveringClusterStopMotionParams * _Nullable)params
               expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -13153,7 +13338,10 @@ using chip::SessionHandle;
                expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                    completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self stopMotionWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self stopMotionWithParams:nil
+                expectedValues:expectedValues
+         expectedValueInterval:expectedValueIntervalMs
+             completionHandler:completionHandler];
 }
 - (void)goToLiftValueWithParams:(MTRWindowCoveringClusterGoToLiftValueParams *)params
                  expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -13589,9 +13777,10 @@ using chip::SessionHandle;
                        expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                            completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self barrierControlStopWithExpectedValues:expectedValues
-                         expectedValueInterval:expectedValueIntervalMs
-                                    completion:completionHandler];
+    [self barrierControlStopWithParams:nil
+                        expectedValues:expectedValues
+                 expectedValueInterval:expectedValueIntervalMs
+                     completionHandler:completionHandler];
 }
 @end
 
@@ -15184,7 +15373,11 @@ using chip::SessionHandle;
     [self getWeeklyScheduleWithParams:params
                        expectedValues:expectedDataValueDictionaries
                 expectedValueInterval:expectedValueIntervalMs
-                           completion:completionHandler];
+                           completion:^(
+                               MTRThermostatClusterGetWeeklyScheduleResponseParams * _Nullable data, NSError * _Nullable error) {
+                               // Cast is safe because subclass does not add any selectors.
+                               completionHandler(static_cast<MTRThermostatClusterGetWeeklyScheduleResponseParams *>(data), error);
+                           }];
 }
 - (void)clearWeeklyScheduleWithParams:(MTRThermostatClusterClearWeeklyScheduleParams * _Nullable)params
                        expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -15200,9 +15393,10 @@ using chip::SessionHandle;
                         expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                             completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self clearWeeklyScheduleWithExpectedValues:expectedValues
-                          expectedValueInterval:expectedValueIntervalMs
-                                     completion:completionHandler];
+    [self clearWeeklyScheduleWithParams:nil
+                         expectedValues:expectedValues
+                  expectedValueInterval:expectedValueIntervalMs
+                      completionHandler:completionHandler];
 }
 @end
 
@@ -19145,7 +19339,10 @@ using chip::SessionHandle;
     [self changeChannelWithParams:params
                    expectedValues:expectedDataValueDictionaries
             expectedValueInterval:expectedValueIntervalMs
-                       completion:completionHandler];
+                       completion:^(MTRChannelClusterChangeChannelResponseParams * _Nullable data, NSError * _Nullable error) {
+                           // Cast is safe because subclass does not add any selectors.
+                           completionHandler(static_cast<MTRChannelClusterChangeChannelResponseParams *>(data), error);
+                       }];
 }
 - (void)changeChannelByNumberWithParams:(MTRChannelClusterChangeChannelByNumberParams *)params
                          expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -19308,7 +19505,11 @@ using chip::SessionHandle;
     [self navigateTargetWithParams:params
                     expectedValues:expectedDataValueDictionaries
              expectedValueInterval:expectedValueIntervalMs
-                        completion:completionHandler];
+                        completion:^(
+                            MTRTargetNavigatorClusterNavigateTargetResponseParams * _Nullable data, NSError * _Nullable error) {
+                            // Cast is safe because subclass does not add any selectors.
+                            completionHandler(static_cast<MTRTargetNavigatorClusterNavigateTargetResponseParams *>(data), error);
+                        }];
 }
 @end
 
@@ -20004,14 +20205,20 @@ using chip::SessionHandle;
     [self playWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRMediaPlaybackClusterPlaybackResponseParams *>(data), error);
+                   }];
 }
 - (void)playWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
          expectedValueInterval:(NSNumber *)expectedValueIntervalMs
              completionHandler:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                    NSError * _Nullable error))completionHandler
 {
-    [self playWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self playWithParams:nil
+               expectedValues:expectedValues
+        expectedValueInterval:expectedValueIntervalMs
+            completionHandler:completionHandler];
 }
 - (void)pauseWithParams:(MTRMediaPlaybackClusterPauseParams * _Nullable)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -20022,14 +20229,20 @@ using chip::SessionHandle;
     [self pauseWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRMediaPlaybackClusterPlaybackResponseParams *>(data), error);
+                   }];
 }
 - (void)pauseWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
           expectedValueInterval:(NSNumber *)expectedValueIntervalMs
               completionHandler:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                     NSError * _Nullable error))completionHandler
 {
-    [self pauseWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self pauseWithParams:nil
+               expectedValues:expectedValues
+        expectedValueInterval:expectedValueIntervalMs
+            completionHandler:completionHandler];
 }
 - (void)stopPlaybackWithParams:(MTRMediaPlaybackClusterStopPlaybackParams * _Nullable)params
                 expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -20040,14 +20253,20 @@ using chip::SessionHandle;
     [self stopPlaybackWithParams:params
                   expectedValues:expectedDataValueDictionaries
            expectedValueInterval:expectedValueIntervalMs
-                      completion:completionHandler];
+                      completion:^(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error) {
+                          // Cast is safe because subclass does not add any selectors.
+                          completionHandler(static_cast<MTRMediaPlaybackClusterPlaybackResponseParams *>(data), error);
+                      }];
 }
 - (void)stopPlaybackWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
                  expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                      completionHandler:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                            NSError * _Nullable error))completionHandler
 {
-    [self stopPlaybackWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self stopPlaybackWithParams:nil
+                  expectedValues:expectedValues
+           expectedValueInterval:expectedValueIntervalMs
+               completionHandler:completionHandler];
 }
 - (void)startOverWithParams:(MTRMediaPlaybackClusterStartOverParams * _Nullable)params
              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -20058,14 +20277,20 @@ using chip::SessionHandle;
     [self startOverWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRMediaPlaybackClusterPlaybackResponseParams *>(data), error);
+                   }];
 }
 - (void)startOverWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
               expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                   completionHandler:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                         NSError * _Nullable error))completionHandler
 {
-    [self startOverWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self startOverWithParams:nil
+               expectedValues:expectedValues
+        expectedValueInterval:expectedValueIntervalMs
+            completionHandler:completionHandler];
 }
 - (void)previousWithParams:(MTRMediaPlaybackClusterPreviousParams * _Nullable)params
             expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -20076,14 +20301,20 @@ using chip::SessionHandle;
     [self previousWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRMediaPlaybackClusterPlaybackResponseParams *>(data), error);
+                   }];
 }
 - (void)previousWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
              expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                  completionHandler:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                        NSError * _Nullable error))completionHandler
 {
-    [self previousWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self previousWithParams:nil
+               expectedValues:expectedValues
+        expectedValueInterval:expectedValueIntervalMs
+            completionHandler:completionHandler];
 }
 - (void)nextWithParams:(MTRMediaPlaybackClusterNextParams * _Nullable)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -20094,14 +20325,20 @@ using chip::SessionHandle;
     [self nextWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRMediaPlaybackClusterPlaybackResponseParams *>(data), error);
+                   }];
 }
 - (void)nextWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
          expectedValueInterval:(NSNumber *)expectedValueIntervalMs
              completionHandler:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                    NSError * _Nullable error))completionHandler
 {
-    [self nextWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self nextWithParams:nil
+               expectedValues:expectedValues
+        expectedValueInterval:expectedValueIntervalMs
+            completionHandler:completionHandler];
 }
 - (void)rewindWithParams:(MTRMediaPlaybackClusterRewindParams * _Nullable)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -20112,14 +20349,20 @@ using chip::SessionHandle;
     [self rewindWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRMediaPlaybackClusterPlaybackResponseParams *>(data), error);
+                   }];
 }
 - (void)rewindWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
            expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                completionHandler:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                      NSError * _Nullable error))completionHandler
 {
-    [self rewindWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self rewindWithParams:nil
+               expectedValues:expectedValues
+        expectedValueInterval:expectedValueIntervalMs
+            completionHandler:completionHandler];
 }
 - (void)fastForwardWithParams:(MTRMediaPlaybackClusterFastForwardParams * _Nullable)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -20130,14 +20373,20 @@ using chip::SessionHandle;
     [self fastForwardWithParams:params
                  expectedValues:expectedDataValueDictionaries
           expectedValueInterval:expectedValueIntervalMs
-                     completion:completionHandler];
+                     completion:^(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error) {
+                         // Cast is safe because subclass does not add any selectors.
+                         completionHandler(static_cast<MTRMediaPlaybackClusterPlaybackResponseParams *>(data), error);
+                     }];
 }
 - (void)fastForwardWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
                 expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                     completionHandler:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                           NSError * _Nullable error))completionHandler
 {
-    [self fastForwardWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self fastForwardWithParams:nil
+                 expectedValues:expectedValues
+          expectedValueInterval:expectedValueIntervalMs
+              completionHandler:completionHandler];
 }
 - (void)skipForwardWithParams:(MTRMediaPlaybackClusterSkipForwardParams *)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -20148,7 +20397,10 @@ using chip::SessionHandle;
     [self skipForwardWithParams:params
                  expectedValues:expectedDataValueDictionaries
           expectedValueInterval:expectedValueIntervalMs
-                     completion:completionHandler];
+                     completion:^(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error) {
+                         // Cast is safe because subclass does not add any selectors.
+                         completionHandler(static_cast<MTRMediaPlaybackClusterPlaybackResponseParams *>(data), error);
+                     }];
 }
 - (void)skipBackwardWithParams:(MTRMediaPlaybackClusterSkipBackwardParams *)params
                 expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -20159,7 +20411,10 @@ using chip::SessionHandle;
     [self skipBackwardWithParams:params
                   expectedValues:expectedDataValueDictionaries
            expectedValueInterval:expectedValueIntervalMs
-                      completion:completionHandler];
+                      completion:^(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error) {
+                          // Cast is safe because subclass does not add any selectors.
+                          completionHandler(static_cast<MTRMediaPlaybackClusterPlaybackResponseParams *>(data), error);
+                      }];
 }
 - (void)seekWithParams:(MTRMediaPlaybackClusterSeekParams *)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -20170,7 +20425,10 @@ using chip::SessionHandle;
     [self seekWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRMediaPlaybackClusterPlaybackResponseParams *>(data), error);
+                   }];
 }
 @end
 
@@ -20491,9 +20749,10 @@ using chip::SessionHandle;
                     expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                         completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self showInputStatusWithExpectedValues:expectedValues
-                      expectedValueInterval:expectedValueIntervalMs
-                                 completion:completionHandler];
+    [self showInputStatusWithParams:nil
+                     expectedValues:expectedValues
+              expectedValueInterval:expectedValueIntervalMs
+                  completionHandler:completionHandler];
 }
 - (void)hideInputStatusWithParams:(MTRMediaInputClusterHideInputStatusParams * _Nullable)params
                    expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -20509,9 +20768,10 @@ using chip::SessionHandle;
                     expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                         completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self hideInputStatusWithExpectedValues:expectedValues
-                      expectedValueInterval:expectedValueIntervalMs
-                                 completion:completionHandler];
+    [self hideInputStatusWithParams:nil
+                     expectedValues:expectedValues
+              expectedValueInterval:expectedValueIntervalMs
+                  completionHandler:completionHandler];
 }
 - (void)renameInputWithParams:(MTRMediaInputClusterRenameInputParams *)params
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -20657,7 +20917,10 @@ using chip::SessionHandle;
           expectedValueInterval:(NSNumber *)expectedValueIntervalMs
               completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self sleepWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self sleepWithParams:nil
+               expectedValues:expectedValues
+        expectedValueInterval:expectedValueIntervalMs
+            completionHandler:completionHandler];
 }
 @end
 
@@ -20780,7 +21043,10 @@ using chip::SessionHandle;
     [self sendKeyWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRKeypadInputClusterSendKeyResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRKeypadInputClusterSendKeyResponseParams *>(data), error);
+                   }];
 }
 @end
 
@@ -21141,7 +21407,10 @@ using chip::SessionHandle;
     [self launchContentWithParams:params
                    expectedValues:expectedDataValueDictionaries
             expectedValueInterval:expectedValueIntervalMs
-                       completion:completionHandler];
+                       completion:^(MTRContentLauncherClusterLaunchResponseParams * _Nullable data, NSError * _Nullable error) {
+                           // Cast is safe because subclass does not add any selectors.
+                           completionHandler(static_cast<MTRContentLauncherClusterLaunchResponseParams *>(data), error);
+                       }];
 }
 - (void)launchURLWithParams:(MTRContentLauncherClusterLaunchURLParams *)params
              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -21152,7 +21421,10 @@ using chip::SessionHandle;
     [self launchURLWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRContentLauncherClusterLaunchResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRContentLauncherClusterLaunchResponseParams *>(data), error);
+                   }];
 }
 @end
 
@@ -21610,7 +21882,10 @@ using chip::SessionHandle;
     [self launchAppWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRApplicationLauncherClusterLauncherResponseParams *>(data), error);
+                   }];
 }
 - (void)stopAppWithParams:(MTRApplicationLauncherClusterStopAppParams *)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -21621,7 +21896,10 @@ using chip::SessionHandle;
     [self stopAppWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRApplicationLauncherClusterLauncherResponseParams *>(data), error);
+                   }];
 }
 - (void)hideAppWithParams:(MTRApplicationLauncherClusterHideAppParams *)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -21632,7 +21910,10 @@ using chip::SessionHandle;
     [self hideAppWithParams:params
                expectedValues:expectedDataValueDictionaries
         expectedValueInterval:expectedValueIntervalMs
-                   completion:completionHandler];
+                   completion:^(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data, NSError * _Nullable error) {
+                       // Cast is safe because subclass does not add any selectors.
+                       completionHandler(static_cast<MTRApplicationLauncherClusterLauncherResponseParams *>(data), error);
+                   }];
 }
 @end
 
@@ -21998,7 +22279,10 @@ using chip::SessionHandle;
     [self getSetupPINWithParams:params
                  expectedValues:expectedDataValueDictionaries
           expectedValueInterval:expectedValueIntervalMs
-                     completion:completionHandler];
+                     completion:^(MTRAccountLoginClusterGetSetupPINResponseParams * _Nullable data, NSError * _Nullable error) {
+                         // Cast is safe because subclass does not add any selectors.
+                         completionHandler(static_cast<MTRAccountLoginClusterGetSetupPINResponseParams *>(data), error);
+                     }];
 }
 - (void)loginWithParams:(MTRAccountLoginClusterLoginParams *)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -22024,7 +22308,10 @@ using chip::SessionHandle;
            expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self logoutWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self logoutWithParams:nil
+               expectedValues:expectedValues
+        expectedValueInterval:expectedValueIntervalMs
+            completionHandler:completionHandler];
 }
 @end
 
@@ -23402,9 +23689,10 @@ using chip::SessionHandle;
                           expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                               completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self getProfileInfoCommandWithExpectedValues:expectedValues
-                            expectedValueInterval:expectedValueIntervalMs
-                                       completion:completionHandler];
+    [self getProfileInfoCommandWithParams:nil
+                           expectedValues:expectedValues
+                    expectedValueInterval:expectedValueIntervalMs
+                        completionHandler:completionHandler];
 }
 - (void)getMeasurementProfileCommandWithParams:(MTRElectricalMeasurementClusterGetMeasurementProfileCommandParams *)params
                                 expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
@@ -27517,14 +27805,17 @@ using chip::SessionHandle;
 
 @end
 
-@implementation MTRClusterUnitTesting (Deprecated)
+@implementation MTRClusterTestCluster
+@end
+
+@implementation MTRClusterTestCluster (Deprecated)
 
 - (instancetype)initWithDevice:(MTRDevice *)device endpoint:(uint16_t)endpoint queue:(dispatch_queue_t)queue
 {
     return [self initWithDevice:device endpointID:@(endpoint) queue:queue];
 }
 
-- (void)testWithParams:(MTRUnitTestingClusterTestParams * _Nullable)params
+- (void)testWithParams:(MTRTestClusterClusterTestParams * _Nullable)params
            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
     expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
         completionHandler:(MTRStatusCompletion)completionHandler
@@ -27538,9 +27829,12 @@ using chip::SessionHandle;
          expectedValueInterval:(NSNumber *)expectedValueIntervalMs
              completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self testWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self testWithParams:nil
+               expectedValues:expectedValues
+        expectedValueInterval:expectedValueIntervalMs
+            completionHandler:completionHandler];
 }
-- (void)testNotHandledWithParams:(MTRUnitTestingClusterTestNotHandledParams * _Nullable)params
+- (void)testNotHandledWithParams:(MTRTestClusterClusterTestNotHandledParams * _Nullable)params
                   expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
            expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                completionHandler:(MTRStatusCompletion)completionHandler
@@ -27554,29 +27848,36 @@ using chip::SessionHandle;
                    expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                        completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self testNotHandledWithExpectedValues:expectedValues
-                     expectedValueInterval:expectedValueIntervalMs
-                                completion:completionHandler];
+    [self testNotHandledWithParams:nil
+                    expectedValues:expectedValues
+             expectedValueInterval:expectedValueIntervalMs
+                 completionHandler:completionHandler];
 }
-- (void)testSpecificWithParams:(MTRUnitTestingClusterTestSpecificParams * _Nullable)params
+- (void)testSpecificWithParams:(MTRTestClusterClusterTestSpecificParams * _Nullable)params
                 expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
          expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-             completionHandler:(void (^)(MTRUnitTestingClusterTestSpecificResponseParams * _Nullable data,
+             completionHandler:(void (^)(MTRTestClusterClusterTestSpecificResponseParams * _Nullable data,
                                    NSError * _Nullable error))completionHandler
 {
     [self testSpecificWithParams:params
                   expectedValues:expectedDataValueDictionaries
            expectedValueInterval:expectedValueIntervalMs
-                      completion:completionHandler];
+                      completion:^(MTRUnitTestingClusterTestSpecificResponseParams * _Nullable data, NSError * _Nullable error) {
+                          // Cast is safe because subclass does not add any selectors.
+                          completionHandler(static_cast<MTRTestClusterClusterTestSpecificResponseParams *>(data), error);
+                      }];
 }
 - (void)testSpecificWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
                  expectedValueInterval:(NSNumber *)expectedValueIntervalMs
-                     completionHandler:(void (^)(MTRUnitTestingClusterTestSpecificResponseParams * _Nullable data,
+                     completionHandler:(void (^)(MTRTestClusterClusterTestSpecificResponseParams * _Nullable data,
                                            NSError * _Nullable error))completionHandler
 {
-    [self testSpecificWithExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completionHandler];
+    [self testSpecificWithParams:nil
+                  expectedValues:expectedValues
+           expectedValueInterval:expectedValueIntervalMs
+               completionHandler:completionHandler];
 }
-- (void)testUnknownCommandWithParams:(MTRUnitTestingClusterTestUnknownCommandParams * _Nullable)params
+- (void)testUnknownCommandWithParams:(MTRTestClusterClusterTestUnknownCommandParams * _Nullable)params
                       expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                    completionHandler:(MTRStatusCompletion)completionHandler
@@ -27590,171 +27891,240 @@ using chip::SessionHandle;
                        expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                            completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self testUnknownCommandWithExpectedValues:expectedValues
-                         expectedValueInterval:expectedValueIntervalMs
-                                    completion:completionHandler];
+    [self testUnknownCommandWithParams:nil
+                        expectedValues:expectedValues
+                 expectedValueInterval:expectedValueIntervalMs
+                     completionHandler:completionHandler];
 }
-- (void)testAddArgumentsWithParams:(MTRUnitTestingClusterTestAddArgumentsParams *)params
+- (void)testAddArgumentsWithParams:(MTRTestClusterClusterTestAddArgumentsParams *)params
                     expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
              expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                 completionHandler:(void (^)(MTRUnitTestingClusterTestAddArgumentsResponseParams * _Nullable data,
+                 completionHandler:(void (^)(MTRTestClusterClusterTestAddArgumentsResponseParams * _Nullable data,
                                        NSError * _Nullable error))completionHandler
 {
     [self testAddArgumentsWithParams:params
                       expectedValues:expectedDataValueDictionaries
                expectedValueInterval:expectedValueIntervalMs
-                          completion:completionHandler];
+                          completion:^(
+                              MTRUnitTestingClusterTestAddArgumentsResponseParams * _Nullable data, NSError * _Nullable error) {
+                              // Cast is safe because subclass does not add any selectors.
+                              completionHandler(static_cast<MTRTestClusterClusterTestAddArgumentsResponseParams *>(data), error);
+                          }];
 }
-- (void)testSimpleArgumentRequestWithParams:(MTRUnitTestingClusterTestSimpleArgumentRequestParams *)params
+- (void)testSimpleArgumentRequestWithParams:(MTRTestClusterClusterTestSimpleArgumentRequestParams *)params
                              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                       expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                          completionHandler:(void (^)(MTRUnitTestingClusterTestSimpleArgumentResponseParams * _Nullable data,
+                          completionHandler:(void (^)(MTRTestClusterClusterTestSimpleArgumentResponseParams * _Nullable data,
                                                 NSError * _Nullable error))completionHandler
 {
     [self testSimpleArgumentRequestWithParams:params
                                expectedValues:expectedDataValueDictionaries
                         expectedValueInterval:expectedValueIntervalMs
-                                   completion:completionHandler];
+                                   completion:^(MTRUnitTestingClusterTestSimpleArgumentResponseParams * _Nullable data,
+                                       NSError * _Nullable error) {
+                                       // Cast is safe because subclass does not add any selectors.
+                                       completionHandler(
+                                           static_cast<MTRTestClusterClusterTestSimpleArgumentResponseParams *>(data), error);
+                                   }];
 }
-- (void)testStructArrayArgumentRequestWithParams:(MTRUnitTestingClusterTestStructArrayArgumentRequestParams *)params
+- (void)testStructArrayArgumentRequestWithParams:(MTRTestClusterClusterTestStructArrayArgumentRequestParams *)params
                                   expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                            expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                                completionHandler:
-                                   (void (^)(MTRUnitTestingClusterTestStructArrayArgumentResponseParams * _Nullable data,
+                                   (void (^)(MTRTestClusterClusterTestStructArrayArgumentResponseParams * _Nullable data,
                                        NSError * _Nullable error))completionHandler
 {
     [self testStructArrayArgumentRequestWithParams:params
                                     expectedValues:expectedDataValueDictionaries
                              expectedValueInterval:expectedValueIntervalMs
-                                        completion:completionHandler];
+                                        completion:^(MTRUnitTestingClusterTestStructArrayArgumentResponseParams * _Nullable data,
+                                            NSError * _Nullable error) {
+                                            // Cast is safe because subclass does not add any selectors.
+                                            completionHandler(
+                                                static_cast<MTRTestClusterClusterTestStructArrayArgumentResponseParams *>(data),
+                                                error);
+                                        }];
 }
-- (void)testStructArgumentRequestWithParams:(MTRUnitTestingClusterTestStructArgumentRequestParams *)params
+- (void)testStructArgumentRequestWithParams:(MTRTestClusterClusterTestStructArgumentRequestParams *)params
                              expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                       expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                          completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                          completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                 NSError * _Nullable error))completionHandler
 {
     [self testStructArgumentRequestWithParams:params
                                expectedValues:expectedDataValueDictionaries
                         expectedValueInterval:expectedValueIntervalMs
-                                   completion:completionHandler];
+                                   completion:^(
+                                       MTRUnitTestingClusterBooleanResponseParams * _Nullable data, NSError * _Nullable error) {
+                                       // Cast is safe because subclass does not add any selectors.
+                                       completionHandler(static_cast<MTRTestClusterClusterBooleanResponseParams *>(data), error);
+                                   }];
 }
-- (void)testNestedStructArgumentRequestWithParams:(MTRUnitTestingClusterTestNestedStructArgumentRequestParams *)params
+- (void)testNestedStructArgumentRequestWithParams:(MTRTestClusterClusterTestNestedStructArgumentRequestParams *)params
                                    expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                             expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                                completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                                completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                       NSError * _Nullable error))completionHandler
 {
     [self testNestedStructArgumentRequestWithParams:params
                                      expectedValues:expectedDataValueDictionaries
                               expectedValueInterval:expectedValueIntervalMs
-                                         completion:completionHandler];
+                                         completion:^(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                                             NSError * _Nullable error) {
+                                             // Cast is safe because subclass does not add any selectors.
+                                             completionHandler(
+                                                 static_cast<MTRTestClusterClusterBooleanResponseParams *>(data), error);
+                                         }];
 }
-- (void)testListStructArgumentRequestWithParams:(MTRUnitTestingClusterTestListStructArgumentRequestParams *)params
+- (void)testListStructArgumentRequestWithParams:(MTRTestClusterClusterTestListStructArgumentRequestParams *)params
                                  expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                           expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                              completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                              completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                     NSError * _Nullable error))completionHandler
 {
-    [self testListStructArgumentRequestWithParams:params
-                                   expectedValues:expectedDataValueDictionaries
-                            expectedValueInterval:expectedValueIntervalMs
-                                       completion:completionHandler];
+    [self
+        testListStructArgumentRequestWithParams:params
+                                 expectedValues:expectedDataValueDictionaries
+                          expectedValueInterval:expectedValueIntervalMs
+                                     completion:^(
+                                         MTRUnitTestingClusterBooleanResponseParams * _Nullable data, NSError * _Nullable error) {
+                                         // Cast is safe because subclass does not add any selectors.
+                                         completionHandler(static_cast<MTRTestClusterClusterBooleanResponseParams *>(data), error);
+                                     }];
 }
-- (void)testListInt8UArgumentRequestWithParams:(MTRUnitTestingClusterTestListInt8UArgumentRequestParams *)params
+- (void)testListInt8UArgumentRequestWithParams:(MTRTestClusterClusterTestListInt8UArgumentRequestParams *)params
                                 expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                          expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                             completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                             completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                    NSError * _Nullable error))completionHandler
 {
     [self testListInt8UArgumentRequestWithParams:params
                                   expectedValues:expectedDataValueDictionaries
                            expectedValueInterval:expectedValueIntervalMs
-                                      completion:completionHandler];
+                                      completion:^(
+                                          MTRUnitTestingClusterBooleanResponseParams * _Nullable data, NSError * _Nullable error) {
+                                          // Cast is safe because subclass does not add any selectors.
+                                          completionHandler(static_cast<MTRTestClusterClusterBooleanResponseParams *>(data), error);
+                                      }];
 }
-- (void)testNestedStructListArgumentRequestWithParams:(MTRUnitTestingClusterTestNestedStructListArgumentRequestParams *)params
+- (void)testNestedStructListArgumentRequestWithParams:(MTRTestClusterClusterTestNestedStructListArgumentRequestParams *)params
                                        expectedValues:
                                            (NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                                 expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                                    completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                                    completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                           NSError * _Nullable error))completionHandler
 {
     [self testNestedStructListArgumentRequestWithParams:params
                                          expectedValues:expectedDataValueDictionaries
                                   expectedValueInterval:expectedValueIntervalMs
-                                             completion:completionHandler];
+                                             completion:^(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                                                 NSError * _Nullable error) {
+                                                 // Cast is safe because subclass does not add any selectors.
+                                                 completionHandler(
+                                                     static_cast<MTRTestClusterClusterBooleanResponseParams *>(data), error);
+                                             }];
 }
 - (void)testListNestedStructListArgumentRequestWithParams:
-            (MTRUnitTestingClusterTestListNestedStructListArgumentRequestParams *)params
+            (MTRTestClusterClusterTestListNestedStructListArgumentRequestParams *)params
                                            expectedValues:
                                                (NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                                     expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                                        completionHandler:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                                        completionHandler:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                               NSError * _Nullable error))completionHandler
 {
     [self testListNestedStructListArgumentRequestWithParams:params
                                              expectedValues:expectedDataValueDictionaries
                                       expectedValueInterval:expectedValueIntervalMs
-                                                 completion:completionHandler];
+                                                 completion:^(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
+                                                     NSError * _Nullable error) {
+                                                     // Cast is safe because subclass does not add any selectors.
+                                                     completionHandler(
+                                                         static_cast<MTRTestClusterClusterBooleanResponseParams *>(data), error);
+                                                 }];
 }
-- (void)testListInt8UReverseRequestWithParams:(MTRUnitTestingClusterTestListInt8UReverseRequestParams *)params
+- (void)testListInt8UReverseRequestWithParams:(MTRTestClusterClusterTestListInt8UReverseRequestParams *)params
                                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                         expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                            completionHandler:(void (^)(MTRUnitTestingClusterTestListInt8UReverseResponseParams * _Nullable data,
+                            completionHandler:(void (^)(MTRTestClusterClusterTestListInt8UReverseResponseParams * _Nullable data,
                                                   NSError * _Nullable error))completionHandler
 {
     [self testListInt8UReverseRequestWithParams:params
                                  expectedValues:expectedDataValueDictionaries
                           expectedValueInterval:expectedValueIntervalMs
-                                     completion:completionHandler];
+                                     completion:^(MTRUnitTestingClusterTestListInt8UReverseResponseParams * _Nullable data,
+                                         NSError * _Nullable error) {
+                                         // Cast is safe because subclass does not add any selectors.
+                                         completionHandler(
+                                             static_cast<MTRTestClusterClusterTestListInt8UReverseResponseParams *>(data), error);
+                                     }];
 }
-- (void)testEnumsRequestWithParams:(MTRUnitTestingClusterTestEnumsRequestParams *)params
+- (void)testEnumsRequestWithParams:(MTRTestClusterClusterTestEnumsRequestParams *)params
                     expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
              expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                 completionHandler:(void (^)(MTRUnitTestingClusterTestEnumsResponseParams * _Nullable data,
+                 completionHandler:(void (^)(MTRTestClusterClusterTestEnumsResponseParams * _Nullable data,
                                        NSError * _Nullable error))completionHandler
 {
     [self testEnumsRequestWithParams:params
                       expectedValues:expectedDataValueDictionaries
                expectedValueInterval:expectedValueIntervalMs
-                          completion:completionHandler];
+                          completion:^(MTRUnitTestingClusterTestEnumsResponseParams * _Nullable data, NSError * _Nullable error) {
+                              // Cast is safe because subclass does not add any selectors.
+                              completionHandler(static_cast<MTRTestClusterClusterTestEnumsResponseParams *>(data), error);
+                          }];
 }
-- (void)testNullableOptionalRequestWithParams:(MTRUnitTestingClusterTestNullableOptionalRequestParams * _Nullable)params
+- (void)testNullableOptionalRequestWithParams:(MTRTestClusterClusterTestNullableOptionalRequestParams * _Nullable)params
                                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                         expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                            completionHandler:(void (^)(MTRUnitTestingClusterTestNullableOptionalResponseParams * _Nullable data,
+                            completionHandler:(void (^)(MTRTestClusterClusterTestNullableOptionalResponseParams * _Nullable data,
                                                   NSError * _Nullable error))completionHandler
 {
     [self testNullableOptionalRequestWithParams:params
                                  expectedValues:expectedDataValueDictionaries
                           expectedValueInterval:expectedValueIntervalMs
-                                     completion:completionHandler];
+                                     completion:^(MTRUnitTestingClusterTestNullableOptionalResponseParams * _Nullable data,
+                                         NSError * _Nullable error) {
+                                         // Cast is safe because subclass does not add any selectors.
+                                         completionHandler(
+                                             static_cast<MTRTestClusterClusterTestNullableOptionalResponseParams *>(data), error);
+                                     }];
 }
-- (void)testComplexNullableOptionalRequestWithParams:(MTRUnitTestingClusterTestComplexNullableOptionalRequestParams *)params
+- (void)testComplexNullableOptionalRequestWithParams:(MTRTestClusterClusterTestComplexNullableOptionalRequestParams *)params
                                       expectedValues:
                                           (NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                                expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                                    completionHandler:
-                                       (void (^)(MTRUnitTestingClusterTestComplexNullableOptionalResponseParams * _Nullable data,
+                                       (void (^)(MTRTestClusterClusterTestComplexNullableOptionalResponseParams * _Nullable data,
                                            NSError * _Nullable error))completionHandler
 {
     [self testComplexNullableOptionalRequestWithParams:params
                                         expectedValues:expectedDataValueDictionaries
                                  expectedValueInterval:expectedValueIntervalMs
-                                            completion:completionHandler];
+                                            completion:^(
+                                                MTRUnitTestingClusterTestComplexNullableOptionalResponseParams * _Nullable data,
+                                                NSError * _Nullable error) {
+                                                // Cast is safe because subclass does not add any selectors.
+                                                completionHandler(
+                                                    static_cast<MTRTestClusterClusterTestComplexNullableOptionalResponseParams *>(
+                                                        data),
+                                                    error);
+                                            }];
 }
-- (void)simpleStructEchoRequestWithParams:(MTRUnitTestingClusterSimpleStructEchoRequestParams *)params
+- (void)simpleStructEchoRequestWithParams:(MTRTestClusterClusterSimpleStructEchoRequestParams *)params
                            expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                     expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                        completionHandler:(void (^)(MTRUnitTestingClusterSimpleStructResponseParams * _Nullable data,
+                        completionHandler:(void (^)(MTRTestClusterClusterSimpleStructResponseParams * _Nullable data,
                                               NSError * _Nullable error))completionHandler
 {
     [self simpleStructEchoRequestWithParams:params
                              expectedValues:expectedDataValueDictionaries
                       expectedValueInterval:expectedValueIntervalMs
-                                 completion:completionHandler];
+                                 completion:^(
+                                     MTRUnitTestingClusterSimpleStructResponseParams * _Nullable data, NSError * _Nullable error) {
+                                     // Cast is safe because subclass does not add any selectors.
+                                     completionHandler(static_cast<MTRTestClusterClusterSimpleStructResponseParams *>(data), error);
+                                 }];
 }
-- (void)timedInvokeRequestWithParams:(MTRUnitTestingClusterTimedInvokeRequestParams * _Nullable)params
+- (void)timedInvokeRequestWithParams:(MTRTestClusterClusterTimedInvokeRequestParams * _Nullable)params
                       expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                    completionHandler:(MTRStatusCompletion)completionHandler
@@ -27768,11 +28138,12 @@ using chip::SessionHandle;
                        expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                            completionHandler:(MTRStatusCompletion)completionHandler
 {
-    [self timedInvokeRequestWithExpectedValues:expectedValues
-                         expectedValueInterval:expectedValueIntervalMs
-                                    completion:completionHandler];
+    [self timedInvokeRequestWithParams:nil
+                        expectedValues:expectedValues
+                 expectedValueInterval:expectedValueIntervalMs
+                     completionHandler:completionHandler];
 }
-- (void)testSimpleOptionalArgumentRequestWithParams:(MTRUnitTestingClusterTestSimpleOptionalArgumentRequestParams * _Nullable)params
+- (void)testSimpleOptionalArgumentRequestWithParams:(MTRTestClusterClusterTestSimpleOptionalArgumentRequestParams * _Nullable)params
                                      expectedValues:
                                          (NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                               expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
@@ -27783,30 +28154,44 @@ using chip::SessionHandle;
                                 expectedValueInterval:expectedValueIntervalMs
                                            completion:completionHandler];
 }
-- (void)testEmitTestEventRequestWithParams:(MTRUnitTestingClusterTestEmitTestEventRequestParams *)params
+- (void)testEmitTestEventRequestWithParams:(MTRTestClusterClusterTestEmitTestEventRequestParams *)params
                             expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                      expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                         completionHandler:(void (^)(MTRUnitTestingClusterTestEmitTestEventResponseParams * _Nullable data,
+                         completionHandler:(void (^)(MTRTestClusterClusterTestEmitTestEventResponseParams * _Nullable data,
                                                NSError * _Nullable error))completionHandler
 {
     [self testEmitTestEventRequestWithParams:params
                               expectedValues:expectedDataValueDictionaries
                        expectedValueInterval:expectedValueIntervalMs
-                                  completion:completionHandler];
+                                  completion:^(MTRUnitTestingClusterTestEmitTestEventResponseParams * _Nullable data,
+                                      NSError * _Nullable error) {
+                                      // Cast is safe because subclass does not add any selectors.
+                                      completionHandler(
+                                          static_cast<MTRTestClusterClusterTestEmitTestEventResponseParams *>(data), error);
+                                  }];
 }
-- (void)testEmitTestFabricScopedEventRequestWithParams:(MTRUnitTestingClusterTestEmitTestFabricScopedEventRequestParams *)params
+- (void)testEmitTestFabricScopedEventRequestWithParams:(MTRTestClusterClusterTestEmitTestFabricScopedEventRequestParams *)params
                                         expectedValues:
                                             (NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                                  expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                                      completionHandler:
                                          (void (^)(
-                                             MTRUnitTestingClusterTestEmitTestFabricScopedEventResponseParams * _Nullable data,
+                                             MTRTestClusterClusterTestEmitTestFabricScopedEventResponseParams * _Nullable data,
                                              NSError * _Nullable error))completionHandler
 {
-    [self testEmitTestFabricScopedEventRequestWithParams:params
-                                          expectedValues:expectedDataValueDictionaries
-                                   expectedValueInterval:expectedValueIntervalMs
-                                              completion:completionHandler];
+    [self
+        testEmitTestFabricScopedEventRequestWithParams:params
+                                        expectedValues:expectedDataValueDictionaries
+                                 expectedValueInterval:expectedValueIntervalMs
+                                            completion:^(
+                                                MTRUnitTestingClusterTestEmitTestFabricScopedEventResponseParams * _Nullable data,
+                                                NSError * _Nullable error) {
+                                                // Cast is safe because subclass does not add any selectors.
+                                                completionHandler(
+                                                    static_cast<MTRTestClusterClusterTestEmitTestFabricScopedEventResponseParams *>(
+                                                        data),
+                                                    error);
+                                            }];
 }
 @end
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
@@ -5196,6 +5196,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
@@ -5216,6 +5217,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestParams")
+@interface MTRTestClusterClusterTestParams : MTRUnitTestingClusterTestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestSpecificResponseParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull returnValue;
@@ -5238,6 +5245,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestSpecificResponseParams")
+@interface MTRTestClusterClusterTestSpecificResponseParams : MTRUnitTestingClusterTestSpecificResponseParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestNotHandledParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
@@ -5258,6 +5271,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestNotHandledParams")
+@interface MTRTestClusterClusterTestNotHandledParams : MTRUnitTestingClusterTestNotHandledParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestAddArgumentsResponseParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull returnValue;
@@ -5280,6 +5299,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestAddArgumentsResponseParams")
+@interface MTRTestClusterClusterTestAddArgumentsResponseParams : MTRUnitTestingClusterTestAddArgumentsResponseParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestSpecificParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
@@ -5300,6 +5325,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestSpecificParams")
+@interface MTRTestClusterClusterTestSpecificParams : MTRUnitTestingClusterTestSpecificParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestSimpleArgumentResponseParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull returnValue;
@@ -5322,6 +5353,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestSimpleArgumentResponseParams")
+@interface MTRTestClusterClusterTestSimpleArgumentResponseParams : MTRUnitTestingClusterTestSimpleArgumentResponseParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestUnknownCommandParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
@@ -5342,6 +5379,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestUnknownCommandParams")
+@interface MTRTestClusterClusterTestUnknownCommandParams : MTRUnitTestingClusterTestUnknownCommandParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestStructArrayArgumentResponseParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSArray * _Nonnull arg1;
@@ -5374,6 +5417,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestStructArrayArgumentResponseParams")
+@interface MTRTestClusterClusterTestStructArrayArgumentResponseParams : MTRUnitTestingClusterTestStructArrayArgumentResponseParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestAddArgumentsParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull arg1;
@@ -5398,6 +5447,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestAddArgumentsParams")
+@interface MTRTestClusterClusterTestAddArgumentsParams : MTRUnitTestingClusterTestAddArgumentsParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestListInt8UReverseResponseParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSArray * _Nonnull arg1;
@@ -5420,6 +5475,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestListInt8UReverseResponseParams")
+@interface MTRTestClusterClusterTestListInt8UReverseResponseParams : MTRUnitTestingClusterTestListInt8UReverseResponseParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestSimpleArgumentRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull arg1;
@@ -5442,6 +5503,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestSimpleArgumentRequestParams")
+@interface MTRTestClusterClusterTestSimpleArgumentRequestParams : MTRUnitTestingClusterTestSimpleArgumentRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestEnumsResponseParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull arg1;
@@ -5466,6 +5533,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestEnumsResponseParams")
+@interface MTRTestClusterClusterTestEnumsResponseParams : MTRUnitTestingClusterTestEnumsResponseParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestStructArrayArgumentRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSArray * _Nonnull arg1;
@@ -5498,6 +5571,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestStructArrayArgumentRequestParams")
+@interface MTRTestClusterClusterTestStructArrayArgumentRequestParams : MTRUnitTestingClusterTestStructArrayArgumentRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestNullableOptionalResponseParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull wasPresent;
@@ -5526,6 +5605,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestNullableOptionalResponseParams")
+@interface MTRTestClusterClusterTestNullableOptionalResponseParams : MTRUnitTestingClusterTestNullableOptionalResponseParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestStructArgumentRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) MTRUnitTestingClusterSimpleStruct * _Nonnull arg1;
@@ -5548,6 +5633,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestStructArgumentRequestParams")
+@interface MTRTestClusterClusterTestStructArgumentRequestParams : MTRUnitTestingClusterTestStructArgumentRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestComplexNullableOptionalResponseParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull nullableIntWasNull;
@@ -5624,6 +5715,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestComplexNullableOptionalResponseParams")
+@interface MTRTestClusterClusterTestComplexNullableOptionalResponseParams
+    : MTRUnitTestingClusterTestComplexNullableOptionalResponseParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestNestedStructArgumentRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) MTRUnitTestingClusterNestedStruct * _Nonnull arg1;
@@ -5646,6 +5744,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestNestedStructArgumentRequestParams")
+@interface MTRTestClusterClusterTestNestedStructArgumentRequestParams : MTRUnitTestingClusterTestNestedStructArgumentRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterBooleanResponseParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull value;
@@ -5668,6 +5772,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterBooleanResponseParams")
+@interface MTRTestClusterClusterBooleanResponseParams : MTRUnitTestingClusterBooleanResponseParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestListStructArgumentRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSArray * _Nonnull arg1;
@@ -5690,6 +5800,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestListStructArgumentRequestParams")
+@interface MTRTestClusterClusterTestListStructArgumentRequestParams : MTRUnitTestingClusterTestListStructArgumentRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterSimpleStructResponseParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) MTRUnitTestingClusterSimpleStruct * _Nonnull arg1;
@@ -5712,6 +5828,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterSimpleStructResponseParams")
+@interface MTRTestClusterClusterSimpleStructResponseParams : MTRUnitTestingClusterSimpleStructResponseParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestListInt8UArgumentRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSArray * _Nonnull arg1;
@@ -5734,6 +5856,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestListInt8UArgumentRequestParams")
+@interface MTRTestClusterClusterTestListInt8UArgumentRequestParams : MTRUnitTestingClusterTestListInt8UArgumentRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestEmitTestEventResponseParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull value;
@@ -5756,6 +5884,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestEmitTestEventResponseParams")
+@interface MTRTestClusterClusterTestEmitTestEventResponseParams : MTRUnitTestingClusterTestEmitTestEventResponseParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestNestedStructListArgumentRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) MTRUnitTestingClusterNestedStructList * _Nonnull arg1;
@@ -5778,6 +5912,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestNestedStructListArgumentRequestParams")
+@interface MTRTestClusterClusterTestNestedStructListArgumentRequestParams
+    : MTRUnitTestingClusterTestNestedStructListArgumentRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestEmitTestFabricScopedEventResponseParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull value;
@@ -5800,6 +5941,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestEmitTestFabricScopedEventResponseParams")
+@interface MTRTestClusterClusterTestEmitTestFabricScopedEventResponseParams
+    : MTRUnitTestingClusterTestEmitTestFabricScopedEventResponseParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestListNestedStructListArgumentRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSArray * _Nonnull arg1;
@@ -5822,6 +5970,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestListNestedStructListArgumentRequestParams")
+@interface MTRTestClusterClusterTestListNestedStructListArgumentRequestParams
+    : MTRUnitTestingClusterTestListNestedStructListArgumentRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestListInt8UReverseRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSArray * _Nonnull arg1;
@@ -5844,6 +5999,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestListInt8UReverseRequestParams")
+@interface MTRTestClusterClusterTestListInt8UReverseRequestParams : MTRUnitTestingClusterTestListInt8UReverseRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestEnumsRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull arg1;
@@ -5868,6 +6029,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestEnumsRequestParams")
+@interface MTRTestClusterClusterTestEnumsRequestParams : MTRUnitTestingClusterTestEnumsRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestNullableOptionalRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nullable arg1;
@@ -5890,6 +6057,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestNullableOptionalRequestParams")
+@interface MTRTestClusterClusterTestNullableOptionalRequestParams : MTRUnitTestingClusterTestNullableOptionalRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestComplexNullableOptionalRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nullable nullableInt;
@@ -5934,6 +6107,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestComplexNullableOptionalRequestParams")
+@interface MTRTestClusterClusterTestComplexNullableOptionalRequestParams
+    : MTRUnitTestingClusterTestComplexNullableOptionalRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterSimpleStructEchoRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) MTRUnitTestingClusterSimpleStruct * _Nonnull arg1;
@@ -5956,6 +6136,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterSimpleStructEchoRequestParams")
+@interface MTRTestClusterClusterSimpleStructEchoRequestParams : MTRUnitTestingClusterSimpleStructEchoRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTimedInvokeRequestParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
@@ -5976,6 +6162,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTimedInvokeRequestParams")
+@interface MTRTestClusterClusterTimedInvokeRequestParams : MTRUnitTestingClusterTimedInvokeRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestSimpleOptionalArgumentRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nullable arg1;
@@ -5998,6 +6190,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestSimpleOptionalArgumentRequestParams")
+@interface MTRTestClusterClusterTestSimpleOptionalArgumentRequestParams
+    : MTRUnitTestingClusterTestSimpleOptionalArgumentRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestEmitTestEventRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull arg1;
@@ -6024,6 +6223,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestEmitTestEventRequestParams")
+@interface MTRTestClusterClusterTestEmitTestEventRequestParams : MTRUnitTestingClusterTestEmitTestEventRequestParams
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestEmitTestFabricScopedEventRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull arg1;
@@ -6046,6 +6251,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestEmitTestFabricScopedEventRequestParams")
+@interface MTRTestClusterClusterTestEmitTestFabricScopedEventRequestParams
+    : MTRUnitTestingClusterTestEmitTestFabricScopedEventRequestParams
+@end
+
 @interface MTRFaultInjectionClusterFailAtFaultParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull type;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
@@ -7003,6 +7003,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestParams
+@end
 @implementation MTRUnitTestingClusterTestSpecificResponseParams
 - (instancetype)init
 {
@@ -7032,6 +7035,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestSpecificResponseParams
+@end
 @implementation MTRUnitTestingClusterTestNotHandledParams
 - (instancetype)init
 {
@@ -7056,6 +7062,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestNotHandledParams
 @end
 @implementation MTRUnitTestingClusterTestAddArgumentsResponseParams
 - (instancetype)init
@@ -7086,6 +7095,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestAddArgumentsResponseParams
+@end
 @implementation MTRUnitTestingClusterTestSpecificParams
 - (instancetype)init
 {
@@ -7110,6 +7122,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestSpecificParams
 @end
 @implementation MTRUnitTestingClusterTestSimpleArgumentResponseParams
 - (instancetype)init
@@ -7140,6 +7155,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestSimpleArgumentResponseParams
+@end
 @implementation MTRUnitTestingClusterTestUnknownCommandParams
 - (instancetype)init
 {
@@ -7164,6 +7182,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestUnknownCommandParams
 @end
 @implementation MTRUnitTestingClusterTestStructArrayArgumentResponseParams
 - (instancetype)init
@@ -7209,6 +7230,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestStructArrayArgumentResponseParams
+@end
 @implementation MTRUnitTestingClusterTestAddArgumentsParams
 - (instancetype)init
 {
@@ -7241,6 +7265,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestAddArgumentsParams
+@end
 @implementation MTRUnitTestingClusterTestListInt8UReverseResponseParams
 - (instancetype)init
 {
@@ -7269,6 +7296,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestListInt8UReverseResponseParams
+@end
 @implementation MTRUnitTestingClusterTestSimpleArgumentRequestParams
 - (instancetype)init
 {
@@ -7296,6 +7326,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestSimpleArgumentRequestParams
 @end
 @implementation MTRUnitTestingClusterTestEnumsResponseParams
 - (instancetype)init
@@ -7328,6 +7361,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestEnumsResponseParams
 @end
 @implementation MTRUnitTestingClusterTestStructArrayArgumentRequestParams
 - (instancetype)init
@@ -7373,6 +7409,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestStructArrayArgumentRequestParams
+@end
 @implementation MTRUnitTestingClusterTestNullableOptionalResponseParams
 - (instancetype)init
 {
@@ -7411,6 +7450,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestNullableOptionalResponseParams
+@end
 @implementation MTRUnitTestingClusterTestStructArgumentRequestParams
 - (instancetype)init
 {
@@ -7438,6 +7480,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestStructArgumentRequestParams
 @end
 @implementation MTRUnitTestingClusterTestComplexNullableOptionalResponseParams
 - (instancetype)init
@@ -7563,6 +7608,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestComplexNullableOptionalResponseParams
+@end
 @implementation MTRUnitTestingClusterTestNestedStructArgumentRequestParams
 - (instancetype)init
 {
@@ -7590,6 +7638,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestNestedStructArgumentRequestParams
 @end
 @implementation MTRUnitTestingClusterBooleanResponseParams
 - (instancetype)init
@@ -7619,6 +7670,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterBooleanResponseParams
+@end
 @implementation MTRUnitTestingClusterTestListStructArgumentRequestParams
 - (instancetype)init
 {
@@ -7646,6 +7700,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestListStructArgumentRequestParams
 @end
 @implementation MTRUnitTestingClusterSimpleStructResponseParams
 - (instancetype)init
@@ -7675,6 +7732,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterSimpleStructResponseParams
+@end
 @implementation MTRUnitTestingClusterTestListInt8UArgumentRequestParams
 - (instancetype)init
 {
@@ -7702,6 +7762,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestListInt8UArgumentRequestParams
 @end
 @implementation MTRUnitTestingClusterTestEmitTestEventResponseParams
 - (instancetype)init
@@ -7731,6 +7794,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestEmitTestEventResponseParams
+@end
 @implementation MTRUnitTestingClusterTestNestedStructListArgumentRequestParams
 - (instancetype)init
 {
@@ -7758,6 +7824,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestNestedStructListArgumentRequestParams
 @end
 @implementation MTRUnitTestingClusterTestEmitTestFabricScopedEventResponseParams
 - (instancetype)init
@@ -7787,6 +7856,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestEmitTestFabricScopedEventResponseParams
+@end
 @implementation MTRUnitTestingClusterTestListNestedStructListArgumentRequestParams
 - (instancetype)init
 {
@@ -7815,6 +7887,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestListNestedStructListArgumentRequestParams
+@end
 @implementation MTRUnitTestingClusterTestListInt8UReverseRequestParams
 - (instancetype)init
 {
@@ -7842,6 +7917,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestListInt8UReverseRequestParams
 @end
 @implementation MTRUnitTestingClusterTestEnumsRequestParams
 - (instancetype)init
@@ -7875,6 +7953,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestEnumsRequestParams
+@end
 @implementation MTRUnitTestingClusterTestNullableOptionalRequestParams
 - (instancetype)init
 {
@@ -7902,6 +7983,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestNullableOptionalRequestParams
 @end
 @implementation MTRUnitTestingClusterTestComplexNullableOptionalRequestParams
 - (instancetype)init
@@ -7970,6 +8054,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestComplexNullableOptionalRequestParams
+@end
 @implementation MTRUnitTestingClusterSimpleStructEchoRequestParams
 - (instancetype)init
 {
@@ -7998,6 +8085,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterSimpleStructEchoRequestParams
+@end
 @implementation MTRUnitTestingClusterTimedInvokeRequestParams
 - (instancetype)init
 {
@@ -8022,6 +8112,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTimedInvokeRequestParams
 @end
 @implementation MTRUnitTestingClusterTestSimpleOptionalArgumentRequestParams
 - (instancetype)init
@@ -8050,6 +8143,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestSimpleOptionalArgumentRequestParams
 @end
 @implementation MTRUnitTestingClusterTestEmitTestEventRequestParams
 - (instancetype)init
@@ -8086,6 +8182,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+@implementation MTRTestClusterClusterTestEmitTestEventRequestParams
+@end
 @implementation MTRUnitTestingClusterTestEmitTestFabricScopedEventRequestParams
 - (instancetype)init
 {
@@ -8113,6 +8212,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestEmitTestFabricScopedEventRequestParams
 @end
 @implementation MTRFaultInjectionClusterFailAtFaultParams
 - (instancetype)init

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
@@ -950,6 +950,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterSimpleStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull a;
 @property (nonatomic, copy) NSNumber * _Nonnull b;
@@ -964,6 +965,10 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterSimpleStruct")
+@interface MTRTestClusterClusterSimpleStruct : MTRUnitTestingClusterSimpleStruct
+@end
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestFabricScoped : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull fabricSensitiveInt8u;
 @property (nonatomic, copy) NSNumber * _Nullable optionalFabricSensitiveInt8u;
@@ -978,6 +983,10 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestFabricScoped")
+@interface MTRTestClusterClusterTestFabricScoped : MTRUnitTestingClusterTestFabricScoped
+@end
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterNullablesAndOptionalsStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nullable nullableInt;
 @property (nonatomic, copy) NSNumber * _Nullable optionalInt;
@@ -996,6 +1005,10 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterNullablesAndOptionalsStruct")
+@interface MTRTestClusterClusterNullablesAndOptionalsStruct : MTRUnitTestingClusterNullablesAndOptionalsStruct
+@end
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterNestedStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull a;
 @property (nonatomic, copy) NSNumber * _Nonnull b;
@@ -1005,6 +1018,10 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterNestedStruct")
+@interface MTRTestClusterClusterNestedStruct : MTRUnitTestingClusterNestedStruct
+@end
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterNestedStructList : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull a;
 @property (nonatomic, copy) NSNumber * _Nonnull b;
@@ -1018,6 +1035,10 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterNestedStructList")
+@interface MTRTestClusterClusterNestedStructList : MTRUnitTestingClusterNestedStructList
+@end
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterDoubleNestedStructList : NSObject <NSCopying>
 @property (nonatomic, copy) NSArray * _Nonnull a;
 
@@ -1025,6 +1046,10 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterDoubleNestedStructList")
+@interface MTRTestClusterClusterDoubleNestedStructList : MTRUnitTestingClusterDoubleNestedStructList
+@end
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestListStructOctet : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull member1;
 @property (nonatomic, copy) NSData * _Nonnull member2;
@@ -1033,6 +1058,11 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestListStructOctet")
+@interface MTRTestClusterClusterTestListStructOctet : MTRUnitTestingClusterTestListStructOctet
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestEventEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull arg1;
 @property (nonatomic, copy) NSNumber * _Nonnull arg2;
@@ -1045,11 +1075,20 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestEventEvent")
+@interface MTRTestClusterClusterTestEventEvent : MTRUnitTestingClusterTestEventEvent
+@end
+
+MTR_NEWLY_AVAILABLE
 @interface MTRUnitTestingClusterTestFabricScopedEventEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
+@end
+
+MTR_NEWLY_DEPRECATED("Please use MTRUnitTestingClusterTestFabricScopedEventEvent")
+@interface MTRTestClusterClusterTestFabricScopedEventEvent : MTRUnitTestingClusterTestFabricScopedEventEvent
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
@@ -3619,6 +3619,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@implementation MTRTestClusterClusterSimpleStruct : MTRUnitTestingClusterSimpleStruct
+@end
+
 @implementation MTRUnitTestingClusterTestFabricScoped
 - (instancetype)init
 {
@@ -3671,6 +3674,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestFabricScoped : MTRUnitTestingClusterTestFabricScoped
 @end
 
 @implementation MTRUnitTestingClusterNullablesAndOptionalsStruct
@@ -3739,6 +3745,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@implementation MTRTestClusterClusterNullablesAndOptionalsStruct : MTRUnitTestingClusterNullablesAndOptionalsStruct
+@end
+
 @implementation MTRUnitTestingClusterNestedStruct
 - (instancetype)init
 {
@@ -3771,6 +3780,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterNestedStruct : MTRUnitTestingClusterNestedStruct
 @end
 
 @implementation MTRUnitTestingClusterNestedStructList
@@ -3819,6 +3831,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@implementation MTRTestClusterClusterNestedStructList : MTRUnitTestingClusterNestedStructList
+@end
+
 @implementation MTRUnitTestingClusterDoubleNestedStructList
 - (instancetype)init
 {
@@ -3844,6 +3859,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterDoubleNestedStructList : MTRUnitTestingClusterDoubleNestedStructList
 @end
 
 @implementation MTRUnitTestingClusterTestListStructOctet
@@ -3875,6 +3893,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestListStructOctet : MTRUnitTestingClusterTestListStructOctet
 @end
 
 @implementation MTRUnitTestingClusterTestEventEvent
@@ -3920,6 +3941,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@implementation MTRTestClusterClusterTestEventEvent : MTRUnitTestingClusterTestEventEvent
+@end
+
 @implementation MTRUnitTestingClusterTestFabricScopedEventEvent
 - (instancetype)init
 {
@@ -3946,6 +3970,9 @@ NS_ASSUME_NONNULL_BEGIN
     return descriptionString;
 }
 
+@end
+
+@implementation MTRTestClusterClusterTestFabricScopedEventEvent : MTRUnitTestingClusterTestFabricScopedEventEvent
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/23495 renamed "TestCluster"
to "UnitTesting", which changed a bunch of Darwin APIs.  This PR puts in place
backwards-compat shims to avoid API changes.  Specifically, compared to revision
9a41c9c3d971797010ab9de4eb04804015674fb0 (right before #23495 landed), the
changes to Darwin code end up looking like this:

1. MTRAttributeTLVValueDecoder.mm: internal-only changes to cluster ids.
2. MTRBaseClusters.h:
   * MTRBaseClusterTestCluster renamed to MTRBaseClusterUnitTesting, which is
     marked MTR_NEWLY_AVAILABLE.
   * Various modifications to methods on MTRBaseClusterUnitTesting that are
     marked MTR_NEWLY_AVAILABLE, so these changes are OK.
   * MTRBaseClusterTestCluster is added as a subclass of
     MTRBaseClusterUnitTesting.
   * The MTRBaseClusterTestCluster (Deprecated) bits are not changed at all.
   * The MTRUnitTesting enums/bitmaps are added as MTR_NEWLY_AVAILABLE.
   * The MTRTestCluster enums/bitmaps are marked as MTR_NEWLY_DEPRECATED.
3. MTRBaseClusters.mm: The various (Deprecated) bits get shims on the
   completion handlers to handle the fact that for MTRBaseClusterTestCluster
   (Deprecated) the types in the completions are TestCluster but we want to
   call things that expect UnitTesting types, so we have to cast between them.
   We could restrict these shims to just TestCluster with enough work, but it
   does not seem worth it.
4. MTRBaseClusters_internal.h: just follows the renaming from MTRBaseClusters.h
5. MTRCallbackBridge.mm: just follows the renamings of the various struct types,
   commands, etc..
6. MTRCallbackBridge_internal.h: just follows the renaming of the various
   struct types.
7. MTRClusterConstants.h: marks the old constants as MTR_NEWLY_DEPRECATED and
   adds the new constants as MTR_NEWLY_AVAILABLE.
8. MTRClusters.h:
   * MTRClusterTestCluster renamed to MTRClusterUnitTesting, which is marked
     MTR_NEWLY_AVAILABLE.
   * Various modifications to methods on MTRClusterUnitTesting that are marked
     MTR_NEWLY_AVAILABLE, so these changes are OK.
   * MTRClusterTestCluster is added as a subclass of MTRClusterUnitTesting.
   * The MTRClusterTestCluster (Deprecated) bits are not changed at all.
9. MTRClusters.mm: The various (Deprecated) bits get shims on the
   completion handlers, like for MTRBaseClusters.mm above.
10. MTRClusters_internal.h: Just follows the renaming from MTRClusters.h
11. MTRCommandPayloadsObjc.h:
    * Renames payload structs to UnitTesting, marks them MTR_NEWLY_AVAILABLE
    * Adds subclasses of the payload structs with the old name that
      are marked as MTR_NEWLY_DEPRECATED and have no extra selectors.
    * Changes types of struct members of payloads to have the UnitTesting types.
12. MTRCommandPayloadsObjc.mm: just follows the header changes.
13. MTREventTLVValueDecoder.mm: Internal changes to ID names.
14. MTRStructsObjc.h:
    * Renames structs defined in the unit testing cluster to UnitTesting names,
      marks them MTR_NEWLY_AVAILABLE.
    * Adds subclasses of the structs with the old name that are marked as
      MTR_NEWLY_DEPRECATED and have no extra selectors.
15. MTRStructsObjc.mm: just follows the header changes.
