### PR TITLE
[Silabs] bugfix/missing_mbedtls_define_crypto_pal

### DIFF
--- a/src/platform/EFR32/CHIPCryptoPALPsaEfr32.cpp
+++ b/src/platform/EFR32/CHIPCryptoPALPsaEfr32.cpp
@@ -56,6 +56,10 @@ extern "C" {
 #include <mbedtls/x509.h>
 #include <mbedtls/x509_csr.h>
 
+#if defined(MBEDTLS_ERROR_C)
+#include <mbedtls/error.h>
+#endif // defined(MBEDTLS_ERROR_C)
+
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/BufferWriter.h>
 #include <lib/support/BytesToHex.h>


### PR DESCRIPTION
Added include in CHIPCryptoPALPsaEfr32.cpp to make sure mbedtls_strerror is declared when MBEDTLS_ERROR_C is defined.

