### PR TITLE
[Silabs] Fix KVS corner case

### DIFF
--- a/examples/platform/efr32/matter_config.cpp
+++ b/examples/platform/efr32/matter_config.cpp
@@ -130,6 +130,8 @@ void EFR32MatterConfig::ConnectivityEventCallback(const ChipDeviceEvent * event,
 
 CHIP_ERROR EFR32MatterConfig::InitMatter(const char * appName)
 {
+    CHIP_ERROR err;
+
     mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
 
     EFR32_LOG("==================================================");
@@ -186,8 +188,10 @@ CHIP_ERROR EFR32MatterConfig::InitMatter(const char * appName)
 #endif
 
     // Init Matter Server and Start Event Loop
-    chip::Server::GetInstance().Init(initParams);
+    err = chip::Server::GetInstance().Init(initParams);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+
+    ReturnErrorOnFailure(err);
 
     // OTA Requestor initialization will be triggered by the connectivity events
     PlatformMgr().AddEventHandler(ConnectivityEventCallback, reinterpret_cast<intptr_t>(nullptr));

--- a/src/platform/EFR32/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/EFR32/KeyValueStoreManagerImpl.cpp
@@ -144,6 +144,11 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
         *read_bytes_size = outLen;
     }
 
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
     return err;
 }
 


### PR DESCRIPTION
A corner case is possible when the Key is written in the nvm3 but not the value (e.g. power cycle in between the two operation). When This happen, the error code returned is `CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND` instead of `CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND`


Fix : 
Addressed this.
Also Assert on `Server::Init()` failure as it should never happen.

