### PR TITLE
Add support to compile java matter controller test example in host without android

### DIFF
--- a/build/chip/java/config.gni
+++ b/build/chip/java/config.gni
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Project CHIP Authors
+# Copyright (c) 2022 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+java_path = getenv("JAVA_PATH")
 declare_args() {
-  # Root directory for build files.
-  build_root = "//third_party/connectedhomeip/build"
+  java_matter_controller_dependent_paths = []
+  build_java_matter_controller = false
+  if (java_path != "") {
+    java_matter_controller_dependent_paths += [
+      "${java_path}/include/",
+      "${java_path}/include/linux/",
+    ]
+    build_java_matter_controller = true
+  }
 }

--- a/build/chip/java/rules.gni
+++ b/build/chip/java/rules.gni
@@ -13,14 +13,15 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-
+import("${chip_root}/build/chip/java/config.gni")
 import("${chip_root}/build/config/android/config.gni")
 
 javac_runner = "${chip_root}/build/chip/java/javac_runner.py"
 jar_runner = "${chip_root}/build/chip/java/jar_runner.py"
 write_build_config = "${chip_root}/build/chip/java/write_build_config.py"
 
-assert(android_sdk_root != "", "android_sdk_root must be specified")
+assert(android_sdk_root != "" || build_java_matter_controller,
+       "android_sdk_root or java_path must be specified")
 
 # Declare a java library target
 #

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -248,6 +248,10 @@ config("strict_warnings") {
     ]
   }
 
+  if (getenv("JAVA_PATH") != "") {
+    cflags -= [ "-Wshadow" ]
+  }
+
   cflags_cc = [ "-Wnon-virtual-dtor" ]
 
   ldflags = []

--- a/examples/java-matter-controller/BUILD.gn
+++ b/examples/java-matter-controller/BUILD.gn
@@ -15,11 +15,8 @@
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
-import("${build_root}/config/android_abi.gni")
 import("${chip_root}/build/chip/java/rules.gni")
 import("${chip_root}/build/chip/tools.gni")
-
-build_java_matter_controller = true
 
 java_binary("java-matter-controller") {
   output_name = "java-matter-controller"

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -100,6 +100,7 @@ def BuildHostTarget():
         TargetPart('all-clusters-minimal', app=HostApp.ALL_CLUSTERS),
         TargetPart('chip-tool', app=HostApp.CHIP_TOOL),
         TargetPart('thermostat', app=HostApp.THERMOSTAT),
+        TargetPart('java-matter-controller', app=HostApp.JAVA_MATTER_CONTROLLER),
         TargetPart('minmdns', app=HostApp.MIN_MDNS),
         TargetPart('light', app=HostApp.LIGHT),
         TargetPart('lock', app=HostApp.LOCK),

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -7,7 +7,7 @@ efr32-{brd4161a,brd4187c,brd4163a,brd4164a,brd4166a,brd4170a,brd4186a,brd4187a,b
 esp32-{m5stack,c3devkit,devkitc,qemu}-{all-clusters,all-clusters-minimal,ota-requestor,ota-requestor,shell,light,lock,bridge,temperature-measurement,ota-requestor,tests}[-rpc][-ipv6only]
 genio-lighting-app
 linux-fake-tests[-mbedtls][-boringssl][-asan][-tsan][-libfuzzer][-coverage][-dmalloc][-clang]
-linux-{x64,arm64}-{rpc-console,all-clusters,all-clusters-minimal,chip-tool,thermostat,minmdns,light,lock,shell,ota-provider,ota-requestor,python-bindings,tv-app,tv-casting-app,bridge,dynamic-bridge,tests,chip-cert,address-resolve-tool}[-nodeps][-minmdns-verbose][-libnl][-same-event-loop][-no-interactive][-ipv6only][-no-ble][-no-wifi][-no-thread][-mbedtls][-boringssl][-asan][-tsan][-libfuzzer][-coverage][-dmalloc][-clang][-test][-rpc]
+linux-{x64,arm64}-{rpc-console,all-clusters,all-clusters-minimal,chip-tool,thermostat,java-matter-controller,minmdns,light,lock,shell,ota-provider,ota-requestor,python-bindings,tv-app,tv-casting-app,bridge,dynamic-bridge,tests,chip-cert,address-resolve-tool}[-nodeps][-minmdns-verbose][-libnl][-same-event-loop][-no-interactive][-ipv6only][-no-ble][-no-wifi][-no-thread][-mbedtls][-boringssl][-asan][-tsan][-libfuzzer][-coverage][-dmalloc][-clang][-test][-rpc]
 linux-x64-efr32-test-runner[-clang]
 imx-{chip-tool,lighting-app,thermostat,all-clusters-app,all-clusters-minimal-app,ota-provider-app}[-release]
 infineon-psoc6-{lock,light,all-clusters,all-clusters-minimal}[-ota][-updateimage]

--- a/src/controller/data_model/BUILD.gn
+++ b/src/controller/data_model/BUILD.gn
@@ -18,6 +18,7 @@ import("//build_overrides/pigweed.gni")
 
 import("$dir_pw_build/python.gni")
 import("${chip_root}/build/chip/chip_codegen.gni")
+import("${chip_root}/build/chip/java/config.gni")
 import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("data_model") {
@@ -29,7 +30,7 @@ chip_data_model("data_model") {
   allow_circular_includes_from = [ "${chip_root}/src/controller" ]
 }
 
-if (current_os == "android") {
+if (current_os == "android" || build_java_matter_controller) {
   chip_codegen("java-jni-generate") {
     input = "controller-clusters.matter"
     generator = "java"
@@ -170,15 +171,21 @@ if (current_os == "android") {
 
   source_set("java-jni-sources") {
     sources = get_target_outputs(":java-jni-generate")
-    public_configs = [ "${chip_root}/src:includes" ]
 
+    public_configs = [ "${chip_root}/src:includes" ]
     deps = [
       ":data_model",
       ":java-jni-generate",
       "${chip_root}/src/inet",
       "${chip_root}/src/lib",
       "${chip_root}/src/platform",
-      "${chip_root}/src/platform/android",
     ]
+
+    if (build_java_matter_controller) {
+      include_dirs = java_matter_controller_dependent_paths
+      deps += [ "${chip_root}/src/platform/Linux" ]
+    } else {
+      deps += [ "${chip_root}/src/platform/android" ]
+    }
   }
 }

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -14,13 +14,11 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("${build_root}/config/android_abi.gni")
+import("${chip_root}/build/chip/java/config.gni")
 import("${chip_root}/build/chip/java/rules.gni")
 
-if (defined(build_java_matter_controller)) {
-  build_java_matter_controller = build_java_matter_controller
-} else {
-  build_java_matter_controller = false
+if (!build_java_matter_controller) {
+  import("${build_root}/config/android_abi.gni")
 }
 
 shared_library("jni") {
@@ -60,12 +58,24 @@ shared_library("jni") {
     "${chip_root}/src/lib",
     "${chip_root}/src/lib/support/jsontlv",
     "${chip_root}/src/platform",
-    "${chip_root}/src/platform/android",
   ]
 
   public_configs = [ "${chip_root}/src:includes" ]
 
-  output_dir = "${root_out_dir}/lib/jni/${android_abi}"
+  if (build_java_matter_controller) {
+    defines = [ "JAVA_MATTER_CONTROLLER_TEST" ]
+    include_dirs = java_matter_controller_dependent_paths
+
+    deps += [ "${chip_root}/src/platform/Linux" ]
+
+    cflags = [ "-Wno-unknown-pragmas" ]
+
+    output_dir = "${root_out_dir}/lib/jni"
+  } else {
+    deps += [ "${chip_root}/src/platform/android" ]
+
+    output_dir = "${root_out_dir}/lib/jni/${android_abi}"
+  }
 
   ldflags = [ "-Wl,--gc-sections" ]
 }
@@ -75,10 +85,7 @@ android_library("java") {
 
   deps = [ "${chip_root}/third_party/java_deps:annotation" ]
 
-  data_deps = [
-    ":jni",
-    "${chip_root}/build/chip/java:shared_cpplib",
-  ]
+  data_deps = [ ":jni" ]
 
   sources = [
     "src/chip/clusterinfo/ClusterCommandCallback.java",

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -20,6 +20,7 @@ import("//build_overrides/nlio.gni")
 import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_version.gni")
+import("${chip_root}/build/chip/java/config.gni")
 import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/src/lib/core/core.gni")
 
@@ -145,8 +146,12 @@ static_library("support") {
     "verhoeff/Verhoeff36.cpp",
   ]
 
-  # added JNI helper on android
-  if (current_os == "android") {
+  if (current_os == "android" || build_java_matter_controller) {
+    if (build_java_matter_controller) {
+      include_dirs = java_matter_controller_dependent_paths
+    }
+
+    # added JNI helper on android
     sources += [
       "CHIPJNIError.h",
       "JniReferences.cpp",

--- a/src/setup_payload/java/BUILD.gn
+++ b/src/setup_payload/java/BUILD.gn
@@ -14,18 +14,21 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-
-import("${build_root}/config/android_abi.gni")
+import("${chip_root}/build/chip/java/config.gni")
 import("${chip_root}/build/chip/java/rules.gni")
 
-if (defined(build_java_matter_controller)) {
-  build_java_matter_controller = build_java_matter_controller
-} else {
-  build_java_matter_controller = false
+if (!build_java_matter_controller) {
+  import("${build_root}/config/android_abi.gni")
 }
 
 shared_library("jni") {
   output_name = "libSetupPayloadParser"
+  if (build_java_matter_controller) {
+    include_dirs = java_matter_controller_dependent_paths
+    output_dir = "${root_out_dir}/lib/jni"
+  } else {
+    output_dir = "${root_out_dir}/lib/jni/${android_abi}"
+  }
 
   sources = [ "SetupPayloadParser-JNI.cpp" ]
 
@@ -33,8 +36,6 @@ shared_library("jni") {
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
   ]
-
-  output_dir = "${root_out_dir}/lib/jni/${android_abi}"
 }
 
 android_library("java") {


### PR DESCRIPTION
Problems:
https://github.com/project-chip/connectedhomeip/issues/23811

Add support to compile java matter controller test example in host without android

-- export JAVA_PATH=/usr/lib/jvm/java-8-openjdk-amd64
-- ./scripts/build/build_examples.py --target linux-x64-java-matter-controller build
-- java -verbose:jni -Xcheck:jni -Djava.library.path=out/linux-x64-java-matter-controller/lib/jni  -cp out/linux-x64-java-matter-controller/lib/third_party/connectedhomeip/src/controller/java/CHIPController.jar:out/linux-x64-java-matter-controller/bin/java-matter-controller  com.matter.controller.Main