### PR TITLE
[Tizen] Enable WiFi management from example app

### DIFF
--- a/examples/all-clusters-app/tizen/tizen-manifest.xml
+++ b/examples/all-clusters-app/tizen/tizen-manifest.xml
@@ -8,6 +8,7 @@
         <privilege>http://tizen.org/privilege/bluetooth</privilege>
         <privilege>http://tizen.org/privilege/internet</privilege>
         <privilege>http://tizen.org/privilege/network.get</privilege>
+        <privilege>http://tizen.org/privilege/network.set</privilege>
     </privileges>
     <feature name="http://tizen.org/feature/network.bluetooth">true</feature>
     <feature name="http://tizen.org/feature/network.bluetooth.le">true</feature>

--- a/examples/all-clusters-minimal-app/tizen/tizen-manifest.xml
+++ b/examples/all-clusters-minimal-app/tizen/tizen-manifest.xml
@@ -8,6 +8,7 @@
         <privilege>http://tizen.org/privilege/bluetooth</privilege>
         <privilege>http://tizen.org/privilege/internet</privilege>
         <privilege>http://tizen.org/privilege/network.get</privilege>
+        <privilege>http://tizen.org/privilege/network.set</privilege>
     </privileges>
     <feature name="http://tizen.org/feature/network.bluetooth">true</feature>
     <feature name="http://tizen.org/feature/network.bluetooth.le">true</feature>

--- a/examples/lighting-app/tizen/tizen-manifest.xml
+++ b/examples/lighting-app/tizen/tizen-manifest.xml
@@ -8,6 +8,7 @@
         <privilege>http://tizen.org/privilege/bluetooth</privilege>
         <privilege>http://tizen.org/privilege/internet</privilege>
         <privilege>http://tizen.org/privilege/network.get</privilege>
+        <privilege>http://tizen.org/privilege/network.set</privilege>
     </privileges>
     <feature name="http://tizen.org/feature/network.bluetooth">true</feature>
     <feature name="http://tizen.org/feature/network.bluetooth.le">true</feature>

--- a/examples/platform/tizen/OptionsProxy.cpp
+++ b/examples/platform/tizen/OptionsProxy.cpp
@@ -38,7 +38,7 @@ static constexpr Option sOptions[] = {
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
     { "ble-device", false },
 #endif
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     { "wifi", true },
 #endif
 #if CHIP_ENABLE_OPENTHREAD

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -191,8 +191,6 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
         "CHIP_DEVICE_LAYER_TARGET=Tizen",
         "CHIP_DEVICE_CONFIG_ENABLE_WIFI=${chip_enable_wifi}",
       ]
-      defines -=
-          [ "CHIP_DEVICE_CONFIG_ENABLE_WPA=${chip_device_config_enable_wpa}" ]
     } else if (chip_device_platform == "nrfconnect") {
       defines += [
         "CHIP_DEVICE_LAYER_TARGET_NRFCONNECT=1",

--- a/src/platform/Tizen/ConnectivityManagerImpl.cpp
+++ b/src/platform/Tizen/ConnectivityManagerImpl.cpp
@@ -209,29 +209,19 @@ void ConnectivityManagerImpl::_SetWiFiAPIdleTimeout(System::Clock::Timeout val) 
 
 void ConnectivityManagerImpl::StartWiFiManagement()
 {
-    SystemLayer().ScheduleWork(ActivateWiFiManager, nullptr);
+    Internal::WiFiMgr().Activate();
 }
 
 void ConnectivityManagerImpl::StopWiFiManagement()
 {
-    SystemLayer().ScheduleWork(DeactivateWiFiManager, nullptr);
+    Internal::WiFiMgr().Deactivate();
 }
 
 bool ConnectivityManagerImpl::IsWiFiManagementStarted()
 {
     bool isActivated = false;
-    WiFiMgr().IsActivated(&isActivated);
+    Internal::WiFiMgr().IsActivated(&isActivated);
     return isActivated;
-}
-
-void ConnectivityManagerImpl::ActivateWiFiManager(System::Layer * aLayer, void * aAppState)
-{
-    Internal::WiFiMgr().Activate();
-}
-
-void ConnectivityManagerImpl::DeactivateWiFiManager(System::Layer * aLayer, void * aAppState)
-{
-    Internal::WiFiMgr().Deactivate();
 }
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI

--- a/src/platform/Tizen/ConnectivityManagerImpl.cpp
+++ b/src/platform/Tizen/ConnectivityManagerImpl.cpp
@@ -217,6 +217,13 @@ void ConnectivityManagerImpl::StopWiFiManagement()
     SystemLayer().ScheduleWork(DeactivateWiFiManager, nullptr);
 }
 
+bool ConnectivityManagerImpl::IsWiFiManagementStarted()
+{
+    bool isActivated = false;
+    WiFiMgr().IsActivated(&isActivated);
+    return isActivated;
+}
+
 void ConnectivityManagerImpl::ActivateWiFiManager(System::Layer * aLayer, void * aAppState)
 {
     Internal::WiFiMgr().Activate();
@@ -226,6 +233,7 @@ void ConnectivityManagerImpl::DeactivateWiFiManager(System::Layer * aLayer, void
 {
     Internal::WiFiMgr().Deactivate();
 }
+
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
 } // namespace DeviceLayer

--- a/src/platform/Tizen/ConnectivityManagerImpl.h
+++ b/src/platform/Tizen/ConnectivityManagerImpl.h
@@ -116,9 +116,6 @@ private:
     void _MaintainOnDemandWiFiAP(void);
     System::Clock::Timeout _GetWiFiAPIdleTimeout(void);
     void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
-
-    static void ActivateWiFiManager(System::Layer * aLayer, void * aAppState);
-    static void DeactivateWiFiManager(System::Layer * aLayer, void * aAppState);
 #endif
 
     // ===== Members for internal use by the following friends.

--- a/src/platform/Tizen/ConnectivityManagerImpl.h
+++ b/src/platform/Tizen/ConnectivityManagerImpl.h
@@ -84,8 +84,9 @@ class ConnectivityManagerImpl final : public ConnectivityManager,
 
 public:
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    void StartWiFiManagement(void);
-    void StopWiFiManagement(void);
+    void StartWiFiManagement();
+    void StopWiFiManagement();
+    bool IsWiFiManagementStarted();
 #endif
 
 private:

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -601,41 +601,25 @@ void WiFiManager::Deinit()
 
 CHIP_ERROR WiFiManager::IsActivated(bool * isWiFiActivated)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    int wifiErr    = WIFI_MANAGER_ERROR_NONE;
-
-    wifiErr = wifi_manager_is_activated(sInstance.mWiFiManagerHandle, isWiFiActivated);
-    if (wifiErr == WIFI_MANAGER_ERROR_NONE)
-    {
-        ChipLogProgress(DeviceLayer, "WiFi is %s", *isWiFiActivated ? "activated" : "deactivated");
-    }
-    else
-    {
-        err = CHIP_ERROR_INCORRECT_STATE;
-        ChipLogError(DeviceLayer, "FAIL: check whether WiFi is activated [%s]", get_error_message(wifiErr));
-    }
-
-    return err;
+    int wifiErr = wifi_manager_is_activated(sInstance.mWiFiManagerHandle, isWiFiActivated);
+    VerifyOrReturnError(wifiErr == WIFI_MANAGER_ERROR_NONE,
+                        (ChipLogError(DeviceLayer, "FAIL: Check whether WiFi is activated: %s", get_error_message(wifiErr)),
+                         CHIP_ERROR_INCORRECT_STATE));
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR WiFiManager::Activate()
 {
     CHIP_ERROR err       = CHIP_NO_ERROR;
-    int wifiErr          = WIFI_MANAGER_ERROR_NONE;
     bool isWiFiActivated = false;
     bool dbusAsyncErr    = false;
 
-    wifiErr = wifi_manager_is_activated(sInstance.mWiFiManagerHandle, &isWiFiActivated);
-    VerifyOrExit(wifiErr == WIFI_MANAGER_ERROR_NONE, err = CHIP_ERROR_INCORRECT_STATE;
-                 ChipLogError(DeviceLayer, "FAIL: check whether WiFi is activated [%s]", get_error_message(wifiErr)));
-
+    VerifyOrExit((err = IsActivated(&isWiFiActivated)) == CHIP_NO_ERROR, );
     VerifyOrExit(isWiFiActivated == false, ChipLogProgress(DeviceLayer, "WiFi is already activated"));
 
     dbusAsyncErr = MainLoop::Instance().AsyncRequest(_WiFiActivate);
-    if (dbusAsyncErr == false)
-    {
-        err = CHIP_ERROR_INCORRECT_STATE;
-    }
+    VerifyOrExit(dbusAsyncErr == true,
+                 (ChipLogError(DeviceLayer, "FAIL: Async request: Activate WiFi"), err = CHIP_ERROR_INTERNAL));
 
 exit:
     return err;
@@ -644,21 +628,15 @@ exit:
 CHIP_ERROR WiFiManager::Deactivate()
 {
     CHIP_ERROR err       = CHIP_NO_ERROR;
-    int wifiErr          = WIFI_MANAGER_ERROR_NONE;
     bool isWiFiActivated = false;
     bool dbusAsyncErr    = false;
 
-    wifiErr = wifi_manager_is_activated(sInstance.mWiFiManagerHandle, &isWiFiActivated);
-    VerifyOrExit(wifiErr == WIFI_MANAGER_ERROR_NONE, err = CHIP_ERROR_INCORRECT_STATE;
-                 ChipLogError(DeviceLayer, "FAIL: check whether WiFi is activated [%s]", get_error_message(wifiErr)));
-
+    VerifyOrExit((err = IsActivated(&isWiFiActivated)) == CHIP_NO_ERROR, );
     VerifyOrExit(isWiFiActivated == true, ChipLogProgress(DeviceLayer, "WiFi is already deactivated"));
 
     dbusAsyncErr = MainLoop::Instance().AsyncRequest(_WiFiDeactivate);
-    if (dbusAsyncErr == false)
-    {
-        err = CHIP_ERROR_INCORRECT_STATE;
-    }
+    VerifyOrExit(dbusAsyncErr == true,
+                 (ChipLogError(DeviceLayer, "FAIL: Async request: Deactivate WiFi"), err = CHIP_ERROR_INTERNAL));
 
 exit:
     return err;
@@ -668,7 +646,6 @@ CHIP_ERROR WiFiManager::Connect(const char * ssid, const char * key,
                                 DeviceLayer::NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * apCallback)
 {
     CHIP_ERROR err            = CHIP_NO_ERROR;
-    int wifiErr               = WIFI_MANAGER_ERROR_NONE;
     bool isWiFiActivated      = false;
     bool dbusAsyncErr         = false;
     wifi_manager_ap_h foundAp = nullptr;
@@ -676,30 +653,24 @@ CHIP_ERROR WiFiManager::Connect(const char * ssid, const char * key,
     g_strlcpy(sInstance.mWiFiSSID, ssid, sizeof(sInstance.mWiFiSSID));
     g_strlcpy(sInstance.mWiFiKey, key, sizeof(sInstance.mWiFiKey));
 
-    wifiErr = wifi_manager_is_activated(sInstance.mWiFiManagerHandle, &isWiFiActivated);
-    VerifyOrExit(wifiErr == WIFI_MANAGER_ERROR_NONE, err = CHIP_ERROR_INCORRECT_STATE;
-                 ChipLogError(DeviceLayer, "FAIL: check whether WiFi is activated [%s]", get_error_message(wifiErr)));
-
-    VerifyOrExit(isWiFiActivated == true, ChipLogProgress(DeviceLayer, "WiFi is deactivated"));
+    VerifyOrExit((err = IsActivated(&isWiFiActivated)) == CHIP_NO_ERROR, );
+    VerifyOrExit(isWiFiActivated == true,
+                 (ChipLogProgress(DeviceLayer, "WiFi is not activated"), err = CHIP_ERROR_INCORRECT_STATE));
 
     sInstance.mpConnectCallback = apCallback;
 
     foundAp = sInstance._WiFiGetFoundAP();
     if (foundAp != nullptr)
     {
-        dbusAsyncErr = MainLoop::Instance().AsyncRequest(_WiFiConnect, static_cast<gpointer>(foundAp));
-        if (dbusAsyncErr == false)
-        {
-            err = CHIP_ERROR_INCORRECT_STATE;
-        }
+        dbusAsyncErr = MainLoop::Instance().AsyncRequest(_WiFiConnect, foundAp);
+        VerifyOrExit(dbusAsyncErr == true,
+                     (ChipLogError(DeviceLayer, "FAIL: Async request: Connect WiFi"), err = CHIP_ERROR_INTERNAL));
     }
     else
     {
         dbusAsyncErr = MainLoop::Instance().AsyncRequest(_WiFiScan);
-        if (dbusAsyncErr == false)
-        {
-            err = CHIP_ERROR_INCORRECT_STATE;
-        }
+        VerifyOrExit(dbusAsyncErr == true,
+                     (ChipLogError(DeviceLayer, "FAIL: Async request: Scan WiFi"), err = CHIP_ERROR_INTERNAL));
     }
 
 exit:
@@ -715,11 +686,9 @@ CHIP_ERROR WiFiManager::Disconnect(const char * ssid)
 
     g_strlcpy(sInstance.mWiFiSSID, ssid, sizeof(sInstance.mWiFiSSID));
 
-    wifiErr = wifi_manager_is_activated(sInstance.mWiFiManagerHandle, &isWiFiActivated);
-    VerifyOrExit(wifiErr == WIFI_MANAGER_ERROR_NONE, err = CHIP_ERROR_INCORRECT_STATE;
-                 ChipLogError(DeviceLayer, "FAIL: check whether WiFi is activated [%s]", get_error_message(wifiErr)));
-
-    VerifyOrExit(isWiFiActivated == true, ChipLogProgress(DeviceLayer, "WiFi is deactivated"));
+    VerifyOrExit((err = IsActivated(&isWiFiActivated)) == CHIP_NO_ERROR, );
+    VerifyOrExit(isWiFiActivated == true,
+                 (ChipLogProgress(DeviceLayer, "WiFi is not activated"), err = CHIP_ERROR_INCORRECT_STATE));
 
     foundAp = sInstance._WiFiGetFoundAP();
     VerifyOrExit(foundAp != nullptr, );

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -602,9 +602,8 @@ void WiFiManager::Deinit()
 CHIP_ERROR WiFiManager::IsActivated(bool * isWiFiActivated)
 {
     int wifiErr = wifi_manager_is_activated(sInstance.mWiFiManagerHandle, isWiFiActivated);
-    VerifyOrReturnError(wifiErr == WIFI_MANAGER_ERROR_NONE,
-                        (ChipLogError(DeviceLayer, "FAIL: Check whether WiFi is activated: %s", get_error_message(wifiErr)),
-                         CHIP_ERROR_INCORRECT_STATE));
+    VerifyOrReturnError(wifiErr == WIFI_MANAGER_ERROR_NONE, CHIP_ERROR_INCORRECT_STATE,
+                        ChipLogError(DeviceLayer, "FAIL: Check whether WiFi is activated: %s", get_error_message(wifiErr)));
     return CHIP_NO_ERROR;
 }
 
@@ -618,8 +617,10 @@ CHIP_ERROR WiFiManager::Activate()
     VerifyOrExit(isWiFiActivated == false, ChipLogProgress(DeviceLayer, "WiFi is already activated"));
 
     dbusAsyncErr = MainLoop::Instance().AsyncRequest(_WiFiActivate);
-    VerifyOrExit(dbusAsyncErr == true,
-                 (ChipLogError(DeviceLayer, "FAIL: Async request: Activate WiFi"), err = CHIP_ERROR_INTERNAL));
+    VerifyOrExit(dbusAsyncErr == true, {
+        ChipLogError(DeviceLayer, "FAIL: Async request: Activate WiFi");
+        err = CHIP_ERROR_INTERNAL;
+    });
 
 exit:
     return err;
@@ -635,8 +636,10 @@ CHIP_ERROR WiFiManager::Deactivate()
     VerifyOrExit(isWiFiActivated == true, ChipLogProgress(DeviceLayer, "WiFi is already deactivated"));
 
     dbusAsyncErr = MainLoop::Instance().AsyncRequest(_WiFiDeactivate);
-    VerifyOrExit(dbusAsyncErr == true,
-                 (ChipLogError(DeviceLayer, "FAIL: Async request: Deactivate WiFi"), err = CHIP_ERROR_INTERNAL));
+    VerifyOrExit(dbusAsyncErr == true, {
+        ChipLogError(DeviceLayer, "FAIL: Async request: Deactivate WiFi");
+        err = CHIP_ERROR_INTERNAL;
+    });
 
 exit:
     return err;
@@ -654,8 +657,10 @@ CHIP_ERROR WiFiManager::Connect(const char * ssid, const char * key,
     g_strlcpy(sInstance.mWiFiKey, key, sizeof(sInstance.mWiFiKey));
 
     VerifyOrExit((err = IsActivated(&isWiFiActivated)) == CHIP_NO_ERROR, );
-    VerifyOrExit(isWiFiActivated == true,
-                 (ChipLogProgress(DeviceLayer, "WiFi is not activated"), err = CHIP_ERROR_INCORRECT_STATE));
+    VerifyOrExit(isWiFiActivated == true, {
+        ChipLogProgress(DeviceLayer, "WiFi is not activated");
+        err = CHIP_ERROR_INCORRECT_STATE;
+    });
 
     sInstance.mpConnectCallback = apCallback;
 
@@ -663,14 +668,18 @@ CHIP_ERROR WiFiManager::Connect(const char * ssid, const char * key,
     if (foundAp != nullptr)
     {
         dbusAsyncErr = MainLoop::Instance().AsyncRequest(_WiFiConnect, foundAp);
-        VerifyOrExit(dbusAsyncErr == true,
-                     (ChipLogError(DeviceLayer, "FAIL: Async request: Connect WiFi"), err = CHIP_ERROR_INTERNAL));
+        VerifyOrExit(dbusAsyncErr == true, {
+            ChipLogError(DeviceLayer, "FAIL: Async request: Connect WiFi");
+            err = CHIP_ERROR_INTERNAL;
+        });
     }
     else
     {
         dbusAsyncErr = MainLoop::Instance().AsyncRequest(_WiFiScan);
-        VerifyOrExit(dbusAsyncErr == true,
-                     (ChipLogError(DeviceLayer, "FAIL: Async request: Scan WiFi"), err = CHIP_ERROR_INTERNAL));
+        VerifyOrExit(dbusAsyncErr == true, {
+            ChipLogError(DeviceLayer, "FAIL: Async request: Scan WiFi");
+            err = CHIP_ERROR_INTERNAL;
+        });
     }
 
 exit:
@@ -687,8 +696,10 @@ CHIP_ERROR WiFiManager::Disconnect(const char * ssid)
     g_strlcpy(sInstance.mWiFiSSID, ssid, sizeof(sInstance.mWiFiSSID));
 
     VerifyOrExit((err = IsActivated(&isWiFiActivated)) == CHIP_NO_ERROR, );
-    VerifyOrExit(isWiFiActivated == true,
-                 (ChipLogProgress(DeviceLayer, "WiFi is not activated"), err = CHIP_ERROR_INCORRECT_STATE));
+    VerifyOrExit(isWiFiActivated == true, {
+        ChipLogProgress(DeviceLayer, "WiFi is not activated");
+        err = CHIP_ERROR_INCORRECT_STATE;
+    });
 
     foundAp = sInstance._WiFiGetFoundAP();
     VerifyOrExit(foundAp != nullptr, );

--- a/src/platform/Tizen/WiFiManager.h
+++ b/src/platform/Tizen/WiFiManager.h
@@ -37,16 +37,16 @@ class WiFiManager
     friend class ConnectivityManagerImpl;
 
 public:
-    void Init(void);
-    void Deinit(void);
+    void Init();
+    void Deinit();
 
     CHIP_ERROR IsActivated(bool * isWiFiActivated);
-    CHIP_ERROR Activate(void);
-    CHIP_ERROR Deactivate(void);
+    CHIP_ERROR Activate();
+    CHIP_ERROR Deactivate();
     CHIP_ERROR Connect(const char * ssid, const char * key,
                        NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * apCallback = nullptr);
     CHIP_ERROR Disconnect(const char * ssid);
-    CHIP_ERROR RemoveAllConfigs(void);
+    CHIP_ERROR RemoveAllConfigs();
 
     CHIP_ERROR GetDeviceMACAddress(uint8_t * macAddress, size_t macAddressLen);
     CHIP_ERROR GetDeviceState(wifi_manager_device_state_e * deviceState);
@@ -75,16 +75,16 @@ private:
     static gboolean _WiFiScan(GMainLoop * mainLoop, gpointer userData);
     static gboolean _WiFiConnect(GMainLoop * mainLoop, gpointer userData);
 
-    void _WiFiDeinitialize(void);
-    void _WiFiSetStates(void);
-    void _WiFiSetCallbacks(void);
-    void _WiFiUnsetCallbacks(void);
+    void _WiFiDeinitialize();
+    void _WiFiSetStates();
+    void _WiFiSetCallbacks();
+    void _WiFiUnsetCallbacks();
     void _WiFiSetDeviceState(wifi_manager_device_state_e deviceState);
     void _WiFiSetModuleState(wifi_manager_module_state_e moduleState);
     void _WiFiSetConnectionState(wifi_manager_connection_state_e connectionState);
-    wifi_manager_ap_h _WiFiGetFoundAP(void);
+    wifi_manager_ap_h _WiFiGetFoundAP();
 
-    friend WiFiManager & WiFiMgr(void);
+    friend WiFiManager & WiFiMgr();
 
     static WiFiManager sInstance;
 


### PR DESCRIPTION
### Problem

Tizen examples are based on Linux code. Tizen and Linux are using wpa_supplicant for WiFi management. In Linux example code, WiFi feature is controlled by `CHIP_DEVICE_CONFIG_ENABLE_WPA` feature flag, however, Tizen configuration does not. In order to properly support WiFi management Tizen needs to use `CHIP_DEVICE_CONFIG_ENABLE_WPA` as well and needs to implement missing functions.

### Changes

- Implement WiFi started check function 
- Fix incorrect feature flag for enabling WiFi in Tizen example
- Simplify `WiFiManager::IsActivated()` usage (reuse it in other functions)
- Apply clang-tidy modernize-redundant-void-arg on modified files
- Activate/deactivate WiFi without async wrapper
- Add missing "network.set" privilege required for WiFi management

### Testing

CI will check potential build failures. Tizen WiFi functionality was tested with Tizen lighting-all:
```
app_launcher -k org.tizen.matter.example.lighting
...
I/CHIP    ( 1935): SVR: Manual pairing code: [34970112332]
I/CHIP    ( 1935): SVR: Server initializing...
...
```

```
app_launcher -k org.tizen.matter.example.lighting wifi true
...
I/CHIP    ( 1888): SVR: Manual pairing code: [34970112332]
I/CHIP    ( 1888): DL: WiFi is already activated              <- WiFi check in EnsureWiFiIsStarted() call done by ChipLinuxAppInit()
I/CHIP    ( 1888): SVR: Server initializing...
...
```