### PR TITLE
Remove using-directives namespaces in Tizen platform [ Tizen ]

### DIFF
--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -31,9 +31,6 @@
 #include "MainLoop.h"
 #include <bluetooth.h>
 
-using namespace ::chip;
-using namespace ::chip::Ble;
-
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
@@ -410,7 +407,7 @@ void BLEManagerImpl::NotifySubscribeOpComplete(BLE_CONNECTION_OBJECT conId, bool
     PlatformMgr().PostEventOrDie(&event);
 }
 
-void BLEManagerImpl::HandleConnectionTimeout(chip::System::Layer * layer, void * data)
+void BLEManagerImpl::HandleConnectionTimeout(System::Layer * layer, void * data)
 {
     sInstance.NotifyHandleConnectFailed(CHIP_ERROR_TIMEOUT);
 }
@@ -448,7 +445,7 @@ void BLEManagerImpl::ConnectHandler(const char * address)
     g_source_unref(idleSource);
 }
 
-void BLEManagerImpl::OnChipDeviceScanned(void * device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info)
+void BLEManagerImpl::OnChipDeviceScanned(void * device, const Ble::ChipBLEDeviceIdentificationInfo & info)
 {
     auto deviceInfo = reinterpret_cast<bt_adapter_le_device_scan_result_info_s *>(device);
     VerifyOrReturn(deviceInfo != nullptr, ChipLogError(DeviceLayer, "Invalid Device Info"));
@@ -479,7 +476,7 @@ void BLEManagerImpl::OnChipDeviceScanned(void * device, const chip::Ble::ChipBLE
 
     /* Set CHIP Connecting state */
     mBLEScanConfig.mBleScanState = BleScanState::kConnecting;
-    chip::DeviceLayer::SystemLayer().StartTimer(kConnectTimeoutMs, HandleConnectionTimeout, nullptr);
+    DeviceLayer::SystemLayer().StartTimer(kConnectTimeoutMs, HandleConnectionTimeout, nullptr);
     mDeviceScanner->StopChipScan();
 
     /* Initiate Connect */
@@ -583,12 +580,12 @@ exit:
 
 int BLEManagerImpl::StartBLEAdvertising()
 {
-    int ret                                                    = BT_ERROR_NONE;
-    CHIP_ERROR err                                             = CHIP_NO_ERROR;
-    char service_data[sizeof(ChipBLEDeviceIdentificationInfo)] = {
+    int ret                                                         = BT_ERROR_NONE;
+    CHIP_ERROR err                                                  = CHIP_NO_ERROR;
+    char service_data[sizeof(Ble::ChipBLEDeviceIdentificationInfo)] = {
         0x0,
     }; // need to fill advertising data. 5.2.3.8.6. Advertising Data, CHIP Specification
-    ChipBLEDeviceIdentificationInfo deviceIdInfo = {
+    Ble::ChipBLEDeviceIdentificationInfo deviceIdInfo = {
         0x0,
     };
 
@@ -1018,7 +1015,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureBle(uint32_t aAdapterId, bool aIsCentral)
 void BLEManagerImpl::CleanScanConfig()
 {
     if (mBLEScanConfig.mBleScanState == BleScanState::kConnecting)
-        chip::DeviceLayer::SystemLayer().CancelTimer(HandleConnectionTimeout, nullptr);
+        DeviceLayer::SystemLayer().CancelTimer(HandleConnectionTimeout, nullptr);
 
     mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
 }
@@ -1045,8 +1042,8 @@ void BLEManagerImpl::HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * apEv
         }
         break;
     case DeviceEventType::kPlatformTizenBLEWriteComplete: {
-        ChipBleUUID service_uuid;
-        ChipBleUUID char_write_uuid;
+        Ble::ChipBleUUID service_uuid;
+        Ble::ChipBleUUID char_write_uuid;
 
         StringToUUID(chip_ble_service_uuid, service_uuid);
         StringToUUID(chip_ble_char_c1_tx_uuid, char_write_uuid);
@@ -1055,8 +1052,8 @@ void BLEManagerImpl::HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * apEv
         break;
     }
     case DeviceEventType::kPlatformTizenBLESubscribeOpComplete: {
-        ChipBleUUID service_uuid;
-        ChipBleUUID char_notif_uuid;
+        Ble::ChipBleUUID service_uuid;
+        Ble::ChipBleUUID char_notif_uuid;
 
         StringToUUID(chip_ble_service_uuid, service_uuid);
         StringToUUID(chip_ble_char_c2_rx_uuid, char_notif_uuid);
@@ -1068,14 +1065,14 @@ void BLEManagerImpl::HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * apEv
         break;
     }
     case DeviceEventType::kPlatformTizenBLEIndicationReceived: {
-        ChipBleUUID service_uuid;
-        ChipBleUUID char_notif_uuid;
+        Ble::ChipBleUUID service_uuid;
+        Ble::ChipBleUUID char_notif_uuid;
 
         StringToUUID(chip_ble_service_uuid, service_uuid);
         StringToUUID(chip_ble_char_c2_rx_uuid, char_notif_uuid);
 
         HandleIndicationReceived(apEvent->Platform.BLEIndicationReceived.mConnection, &service_uuid, &char_notif_uuid,
-                                 PacketBufferHandle::Adopt(apEvent->Platform.BLEIndicationReceived.mData));
+                                 System::PacketBufferHandle::Adopt(apEvent->Platform.BLEIndicationReceived.mData));
         break;
     }
     default:
@@ -1085,9 +1082,9 @@ void BLEManagerImpl::HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * apEv
 
 void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 {
-    ChipBleUUID service_uuid;
-    ChipBleUUID char_notification_uuid;
-    ChipBleUUID char_write_uuid;
+    Ble::ChipBleUUID service_uuid;
+    Ble::ChipBleUUID char_notification_uuid;
+    Ble::ChipBleUUID char_write_uuid;
 
     switch (event->Type)
     {
@@ -1114,7 +1111,7 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
         StringToUUID(chip_ble_service_uuid, service_uuid);
         StringToUUID(chip_ble_char_c1_tx_uuid, char_write_uuid);
         HandleWriteReceived(event->CHIPoBLEWriteReceived.ConId, &service_uuid, &char_write_uuid,
-                            PacketBufferHandle::Adopt(event->CHIPoBLEWriteReceived.Data));
+                            System::PacketBufferHandle::Adopt(event->CHIPoBLEWriteReceived.Data));
         break;
     case DeviceEventType::kCHIPoBLEIndicateConfirm:
         ChipLogProgress(DeviceLayer, "CHIPoBLEIndicateConfirm");
@@ -1142,10 +1139,11 @@ uint16_t BLEManagerImpl::GetMTU(BLE_CONNECTION_OBJECT conId) const
     return (conn != nullptr) ? conn->mtu : 0;
 }
 
-bool BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const ChipBleUUID * charId)
+bool BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const Ble::ChipBleUUID * svcId,
+                                             const Ble::ChipBleUUID * charId)
 {
-    ChipBleUUID service_uuid;
-    ChipBleUUID char_notif_uuid;
+    Ble::ChipBleUUID service_uuid;
+    Ble::ChipBleUUID char_notif_uuid;
     auto conn = static_cast<BLEConnection *>(conId);
     int ret   = BT_ERROR_NONE;
 
@@ -1172,10 +1170,11 @@ exit:
     return false;
 }
 
-bool BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const ChipBleUUID * charId)
+bool BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const Ble::ChipBleUUID * svcId,
+                                               const Ble::ChipBleUUID * charId)
 {
-    ChipBleUUID service_uuid;
-    ChipBleUUID char_notif_uuid;
+    Ble::ChipBleUUID service_uuid;
+    Ble::ChipBleUUID char_notif_uuid;
     auto conn = static_cast<BLEConnection *>(conId);
     int ret   = BT_ERROR_NONE;
 
@@ -1223,8 +1222,8 @@ exit:
     return false;
 }
 
-bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const Ble::ChipBleUUID * charId,
-                                    chip::System::PacketBufferHandle pBuf)
+bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const Ble::ChipBleUUID * svcId, const Ble::ChipBleUUID * charId,
+                                    System::PacketBufferHandle pBuf)
 {
     auto conn = static_cast<BLEConnection *>(conId);
     int ret   = BT_ERROR_NONE;
@@ -1250,10 +1249,10 @@ exit:
 }
 
 bool BLEManagerImpl::SendWriteRequest(BLE_CONNECTION_OBJECT conId, const Ble::ChipBleUUID * svcId, const Ble::ChipBleUUID * charId,
-                                      chip::System::PacketBufferHandle pBuf)
+                                      System::PacketBufferHandle pBuf)
 {
-    ChipBleUUID service_uuid;
-    ChipBleUUID char_write_uuid;
+    Ble::ChipBleUUID service_uuid;
+    Ble::ChipBleUUID char_write_uuid;
     auto conn = static_cast<BLEConnection *>(conId);
     int ret   = BT_ERROR_NONE;
 
@@ -1283,7 +1282,7 @@ exit:
 }
 
 bool BLEManagerImpl::SendReadRequest(BLE_CONNECTION_OBJECT conId, const Ble::ChipBleUUID * svcId, const Ble::ChipBleUUID * charId,
-                                     chip::System::PacketBufferHandle pBuf)
+                                     System::PacketBufferHandle pBuf)
 {
     return false;
 }
@@ -1357,7 +1356,7 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Failed to start a BLE Scan: %s", chip::ErrorStr(err));
+        ChipLogError(DeviceLayer, "Failed to start a BLE Scan: %s", ErrorStr(err));
         goto exit;
     }
 

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -35,8 +35,6 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-using namespace chip::Ble;
-
 /**
  * enum Class for BLE Scanning state. CHIP supports Scanning by Discriminator or Address
  */
@@ -127,7 +125,7 @@ private:
     CHIP_ERROR CancelConnection() override;
 
     //  ===== Members that implement virtual methods on ChipDeviceScannerDelegate
-    void OnChipDeviceScanned(void * device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info) override;
+    void OnChipDeviceScanned(void * device, const Ble::ChipBLEDeviceIdentificationInfo & info) override;
     void OnChipScanComplete() override;
 
     // ===== Members for internal use by the following friends.
@@ -180,7 +178,7 @@ private:
     void HandleC1CharWriteEvent(BLE_CONNECTION_OBJECT conId, const uint8_t * value, size_t len);
     void HandleRXCharChanged(BLE_CONNECTION_OBJECT conId, const uint8_t * value, size_t len);
     void HandleConnectionEvent(bool connected, const char * remoteAddress);
-    static void HandleConnectionTimeout(chip::System::Layer * layer, void * data);
+    static void HandleConnectionTimeout(System::Layer * layer, void * data);
     static bool IsDeviceChipPeripheral(BLE_CONNECTION_OBJECT conId);
 
     // ==== BLE Adv & GATT Server.

--- a/src/platform/Tizen/ConfigurationManagerImpl.cpp
+++ b/src/platform/Tizen/ConfigurationManagerImpl.cpp
@@ -37,8 +37,6 @@
 namespace chip {
 namespace DeviceLayer {
 
-using namespace ::chip::DeviceLayer::Internal;
-
 ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 {
     static ConfigurationManagerImpl sInstance;
@@ -49,16 +47,16 @@ CHIP_ERROR ConfigurationManagerImpl::Init(void)
 {
     CHIP_ERROR error;
 
-    error = Internal::GenericConfigurationManagerImpl<PosixConfig>::Init();
+    error = Internal::GenericConfigurationManagerImpl<Internal::PosixConfig>::Init();
     SuccessOrExit(error);
 
-    if (!PosixConfig::ConfigValueExists(PosixConfig::kConfigKey_VendorId))
+    if (!Internal::PosixConfig::ConfigValueExists(Internal::PosixConfig::kConfigKey_VendorId))
     {
         error = StoreVendorId(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID);
         SuccessOrExit(error);
     }
 
-    if (!PosixConfig::ConfigValueExists(PosixConfig::kConfigKey_ProductId))
+    if (!Internal::PosixConfig::ConfigValueExists(Internal::PosixConfig::kConfigKey_ProductId))
     {
         error = StoreProductId(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID);
         SuccessOrExit(error);
@@ -72,19 +70,19 @@ exit:
 
 CHIP_ERROR ConfigurationManagerImpl::StoreVendorId(uint16_t vendorId)
 {
-    return WriteConfigValue(PosixConfig::kConfigKey_VendorId, vendorId);
+    return WriteConfigValue(Internal::PosixConfig::kConfigKey_VendorId, vendorId);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreProductId(uint16_t productId)
 {
-    return WriteConfigValue(PosixConfig::kConfigKey_ProductId, productId);
+    return WriteConfigValue(Internal::PosixConfig::kConfigKey_ProductId, productId);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     constexpr size_t kExpectedBufSize = ConfigurationManager::kPrimaryMACAddressLength;
-    return WiFiMgr().GetDeviceMACAddress(buf, kExpectedBufSize);
+    return Internal::WiFiMgr().GetDeviceMACAddress(buf, kExpectedBufSize);
 #else
     return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif
@@ -97,84 +95,84 @@ bool ConfigurationManagerImpl::CanFactoryReset(void)
 
 void ConfigurationManagerImpl::InitiateFactoryReset(void) {}
 
-CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
+CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(Platform::PersistedStorage::Key key, uint32_t & value)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
+CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(Platform::PersistedStorage::Key key, uint32_t value)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
-    return PosixConfig::ReadConfigValue(key, val);
+    return Internal::PosixConfig::ReadConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint16_t & val)
 {
-    return PosixConfig::ReadConfigValue(key, val);
+    return Internal::PosixConfig::ReadConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
-    return PosixConfig::ReadConfigValue(key, val);
+    return Internal::PosixConfig::ReadConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
-    return PosixConfig::ReadConfigValue(key, val);
+    return Internal::PosixConfig::ReadConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
-    return PosixConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
+    return Internal::PosixConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
-    return PosixConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
+    return Internal::PosixConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
-    return PosixConfig::WriteConfigValue(key, val);
+    return Internal::PosixConfig::WriteConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint16_t val)
 {
-    return PosixConfig::WriteConfigValue(key, val);
+    return Internal::PosixConfig::WriteConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
-    return PosixConfig::WriteConfigValue(key, val);
+    return Internal::PosixConfig::WriteConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
-    return PosixConfig::WriteConfigValue(key, val);
+    return Internal::PosixConfig::WriteConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
-    return PosixConfig::WriteConfigValueStr(key, str);
+    return Internal::PosixConfig::WriteConfigValueStr(key, str);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
-    return PosixConfig::WriteConfigValueStr(key, str, strLen);
+    return Internal::PosixConfig::WriteConfigValueStr(key, str, strLen);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
-    return PosixConfig::WriteConfigValueBin(key, data, dataLen);
+    return Internal::PosixConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
 void ConfigurationManagerImpl::RunConfigUnitTest(void)
 {
-    PosixConfig::RunConfigUnitTest();
+    Internal::PosixConfig::RunConfigUnitTest();
 }
 
 ConfigurationManager & ConfigurationMgrImpl()

--- a/src/platform/Tizen/ConfigurationManagerImpl.h
+++ b/src/platform/Tizen/ConfigurationManagerImpl.h
@@ -50,8 +50,8 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
-    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
+    CHIP_ERROR ReadPersistedStorageValue(Platform::PersistedStorage::Key key, uint32_t & value) override;
+    CHIP_ERROR WritePersistedStorageValue(Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
     CHIP_ERROR WriteConfigValue(Key key, uint16_t val);

--- a/src/platform/Tizen/ConnectivityManagerImpl.cpp
+++ b/src/platform/Tizen/ConnectivityManagerImpl.cpp
@@ -45,10 +45,6 @@
 #include <platform/internal/GenericConnectivityManagerImpl_WiFi.ipp>
 #endif
 
-using namespace ::chip;
-using namespace ::chip::TLV;
-using namespace ::chip::DeviceLayer::Internal;
-
 namespace chip {
 namespace DeviceLayer {
 
@@ -66,7 +62,7 @@ CHIP_ERROR ConnectivityManagerImpl::_Init(void)
     mWiFiStationReconnectInterval = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL);
     mWiFiAPIdleTimeout            = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_AP_IDLE_TIMEOUT);
 
-    WiFiMgr().Init();
+    Internal::WiFiMgr().Init();
 #endif
 
     return err;
@@ -83,7 +79,7 @@ ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMod
 
     ReturnErrorCodeIf(mWiFiStationMode == kWiFiStationMode_ApplicationControlled, mWiFiStationMode);
 
-    err = WiFiMgr().GetDeviceState(&deviceState);
+    err = Internal::WiFiMgr().GetDeviceState(&deviceState);
     VerifyOrReturnError(err == CHIP_NO_ERROR, mWiFiStationMode);
 
     mWiFiStationMode = (deviceState == WIFI_MANAGER_DEVICE_STATE_ACTIVATED) ? kWiFiStationMode_Enabled : kWiFiStationMode_Disabled;
@@ -102,7 +98,7 @@ CHIP_ERROR ConnectivityManagerImpl::_SetWiFiStationMode(ConnectivityManager::WiF
     {
         deviceState =
             (val == kWiFiStationMode_Disabled) ? WIFI_MANAGER_DEVICE_STATE_DEACTIVATED : WIFI_MANAGER_DEVICE_STATE_ACTIVATED;
-        err = WiFiMgr().SetDeviceState(deviceState);
+        err = Internal::WiFiMgr().SetDeviceState(deviceState);
         VerifyOrReturnError(err == CHIP_NO_ERROR, err);
     }
 
@@ -133,7 +129,7 @@ bool ConnectivityManagerImpl::_IsWiFiStationEnabled(void)
 {
     bool isWiFiStationEnabled = false;
 
-    WiFiMgr().IsActivated(&isWiFiStationEnabled);
+    Internal::WiFiMgr().IsActivated(&isWiFiStationEnabled);
 
     return isWiFiStationEnabled;
 }
@@ -144,7 +140,7 @@ bool ConnectivityManagerImpl::_IsWiFiStationConnected(void)
     wifi_manager_connection_state_e connectionState = WIFI_MANAGER_CONNECTION_STATE_DISCONNECTED;
     bool isWiFiStationConnected                     = false;
 
-    err = WiFiMgr().GetConnectionState(&connectionState);
+    err = Internal::WiFiMgr().GetConnectionState(&connectionState);
     VerifyOrReturnError(err == CHIP_NO_ERROR, isWiFiStationConnected);
 
     if (connectionState == WIFI_MANAGER_CONNECTION_STATE_CONNECTED)
@@ -159,7 +155,7 @@ bool ConnectivityManagerImpl::_IsWiFiStationProvisioned(void)
     wifi_manager_connection_state_e connectionState = WIFI_MANAGER_CONNECTION_STATE_DISCONNECTED;
     bool isWiFiStationProvisioned                   = false;
 
-    err = WiFiMgr().GetConnectionState(&connectionState);
+    err = Internal::WiFiMgr().GetConnectionState(&connectionState);
     VerifyOrReturnError(err == CHIP_NO_ERROR, isWiFiStationProvisioned);
 
     if (connectionState >= WIFI_MANAGER_CONNECTION_STATE_ASSOCIATION)
@@ -170,7 +166,7 @@ bool ConnectivityManagerImpl::_IsWiFiStationProvisioned(void)
 
 void ConnectivityManagerImpl::_ClearWiFiStationProvision(void)
 {
-    WiFiMgr().RemoveAllConfigs();
+    Internal::WiFiMgr().RemoveAllConfigs();
 }
 
 bool ConnectivityManagerImpl::_CanStartWiFiScan(void)
@@ -211,14 +207,14 @@ void ConnectivityManagerImpl::StopWiFiManagement(void)
     SystemLayer().ScheduleWork(DeactivateWiFiManager, nullptr);
 }
 
-void ConnectivityManagerImpl::ActivateWiFiManager(::chip::System::Layer * aLayer, void * aAppState)
+void ConnectivityManagerImpl::ActivateWiFiManager(System::Layer * aLayer, void * aAppState)
 {
-    WiFiMgr().Activate();
+    Internal::WiFiMgr().Activate();
 }
 
-void ConnectivityManagerImpl::DeactivateWiFiManager(::chip::System::Layer * aLayer, void * aAppState)
+void ConnectivityManagerImpl::DeactivateWiFiManager(System::Layer * aLayer, void * aAppState)
 {
-    WiFiMgr().Deactivate();
+    Internal::WiFiMgr().Deactivate();
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 

--- a/src/platform/Tizen/ConnectivityManagerImpl.h
+++ b/src/platform/Tizen/ConnectivityManagerImpl.h
@@ -117,8 +117,8 @@ private:
     System::Clock::Timeout _GetWiFiAPIdleTimeout(void);
     void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
 
-    static void ActivateWiFiManager(::chip::System::Layer * aLayer, void * aAppState);
-    static void DeactivateWiFiManager(::chip::System::Layer * aLayer, void * aAppState);
+    static void ActivateWiFiManager(System::Layer * aLayer, void * aAppState);
+    static void DeactivateWiFiManager(System::Layer * aLayer, void * aAppState);
 #endif
 
     // ===== Members for internal use by the following friends.

--- a/src/platform/Tizen/ConnectivityUtils.cpp
+++ b/src/platform/Tizen/ConnectivityUtils.cpp
@@ -36,16 +36,15 @@
 
 #include <lib/support/CHIPMemString.h>
 
-using namespace ::chip::app::Clusters::GeneralDiagnostics;
-
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-InterfaceType ConnectivityUtils::GetInterfaceConnectionType(const char * ifname)
+app::Clusters::GeneralDiagnostics::InterfaceType ConnectivityUtils::GetInterfaceConnectionType(const char * ifname)
 {
-    InterfaceType ret = InterfaceType::EMBER_ZCL_INTERFACE_TYPE_UNSPECIFIED;
-    int sock          = -1;
+    app::Clusters::GeneralDiagnostics::InterfaceType ret =
+        app::Clusters::GeneralDiagnostics::InterfaceType::EMBER_ZCL_INTERFACE_TYPE_UNSPECIFIED;
+    int sock = -1;
 
     if ((sock = socket(AF_INET, SOCK_STREAM, 0)) == -1)
     {
@@ -59,7 +58,7 @@ InterfaceType ConnectivityUtils::GetInterfaceConnectionType(const char * ifname)
 
     if (ioctl(sock, SIOCGIWNAME, &pwrq) != -1)
     {
-        ret = InterfaceType::EMBER_ZCL_INTERFACE_TYPE_WI_FI;
+        ret = app::Clusters::GeneralDiagnostics::InterfaceType::EMBER_ZCL_INTERFACE_TYPE_WI_FI;
     }
     else if ((strncmp(ifname, "en", 2) == 0) || (strncmp(ifname, "eth", 3) == 0))
     {
@@ -70,7 +69,7 @@ InterfaceType ConnectivityUtils::GetInterfaceConnectionType(const char * ifname)
         Platform::CopyString(ifr.ifr_name, ifname);
 
         if (ioctl(sock, SIOCETHTOOL, &ifr) != -1)
-            ret = InterfaceType::EMBER_ZCL_INTERFACE_TYPE_ETHERNET;
+            ret = app::Clusters::GeneralDiagnostics::InterfaceType::EMBER_ZCL_INTERFACE_TYPE_ETHERNET;
     }
 
     close(sock);

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -74,7 +74,7 @@ struct RegisterContext : public GenericContext
 struct BrowseContext : public GenericContext
 {
     char mType[kDnssdTypeAndProtocolMaxSize + 1];
-    DnssdServiceProtocol mProtocol;
+    Dnssd::DnssdServiceProtocol mProtocol;
     uint32_t mInterfaceId;
 
     DnssdBrowseCallback mCallback;
@@ -87,7 +87,7 @@ struct BrowseContext : public GenericContext
     std::vector<DnssdService> mServices;
     bool mIsBrowsing = false;
 
-    BrowseContext(DnssdTizen * instance, const char * type, DnssdServiceProtocol protocol, uint32_t interfaceId,
+    BrowseContext(DnssdTizen * instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
                   DnssdBrowseCallback callback, void * context);
     ~BrowseContext() override;
 };
@@ -112,7 +112,7 @@ struct ResolveContext : public GenericContext
 class DnssdTizen
 {
 public:
-    DnssdTizen(const DnssdTizen &) = delete;
+    DnssdTizen(const DnssdTizen &)             = delete;
     DnssdTizen & operator=(const DnssdTizen &) = delete;
 
     CHIP_ERROR Init(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context);
@@ -121,7 +121,7 @@ public:
     CHIP_ERROR RegisterService(const DnssdService & service, DnssdPublishCallback callback, void * context);
     CHIP_ERROR UnregisterAllServices();
 
-    CHIP_ERROR Browse(const char * type, DnssdServiceProtocol protocol, chip::Inet::IPAddressType addressType,
+    CHIP_ERROR Browse(const char * type, Dnssd::DnssdServiceProtocol protocol, chip::Inet::IPAddressType addressType,
                       chip::Inet::InterfaceId interface, DnssdBrowseCallback callback, void * context);
 
     CHIP_ERROR Resolve(const DnssdService & browseResult, chip::Inet::InterfaceId interface, DnssdResolveCallback callback,
@@ -138,7 +138,7 @@ private:
 
     RegisterContext * CreateRegisterContext(const char * type, const DnssdService & service, DnssdPublishCallback callback,
                                             void * context);
-    BrowseContext * CreateBrowseContext(const char * type, DnssdServiceProtocol protocol, uint32_t interfaceId,
+    BrowseContext * CreateBrowseContext(const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
                                         DnssdBrowseCallback callback, void * context);
     ResolveContext * CreateResolveContext(const char * name, const char * type, uint32_t interfaceId, DnssdResolveCallback callback,
                                           void * context);

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -112,7 +112,7 @@ struct ResolveContext : public GenericContext
 class DnssdTizen
 {
 public:
-    DnssdTizen(const DnssdTizen &)             = delete;
+    DnssdTizen(const DnssdTizen &) = delete;
     DnssdTizen & operator=(const DnssdTizen &) = delete;
 
     CHIP_ERROR Init(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context);

--- a/src/platform/Tizen/NetworkCommissioningEthernetDriver.cpp
+++ b/src/platform/Tizen/NetworkCommissioningEthernetDriver.cpp
@@ -26,9 +26,6 @@
 #include <string>
 #include <vector>
 
-using namespace chip::app::Clusters::GeneralDiagnostics;
-using namespace chip::DeviceLayer::Internal;
-
 namespace chip {
 namespace DeviceLayer {
 namespace NetworkCommissioning {
@@ -40,7 +37,8 @@ TizenEthernetDriver::EthernetNetworkIterator::EthernetNetworkIterator(TizenEther
 
     for (const auto * ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
     {
-        if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::EMBER_ZCL_INTERFACE_TYPE_ETHERNET)
+        if (DeviceLayer::Internal::ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
+            app::Clusters::GeneralDiagnostics::InterfaceType::EMBER_ZCL_INTERFACE_TYPE_ETHERNET)
         {
             mInterfaces.push_back(ifa->ifa_name);
             if (mInterfaces.size() == mDriver->GetMaxNetworks())

--- a/src/platform/Tizen/NetworkCommissioningThreadDriver.cpp
+++ b/src/platform/Tizen/NetworkCommissioningThreadDriver.cpp
@@ -26,9 +26,6 @@
 #include <string>
 #include <vector>
 
-using namespace chip;
-using namespace chip::Thread;
-
 namespace chip {
 namespace DeviceLayer {
 namespace NetworkCommissioning {
@@ -59,15 +56,15 @@ CHIP_ERROR TizenThreadDriver::RevertConfiguration()
 
 Status TizenThreadDriver::AddOrUpdateNetwork(ByteSpan operationalDataset, MutableCharSpan & outDebugText, uint8_t & outNetworkIndex)
 {
-    uint8_t extpanid[kSizeExtendedPanId];
-    uint8_t newExtpanid[kSizeExtendedPanId];
+    uint8_t extpanid[Thread::kSizeExtendedPanId];
+    uint8_t newExtpanid[Thread::kSizeExtendedPanId];
     Thread::OperationalDataset newDataset;
     outDebugText.reduce_size(0);
     outNetworkIndex = 0;
     newDataset.Init(operationalDataset);
     VerifyOrReturnError(newDataset.IsCommissioned(), Status::kOutOfRange);
 
-    VerifyOrReturnError(!mStagingNetwork.IsCommissioned() || memcmp(extpanid, newExtpanid, kSizeExtendedPanId) == 0,
+    VerifyOrReturnError(!mStagingNetwork.IsCommissioned() || memcmp(extpanid, newExtpanid, Thread::kSizeExtendedPanId) == 0,
                         Status::kBoundsExceeded);
 
     mStagingNetwork = newDataset;
@@ -78,7 +75,7 @@ Status TizenThreadDriver::RemoveNetwork(ByteSpan networkId, MutableCharSpan & ou
 {
     outDebugText.reduce_size(0);
     outNetworkIndex = 0;
-    uint8_t extpanid[kSizeExtendedPanId];
+    uint8_t extpanid[Thread::kSizeExtendedPanId];
     if (!mStagingNetwork.IsCommissioned())
     {
         return Status::kNetworkNotFound;
@@ -88,7 +85,8 @@ Status TizenThreadDriver::RemoveNetwork(ByteSpan networkId, MutableCharSpan & ou
         return Status::kUnknownError;
     }
 
-    VerifyOrReturnError(networkId.size() == kSizeExtendedPanId && memcmp(networkId.data(), extpanid, kSizeExtendedPanId) == 0,
+    VerifyOrReturnError(networkId.size() == Thread::kSizeExtendedPanId &&
+                            memcmp(networkId.data(), extpanid, Thread::kSizeExtendedPanId) == 0,
                         Status::kNetworkNotFound);
     mStagingNetwork.Clear();
     return Status::kSuccess;
@@ -97,7 +95,7 @@ Status TizenThreadDriver::RemoveNetwork(ByteSpan networkId, MutableCharSpan & ou
 Status TizenThreadDriver::ReorderNetwork(ByteSpan networkId, uint8_t index, MutableCharSpan & outDebugText)
 {
     outDebugText.reduce_size(0);
-    uint8_t extpanid[kSizeExtendedPanId];
+    uint8_t extpanid[Thread::kSizeExtendedPanId];
     if (!mStagingNetwork.IsCommissioned())
     {
         return Status::kNetworkNotFound;
@@ -107,7 +105,8 @@ Status TizenThreadDriver::ReorderNetwork(ByteSpan networkId, uint8_t index, Muta
         return Status::kUnknownError;
     }
 
-    VerifyOrReturnError(networkId.size() == kSizeExtendedPanId && memcmp(networkId.data(), extpanid, kSizeExtendedPanId) == 0,
+    VerifyOrReturnError(networkId.size() == Thread::kSizeExtendedPanId &&
+                            memcmp(networkId.data(), extpanid, Thread::kSizeExtendedPanId) == 0,
                         Status::kNetworkNotFound);
 
     return Status::kSuccess;
@@ -116,7 +115,7 @@ Status TizenThreadDriver::ReorderNetwork(ByteSpan networkId, uint8_t index, Muta
 void TizenThreadDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callback)
 {
     NetworkCommissioning::Status status = Status::kSuccess;
-    uint8_t extpanid[kSizeExtendedPanId];
+    uint8_t extpanid[Thread::kSizeExtendedPanId];
     if (!mStagingNetwork.IsCommissioned())
     {
         ExitNow(status = Status::kNetworkNotFound);
@@ -126,8 +125,9 @@ void TizenThreadDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * cal
         ExitNow(status = Status::kUnknownError);
     }
 
-    VerifyOrExit((networkId.size() == kSizeExtendedPanId && memcmp(networkId.data(), extpanid, kSizeExtendedPanId) == 0),
-                 status = Status::kNetworkNotFound);
+    VerifyOrExit(
+        (networkId.size() == Thread::kSizeExtendedPanId && memcmp(networkId.data(), extpanid, Thread::kSizeExtendedPanId) == 0),
+        status = Status::kNetworkNotFound);
 
     VerifyOrExit(DeviceLayer::ThreadStackMgrImpl().AttachToThreadNetwork(mStagingNetwork, callback) == CHIP_NO_ERROR,
                  status = Status::kUnknownError);

--- a/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
@@ -24,10 +24,6 @@
 #include <string>
 #include <vector>
 
-using namespace chip;
-using namespace chip::Thread;
-using namespace chip::DeviceLayer::Internal;
-
 namespace chip {
 namespace DeviceLayer {
 namespace NetworkCommissioning {
@@ -137,8 +133,8 @@ void TizenWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callb
     ChipLogProgress(NetworkProvisioning, "TizenNetworkCommissioningDelegate: SSID: %.*s",
                     static_cast<int>(sizeof(mStagingNetwork.ssid)), reinterpret_cast<char *>(mStagingNetwork.ssid));
 
-    err = WiFiMgr().Connect(reinterpret_cast<char *>(mStagingNetwork.ssid), reinterpret_cast<char *>(mStagingNetwork.credentials),
-                            callback);
+    err = DeviceLayer::Internal::WiFiMgr().Connect(reinterpret_cast<char *>(mStagingNetwork.ssid),
+                                                   reinterpret_cast<char *>(mStagingNetwork.credentials), callback);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -33,9 +33,6 @@
 #include "ThreadStackManagerImpl.h"
 #include <lib/dnssd/platform/Dnssd.h>
 
-using namespace ::chip::DeviceLayer::Internal;
-using namespace chip::DeviceLayer::NetworkCommissioning;
-
 namespace chip {
 namespace DeviceLayer {
 
@@ -454,7 +451,7 @@ CHIP_ERROR ThreadStackManagerImpl::_JoinerStart()
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ThreadStackManagerImpl::_StartThreadScan(ThreadDriver::ScanCallback * callback)
+CHIP_ERROR ThreadStackManagerImpl::_StartThreadScan(NetworkCommissioning::ThreadDriver::ScanCallback * callback)
 {
     ChipLogError(DeviceLayer, "Not implemented");
     return CHIP_ERROR_NOT_IMPLEMENTED;
@@ -489,12 +486,12 @@ ThreadStackManagerImpl::_AttachToThreadNetwork(const Thread::OperationalDataset 
 
 ThreadStackManager & ThreadStackMgr()
 {
-    return chip::DeviceLayer::ThreadStackManagerImpl::sInstance;
+    return DeviceLayer::ThreadStackManagerImpl::sInstance;
 }
 
 ThreadStackManagerImpl & ThreadStackMgrImpl()
 {
-    return chip::DeviceLayer::ThreadStackManagerImpl::sInstance;
+    return DeviceLayer::ThreadStackManagerImpl::sInstance;
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT

--- a/src/platform/Tizen/WiFiManager.h
+++ b/src/platform/Tizen/WiFiManager.h
@@ -28,8 +28,6 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-using namespace chip::DeviceLayer::NetworkCommissioning::Internal;
-
 class WiFiManager
 {
     friend class ConnectivityManagerImpl;
@@ -41,7 +39,8 @@ public:
     CHIP_ERROR IsActivated(bool * isWiFiActivated);
     CHIP_ERROR Activate(void);
     CHIP_ERROR Deactivate(void);
-    CHIP_ERROR Connect(const char * ssid, const char * key, WirelessDriver::ConnectCallback * apCallback = nullptr);
+    CHIP_ERROR Connect(const char * ssid, const char * key,
+                       NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * apCallback = nullptr);
     CHIP_ERROR Disconnect(const char * ssid);
     CHIP_ERROR RemoveAllConfigs(void);
 
@@ -93,7 +92,7 @@ private:
     char mWiFiSSID[kMaxWiFiSSIDLength + 1];
     char mWiFiKey[kMaxWiFiKeyLength + 1];
 
-    WirelessDriver::ConnectCallback * mpConnectCallback;
+    NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * mpConnectCallback;
 };
 
 inline WiFiManager & WiFiMgr()


### PR DESCRIPTION
### Problem

Using using-directives (e.g., using namespace foo) is not recommended. Some files in Tizen platform using this directives. Google style guide: https://google.github.io/styleguide/cppguide.html#Namespaces

### Changes

Removed using-directives from src/platform/Tizen/* for more quality code.

### Testing

Testing is not needed.