### PR TITLE
tv-casting-app: Adding new app params

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/AppParameters.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/AppParameters.java
@@ -25,6 +25,9 @@ public class AppParameters {
 
   private byte[] rotatingDeviceIdUniqueId;
   private DACProvider dacProvider = TEST_DAC_PROVIDER;
+  private String spake2pVerifierBase64;
+  private String Spake2pSaltBase64;
+  private int spake2pIterationCount;
   private int setupPasscode = TEST_SETUP_PASSCODE;
   private int discriminator = TEST_DISCRIMINATOR;
 
@@ -42,6 +45,30 @@ public class AppParameters {
 
   public void setDacProvider(DACProvider dacProvider) {
     this.dacProvider = dacProvider;
+  }
+
+  public String getSpake2pVerifierBase64() {
+    return spake2pVerifierBase64;
+  }
+
+  public void setSpake2pVerifierBase64(String spake2pVerifierBase64) {
+    this.spake2pVerifierBase64 = spake2pVerifierBase64;
+  }
+
+  public String getSpake2pSaltBase64() {
+    return Spake2pSaltBase64;
+  }
+
+  public void setSpake2pSaltBase64(String spake2pSaltBase64) {
+    Spake2pSaltBase64 = spake2pSaltBase64;
+  }
+
+  public int getSpake2pIterationCount() {
+    return spake2pIterationCount;
+  }
+
+  public void setSpake2pIterationCount(int spake2pIterationCount) {
+    this.spake2pIterationCount = spake2pIterationCount;
   }
 
   public int getSetupPasscode() {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -46,6 +46,10 @@ public class TvCastingApp {
   private NsdManagerServiceResolver.NsdManagerResolverAvailState nsdManagerResolverAvailState;
 
   public boolean initApp(Context applicationContext, AppParameters appParameters) {
+    if (applicationContext == null || appParameters == null) {
+      return false;
+    }
+
     this.applicationContext = applicationContext;
     nsdManagerResolverAvailState = new NsdManagerServiceResolver.NsdManagerResolverAvailState();
     NsdManagerServiceResolver nsdManagerServiceResolver =
@@ -62,7 +66,11 @@ public class TvCastingApp {
             new DiagnosticDataProviderImpl(applicationContext));
 
     chipPlatform.updateCommissionableDataProviderData(
-        null, null, 0, appParameters.getSetupPasscode(), appParameters.getDiscriminator());
+        appParameters.getSpake2pVerifierBase64(),
+        appParameters.getSpake2pSaltBase64(),
+        appParameters.getSpake2pIterationCount(),
+        appParameters.getSetupPasscode(),
+        appParameters.getDiscriminator());
 
     chipAppServer = new ChipAppServer();
     chipAppServer.startApp();

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -1358,7 +1358,7 @@ JNI_METHOD(jboolean, targetNavigator_1navigateTarget)
 
     ChipLogProgress(AppServer, "JNI_METHOD targetNavigator_navigateTarget called");
 
-    const char * nativeData = env->GetStringUTFChars(data, 0);
+    const char * nativeData = (data != nullptr ? env->GetStringUTFChars(data, 0) : nullptr);
 
     TargetEndpointInfo endpoint;
     CHIP_ERROR err = convertJContentAppToTargetEndpointInfo(contentApp, endpoint);
@@ -1371,12 +1371,16 @@ JNI_METHOD(jboolean, targetNavigator_1navigateTarget)
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = CastingServer::GetInstance()->TargetNavigator_NavigateTarget(
-        &endpoint, static_cast<uint8_t>(target), chip::MakeOptional(CharSpan::fromCharString(nativeData)),
+        &endpoint, static_cast<uint8_t>(target),
+        (nativeData != nullptr ? chip::MakeOptional(CharSpan::fromCharString(nativeData)) : chip::NullOptional),
         [](CHIP_ERROR err) { TvCastingAppJNIMgr().getMediaCommandResponseHandler(TargetNavigator_NavigateTarget).Handle(err); });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.TargetNavigator_NavigateTarget failed %" CHIP_ERROR_FORMAT, err.Format()));
 
-    env->ReleaseStringUTFChars(data, nativeData);
+    if (nativeData != nullptr)
+    {
+        env->ReleaseStringUTFChars(data, nativeData);
+    }
 exit:
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		3C4E53B028E4F28100F293E8 /* MediaPlaybackTypes.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C4E53AF28E4F28100F293E8 /* MediaPlaybackTypes.mm */; };
 		3C4E53B228E5184C00F293E8 /* TargetNavigatorTypes.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C4E53B128E5184C00F293E8 /* TargetNavigatorTypes.mm */; };
 		3C4E53B628E5595A00F293E8 /* ContentLauncherTypes.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C4E53B528E5595A00F293E8 /* ContentLauncherTypes.mm */; };
-		3C66FBFC290327BB00B63FE7 /* AppParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C66FBFB290327BB00B63FE7 /* AppParameters.m */; };
+		3C66FBFC290327BB00B63FE7 /* AppParameters.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C66FBFB290327BB00B63FE7 /* AppParameters.mm */; };
 		3C81C74C28F7A777001CB9D1 /* ContentApp.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C81C74B28F7A777001CB9D1 /* ContentApp.mm */; };
 		3C81C75028F7A7D3001CB9D1 /* VideoPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C81C74F28F7A7D3001CB9D1 /* VideoPlayer.m */; };
 		3CCB87212869085400771BAD /* MatterTvCastingBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CCB87202869085400771BAD /* MatterTvCastingBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -27,6 +27,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3C0D9CDF2920A30C00D3332B /* CommissionableDataProviderImpl.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CommissionableDataProviderImpl.hpp; sourceTree = "<group>"; };
 		3C4AE64E286A7D40005B52A4 /* OnboardingPayload.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OnboardingPayload.h; sourceTree = "<group>"; };
 		3C4AE64F286A7D4D005B52A4 /* OnboardingPayload.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnboardingPayload.m; sourceTree = "<group>"; };
 		3C4E53AF28E4F28100F293E8 /* MediaPlaybackTypes.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaPlaybackTypes.mm; sourceTree = "<group>"; };
@@ -35,7 +36,7 @@
 		3C4E53B428E5593700F293E8 /* ContentLauncherTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContentLauncherTypes.h; sourceTree = "<group>"; };
 		3C4E53B528E5595A00F293E8 /* ContentLauncherTypes.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ContentLauncherTypes.mm; sourceTree = "<group>"; };
 		3C66FBFA2903279A00B63FE7 /* AppParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppParameters.h; sourceTree = "<group>"; };
-		3C66FBFB290327BB00B63FE7 /* AppParameters.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppParameters.m; sourceTree = "<group>"; };
+		3C66FBFB290327BB00B63FE7 /* AppParameters.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AppParameters.mm; sourceTree = "<group>"; };
 		3C81C74B28F7A777001CB9D1 /* ContentApp.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ContentApp.mm; sourceTree = "<group>"; };
 		3C81C74E28F7A7AE001CB9D1 /* ContentApp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContentApp.h; sourceTree = "<group>"; };
 		3C81C74F28F7A7D3001CB9D1 /* VideoPlayer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VideoPlayer.m; sourceTree = "<group>"; };
@@ -93,7 +94,7 @@
 				3CCB873A286A593700771BAD /* CastingServerBridge.h */,
 				3CCB873D286A593700771BAD /* CastingServerBridge.mm */,
 				3C66FBFA2903279A00B63FE7 /* AppParameters.h */,
-				3C66FBFB290327BB00B63FE7 /* AppParameters.m */,
+				3C66FBFB290327BB00B63FE7 /* AppParameters.mm */,
 				3CCB873B286A593700771BAD /* DiscoveredNodeData.h */,
 				3CCB8739286A593700771BAD /* DiscoveredNodeData.mm */,
 				3CCB873C286A593700771BAD /* ConversionUtils.hpp */,
@@ -112,6 +113,7 @@
 				3C4E53AF28E4F28100F293E8 /* MediaPlaybackTypes.mm */,
 				3C4E53B328E5185F00F293E8 /* TargetNavigatorTypes.h */,
 				3C4E53B128E5184C00F293E8 /* TargetNavigatorTypes.mm */,
+				3C0D9CDF2920A30C00D3332B /* CommissionableDataProviderImpl.hpp */,
 			);
 			path = MatterTvCastingBridge;
 			sourceTree = "<group>";
@@ -226,7 +228,7 @@
 				3C81C75028F7A7D3001CB9D1 /* VideoPlayer.m in Sources */,
 				3CCB8744286A593700771BAD /* ConversionUtils.mm in Sources */,
 				3C4E53B028E4F28100F293E8 /* MediaPlaybackTypes.mm in Sources */,
-				3C66FBFC290327BB00B63FE7 /* AppParameters.m in Sources */,
+				3C66FBFC290327BB00B63FE7 /* AppParameters.mm in Sources */,
 				3CCB873F286A593700771BAD /* DiscoveredNodeData.mm in Sources */,
 				3C81C74C28F7A777001CB9D1 /* ContentApp.mm in Sources */,
 				3C4AE650286A7D4D005B52A4 /* OnboardingPayload.m in Sources */,

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/AppParameters.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/AppParameters.h
@@ -17,6 +17,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "OnboardingPayload.h"
+
 #ifndef AppParameters_h
 #define AppParameters_h
 
@@ -24,7 +26,13 @@
 
 @property NSData * rotatingDeviceIdUniqueId;
 
-- (AppParameters *)initWithRotatingDeviceIdUniqueId:(NSData *)rotatingDeviceIdUniqueId;
+@property OnboardingPayload * onboardingPayload;
+
+@property uint32_t spake2pIterationCount;
+
+@property NSData * spake2pSalt;
+
+@property NSData * spake2pVerifier;
 
 @end
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/AppParameters.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/AppParameters.mm
@@ -21,13 +21,12 @@
 
 @implementation AppParameters
 
-- (AppParameters *)initWithRotatingDeviceIdUniqueId:(NSData *)rotatingDeviceIdUniqueId
+/**
+ * Initialize with default values
+ */
+- (AppParameters *)init
 {
-    self = [super init];
-    if (self) {
-        _rotatingDeviceIdUniqueId = rotatingDeviceIdUniqueId;
-    }
-    return self;
+    return [super init];
 }
 
 @end

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CommissionableDataProviderImpl.hpp
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CommissionableDataProviderImpl.hpp
@@ -1,0 +1,180 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef CommissionableDataProviderImpl_h
+#define CommissionableDataProviderImpl_h
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/Span.h>
+#include <platform/CommissionableDataProvider.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+class CommissionableDataProviderImpl : public CommissionableDataProvider
+{
+public:
+    CommissionableDataProviderImpl() {}
+
+    CHIP_ERROR GetSetupPasscode(uint32_t & setupPasscode) override
+    {
+        if (mSetupPasscode > 0)
+        {
+            setupPasscode = mSetupPasscode;
+        }
+        else
+        {
+            setupPasscode = kDefaultTestPasscode;
+        }
+
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR SetSetupPasscode(uint32_t setupPasscode) override
+    {
+        mSetupPasscode = setupPasscode;
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR GetSetupDiscriminator(uint16_t & setupDiscriminator) override
+    {
+        if (mSetupDiscriminator > 0)
+        {
+            setupDiscriminator = mSetupDiscriminator;
+        }
+        else
+        {
+            setupDiscriminator = kDefaultTestDiscriminator;
+        }
+
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR SetSetupDiscriminator(uint16_t setupDiscriminator) override
+    {
+        mSetupDiscriminator = setupDiscriminator;
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR GetSpake2pIterationCount(uint32_t & iterationCount) override
+    {
+        if (mSetupDiscriminator > 0)
+        {
+            iterationCount = mSpake2pIterationCount;
+        }
+        else
+        {
+            iterationCount = kDefaultTestVerifierIterationCount;
+        }
+
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR SetSpake2pIterationCount(uint32_t iterationCount)
+    {
+        mSpake2pIterationCount = iterationCount;
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR GetSpake2pSalt(MutableByteSpan & saltBuf) override
+    {
+        size_t saltLen = mSpake2pSalt.data() == nullptr ? sizeof(kDefaultTestVerifierSalt) : mSpake2pSalt.size();
+        if (saltBuf.size() < saltLen)
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+
+        memcpy(saltBuf.data(), mSpake2pSalt.data() == nullptr ? kDefaultTestVerifierSalt : mSpake2pSalt.data(), saltLen);
+        saltBuf.reduce_size(saltLen);
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR SetSpake2pSalt(ByteSpan saltBuf)
+    {
+        size_t saltLen = saltBuf.size();
+        if (chip::Crypto::kSpake2p_Max_PBKDF_Salt_Length < saltLen)
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+
+        mSpake2pSalt = MutableByteSpan(mSpake2pSaltBuf, chip::Crypto::kSpake2p_Max_PBKDF_Salt_Length);
+
+        memcpy(mSpake2pSalt.data(), saltBuf.data(), saltLen);
+        mSpake2pSalt.reduce_size(saltLen);
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR GetSpake2pVerifier(MutableByteSpan & verifierBuf, size_t & outVerifierLen) override
+    {
+        outVerifierLen = mSpake2pVerifier.data() == nullptr ? sizeof(kDefaultTestVerifier) : mSpake2pVerifier.size();
+        if (verifierBuf.size() < outVerifierLen)
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+        memcpy(verifierBuf.data(), mSpake2pVerifier.data() == nullptr ? kDefaultTestVerifier : mSpake2pVerifier.data(),
+               outVerifierLen);
+        verifierBuf.reduce_size(outVerifierLen);
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR SetSpake2pVerifier(MutableByteSpan verifierBuf)
+    {
+        size_t inVerifierBufLen = verifierBuf.size();
+        if (chip::Crypto::kSpake2p_VerifierSerialized_Length < inVerifierBufLen)
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+
+        mSpake2pVerifier = MutableByteSpan(mSpake2pSaltBuf, chip::Crypto::kSpake2p_VerifierSerialized_Length);
+
+        memcpy(mSpake2pVerifier.data(), verifierBuf.data(), inVerifierBufLen);
+        mSpake2pVerifier.reduce_size(inVerifierBufLen);
+        return CHIP_NO_ERROR;
+    }
+
+private:
+    static constexpr uint32_t kDefaultTestPasscode               = 20202021;
+    static constexpr uint16_t kDefaultTestDiscriminator          = 3840;
+    static constexpr uint32_t kDefaultTestVerifierIterationCount = 1000;
+    static constexpr uint8_t kDefaultTestVerifierSalt[16]        = {
+        0x53, 0x50, 0x41, 0x4b, 0x45, 0x32, 0x50, 0x20, 0x4b, 0x65, 0x79, 0x20, 0x53, 0x61, 0x6c, 0x74,
+    };
+    static constexpr uint8_t kDefaultTestVerifier[97] = {
+        0xb9, 0x61, 0x70, 0xaa, 0xe8, 0x03, 0x34, 0x68, 0x84, 0x72, 0x4f, 0xe9, 0xa3, 0xb2, 0x87, 0xc3, 0x03, 0x30, 0xc2, 0xa6,
+        0x60, 0x37, 0x5d, 0x17, 0xbb, 0x20, 0x5a, 0x8c, 0xf1, 0xae, 0xcb, 0x35, 0x04, 0x57, 0xf8, 0xab, 0x79, 0xee, 0x25, 0x3a,
+        0xb6, 0xa8, 0xe4, 0x6b, 0xb0, 0x9e, 0x54, 0x3a, 0xe4, 0x22, 0x73, 0x6d, 0xe5, 0x01, 0xe3, 0xdb, 0x37, 0xd4, 0x41, 0xfe,
+        0x34, 0x49, 0x20, 0xd0, 0x95, 0x48, 0xe4, 0xc1, 0x82, 0x40, 0x63, 0x0c, 0x4f, 0xf4, 0x91, 0x3c, 0x53, 0x51, 0x38, 0x39,
+        0xb7, 0xc0, 0x7f, 0xcc, 0x06, 0x27, 0xa1, 0xb8, 0x57, 0x3a, 0x14, 0x9f, 0xcd, 0x1f, 0xa4, 0x66, 0xcf,
+    };
+
+    uint32_t mSetupPasscode         = 0;
+    uint16_t mSetupDiscriminator    = 0;
+    uint32_t mSpake2pIterationCount = 0;
+
+    uint8_t mSpake2pSaltBuf[chip::Crypto::kSpake2p_Max_PBKDF_Salt_Length];
+    MutableByteSpan mSpake2pSalt;
+
+    MutableByteSpan mSpake2pVerifier;
+    uint8_t mSpake2pVerifierBuf[chip::Crypto::kSpake2p_VerifierSerialized_Length];
+};
+
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif /* CommissionableDataProviderImpl_h */

--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -31,10 +31,7 @@ public:
         mOnConnectedCallback(HandleDeviceConnected, this), mOnConnectionFailureCallback(HandleDeviceConnectionFailure, this)
     {}
 
-    bool operator==(const TargetVideoPlayerInfo & other)
-    {
-        return this->mNodeId == other.mNodeId && this->mFabricIndex == other.mFabricIndex;
-    }
+    bool operator==(const TargetVideoPlayerInfo & other) { return this->mNodeId == other.mNodeId; }
 
     bool IsInitialized() { return mInitialized; }
     uint16_t GetVendorId() const { return mVendorId; }


### PR DESCRIPTION
Fixes #23623 and #20073

####Change summary
Added new AppParameter fields to both Android and iOS to pass in setupPasscode, discriminator, spake2p fields and DAC.

####Testing
Tested using the Android and iOS tv-casting-apps against the tv-app.