### PR TITLE
[Tizen] Check app options by iterate over given set

### DIFF
--- a/examples/platform/tizen/OptionsProxy.cpp
+++ b/examples/platform/tizen/OptionsProxy.cpp
@@ -20,6 +20,8 @@
 
 #include <cstring>
 
+#include <app_control.h>
+
 #include <platform/CHIPDeviceBuildConfig.h>
 
 namespace {
@@ -65,6 +67,38 @@ static constexpr Option sOptions[] = {
 #endif
 };
 
+bool ParseAppExtraData(app_control_h app_control, const char * key, void * userData)
+{
+    auto * args = static_cast<std::vector<std::string> *>(userData);
+
+    for (const auto & option : sOptions)
+    {
+        if (strcmp(key, option.name) != 0)
+        {
+            continue;
+        }
+
+        char * value = nullptr;
+        if (app_control_get_extra_data(app_control, option.name, &value) == APP_CONTROL_ERROR_NONE && value != nullptr)
+        {
+            if (!option.isBoolean)
+            {
+                args->push_back(std::string("--") + option.name);
+                args->push_back(value);
+            }
+            else if (strcmp(value, "true") == 0)
+            {
+                args->push_back(std::string("--") + option.name);
+            }
+            // Release memory allocated by app_control_get_extra_data()
+            free(value);
+        }
+    }
+
+    // Continue iterating over all extra data
+    return true;
+}
+
 }; // namespace
 
 void OptionsProxy::Parse(const char * argv0, app_control_h app_control)
@@ -75,24 +109,7 @@ void OptionsProxy::Parse(const char * argv0, app_control_h app_control)
         mArgs.push_back(argv0);
     }
 
-    for (const auto & option : sOptions)
-    {
-        char * value = nullptr;
-        if (app_control_get_extra_data(app_control, option.name, &value) == APP_CONTROL_ERROR_NONE && value != nullptr)
-        {
-            if (!option.isBoolean)
-            {
-                mArgs.push_back(std::string("--") + option.name);
-                mArgs.push_back(value);
-            }
-            else if (strcmp(value, "true") == 0)
-            {
-                mArgs.push_back(std::string("--") + option.name);
-            }
-            // Release memory allocated by app_control_get_extra_data()
-            free(value);
-        }
-    }
+    app_control_foreach_extra_data(app_control, ParseAppExtraData, &mArgs);
 
     // Convert vector of strings into NULL-terminated vector of char pointers
     mArgv.reserve(mArgs.size() + 1);


### PR DESCRIPTION
### Problem

There is lots of error messages in Tizen log when launching Tizen example CHIP app. Tizen API call `app_control_get_extra_data()` reports error when used with not available key.

### Changes

Instead of iterating over available options and trying to get them from app extra data, iterate over extra data and match them with available options. 

### Testing

Tested with Tizen lighting app. After these changes, `app_control_get_extra_data()` does not report errors like these any more:
```
I/CHIP    ( 2522): -: Tizen app control
E/CAPI_APPFW_APP_CONTROL( 2522): stub.cc: app_control_get_extra_data(711) > Failed to get extra data. error(-126)
E/CAPI_APPFW_APP_CONTROL( 2522): stub.cc: app_control_get_extra_data(711) > Failed to get extra data. error(-126)
...
```