### PR TITLE
Update BdxOtaSender to only cease polling upon successful transfer of the bulk data

### DIFF
--- a/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
@@ -174,6 +174,7 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
         {
             ChipLogError(BDX, "onTransferComplete Callback not set");
         }
+        mStopPolling = true; // Stop polling the TransferSession only after receiving BlockAckEOF
         Reset();
         break;
     case TransferSession::OutputEventType::kStatusReceived:

--- a/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
@@ -180,6 +180,7 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
         break;
     case TransferSession::OutputEventType::kAckEOFReceived:
         ChipLogDetail(BDX, "Transfer completed, got AckEOF");
+        mStopPolling = true; // Stop polling the TransferSession only after receiving BlockAckEOF
         Reset();
         break;
     case TransferSession::OutputEventType::kStatusReceived:

--- a/scripts/tests/ota_test.sh
+++ b/scripts/tests/ota_test.sh
@@ -26,7 +26,7 @@ scripts/examples/gn_build_example.sh examples/ota-provider-app/linux "$OTA_PROVI
 
 echo "Test" >"$FIRMWARE_BIN"
 
-rm /tmp/chip_*
+rm -f /tmp/chip_*
 
 ./src/app/ota_image_tool.py create -v 0xDEAD -p 0xBEEF -vn 10 -vs "10.0" -da sha256 "$FIRMWARE_BIN" "$FIRMWARE_OTA"
 
@@ -75,7 +75,7 @@ else
     RETURN_VALUE=1
 fi
 
-killall -e "$OTA_PROVIDER_APP" "$OTA_REQUESTOR_APP"
+killall -s SIGKILL -e "$OTA_PROVIDER_APP" "$OTA_REQUESTOR_APP"
 rm -f "$FIRMWARE_OTA" "$FIRMWARE_BIN" "$OTA_DOWNLOAD_PATH"
 
 echo "$TEST_RESULT"

--- a/src/protocols/bdx/TransferFacilitator.cpp
+++ b/src/protocols/bdx/TransferFacilitator.cpp
@@ -112,7 +112,6 @@ CHIP_ERROR Responder::PrepareForTransfer(System::Layer * layer, TransferRole rol
 void Responder::ResetTransfer()
 {
     mTransfer.Reset();
-    mStopPolling = true;
 }
 
 CHIP_ERROR Initiator::InitiateTransfer(System::Layer * layer, TransferRole role, const TransferSession::TransferInitData & initData,


### PR DESCRIPTION
Fixes #23573 

The  BdxOtaSender should ensure that the TransferFacilitator stops polling the TransferSession ONLY upon successfully finishing the Bulk data transfer. In all other cases (error, timeout, etc.), the OTAProvider needs to be able to facilitate delivery of the OTA image.

Tested using the following strategies on Linux OS:
- Scenario mentioned in the bug ticket (Note that this scenario was failing before this fix):
    - Start OTAProvider with image SW version 0. 
    - OTARequestor rightfully ignores the update, since it is currently running image SW version 1. 
    - Copy over the OTAProvider's image with another having SW version 2 (Ensure that you do not kill the provider during this process).
    - OTARequestor accepts the image and OTA is completed successfully.
-  Ran ota_test.sh with varying SW version combinations to ensure OTA succeeds/gets-ignored as per the spec.
