### PR TITLE
allow im sub over pase

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -416,12 +416,6 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
         System::PacketBufferTLVReader reader;
         bool keepExistingSubscriptions = true;
 
-        if (apExchangeContext->GetSessionHandle()->GetFabricIndex() == kUndefinedFabricIndex)
-        {
-            // Subscriptions must be associated to a fabric.
-            return Status::UnsupportedAccess;
-        }
-
         reader.Init(aPayload.Retain());
 
         SubscribeRequestMessage::Parser subscribeRequestParser;


### PR DESCRIPTION
https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/Ch02_Architecture.adoc#1122-subscribe-interaction-limits

Per spec, IM subscription is allowed over pase, we need to fix this by this PR.
