### PR TITLE
[darwin] Make sure the prefixes on the enum names match the type

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRClusterConstants.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterConstants.zapt
@@ -7,20 +7,29 @@
 
 typedef NS_ENUM(uint32_t, MTRClusterIDType) {
 {{#zcl_clusters}}
-MTRCluster{{asUpperCamelCase label}}ID {{#if (isStrEqual (asUpperCamelCase label) "UnitTesting")}}MTR_NEWLY_AVAILABLE{{/if}}= {{asMEI manufacturerCode code}},
-{{#if (isStrEqual (asUpperCamelCase label) "UnitTesting")}}
-MTRClusterTestClusterID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingID") = {{asMEI manufacturerCode code}},
-{{/if}}
+MTRCluster{{compatClusterNameRemapping label}}ID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDType{{asUpperCamelCase label}}ID")= {{asMEI manufacturerCode code}},
+{{/zcl_clusters}}
+{{#zcl_clusters}}
+MTRClusterIDType{{asUpperCamelCase label}}ID MTR_NEWLY_AVAILABLE = {{asMEI manufacturerCode code}},
 {{/zcl_clusters}}
 };
 
 #pragma mark - Attributes IDs
 
-typedef NS_ENUM(uint32_t, MTRClusterAttributeIDType) {
+typedef NS_ENUM(uint32_t, MTRAttributeIDType) {
+// Deprecated global attribute names
+{{#zcl_attributes_server}}
+{{#unless clusterRef}}
+MTRClusterGlobalAttribute{{asUpperCamelCase label}}ID
+MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeGlobalAttribute{{asUpperCamelCase label}}ID")
+= {{asMEI manufacturerCode code}},
+{{/unless}}
+{{/zcl_attributes_server}}
+
 // Global attributes
 {{#zcl_attributes_server}}
 {{#unless clusterRef}}
-MTRClusterGlobalAttribute{{asUpperCamelCase label}}ID = {{asMEI manufacturerCode code}},
+MTRAttributeIDTypeGlobalAttribute{{asUpperCamelCase label}}ID MTR_NEWLY_AVAILABLE = {{asMEI manufacturerCode code}},
 {{/unless}}
 {{/zcl_attributes_server}}
 
@@ -28,29 +37,39 @@ MTRClusterGlobalAttribute{{asUpperCamelCase label}}ID = {{asMEI manufacturerCode
 {{#*inline "attributeIDs"}}
 {{#zcl_attributes_server}}
 {{#first}}
-// Cluster {{asUpperCamelCase ../clusterName}} attributes
+// Cluster {{compatClusterNameRemapping ../clusterName}} deprecated attribute names
 {{/first}}
 {{#if clusterRef}}
-{{! TODO: We need a better setup for the API_AVALABLE annotations here; this does not scale at all sanely. }}
-MTRCluster{{asUpperCamelCase ../clusterName}}Attribute{{asUpperCamelCase label}}ID
+{{! TODO: We need a better setup for the API_AVAILABLE annotations here; this does not scale at all sanely. }}
+MTRCluster{{compatClusterNameRemapping ../clusterName}}Attribute{{asUpperCamelCase label}}ID
+MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeCluster{{asUpperCamelCase ../clusterName}}Attribute{{asUpperCamelCase label}}ID")
 {{#if (isStrEqual (asUpperCamelCase ../clusterName) "Descriptor")}}
 {{#if (isStrEqual (asUpperCamelCase label) "DeviceTypeList")}}
 API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 {{/if}}
-{{else if (isStrEqual (asUpperCamelCase ../clusterName) "TestCluster")}}
-MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttribute{{asUpperCamelCase label}}ID")
-{{else if (isStrEqual (asUpperCamelCase ../clusterName) "UnitTesting")}}
-MTR_NEWLY_AVAILABLE
 {{/if}}
 = {{asMEI manufacturerCode code}},
 {{!Backwards compat for now: DeviceList as an alias for DeviceTypeList}}
 {{#if (isStrEqual (asUpperCamelCase ../clusterName) "Descriptor")}}
 {{#if (isStrEqual (asUpperCamelCase label) "DeviceTypeList")}}
-MTRClusterDescriptorAttributeDeviceListID = {{asMEI manufacturerCode code}},
+MTRClusterDescriptorAttributeDeviceListID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeCluster{{asUpperCamelCase ../clusterName}}Attribute{{asUpperCamelCase label}}ID") = {{asMEI manufacturerCode code}},
 {{/if}}
 {{/if}}
 {{else}}
-MTRCluster{{asUpperCamelCase ../clusterName}}Attribute{{asUpperCamelCase label}}ID = MTRClusterGlobalAttribute{{asUpperCamelCase label}}ID,
+MTRCluster{{compatClusterNameRemapping ../clusterName}}Attribute{{asUpperCamelCase label}}ID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeCluster{{asUpperCamelCase parent.label}}Attribute{{asUpperCamelCase label}}ID") = MTRClusterGlobalAttribute{{asUpperCamelCase label}}ID,
+{{/if}}
+{{#last}}
+
+{{/last}}
+{{/zcl_attributes_server}}
+{{#zcl_attributes_server}}
+{{#first}}
+// Cluster {{asUpperCamelCase ../clusterName}} attributes
+{{/first}}
+{{#if clusterRef}}
+MTRAttributeIDTypeCluster{{asUpperCamelCase parent.label}}Attribute{{asUpperCamelCase label}}ID MTR_NEWLY_AVAILABLE = {{asMEI manufacturerCode code}},
+{{else}}
+MTRAttributeIDTypeCluster{{asUpperCamelCase ../clusterName}}Attribute{{asUpperCamelCase label}}ID MTR_NEWLY_AVAILABLE= MTRAttributeIDTypeGlobalAttribute{{asUpperCamelCase label}}ID,
 {{/if}}
 {{#last}}
 
@@ -59,29 +78,30 @@ MTRCluster{{asUpperCamelCase ../clusterName}}Attribute{{asUpperCamelCase label}}
 {{/inline}}
 
 {{> attributeIDs clusterName=label}}
-{{#if (isStrEqual (asUpperCamelCase label) "UnitTesting")}}
-
-{{> attributeIDs clusterName="TestCluster"}}
-{{/if}}
 {{/zcl_clusters}}
 };
 
 #pragma mark - Commands IDs
 
-typedef NS_ENUM(uint32_t, MTRClusterCommandIDType) {
+typedef NS_ENUM(uint32_t, MTRCommandIDType) {
 {{#zcl_clusters}}
 {{#*inline "commandIDs"}}
 {{#zcl_commands}}
 {{#first}}
+// Cluster {{compatClusterNameRemapping ../clusterName}} deprecated command id names
+{{/first}}
+MTRCluster{{compatClusterNameRemapping ../clusterName}}Command{{asUpperCamelCase label}}ID
+MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeCluster{{asUpperCamelCase ../clusterName}}Command{{asUpperCamelCase label}}ID")
+= {{asMEI manufacturerCode code}},
+{{#last}}
+
+{{/last}}
+{{/zcl_commands}}
+{{#zcl_commands}}
+{{#first}}
 // Cluster {{asUpperCamelCase ../clusterName}} commands
 {{/first}}
-MTRCluster{{asUpperCamelCase ../clusterName}}Command{{asUpperCamelCase label}}ID
-{{#if (isStrEqual (asUpperCamelCase ../clusterName) "TestCluster")}}
-MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingCommand{{asUpperCamelCase label}}ID")
-{{else if (isStrEqual (asUpperCamelCase ../clusterName) "UnitTesting")}}
-MTR_NEWLY_AVAILABLE
-{{/if}}
-= {{asMEI manufacturerCode code}},
+MTRCommandIDTypeCluster{{asUpperCamelCase ../clusterName}}Command{{asUpperCamelCase label}}ID MTR_NEWLY_AVAILABLE = {{asMEI manufacturerCode code}},
 {{#last}}
 
 {{/last}}
@@ -89,29 +109,30 @@ MTR_NEWLY_AVAILABLE
 {{/inline}}
 
 {{> commandIDs clusterName=label}}
-{{#if (isStrEqual (asUpperCamelCase label) "UnitTesting")}}
-
-{{> commandIDs clusterName="TestCluster"}}
-{{/if}}
 {{/zcl_clusters}}
 };
 
 #pragma mark - Events IDs
 
-typedef NS_ENUM(uint32_t, MTRClusterEventIDType) {
+typedef NS_ENUM(uint32_t, MTREventIDType) {
 {{#zcl_clusters}}
 {{#*inline "eventIDs"}}
 {{#zcl_events}}
 {{#first}}
+// Cluster {{compatClusterNameRemapping ../clusterName}} deprecated event names
+{{/first}}
+MTRCluster{{compatClusterNameRemapping ../clusterName}}Event{{asUpperCamelCase name}}ID
+MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeCluster{{asUpperCamelCase ../clusterName}}Event{{asUpperCamelCase name}}ID")
+= {{asMEI manufacturerCode code}},
+{{#last}}
+
+{{/last}}
+{{/zcl_events}}
+{{#zcl_events}}
+{{#first}}
 // Cluster {{asUpperCamelCase ../clusterName}} events
 {{/first}}
-MTRCluster{{asUpperCamelCase ../clusterName}}Event{{asUpperCamelCase name}}ID
-{{#if (isStrEqual (asUpperCamelCase ../clusterName) "TestCluster")}}
-MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingEvent{{asUpperCamelCase name}}ID")
-{{else if (isStrEqual (asUpperCamelCase ../clusterName) "UnitTesting")}}
-MTR_NEWLY_AVAILABLE
-{{/if}}
-= {{asMEI manufacturerCode code}},
+MTREventIDTypeCluster{{asUpperCamelCase ../clusterName}}Event{{asUpperCamelCase name}}ID MTR_NEWLY_AVAILABLE = {{asMEI manufacturerCode code}},
 {{#last}}
 
 {{/last}}
@@ -119,9 +140,5 @@ MTR_NEWLY_AVAILABLE
 {{/inline}}
 
 {{> eventIDs clusterName=label}}
-{{#if (isStrEqual (asUpperCamelCase label) "UnitTesting")}}
-
-{{> eventIDs clusterName="TestCluster"}}
-{{/if}}
 {{/zcl_clusters}}
 };

--- a/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
@@ -125,7 +125,7 @@ using chip::SessionHandle;
 {{!Backwards compat for now: Treat DeviceTypeList as DeviceList.  Ideally we would have both, not just DeviceList. }}
 {{#*inline "attribute"}}Attribute{{#if (isStrEqual (asUpperCamelCase parent.name) "Descriptor")}}{{#if (isStrEqual (asUpperCamelCase name) "DeviceTypeList")}}DeviceList{{else}}{{asUpperCamelCase name}}{{/if}}{{else}}{{asUpperCamelCase name}}{{/if}}{{/inline}}
 - (NSDictionary<NSString *, id> *)read{{>attribute}}WithParams:(MTRReadParams * _Nullable)params {
-    return [self.device readAttributeWithEndpointID:@(_endpoint) clusterID:@(MTRCluster{{asUpperCamelCase parent.name}}ID) attributeID:@(MTRCluster{{asUpperCamelCase parent.name}}Attribute{{asUpperCamelCase name}}ID) params:params];
+    return [self.device readAttributeWithEndpointID:@(_endpoint) clusterID:@(MTRClusterIDType{{asUpperCamelCase parent.name}}ID) attributeID:@(MTRAttributeIDTypeCluster{{asUpperCamelCase parent.name}}Attribute{{asUpperCamelCase name}}ID) params:params];
 }
 
 {{#if isWritableAttribute}}
@@ -143,7 +143,7 @@ using chip::SessionHandle;
     }
     {{/if}}
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint) clusterID:@(MTRCluster{{asUpperCamelCase parent.name}}ID) attributeID:@(MTRCluster{{asUpperCamelCase parent.name}}Attribute{{asUpperCamelCase name}}ID) value:dataValueDictionary expectedValueInterval:expectedValueIntervalMs timedWriteTimeout:timedWriteTimeout];
+    [self.device writeAttributeWithEndpointID:@(_endpoint) clusterID:@(MTRClusterIDType{{asUpperCamelCase parent.name}}ID) attributeID:@(MTRAttributeIDTypeCluster{{asUpperCamelCase parent.name}}Attribute{{asUpperCamelCase name}}ID) value:dataValueDictionary expectedValueInterval:expectedValueIntervalMs timedWriteTimeout:timedWriteTimeout];
 }
 
 {{/if}}

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
@@ -21,2059 +21,6600 @@
 #pragma mark - Clusters IDs
 
 typedef NS_ENUM(uint32_t, MTRClusterIDType) {
-    MTRClusterIdentifyID = 0x00000003,
-    MTRClusterGroupsID = 0x00000004,
-    MTRClusterScenesID = 0x00000005,
-    MTRClusterOnOffID = 0x00000006,
-    MTRClusterOnOffSwitchConfigurationID = 0x00000007,
-    MTRClusterLevelControlID = 0x00000008,
-    MTRClusterBinaryInputBasicID = 0x0000000F,
-    MTRClusterPulseWidthModulationID = 0x0000001C,
-    MTRClusterDescriptorID = 0x0000001D,
-    MTRClusterBindingID = 0x0000001E,
-    MTRClusterAccessControlID = 0x0000001F,
-    MTRClusterActionsID = 0x00000025,
-    MTRClusterBasicID = 0x00000028,
-    MTRClusterOtaSoftwareUpdateProviderID = 0x00000029,
-    MTRClusterOtaSoftwareUpdateRequestorID = 0x0000002A,
-    MTRClusterLocalizationConfigurationID = 0x0000002B,
-    MTRClusterTimeFormatLocalizationID = 0x0000002C,
-    MTRClusterUnitLocalizationID = 0x0000002D,
-    MTRClusterPowerSourceConfigurationID = 0x0000002E,
-    MTRClusterPowerSourceID = 0x0000002F,
-    MTRClusterGeneralCommissioningID = 0x00000030,
-    MTRClusterNetworkCommissioningID = 0x00000031,
-    MTRClusterDiagnosticLogsID = 0x00000032,
-    MTRClusterGeneralDiagnosticsID = 0x00000033,
-    MTRClusterSoftwareDiagnosticsID = 0x00000034,
-    MTRClusterThreadNetworkDiagnosticsID = 0x00000035,
-    MTRClusterWiFiNetworkDiagnosticsID = 0x00000036,
-    MTRClusterEthernetNetworkDiagnosticsID = 0x00000037,
-    MTRClusterTimeSynchronizationID = 0x00000038,
-    MTRClusterBridgedDeviceBasicID = 0x00000039,
-    MTRClusterSwitchID = 0x0000003B,
-    MTRClusterAdministratorCommissioningID = 0x0000003C,
-    MTRClusterOperationalCredentialsID = 0x0000003E,
-    MTRClusterGroupKeyManagementID = 0x0000003F,
-    MTRClusterFixedLabelID = 0x00000040,
-    MTRClusterUserLabelID = 0x00000041,
-    MTRClusterProxyConfigurationID = 0x00000042,
-    MTRClusterProxyDiscoveryID = 0x00000043,
-    MTRClusterProxyValidID = 0x00000044,
-    MTRClusterBooleanStateID = 0x00000045,
-    MTRClusterModeSelectID = 0x00000050,
-    MTRClusterDoorLockID = 0x00000101,
-    MTRClusterWindowCoveringID = 0x00000102,
-    MTRClusterBarrierControlID = 0x00000103,
-    MTRClusterPumpConfigurationAndControlID = 0x00000200,
-    MTRClusterThermostatID = 0x00000201,
-    MTRClusterFanControlID = 0x00000202,
-    MTRClusterThermostatUserInterfaceConfigurationID = 0x00000204,
-    MTRClusterColorControlID = 0x00000300,
-    MTRClusterBallastConfigurationID = 0x00000301,
-    MTRClusterIlluminanceMeasurementID = 0x00000400,
-    MTRClusterTemperatureMeasurementID = 0x00000402,
-    MTRClusterPressureMeasurementID = 0x00000403,
-    MTRClusterFlowMeasurementID = 0x00000404,
-    MTRClusterRelativeHumidityMeasurementID = 0x00000405,
-    MTRClusterOccupancySensingID = 0x00000406,
-    MTRClusterWakeOnLanID = 0x00000503,
-    MTRClusterChannelID = 0x00000504,
-    MTRClusterTargetNavigatorID = 0x00000505,
-    MTRClusterMediaPlaybackID = 0x00000506,
-    MTRClusterMediaInputID = 0x00000507,
-    MTRClusterLowPowerID = 0x00000508,
-    MTRClusterKeypadInputID = 0x00000509,
-    MTRClusterContentLauncherID = 0x0000050A,
-    MTRClusterAudioOutputID = 0x0000050B,
-    MTRClusterApplicationLauncherID = 0x0000050C,
-    MTRClusterApplicationBasicID = 0x0000050D,
-    MTRClusterAccountLoginID = 0x0000050E,
-    MTRClusterElectricalMeasurementID = 0x00000B04,
-    MTRClusterUnitTestingID MTR_NEWLY_AVAILABLE = 0xFFF1FC05,
-    MTRClusterTestClusterID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingID") = 0xFFF1FC05,
-    MTRClusterFaultInjectionID = 0xFFF1FC06,
+    MTRClusterIdentifyID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeIdentifyID") = 0x00000003,
+    MTRClusterGroupsID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeGroupsID") = 0x00000004,
+    MTRClusterScenesID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeScenesID") = 0x00000005,
+    MTRClusterOnOffID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeOnOffID") = 0x00000006,
+    MTRClusterOnOffSwitchConfigurationID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeOnOffSwitchConfigurationID") = 0x00000007,
+    MTRClusterLevelControlID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeLevelControlID") = 0x00000008,
+    MTRClusterBinaryInputBasicID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeBinaryInputBasicID") = 0x0000000F,
+    MTRClusterPulseWidthModulationID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypePulseWidthModulationID") = 0x0000001C,
+    MTRClusterDescriptorID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeDescriptorID") = 0x0000001D,
+    MTRClusterBindingID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeBindingID") = 0x0000001E,
+    MTRClusterAccessControlID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeAccessControlID") = 0x0000001F,
+    MTRClusterActionsID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeActionsID") = 0x00000025,
+    MTRClusterBasicID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeBasicID") = 0x00000028,
+    MTRClusterOtaSoftwareUpdateProviderID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeOtaSoftwareUpdateProviderID")
+    = 0x00000029,
+    MTRClusterOtaSoftwareUpdateRequestorID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeOtaSoftwareUpdateRequestorID")
+    = 0x0000002A,
+    MTRClusterLocalizationConfigurationID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeLocalizationConfigurationID")
+    = 0x0000002B,
+    MTRClusterTimeFormatLocalizationID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeTimeFormatLocalizationID") = 0x0000002C,
+    MTRClusterUnitLocalizationID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeUnitLocalizationID") = 0x0000002D,
+    MTRClusterPowerSourceConfigurationID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypePowerSourceConfigurationID") = 0x0000002E,
+    MTRClusterPowerSourceID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypePowerSourceID") = 0x0000002F,
+    MTRClusterGeneralCommissioningID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeGeneralCommissioningID") = 0x00000030,
+    MTRClusterNetworkCommissioningID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeNetworkCommissioningID") = 0x00000031,
+    MTRClusterDiagnosticLogsID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeDiagnosticLogsID") = 0x00000032,
+    MTRClusterGeneralDiagnosticsID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeGeneralDiagnosticsID") = 0x00000033,
+    MTRClusterSoftwareDiagnosticsID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeSoftwareDiagnosticsID") = 0x00000034,
+    MTRClusterThreadNetworkDiagnosticsID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeThreadNetworkDiagnosticsID") = 0x00000035,
+    MTRClusterWiFiNetworkDiagnosticsID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeWiFiNetworkDiagnosticsID") = 0x00000036,
+    MTRClusterEthernetNetworkDiagnosticsID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeEthernetNetworkDiagnosticsID")
+    = 0x00000037,
+    MTRClusterTimeSynchronizationID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeTimeSynchronizationID") = 0x00000038,
+    MTRClusterBridgedDeviceBasicID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeBridgedDeviceBasicID") = 0x00000039,
+    MTRClusterSwitchID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeSwitchID") = 0x0000003B,
+    MTRClusterAdministratorCommissioningID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeAdministratorCommissioningID")
+    = 0x0000003C,
+    MTRClusterOperationalCredentialsID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeOperationalCredentialsID") = 0x0000003E,
+    MTRClusterGroupKeyManagementID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeGroupKeyManagementID") = 0x0000003F,
+    MTRClusterFixedLabelID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeFixedLabelID") = 0x00000040,
+    MTRClusterUserLabelID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeUserLabelID") = 0x00000041,
+    MTRClusterProxyConfigurationID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeProxyConfigurationID") = 0x00000042,
+    MTRClusterProxyDiscoveryID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeProxyDiscoveryID") = 0x00000043,
+    MTRClusterProxyValidID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeProxyValidID") = 0x00000044,
+    MTRClusterBooleanStateID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeBooleanStateID") = 0x00000045,
+    MTRClusterModeSelectID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeModeSelectID") = 0x00000050,
+    MTRClusterDoorLockID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeDoorLockID") = 0x00000101,
+    MTRClusterWindowCoveringID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeWindowCoveringID") = 0x00000102,
+    MTRClusterBarrierControlID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeBarrierControlID") = 0x00000103,
+    MTRClusterPumpConfigurationAndControlID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypePumpConfigurationAndControlID")
+    = 0x00000200,
+    MTRClusterThermostatID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeThermostatID") = 0x00000201,
+    MTRClusterFanControlID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeFanControlID") = 0x00000202,
+    MTRClusterThermostatUserInterfaceConfigurationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRClusterIDTypeThermostatUserInterfaceConfigurationID")
+    = 0x00000204,
+    MTRClusterColorControlID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeColorControlID") = 0x00000300,
+    MTRClusterBallastConfigurationID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeBallastConfigurationID") = 0x00000301,
+    MTRClusterIlluminanceMeasurementID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeIlluminanceMeasurementID") = 0x00000400,
+    MTRClusterTemperatureMeasurementID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeTemperatureMeasurementID") = 0x00000402,
+    MTRClusterPressureMeasurementID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypePressureMeasurementID") = 0x00000403,
+    MTRClusterFlowMeasurementID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeFlowMeasurementID") = 0x00000404,
+    MTRClusterRelativeHumidityMeasurementID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeRelativeHumidityMeasurementID")
+    = 0x00000405,
+    MTRClusterOccupancySensingID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeOccupancySensingID") = 0x00000406,
+    MTRClusterWakeOnLanID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeWakeOnLanID") = 0x00000503,
+    MTRClusterChannelID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeChannelID") = 0x00000504,
+    MTRClusterTargetNavigatorID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeTargetNavigatorID") = 0x00000505,
+    MTRClusterMediaPlaybackID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeMediaPlaybackID") = 0x00000506,
+    MTRClusterMediaInputID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeMediaInputID") = 0x00000507,
+    MTRClusterLowPowerID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeLowPowerID") = 0x00000508,
+    MTRClusterKeypadInputID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeKeypadInputID") = 0x00000509,
+    MTRClusterContentLauncherID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeContentLauncherID") = 0x0000050A,
+    MTRClusterAudioOutputID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeAudioOutputID") = 0x0000050B,
+    MTRClusterApplicationLauncherID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeApplicationLauncherID") = 0x0000050C,
+    MTRClusterApplicationBasicID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeApplicationBasicID") = 0x0000050D,
+    MTRClusterAccountLoginID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeAccountLoginID") = 0x0000050E,
+    MTRClusterElectricalMeasurementID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeElectricalMeasurementID") = 0x00000B04,
+    MTRClusterTestClusterID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeUnitTestingID") = 0xFFF1FC05,
+    MTRClusterFaultInjectionID MTR_NEWLY_DEPRECATED("Please use MTRClusterIDTypeFaultInjectionID") = 0xFFF1FC06,
+    MTRClusterIDTypeIdentifyID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRClusterIDTypeGroupsID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRClusterIDTypeScenesID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRClusterIDTypeOnOffID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRClusterIDTypeOnOffSwitchConfigurationID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRClusterIDTypeLevelControlID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRClusterIDTypeBinaryInputBasicID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTRClusterIDTypePulseWidthModulationID MTR_NEWLY_AVAILABLE = 0x0000001C,
+    MTRClusterIDTypeDescriptorID MTR_NEWLY_AVAILABLE = 0x0000001D,
+    MTRClusterIDTypeBindingID MTR_NEWLY_AVAILABLE = 0x0000001E,
+    MTRClusterIDTypeAccessControlID MTR_NEWLY_AVAILABLE = 0x0000001F,
+    MTRClusterIDTypeActionsID MTR_NEWLY_AVAILABLE = 0x00000025,
+    MTRClusterIDTypeBasicID MTR_NEWLY_AVAILABLE = 0x00000028,
+    MTRClusterIDTypeOtaSoftwareUpdateProviderID MTR_NEWLY_AVAILABLE = 0x00000029,
+    MTRClusterIDTypeOtaSoftwareUpdateRequestorID MTR_NEWLY_AVAILABLE = 0x0000002A,
+    MTRClusterIDTypeLocalizationConfigurationID MTR_NEWLY_AVAILABLE = 0x0000002B,
+    MTRClusterIDTypeTimeFormatLocalizationID MTR_NEWLY_AVAILABLE = 0x0000002C,
+    MTRClusterIDTypeUnitLocalizationID MTR_NEWLY_AVAILABLE = 0x0000002D,
+    MTRClusterIDTypePowerSourceConfigurationID MTR_NEWLY_AVAILABLE = 0x0000002E,
+    MTRClusterIDTypePowerSourceID MTR_NEWLY_AVAILABLE = 0x0000002F,
+    MTRClusterIDTypeGeneralCommissioningID MTR_NEWLY_AVAILABLE = 0x00000030,
+    MTRClusterIDTypeNetworkCommissioningID MTR_NEWLY_AVAILABLE = 0x00000031,
+    MTRClusterIDTypeDiagnosticLogsID MTR_NEWLY_AVAILABLE = 0x00000032,
+    MTRClusterIDTypeGeneralDiagnosticsID MTR_NEWLY_AVAILABLE = 0x00000033,
+    MTRClusterIDTypeSoftwareDiagnosticsID MTR_NEWLY_AVAILABLE = 0x00000034,
+    MTRClusterIDTypeThreadNetworkDiagnosticsID MTR_NEWLY_AVAILABLE = 0x00000035,
+    MTRClusterIDTypeWiFiNetworkDiagnosticsID MTR_NEWLY_AVAILABLE = 0x00000036,
+    MTRClusterIDTypeEthernetNetworkDiagnosticsID MTR_NEWLY_AVAILABLE = 0x00000037,
+    MTRClusterIDTypeTimeSynchronizationID MTR_NEWLY_AVAILABLE = 0x00000038,
+    MTRClusterIDTypeBridgedDeviceBasicID MTR_NEWLY_AVAILABLE = 0x00000039,
+    MTRClusterIDTypeSwitchID MTR_NEWLY_AVAILABLE = 0x0000003B,
+    MTRClusterIDTypeAdministratorCommissioningID MTR_NEWLY_AVAILABLE = 0x0000003C,
+    MTRClusterIDTypeOperationalCredentialsID MTR_NEWLY_AVAILABLE = 0x0000003E,
+    MTRClusterIDTypeGroupKeyManagementID MTR_NEWLY_AVAILABLE = 0x0000003F,
+    MTRClusterIDTypeFixedLabelID MTR_NEWLY_AVAILABLE = 0x00000040,
+    MTRClusterIDTypeUserLabelID MTR_NEWLY_AVAILABLE = 0x00000041,
+    MTRClusterIDTypeProxyConfigurationID MTR_NEWLY_AVAILABLE = 0x00000042,
+    MTRClusterIDTypeProxyDiscoveryID MTR_NEWLY_AVAILABLE = 0x00000043,
+    MTRClusterIDTypeProxyValidID MTR_NEWLY_AVAILABLE = 0x00000044,
+    MTRClusterIDTypeBooleanStateID MTR_NEWLY_AVAILABLE = 0x00000045,
+    MTRClusterIDTypeModeSelectID MTR_NEWLY_AVAILABLE = 0x00000050,
+    MTRClusterIDTypeDoorLockID MTR_NEWLY_AVAILABLE = 0x00000101,
+    MTRClusterIDTypeWindowCoveringID MTR_NEWLY_AVAILABLE = 0x00000102,
+    MTRClusterIDTypeBarrierControlID MTR_NEWLY_AVAILABLE = 0x00000103,
+    MTRClusterIDTypePumpConfigurationAndControlID MTR_NEWLY_AVAILABLE = 0x00000200,
+    MTRClusterIDTypeThermostatID MTR_NEWLY_AVAILABLE = 0x00000201,
+    MTRClusterIDTypeFanControlID MTR_NEWLY_AVAILABLE = 0x00000202,
+    MTRClusterIDTypeThermostatUserInterfaceConfigurationID MTR_NEWLY_AVAILABLE = 0x00000204,
+    MTRClusterIDTypeColorControlID MTR_NEWLY_AVAILABLE = 0x00000300,
+    MTRClusterIDTypeBallastConfigurationID MTR_NEWLY_AVAILABLE = 0x00000301,
+    MTRClusterIDTypeIlluminanceMeasurementID MTR_NEWLY_AVAILABLE = 0x00000400,
+    MTRClusterIDTypeTemperatureMeasurementID MTR_NEWLY_AVAILABLE = 0x00000402,
+    MTRClusterIDTypePressureMeasurementID MTR_NEWLY_AVAILABLE = 0x00000403,
+    MTRClusterIDTypeFlowMeasurementID MTR_NEWLY_AVAILABLE = 0x00000404,
+    MTRClusterIDTypeRelativeHumidityMeasurementID MTR_NEWLY_AVAILABLE = 0x00000405,
+    MTRClusterIDTypeOccupancySensingID MTR_NEWLY_AVAILABLE = 0x00000406,
+    MTRClusterIDTypeWakeOnLanID MTR_NEWLY_AVAILABLE = 0x00000503,
+    MTRClusterIDTypeChannelID MTR_NEWLY_AVAILABLE = 0x00000504,
+    MTRClusterIDTypeTargetNavigatorID MTR_NEWLY_AVAILABLE = 0x00000505,
+    MTRClusterIDTypeMediaPlaybackID MTR_NEWLY_AVAILABLE = 0x00000506,
+    MTRClusterIDTypeMediaInputID MTR_NEWLY_AVAILABLE = 0x00000507,
+    MTRClusterIDTypeLowPowerID MTR_NEWLY_AVAILABLE = 0x00000508,
+    MTRClusterIDTypeKeypadInputID MTR_NEWLY_AVAILABLE = 0x00000509,
+    MTRClusterIDTypeContentLauncherID MTR_NEWLY_AVAILABLE = 0x0000050A,
+    MTRClusterIDTypeAudioOutputID MTR_NEWLY_AVAILABLE = 0x0000050B,
+    MTRClusterIDTypeApplicationLauncherID MTR_NEWLY_AVAILABLE = 0x0000050C,
+    MTRClusterIDTypeApplicationBasicID MTR_NEWLY_AVAILABLE = 0x0000050D,
+    MTRClusterIDTypeAccountLoginID MTR_NEWLY_AVAILABLE = 0x0000050E,
+    MTRClusterIDTypeElectricalMeasurementID MTR_NEWLY_AVAILABLE = 0x00000B04,
+    MTRClusterIDTypeUnitTestingID MTR_NEWLY_AVAILABLE = 0xFFF1FC05,
+    MTRClusterIDTypeFaultInjectionID MTR_NEWLY_AVAILABLE = 0xFFF1FC06,
 };
 
 #pragma mark - Attributes IDs
 
-typedef NS_ENUM(uint32_t, MTRClusterAttributeIDType) {
+typedef NS_ENUM(uint32_t, MTRAttributeIDType) {
+    // Deprecated global attribute names
+    MTRClusterGlobalAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID")
+    = 0x0000FFF8,
+    MTRClusterGlobalAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID")
+    = 0x0000FFF9,
+    MTRClusterGlobalAttributeAttributeListID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeGlobalAttributeAttributeListID")
+    = 0x0000FFFB,
+    MTRClusterGlobalAttributeFeatureMapID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeGlobalAttributeFeatureMapID")
+    = 0x0000FFFC,
+    MTRClusterGlobalAttributeClusterRevisionID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeGlobalAttributeClusterRevisionID")
+    = 0x0000FFFD,
+
     // Global attributes
-    MTRClusterGlobalAttributeGeneratedCommandListID = 0x0000FFF8,
-    MTRClusterGlobalAttributeAcceptedCommandListID = 0x0000FFF9,
-    MTRClusterGlobalAttributeAttributeListID = 0x0000FFFB,
-    MTRClusterGlobalAttributeFeatureMapID = 0x0000FFFC,
-    MTRClusterGlobalAttributeClusterRevisionID = 0x0000FFFD,
+    MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE = 0x0000FFF8,
+    MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE = 0x0000FFF9,
+    MTRAttributeIDTypeGlobalAttributeAttributeListID MTR_NEWLY_AVAILABLE = 0x0000FFFB,
+    MTRAttributeIDTypeGlobalAttributeFeatureMapID MTR_NEWLY_AVAILABLE = 0x0000FFFC,
+    MTRAttributeIDTypeGlobalAttributeClusterRevisionID MTR_NEWLY_AVAILABLE = 0x0000FFFD,
+
+    // Cluster Identify deprecated attribute names
+    MTRClusterIdentifyAttributeIdentifyTimeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIdentifyAttributeIdentifyTimeID")
+    = 0x00000000,
+    MTRClusterIdentifyAttributeIdentifyTypeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIdentifyAttributeIdentifyTypeID")
+    = 0x00000001,
+    MTRClusterIdentifyAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIdentifyAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterIdentifyAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIdentifyAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterIdentifyAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIdentifyAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterIdentifyAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIdentifyAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterIdentifyAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIdentifyAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster Identify attributes
-    MTRClusterIdentifyAttributeIdentifyTimeID = 0x00000000,
-    MTRClusterIdentifyAttributeIdentifyTypeID = 0x00000001,
-    MTRClusterIdentifyAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterIdentifyAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterIdentifyAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterIdentifyAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterIdentifyAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterIdentifyAttributeIdentifyTimeID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterIdentifyAttributeIdentifyTypeID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterIdentifyAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterIdentifyAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterIdentifyAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterIdentifyAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterIdentifyAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster Groups deprecated attribute names
+    MTRClusterGroupsAttributeNameSupportID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterGroupsAttributeNameSupportID")
+    = 0x00000000,
+    MTRClusterGroupsAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGroupsAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterGroupsAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGroupsAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterGroupsAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGroupsAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterGroupsAttributeFeatureMapID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterGroupsAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterGroupsAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGroupsAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster Groups attributes
-    MTRClusterGroupsAttributeNameSupportID = 0x00000000,
-    MTRClusterGroupsAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterGroupsAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterGroupsAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterGroupsAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterGroupsAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterGroupsAttributeNameSupportID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterGroupsAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterGroupsAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterGroupsAttributeAttributeListID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterGroupsAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterGroupsAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster Scenes deprecated attribute names
+    MTRClusterScenesAttributeSceneCountID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterScenesAttributeSceneCountID")
+    = 0x00000000,
+    MTRClusterScenesAttributeCurrentSceneID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterScenesAttributeCurrentSceneID")
+    = 0x00000001,
+    MTRClusterScenesAttributeCurrentGroupID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterScenesAttributeCurrentGroupID")
+    = 0x00000002,
+    MTRClusterScenesAttributeSceneValidID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterScenesAttributeSceneValidID")
+    = 0x00000003,
+    MTRClusterScenesAttributeNameSupportID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterScenesAttributeNameSupportID")
+    = 0x00000004,
+    MTRClusterScenesAttributeLastConfiguredByID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterScenesAttributeLastConfiguredByID")
+    = 0x00000005,
+    MTRClusterScenesAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterScenesAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterScenesAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterScenesAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterScenesAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterScenesAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterScenesAttributeFeatureMapID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterScenesAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterScenesAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterScenesAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster Scenes attributes
-    MTRClusterScenesAttributeSceneCountID = 0x00000000,
-    MTRClusterScenesAttributeCurrentSceneID = 0x00000001,
-    MTRClusterScenesAttributeCurrentGroupID = 0x00000002,
-    MTRClusterScenesAttributeSceneValidID = 0x00000003,
-    MTRClusterScenesAttributeNameSupportID = 0x00000004,
-    MTRClusterScenesAttributeLastConfiguredByID = 0x00000005,
-    MTRClusterScenesAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterScenesAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterScenesAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterScenesAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterScenesAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterScenesAttributeSceneCountID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterScenesAttributeCurrentSceneID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterScenesAttributeCurrentGroupID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterScenesAttributeSceneValidID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterScenesAttributeNameSupportID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterScenesAttributeLastConfiguredByID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterScenesAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterScenesAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterScenesAttributeAttributeListID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterScenesAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterScenesAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster OnOff deprecated attribute names
+    MTRClusterOnOffAttributeOnOffID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterOnOffAttributeOnOffID") = 0x00000000,
+    MTRClusterOnOffAttributeGlobalSceneControlID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOnOffAttributeGlobalSceneControlID")
+    = 0x00004000,
+    MTRClusterOnOffAttributeOnTimeID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterOnOffAttributeOnTimeID")
+    = 0x00004001,
+    MTRClusterOnOffAttributeOffWaitTimeID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterOnOffAttributeOffWaitTimeID")
+    = 0x00004002,
+    MTRClusterOnOffAttributeStartUpOnOffID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterOnOffAttributeStartUpOnOffID")
+    = 0x00004003,
+    MTRClusterOnOffAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOnOffAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterOnOffAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOnOffAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterOnOffAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOnOffAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterOnOffAttributeFeatureMapID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterOnOffAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterOnOffAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOnOffAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster OnOff attributes
-    MTRClusterOnOffAttributeOnOffID = 0x00000000,
-    MTRClusterOnOffAttributeGlobalSceneControlID = 0x00004000,
-    MTRClusterOnOffAttributeOnTimeID = 0x00004001,
-    MTRClusterOnOffAttributeOffWaitTimeID = 0x00004002,
-    MTRClusterOnOffAttributeStartUpOnOffID = 0x00004003,
-    MTRClusterOnOffAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterOnOffAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterOnOffAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterOnOffAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterOnOffAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterOnOffAttributeOnOffID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterOnOffAttributeGlobalSceneControlID MTR_NEWLY_AVAILABLE = 0x00004000,
+    MTRAttributeIDTypeClusterOnOffAttributeOnTimeID MTR_NEWLY_AVAILABLE = 0x00004001,
+    MTRAttributeIDTypeClusterOnOffAttributeOffWaitTimeID MTR_NEWLY_AVAILABLE = 0x00004002,
+    MTRAttributeIDTypeClusterOnOffAttributeStartUpOnOffID MTR_NEWLY_AVAILABLE = 0x00004003,
+    MTRAttributeIDTypeClusterOnOffAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterOnOffAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterOnOffAttributeAttributeListID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterOnOffAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterOnOffAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster OnOffSwitchConfiguration deprecated attribute names
+    MTRClusterOnOffSwitchConfigurationAttributeSwitchTypeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeSwitchTypeID")
+    = 0x00000000,
+    MTRClusterOnOffSwitchConfigurationAttributeSwitchActionsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeSwitchActionsID")
+    = 0x00000010,
+    MTRClusterOnOffSwitchConfigurationAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterOnOffSwitchConfigurationAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterOnOffSwitchConfigurationAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterOnOffSwitchConfigurationAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterOnOffSwitchConfigurationAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster OnOffSwitchConfiguration attributes
-    MTRClusterOnOffSwitchConfigurationAttributeSwitchTypeID = 0x00000000,
-    MTRClusterOnOffSwitchConfigurationAttributeSwitchActionsID = 0x00000010,
-    MTRClusterOnOffSwitchConfigurationAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterOnOffSwitchConfigurationAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterOnOffSwitchConfigurationAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterOnOffSwitchConfigurationAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterOnOffSwitchConfigurationAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeSwitchTypeID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeSwitchActionsID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster LevelControl deprecated attribute names
+    MTRClusterLevelControlAttributeCurrentLevelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeCurrentLevelID")
+    = 0x00000000,
+    MTRClusterLevelControlAttributeRemainingTimeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeRemainingTimeID")
+    = 0x00000001,
+    MTRClusterLevelControlAttributeMinLevelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeMinLevelID")
+    = 0x00000002,
+    MTRClusterLevelControlAttributeMaxLevelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeMaxLevelID")
+    = 0x00000003,
+    MTRClusterLevelControlAttributeCurrentFrequencyID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeCurrentFrequencyID")
+    = 0x00000004,
+    MTRClusterLevelControlAttributeMinFrequencyID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeMinFrequencyID")
+    = 0x00000005,
+    MTRClusterLevelControlAttributeMaxFrequencyID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeMaxFrequencyID")
+    = 0x00000006,
+    MTRClusterLevelControlAttributeOptionsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeOptionsID")
+    = 0x0000000F,
+    MTRClusterLevelControlAttributeOnOffTransitionTimeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeOnOffTransitionTimeID")
+    = 0x00000010,
+    MTRClusterLevelControlAttributeOnLevelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeOnLevelID")
+    = 0x00000011,
+    MTRClusterLevelControlAttributeOnTransitionTimeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeOnTransitionTimeID")
+    = 0x00000012,
+    MTRClusterLevelControlAttributeOffTransitionTimeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeOffTransitionTimeID")
+    = 0x00000013,
+    MTRClusterLevelControlAttributeDefaultMoveRateID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeDefaultMoveRateID")
+    = 0x00000014,
+    MTRClusterLevelControlAttributeStartUpCurrentLevelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeStartUpCurrentLevelID")
+    = 0x00004000,
+    MTRClusterLevelControlAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterLevelControlAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterLevelControlAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterLevelControlAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterLevelControlAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLevelControlAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster LevelControl attributes
-    MTRClusterLevelControlAttributeCurrentLevelID = 0x00000000,
-    MTRClusterLevelControlAttributeRemainingTimeID = 0x00000001,
-    MTRClusterLevelControlAttributeMinLevelID = 0x00000002,
-    MTRClusterLevelControlAttributeMaxLevelID = 0x00000003,
-    MTRClusterLevelControlAttributeCurrentFrequencyID = 0x00000004,
-    MTRClusterLevelControlAttributeMinFrequencyID = 0x00000005,
-    MTRClusterLevelControlAttributeMaxFrequencyID = 0x00000006,
-    MTRClusterLevelControlAttributeOptionsID = 0x0000000F,
-    MTRClusterLevelControlAttributeOnOffTransitionTimeID = 0x00000010,
-    MTRClusterLevelControlAttributeOnLevelID = 0x00000011,
-    MTRClusterLevelControlAttributeOnTransitionTimeID = 0x00000012,
-    MTRClusterLevelControlAttributeOffTransitionTimeID = 0x00000013,
-    MTRClusterLevelControlAttributeDefaultMoveRateID = 0x00000014,
-    MTRClusterLevelControlAttributeStartUpCurrentLevelID = 0x00004000,
-    MTRClusterLevelControlAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterLevelControlAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterLevelControlAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterLevelControlAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterLevelControlAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterLevelControlAttributeCurrentLevelID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterLevelControlAttributeRemainingTimeID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterLevelControlAttributeMinLevelID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterLevelControlAttributeMaxLevelID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterLevelControlAttributeCurrentFrequencyID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterLevelControlAttributeMinFrequencyID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterLevelControlAttributeMaxFrequencyID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterLevelControlAttributeOptionsID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTRAttributeIDTypeClusterLevelControlAttributeOnOffTransitionTimeID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRAttributeIDTypeClusterLevelControlAttributeOnLevelID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRAttributeIDTypeClusterLevelControlAttributeOnTransitionTimeID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRAttributeIDTypeClusterLevelControlAttributeOffTransitionTimeID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRAttributeIDTypeClusterLevelControlAttributeDefaultMoveRateID MTR_NEWLY_AVAILABLE = 0x00000014,
+    MTRAttributeIDTypeClusterLevelControlAttributeStartUpCurrentLevelID MTR_NEWLY_AVAILABLE = 0x00004000,
+    MTRAttributeIDTypeClusterLevelControlAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterLevelControlAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterLevelControlAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterLevelControlAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterLevelControlAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster BinaryInputBasic deprecated attribute names
+    MTRClusterBinaryInputBasicAttributeActiveTextID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBinaryInputBasicAttributeActiveTextID")
+    = 0x00000004,
+    MTRClusterBinaryInputBasicAttributeDescriptionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBinaryInputBasicAttributeDescriptionID")
+    = 0x0000001C,
+    MTRClusterBinaryInputBasicAttributeInactiveTextID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBinaryInputBasicAttributeInactiveTextID")
+    = 0x0000002E,
+    MTRClusterBinaryInputBasicAttributeOutOfServiceID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBinaryInputBasicAttributeOutOfServiceID")
+    = 0x00000051,
+    MTRClusterBinaryInputBasicAttributePolarityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBinaryInputBasicAttributePolarityID")
+    = 0x00000054,
+    MTRClusterBinaryInputBasicAttributePresentValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBinaryInputBasicAttributePresentValueID")
+    = 0x00000055,
+    MTRClusterBinaryInputBasicAttributeReliabilityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBinaryInputBasicAttributeReliabilityID")
+    = 0x00000067,
+    MTRClusterBinaryInputBasicAttributeStatusFlagsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBinaryInputBasicAttributeStatusFlagsID")
+    = 0x0000006F,
+    MTRClusterBinaryInputBasicAttributeApplicationTypeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBinaryInputBasicAttributeApplicationTypeID")
+    = 0x00000100,
+    MTRClusterBinaryInputBasicAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBinaryInputBasicAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterBinaryInputBasicAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBinaryInputBasicAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterBinaryInputBasicAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBinaryInputBasicAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterBinaryInputBasicAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBinaryInputBasicAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterBinaryInputBasicAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBinaryInputBasicAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster BinaryInputBasic attributes
-    MTRClusterBinaryInputBasicAttributeActiveTextID = 0x00000004,
-    MTRClusterBinaryInputBasicAttributeDescriptionID = 0x0000001C,
-    MTRClusterBinaryInputBasicAttributeInactiveTextID = 0x0000002E,
-    MTRClusterBinaryInputBasicAttributeOutOfServiceID = 0x00000051,
-    MTRClusterBinaryInputBasicAttributePolarityID = 0x00000054,
-    MTRClusterBinaryInputBasicAttributePresentValueID = 0x00000055,
-    MTRClusterBinaryInputBasicAttributeReliabilityID = 0x00000067,
-    MTRClusterBinaryInputBasicAttributeStatusFlagsID = 0x0000006F,
-    MTRClusterBinaryInputBasicAttributeApplicationTypeID = 0x00000100,
-    MTRClusterBinaryInputBasicAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterBinaryInputBasicAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterBinaryInputBasicAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterBinaryInputBasicAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterBinaryInputBasicAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterBinaryInputBasicAttributeActiveTextID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterBinaryInputBasicAttributeDescriptionID MTR_NEWLY_AVAILABLE = 0x0000001C,
+    MTRAttributeIDTypeClusterBinaryInputBasicAttributeInactiveTextID MTR_NEWLY_AVAILABLE = 0x0000002E,
+    MTRAttributeIDTypeClusterBinaryInputBasicAttributeOutOfServiceID MTR_NEWLY_AVAILABLE = 0x00000051,
+    MTRAttributeIDTypeClusterBinaryInputBasicAttributePolarityID MTR_NEWLY_AVAILABLE = 0x00000054,
+    MTRAttributeIDTypeClusterBinaryInputBasicAttributePresentValueID MTR_NEWLY_AVAILABLE = 0x00000055,
+    MTRAttributeIDTypeClusterBinaryInputBasicAttributeReliabilityID MTR_NEWLY_AVAILABLE = 0x00000067,
+    MTRAttributeIDTypeClusterBinaryInputBasicAttributeStatusFlagsID MTR_NEWLY_AVAILABLE = 0x0000006F,
+    MTRAttributeIDTypeClusterBinaryInputBasicAttributeApplicationTypeID MTR_NEWLY_AVAILABLE = 0x00000100,
+    MTRAttributeIDTypeClusterBinaryInputBasicAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterBinaryInputBasicAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterBinaryInputBasicAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterBinaryInputBasicAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterBinaryInputBasicAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster PulseWidthModulation deprecated attribute names
+    MTRClusterPulseWidthModulationAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPulseWidthModulationAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterPulseWidthModulationAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPulseWidthModulationAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterPulseWidthModulationAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPulseWidthModulationAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterPulseWidthModulationAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPulseWidthModulationAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterPulseWidthModulationAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPulseWidthModulationAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster PulseWidthModulation attributes
-    MTRClusterPulseWidthModulationAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterPulseWidthModulationAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterPulseWidthModulationAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterPulseWidthModulationAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterPulseWidthModulationAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterPulseWidthModulationAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterPulseWidthModulationAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterPulseWidthModulationAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterPulseWidthModulationAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterPulseWidthModulationAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster Descriptor deprecated attribute names
+    MTRClusterDescriptorAttributeDeviceTypeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDescriptorAttributeDeviceTypeListID")
+        API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
+    = 0x00000000,
+    MTRClusterDescriptorAttributeDeviceListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDescriptorAttributeDeviceTypeListID")
+    = 0x00000000,
+    MTRClusterDescriptorAttributeServerListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDescriptorAttributeServerListID")
+    = 0x00000001,
+    MTRClusterDescriptorAttributeClientListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDescriptorAttributeClientListID")
+    = 0x00000002,
+    MTRClusterDescriptorAttributePartsListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDescriptorAttributePartsListID")
+    = 0x00000003,
+    MTRClusterDescriptorAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDescriptorAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterDescriptorAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDescriptorAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterDescriptorAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDescriptorAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterDescriptorAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDescriptorAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterDescriptorAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDescriptorAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster Descriptor attributes
-    MTRClusterDescriptorAttributeDeviceTypeListID API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)) = 0x00000000,
-    MTRClusterDescriptorAttributeDeviceListID = 0x00000000,
-    MTRClusterDescriptorAttributeServerListID = 0x00000001,
-    MTRClusterDescriptorAttributeClientListID = 0x00000002,
-    MTRClusterDescriptorAttributePartsListID = 0x00000003,
-    MTRClusterDescriptorAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterDescriptorAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterDescriptorAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterDescriptorAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterDescriptorAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterDescriptorAttributeDeviceTypeListID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterDescriptorAttributeServerListID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterDescriptorAttributeClientListID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterDescriptorAttributePartsListID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterDescriptorAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterDescriptorAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterDescriptorAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterDescriptorAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterDescriptorAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster Binding deprecated attribute names
+    MTRClusterBindingAttributeBindingID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBindingAttributeBindingID")
+    = 0x00000000,
+    MTRClusterBindingAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBindingAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterBindingAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBindingAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterBindingAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBindingAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterBindingAttributeFeatureMapID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBindingAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterBindingAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBindingAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster Binding attributes
-    MTRClusterBindingAttributeBindingID = 0x00000000,
-    MTRClusterBindingAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterBindingAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterBindingAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterBindingAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterBindingAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterBindingAttributeBindingID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterBindingAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterBindingAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterBindingAttributeAttributeListID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterBindingAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterBindingAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster AccessControl deprecated attribute names
+    MTRClusterAccessControlAttributeAclID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterAccessControlAttributeAclID")
+    = 0x00000000,
+    MTRClusterAccessControlAttributeExtensionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAccessControlAttributeExtensionID")
+    = 0x00000001,
+    MTRClusterAccessControlAttributeSubjectsPerAccessControlEntryID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAccessControlAttributeSubjectsPerAccessControlEntryID")
+    = 0x00000002,
+    MTRClusterAccessControlAttributeTargetsPerAccessControlEntryID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAccessControlAttributeTargetsPerAccessControlEntryID")
+    = 0x00000003,
+    MTRClusterAccessControlAttributeAccessControlEntriesPerFabricID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAccessControlAttributeAccessControlEntriesPerFabricID")
+    = 0x00000004,
+    MTRClusterAccessControlAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAccessControlAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterAccessControlAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAccessControlAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterAccessControlAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAccessControlAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterAccessControlAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAccessControlAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterAccessControlAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAccessControlAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster AccessControl attributes
-    MTRClusterAccessControlAttributeAclID = 0x00000000,
-    MTRClusterAccessControlAttributeExtensionID = 0x00000001,
-    MTRClusterAccessControlAttributeSubjectsPerAccessControlEntryID = 0x00000002,
-    MTRClusterAccessControlAttributeTargetsPerAccessControlEntryID = 0x00000003,
-    MTRClusterAccessControlAttributeAccessControlEntriesPerFabricID = 0x00000004,
-    MTRClusterAccessControlAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterAccessControlAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterAccessControlAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterAccessControlAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterAccessControlAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterAccessControlAttributeAclID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterAccessControlAttributeExtensionID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterAccessControlAttributeSubjectsPerAccessControlEntryID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterAccessControlAttributeTargetsPerAccessControlEntryID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterAccessControlAttributeAccessControlEntriesPerFabricID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterAccessControlAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterAccessControlAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterAccessControlAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterAccessControlAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterAccessControlAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster Actions deprecated attribute names
+    MTRClusterActionsAttributeActionListID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterActionsAttributeActionListID")
+    = 0x00000000,
+    MTRClusterActionsAttributeEndpointListsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterActionsAttributeEndpointListsID")
+    = 0x00000001,
+    MTRClusterActionsAttributeSetupURLID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterActionsAttributeSetupURLID")
+    = 0x00000002,
+    MTRClusterActionsAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterActionsAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterActionsAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterActionsAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterActionsAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterActionsAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterActionsAttributeFeatureMapID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterActionsAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterActionsAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterActionsAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster Actions attributes
-    MTRClusterActionsAttributeActionListID = 0x00000000,
-    MTRClusterActionsAttributeEndpointListsID = 0x00000001,
-    MTRClusterActionsAttributeSetupURLID = 0x00000002,
-    MTRClusterActionsAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterActionsAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterActionsAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterActionsAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterActionsAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterActionsAttributeActionListID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterActionsAttributeEndpointListsID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterActionsAttributeSetupURLID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterActionsAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterActionsAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterActionsAttributeAttributeListID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterActionsAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterActionsAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster Basic deprecated attribute names
+    MTRClusterBasicAttributeDataModelRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBasicAttributeDataModelRevisionID")
+    = 0x00000000,
+    MTRClusterBasicAttributeVendorNameID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBasicAttributeVendorNameID")
+    = 0x00000001,
+    MTRClusterBasicAttributeVendorIDID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBasicAttributeVendorIDID")
+    = 0x00000002,
+    MTRClusterBasicAttributeProductNameID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBasicAttributeProductNameID")
+    = 0x00000003,
+    MTRClusterBasicAttributeProductIDID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBasicAttributeProductIDID")
+    = 0x00000004,
+    MTRClusterBasicAttributeNodeLabelID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBasicAttributeNodeLabelID")
+    = 0x00000005,
+    MTRClusterBasicAttributeLocationID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBasicAttributeLocationID")
+    = 0x00000006,
+    MTRClusterBasicAttributeHardwareVersionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBasicAttributeHardwareVersionID")
+    = 0x00000007,
+    MTRClusterBasicAttributeHardwareVersionStringID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBasicAttributeHardwareVersionStringID")
+    = 0x00000008,
+    MTRClusterBasicAttributeSoftwareVersionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBasicAttributeSoftwareVersionID")
+    = 0x00000009,
+    MTRClusterBasicAttributeSoftwareVersionStringID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBasicAttributeSoftwareVersionStringID")
+    = 0x0000000A,
+    MTRClusterBasicAttributeManufacturingDateID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBasicAttributeManufacturingDateID")
+    = 0x0000000B,
+    MTRClusterBasicAttributePartNumberID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBasicAttributePartNumberID")
+    = 0x0000000C,
+    MTRClusterBasicAttributeProductURLID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBasicAttributeProductURLID")
+    = 0x0000000D,
+    MTRClusterBasicAttributeProductLabelID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBasicAttributeProductLabelID")
+    = 0x0000000E,
+    MTRClusterBasicAttributeSerialNumberID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBasicAttributeSerialNumberID")
+    = 0x0000000F,
+    MTRClusterBasicAttributeLocalConfigDisabledID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBasicAttributeLocalConfigDisabledID")
+    = 0x00000010,
+    MTRClusterBasicAttributeReachableID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBasicAttributeReachableID")
+    = 0x00000011,
+    MTRClusterBasicAttributeUniqueIDID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBasicAttributeUniqueIDID")
+    = 0x00000012,
+    MTRClusterBasicAttributeCapabilityMinimaID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBasicAttributeCapabilityMinimaID")
+    = 0x00000013,
+    MTRClusterBasicAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBasicAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterBasicAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBasicAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterBasicAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBasicAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterBasicAttributeFeatureMapID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterBasicAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterBasicAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBasicAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster Basic attributes
-    MTRClusterBasicAttributeDataModelRevisionID = 0x00000000,
-    MTRClusterBasicAttributeVendorNameID = 0x00000001,
-    MTRClusterBasicAttributeVendorIDID = 0x00000002,
-    MTRClusterBasicAttributeProductNameID = 0x00000003,
-    MTRClusterBasicAttributeProductIDID = 0x00000004,
-    MTRClusterBasicAttributeNodeLabelID = 0x00000005,
-    MTRClusterBasicAttributeLocationID = 0x00000006,
-    MTRClusterBasicAttributeHardwareVersionID = 0x00000007,
-    MTRClusterBasicAttributeHardwareVersionStringID = 0x00000008,
-    MTRClusterBasicAttributeSoftwareVersionID = 0x00000009,
-    MTRClusterBasicAttributeSoftwareVersionStringID = 0x0000000A,
-    MTRClusterBasicAttributeManufacturingDateID = 0x0000000B,
-    MTRClusterBasicAttributePartNumberID = 0x0000000C,
-    MTRClusterBasicAttributeProductURLID = 0x0000000D,
-    MTRClusterBasicAttributeProductLabelID = 0x0000000E,
-    MTRClusterBasicAttributeSerialNumberID = 0x0000000F,
-    MTRClusterBasicAttributeLocalConfigDisabledID = 0x00000010,
-    MTRClusterBasicAttributeReachableID = 0x00000011,
-    MTRClusterBasicAttributeUniqueIDID = 0x00000012,
-    MTRClusterBasicAttributeCapabilityMinimaID = 0x00000013,
-    MTRClusterBasicAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterBasicAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterBasicAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterBasicAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterBasicAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterBasicAttributeDataModelRevisionID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterBasicAttributeVendorNameID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterBasicAttributeVendorIDID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterBasicAttributeProductNameID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterBasicAttributeProductIDID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterBasicAttributeNodeLabelID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterBasicAttributeLocationID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterBasicAttributeHardwareVersionID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterBasicAttributeHardwareVersionStringID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterBasicAttributeSoftwareVersionID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRAttributeIDTypeClusterBasicAttributeSoftwareVersionStringID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRAttributeIDTypeClusterBasicAttributeManufacturingDateID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTRAttributeIDTypeClusterBasicAttributePartNumberID MTR_NEWLY_AVAILABLE = 0x0000000C,
+    MTRAttributeIDTypeClusterBasicAttributeProductURLID MTR_NEWLY_AVAILABLE = 0x0000000D,
+    MTRAttributeIDTypeClusterBasicAttributeProductLabelID MTR_NEWLY_AVAILABLE = 0x0000000E,
+    MTRAttributeIDTypeClusterBasicAttributeSerialNumberID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTRAttributeIDTypeClusterBasicAttributeLocalConfigDisabledID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRAttributeIDTypeClusterBasicAttributeReachableID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRAttributeIDTypeClusterBasicAttributeUniqueIDID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRAttributeIDTypeClusterBasicAttributeCapabilityMinimaID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRAttributeIDTypeClusterBasicAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterBasicAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterBasicAttributeAttributeListID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterBasicAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterBasicAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster OtaSoftwareUpdateProvider deprecated attribute names
+    MTRClusterOtaSoftwareUpdateProviderAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterOtaSoftwareUpdateProviderAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterOtaSoftwareUpdateProviderAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterOtaSoftwareUpdateProviderAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterOtaSoftwareUpdateProviderAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster OtaSoftwareUpdateProvider attributes
-    MTRClusterOtaSoftwareUpdateProviderAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterOtaSoftwareUpdateProviderAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterOtaSoftwareUpdateProviderAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterOtaSoftwareUpdateProviderAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterOtaSoftwareUpdateProviderAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster OtaSoftwareUpdateRequestor deprecated attribute names
+    MTRClusterOtaSoftwareUpdateRequestorAttributeDefaultOtaProvidersID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeDefaultOtaProvidersID")
+    = 0x00000000,
+    MTRClusterOtaSoftwareUpdateRequestorAttributeUpdatePossibleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdatePossibleID")
+    = 0x00000001,
+    MTRClusterOtaSoftwareUpdateRequestorAttributeUpdateStateID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdateStateID")
+    = 0x00000002,
+    MTRClusterOtaSoftwareUpdateRequestorAttributeUpdateStateProgressID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdateStateProgressID")
+    = 0x00000003,
+    MTRClusterOtaSoftwareUpdateRequestorAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterOtaSoftwareUpdateRequestorAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterOtaSoftwareUpdateRequestorAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterOtaSoftwareUpdateRequestorAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterOtaSoftwareUpdateRequestorAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster OtaSoftwareUpdateRequestor attributes
-    MTRClusterOtaSoftwareUpdateRequestorAttributeDefaultOtaProvidersID = 0x00000000,
-    MTRClusterOtaSoftwareUpdateRequestorAttributeUpdatePossibleID = 0x00000001,
-    MTRClusterOtaSoftwareUpdateRequestorAttributeUpdateStateID = 0x00000002,
-    MTRClusterOtaSoftwareUpdateRequestorAttributeUpdateStateProgressID = 0x00000003,
-    MTRClusterOtaSoftwareUpdateRequestorAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterOtaSoftwareUpdateRequestorAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterOtaSoftwareUpdateRequestorAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterOtaSoftwareUpdateRequestorAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterOtaSoftwareUpdateRequestorAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeDefaultOtaProvidersID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdatePossibleID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdateStateID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdateStateProgressID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster LocalizationConfiguration deprecated attribute names
+    MTRClusterLocalizationConfigurationAttributeActiveLocaleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLocalizationConfigurationAttributeActiveLocaleID")
+    = 0x00000000,
+    MTRClusterLocalizationConfigurationAttributeSupportedLocalesID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLocalizationConfigurationAttributeSupportedLocalesID")
+    = 0x00000001,
+    MTRClusterLocalizationConfigurationAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLocalizationConfigurationAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterLocalizationConfigurationAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLocalizationConfigurationAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterLocalizationConfigurationAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLocalizationConfigurationAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterLocalizationConfigurationAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLocalizationConfigurationAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterLocalizationConfigurationAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLocalizationConfigurationAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster LocalizationConfiguration attributes
-    MTRClusterLocalizationConfigurationAttributeActiveLocaleID = 0x00000000,
-    MTRClusterLocalizationConfigurationAttributeSupportedLocalesID = 0x00000001,
-    MTRClusterLocalizationConfigurationAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterLocalizationConfigurationAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterLocalizationConfigurationAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterLocalizationConfigurationAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterLocalizationConfigurationAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterLocalizationConfigurationAttributeActiveLocaleID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterLocalizationConfigurationAttributeSupportedLocalesID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterLocalizationConfigurationAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterLocalizationConfigurationAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterLocalizationConfigurationAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterLocalizationConfigurationAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterLocalizationConfigurationAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster TimeFormatLocalization deprecated attribute names
+    MTRClusterTimeFormatLocalizationAttributeHourFormatID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeHourFormatID")
+    = 0x00000000,
+    MTRClusterTimeFormatLocalizationAttributeActiveCalendarTypeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeActiveCalendarTypeID")
+    = 0x00000001,
+    MTRClusterTimeFormatLocalizationAttributeSupportedCalendarTypesID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeSupportedCalendarTypesID")
+    = 0x00000002,
+    MTRClusterTimeFormatLocalizationAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterTimeFormatLocalizationAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterTimeFormatLocalizationAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterTimeFormatLocalizationAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterTimeFormatLocalizationAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster TimeFormatLocalization attributes
-    MTRClusterTimeFormatLocalizationAttributeHourFormatID = 0x00000000,
-    MTRClusterTimeFormatLocalizationAttributeActiveCalendarTypeID = 0x00000001,
-    MTRClusterTimeFormatLocalizationAttributeSupportedCalendarTypesID = 0x00000002,
-    MTRClusterTimeFormatLocalizationAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterTimeFormatLocalizationAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterTimeFormatLocalizationAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterTimeFormatLocalizationAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterTimeFormatLocalizationAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeHourFormatID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeActiveCalendarTypeID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeSupportedCalendarTypesID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster UnitLocalization deprecated attribute names
+    MTRClusterUnitLocalizationAttributeTemperatureUnitID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitLocalizationAttributeTemperatureUnitID")
+    = 0x00000000,
+    MTRClusterUnitLocalizationAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitLocalizationAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterUnitLocalizationAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitLocalizationAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterUnitLocalizationAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitLocalizationAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterUnitLocalizationAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitLocalizationAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterUnitLocalizationAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitLocalizationAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster UnitLocalization attributes
-    MTRClusterUnitLocalizationAttributeTemperatureUnitID = 0x00000000,
-    MTRClusterUnitLocalizationAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterUnitLocalizationAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterUnitLocalizationAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterUnitLocalizationAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterUnitLocalizationAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterUnitLocalizationAttributeTemperatureUnitID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterUnitLocalizationAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterUnitLocalizationAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterUnitLocalizationAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterUnitLocalizationAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterUnitLocalizationAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster PowerSourceConfiguration deprecated attribute names
+    MTRClusterPowerSourceConfigurationAttributeSourcesID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeSourcesID")
+    = 0x00000000,
+    MTRClusterPowerSourceConfigurationAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterPowerSourceConfigurationAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterPowerSourceConfigurationAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterPowerSourceConfigurationAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterPowerSourceConfigurationAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster PowerSourceConfiguration attributes
-    MTRClusterPowerSourceConfigurationAttributeSourcesID = 0x00000000,
-    MTRClusterPowerSourceConfigurationAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterPowerSourceConfigurationAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterPowerSourceConfigurationAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterPowerSourceConfigurationAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterPowerSourceConfigurationAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeSourcesID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster PowerSource deprecated attribute names
+    MTRClusterPowerSourceAttributeStatusID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterPowerSourceAttributeStatusID")
+    = 0x00000000,
+    MTRClusterPowerSourceAttributeOrderID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterPowerSourceAttributeOrderID")
+    = 0x00000001,
+    MTRClusterPowerSourceAttributeDescriptionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeDescriptionID")
+    = 0x00000002,
+    MTRClusterPowerSourceAttributeWiredAssessedInputVoltageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeWiredAssessedInputVoltageID")
+    = 0x00000003,
+    MTRClusterPowerSourceAttributeWiredAssessedInputFrequencyID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeWiredAssessedInputFrequencyID")
+    = 0x00000004,
+    MTRClusterPowerSourceAttributeWiredCurrentTypeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeWiredCurrentTypeID")
+    = 0x00000005,
+    MTRClusterPowerSourceAttributeWiredAssessedCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeWiredAssessedCurrentID")
+    = 0x00000006,
+    MTRClusterPowerSourceAttributeWiredNominalVoltageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeWiredNominalVoltageID")
+    = 0x00000007,
+    MTRClusterPowerSourceAttributeWiredMaximumCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeWiredMaximumCurrentID")
+    = 0x00000008,
+    MTRClusterPowerSourceAttributeWiredPresentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeWiredPresentID")
+    = 0x00000009,
+    MTRClusterPowerSourceAttributeActiveWiredFaultsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeActiveWiredFaultsID")
+    = 0x0000000A,
+    MTRClusterPowerSourceAttributeBatVoltageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatVoltageID")
+    = 0x0000000B,
+    MTRClusterPowerSourceAttributeBatPercentRemainingID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatPercentRemainingID")
+    = 0x0000000C,
+    MTRClusterPowerSourceAttributeBatTimeRemainingID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatTimeRemainingID")
+    = 0x0000000D,
+    MTRClusterPowerSourceAttributeBatChargeLevelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatChargeLevelID")
+    = 0x0000000E,
+    MTRClusterPowerSourceAttributeBatReplacementNeededID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatReplacementNeededID")
+    = 0x0000000F,
+    MTRClusterPowerSourceAttributeBatReplaceabilityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatReplaceabilityID")
+    = 0x00000010,
+    MTRClusterPowerSourceAttributeBatPresentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatPresentID")
+    = 0x00000011,
+    MTRClusterPowerSourceAttributeActiveBatFaultsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeActiveBatFaultsID")
+    = 0x00000012,
+    MTRClusterPowerSourceAttributeBatReplacementDescriptionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatReplacementDescriptionID")
+    = 0x00000013,
+    MTRClusterPowerSourceAttributeBatCommonDesignationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatCommonDesignationID")
+    = 0x00000014,
+    MTRClusterPowerSourceAttributeBatANSIDesignationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatANSIDesignationID")
+    = 0x00000015,
+    MTRClusterPowerSourceAttributeBatIECDesignationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatIECDesignationID")
+    = 0x00000016,
+    MTRClusterPowerSourceAttributeBatApprovedChemistryID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatApprovedChemistryID")
+    = 0x00000017,
+    MTRClusterPowerSourceAttributeBatCapacityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatCapacityID")
+    = 0x00000018,
+    MTRClusterPowerSourceAttributeBatQuantityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatQuantityID")
+    = 0x00000019,
+    MTRClusterPowerSourceAttributeBatChargeStateID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatChargeStateID")
+    = 0x0000001A,
+    MTRClusterPowerSourceAttributeBatTimeToFullChargeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatTimeToFullChargeID")
+    = 0x0000001B,
+    MTRClusterPowerSourceAttributeBatFunctionalWhileChargingID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatFunctionalWhileChargingID")
+    = 0x0000001C,
+    MTRClusterPowerSourceAttributeBatChargingCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeBatChargingCurrentID")
+    = 0x0000001D,
+    MTRClusterPowerSourceAttributeActiveBatChargeFaultsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeActiveBatChargeFaultsID")
+    = 0x0000001E,
+    MTRClusterPowerSourceAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterPowerSourceAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterPowerSourceAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterPowerSourceAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterPowerSourceAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPowerSourceAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster PowerSource attributes
-    MTRClusterPowerSourceAttributeStatusID = 0x00000000,
-    MTRClusterPowerSourceAttributeOrderID = 0x00000001,
-    MTRClusterPowerSourceAttributeDescriptionID = 0x00000002,
-    MTRClusterPowerSourceAttributeWiredAssessedInputVoltageID = 0x00000003,
-    MTRClusterPowerSourceAttributeWiredAssessedInputFrequencyID = 0x00000004,
-    MTRClusterPowerSourceAttributeWiredCurrentTypeID = 0x00000005,
-    MTRClusterPowerSourceAttributeWiredAssessedCurrentID = 0x00000006,
-    MTRClusterPowerSourceAttributeWiredNominalVoltageID = 0x00000007,
-    MTRClusterPowerSourceAttributeWiredMaximumCurrentID = 0x00000008,
-    MTRClusterPowerSourceAttributeWiredPresentID = 0x00000009,
-    MTRClusterPowerSourceAttributeActiveWiredFaultsID = 0x0000000A,
-    MTRClusterPowerSourceAttributeBatVoltageID = 0x0000000B,
-    MTRClusterPowerSourceAttributeBatPercentRemainingID = 0x0000000C,
-    MTRClusterPowerSourceAttributeBatTimeRemainingID = 0x0000000D,
-    MTRClusterPowerSourceAttributeBatChargeLevelID = 0x0000000E,
-    MTRClusterPowerSourceAttributeBatReplacementNeededID = 0x0000000F,
-    MTRClusterPowerSourceAttributeBatReplaceabilityID = 0x00000010,
-    MTRClusterPowerSourceAttributeBatPresentID = 0x00000011,
-    MTRClusterPowerSourceAttributeActiveBatFaultsID = 0x00000012,
-    MTRClusterPowerSourceAttributeBatReplacementDescriptionID = 0x00000013,
-    MTRClusterPowerSourceAttributeBatCommonDesignationID = 0x00000014,
-    MTRClusterPowerSourceAttributeBatANSIDesignationID = 0x00000015,
-    MTRClusterPowerSourceAttributeBatIECDesignationID = 0x00000016,
-    MTRClusterPowerSourceAttributeBatApprovedChemistryID = 0x00000017,
-    MTRClusterPowerSourceAttributeBatCapacityID = 0x00000018,
-    MTRClusterPowerSourceAttributeBatQuantityID = 0x00000019,
-    MTRClusterPowerSourceAttributeBatChargeStateID = 0x0000001A,
-    MTRClusterPowerSourceAttributeBatTimeToFullChargeID = 0x0000001B,
-    MTRClusterPowerSourceAttributeBatFunctionalWhileChargingID = 0x0000001C,
-    MTRClusterPowerSourceAttributeBatChargingCurrentID = 0x0000001D,
-    MTRClusterPowerSourceAttributeActiveBatChargeFaultsID = 0x0000001E,
-    MTRClusterPowerSourceAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterPowerSourceAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterPowerSourceAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterPowerSourceAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterPowerSourceAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterPowerSourceAttributeStatusID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterPowerSourceAttributeOrderID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterPowerSourceAttributeDescriptionID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterPowerSourceAttributeWiredAssessedInputVoltageID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterPowerSourceAttributeWiredAssessedInputFrequencyID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterPowerSourceAttributeWiredCurrentTypeID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterPowerSourceAttributeWiredAssessedCurrentID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterPowerSourceAttributeWiredNominalVoltageID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterPowerSourceAttributeWiredMaximumCurrentID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterPowerSourceAttributeWiredPresentID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRAttributeIDTypeClusterPowerSourceAttributeActiveWiredFaultsID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatVoltageID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatPercentRemainingID MTR_NEWLY_AVAILABLE = 0x0000000C,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatTimeRemainingID MTR_NEWLY_AVAILABLE = 0x0000000D,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatChargeLevelID MTR_NEWLY_AVAILABLE = 0x0000000E,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatReplacementNeededID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatReplaceabilityID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatPresentID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRAttributeIDTypeClusterPowerSourceAttributeActiveBatFaultsID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatReplacementDescriptionID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatCommonDesignationID MTR_NEWLY_AVAILABLE = 0x00000014,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatANSIDesignationID MTR_NEWLY_AVAILABLE = 0x00000015,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatIECDesignationID MTR_NEWLY_AVAILABLE = 0x00000016,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatApprovedChemistryID MTR_NEWLY_AVAILABLE = 0x00000017,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatCapacityID MTR_NEWLY_AVAILABLE = 0x00000018,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatQuantityID MTR_NEWLY_AVAILABLE = 0x00000019,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatChargeStateID MTR_NEWLY_AVAILABLE = 0x0000001A,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatTimeToFullChargeID MTR_NEWLY_AVAILABLE = 0x0000001B,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatFunctionalWhileChargingID MTR_NEWLY_AVAILABLE = 0x0000001C,
+    MTRAttributeIDTypeClusterPowerSourceAttributeBatChargingCurrentID MTR_NEWLY_AVAILABLE = 0x0000001D,
+    MTRAttributeIDTypeClusterPowerSourceAttributeActiveBatChargeFaultsID MTR_NEWLY_AVAILABLE = 0x0000001E,
+    MTRAttributeIDTypeClusterPowerSourceAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterPowerSourceAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterPowerSourceAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterPowerSourceAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterPowerSourceAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster GeneralCommissioning deprecated attribute names
+    MTRClusterGeneralCommissioningAttributeBreadcrumbID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralCommissioningAttributeBreadcrumbID")
+    = 0x00000000,
+    MTRClusterGeneralCommissioningAttributeBasicCommissioningInfoID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralCommissioningAttributeBasicCommissioningInfoID")
+    = 0x00000001,
+    MTRClusterGeneralCommissioningAttributeRegulatoryConfigID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralCommissioningAttributeRegulatoryConfigID")
+    = 0x00000002,
+    MTRClusterGeneralCommissioningAttributeLocationCapabilityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralCommissioningAttributeLocationCapabilityID")
+    = 0x00000003,
+    MTRClusterGeneralCommissioningAttributeSupportsConcurrentConnectionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralCommissioningAttributeSupportsConcurrentConnectionID")
+    = 0x00000004,
+    MTRClusterGeneralCommissioningAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralCommissioningAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterGeneralCommissioningAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralCommissioningAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterGeneralCommissioningAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralCommissioningAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterGeneralCommissioningAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralCommissioningAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterGeneralCommissioningAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralCommissioningAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster GeneralCommissioning attributes
-    MTRClusterGeneralCommissioningAttributeBreadcrumbID = 0x00000000,
-    MTRClusterGeneralCommissioningAttributeBasicCommissioningInfoID = 0x00000001,
-    MTRClusterGeneralCommissioningAttributeRegulatoryConfigID = 0x00000002,
-    MTRClusterGeneralCommissioningAttributeLocationCapabilityID = 0x00000003,
-    MTRClusterGeneralCommissioningAttributeSupportsConcurrentConnectionID = 0x00000004,
-    MTRClusterGeneralCommissioningAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterGeneralCommissioningAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterGeneralCommissioningAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterGeneralCommissioningAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterGeneralCommissioningAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterGeneralCommissioningAttributeBreadcrumbID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterGeneralCommissioningAttributeBasicCommissioningInfoID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterGeneralCommissioningAttributeRegulatoryConfigID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterGeneralCommissioningAttributeLocationCapabilityID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterGeneralCommissioningAttributeSupportsConcurrentConnectionID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterGeneralCommissioningAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterGeneralCommissioningAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterGeneralCommissioningAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterGeneralCommissioningAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterGeneralCommissioningAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster NetworkCommissioning deprecated attribute names
+    MTRClusterNetworkCommissioningAttributeMaxNetworksID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterNetworkCommissioningAttributeMaxNetworksID")
+    = 0x00000000,
+    MTRClusterNetworkCommissioningAttributeNetworksID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterNetworkCommissioningAttributeNetworksID")
+    = 0x00000001,
+    MTRClusterNetworkCommissioningAttributeScanMaxTimeSecondsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterNetworkCommissioningAttributeScanMaxTimeSecondsID")
+    = 0x00000002,
+    MTRClusterNetworkCommissioningAttributeConnectMaxTimeSecondsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterNetworkCommissioningAttributeConnectMaxTimeSecondsID")
+    = 0x00000003,
+    MTRClusterNetworkCommissioningAttributeInterfaceEnabledID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterNetworkCommissioningAttributeInterfaceEnabledID")
+    = 0x00000004,
+    MTRClusterNetworkCommissioningAttributeLastNetworkingStatusID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterNetworkCommissioningAttributeLastNetworkingStatusID")
+    = 0x00000005,
+    MTRClusterNetworkCommissioningAttributeLastNetworkIDID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterNetworkCommissioningAttributeLastNetworkIDID")
+    = 0x00000006,
+    MTRClusterNetworkCommissioningAttributeLastConnectErrorValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterNetworkCommissioningAttributeLastConnectErrorValueID")
+    = 0x00000007,
+    MTRClusterNetworkCommissioningAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterNetworkCommissioningAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterNetworkCommissioningAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterNetworkCommissioningAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterNetworkCommissioningAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterNetworkCommissioningAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterNetworkCommissioningAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterNetworkCommissioningAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterNetworkCommissioningAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterNetworkCommissioningAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster NetworkCommissioning attributes
-    MTRClusterNetworkCommissioningAttributeMaxNetworksID = 0x00000000,
-    MTRClusterNetworkCommissioningAttributeNetworksID = 0x00000001,
-    MTRClusterNetworkCommissioningAttributeScanMaxTimeSecondsID = 0x00000002,
-    MTRClusterNetworkCommissioningAttributeConnectMaxTimeSecondsID = 0x00000003,
-    MTRClusterNetworkCommissioningAttributeInterfaceEnabledID = 0x00000004,
-    MTRClusterNetworkCommissioningAttributeLastNetworkingStatusID = 0x00000005,
-    MTRClusterNetworkCommissioningAttributeLastNetworkIDID = 0x00000006,
-    MTRClusterNetworkCommissioningAttributeLastConnectErrorValueID = 0x00000007,
-    MTRClusterNetworkCommissioningAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterNetworkCommissioningAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterNetworkCommissioningAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterNetworkCommissioningAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterNetworkCommissioningAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterNetworkCommissioningAttributeMaxNetworksID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterNetworkCommissioningAttributeNetworksID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterNetworkCommissioningAttributeScanMaxTimeSecondsID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterNetworkCommissioningAttributeConnectMaxTimeSecondsID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterNetworkCommissioningAttributeInterfaceEnabledID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterNetworkCommissioningAttributeLastNetworkingStatusID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterNetworkCommissioningAttributeLastNetworkIDID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterNetworkCommissioningAttributeLastConnectErrorValueID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterNetworkCommissioningAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterNetworkCommissioningAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterNetworkCommissioningAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterNetworkCommissioningAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterNetworkCommissioningAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster DiagnosticLogs deprecated attribute names
+    MTRClusterDiagnosticLogsAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDiagnosticLogsAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterDiagnosticLogsAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDiagnosticLogsAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterDiagnosticLogsAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDiagnosticLogsAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterDiagnosticLogsAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDiagnosticLogsAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterDiagnosticLogsAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDiagnosticLogsAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster DiagnosticLogs attributes
-    MTRClusterDiagnosticLogsAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterDiagnosticLogsAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterDiagnosticLogsAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterDiagnosticLogsAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterDiagnosticLogsAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterDiagnosticLogsAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterDiagnosticLogsAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterDiagnosticLogsAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterDiagnosticLogsAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterDiagnosticLogsAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster GeneralDiagnostics deprecated attribute names
+    MTRClusterGeneralDiagnosticsAttributeNetworkInterfacesID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeNetworkInterfacesID")
+    = 0x00000000,
+    MTRClusterGeneralDiagnosticsAttributeRebootCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeRebootCountID")
+    = 0x00000001,
+    MTRClusterGeneralDiagnosticsAttributeUpTimeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeUpTimeID")
+    = 0x00000002,
+    MTRClusterGeneralDiagnosticsAttributeTotalOperationalHoursID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeTotalOperationalHoursID")
+    = 0x00000003,
+    MTRClusterGeneralDiagnosticsAttributeBootReasonsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeBootReasonsID")
+    = 0x00000004,
+    MTRClusterGeneralDiagnosticsAttributeActiveHardwareFaultsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeActiveHardwareFaultsID")
+    = 0x00000005,
+    MTRClusterGeneralDiagnosticsAttributeActiveRadioFaultsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeActiveRadioFaultsID")
+    = 0x00000006,
+    MTRClusterGeneralDiagnosticsAttributeActiveNetworkFaultsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeActiveNetworkFaultsID")
+    = 0x00000007,
+    MTRClusterGeneralDiagnosticsAttributeTestEventTriggersEnabledID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeTestEventTriggersEnabledID")
+    = 0x00000008,
+    MTRClusterGeneralDiagnosticsAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterGeneralDiagnosticsAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterGeneralDiagnosticsAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterGeneralDiagnosticsAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterGeneralDiagnosticsAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster GeneralDiagnostics attributes
-    MTRClusterGeneralDiagnosticsAttributeNetworkInterfacesID = 0x00000000,
-    MTRClusterGeneralDiagnosticsAttributeRebootCountID = 0x00000001,
-    MTRClusterGeneralDiagnosticsAttributeUpTimeID = 0x00000002,
-    MTRClusterGeneralDiagnosticsAttributeTotalOperationalHoursID = 0x00000003,
-    MTRClusterGeneralDiagnosticsAttributeBootReasonsID = 0x00000004,
-    MTRClusterGeneralDiagnosticsAttributeActiveHardwareFaultsID = 0x00000005,
-    MTRClusterGeneralDiagnosticsAttributeActiveRadioFaultsID = 0x00000006,
-    MTRClusterGeneralDiagnosticsAttributeActiveNetworkFaultsID = 0x00000007,
-    MTRClusterGeneralDiagnosticsAttributeTestEventTriggersEnabledID = 0x00000008,
-    MTRClusterGeneralDiagnosticsAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterGeneralDiagnosticsAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterGeneralDiagnosticsAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterGeneralDiagnosticsAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterGeneralDiagnosticsAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeNetworkInterfacesID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeRebootCountID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeUpTimeID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeTotalOperationalHoursID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeBootReasonsID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeActiveHardwareFaultsID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeActiveRadioFaultsID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeActiveNetworkFaultsID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeTestEventTriggersEnabledID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster SoftwareDiagnostics deprecated attribute names
+    MTRClusterSoftwareDiagnosticsAttributeThreadMetricsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeThreadMetricsID")
+    = 0x00000000,
+    MTRClusterSoftwareDiagnosticsAttributeCurrentHeapFreeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeCurrentHeapFreeID")
+    = 0x00000001,
+    MTRClusterSoftwareDiagnosticsAttributeCurrentHeapUsedID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeCurrentHeapUsedID")
+    = 0x00000002,
+    MTRClusterSoftwareDiagnosticsAttributeCurrentHeapHighWatermarkID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeCurrentHeapHighWatermarkID")
+    = 0x00000003,
+    MTRClusterSoftwareDiagnosticsAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterSoftwareDiagnosticsAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterSoftwareDiagnosticsAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterSoftwareDiagnosticsAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterSoftwareDiagnosticsAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster SoftwareDiagnostics attributes
-    MTRClusterSoftwareDiagnosticsAttributeThreadMetricsID = 0x00000000,
-    MTRClusterSoftwareDiagnosticsAttributeCurrentHeapFreeID = 0x00000001,
-    MTRClusterSoftwareDiagnosticsAttributeCurrentHeapUsedID = 0x00000002,
-    MTRClusterSoftwareDiagnosticsAttributeCurrentHeapHighWatermarkID = 0x00000003,
-    MTRClusterSoftwareDiagnosticsAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterSoftwareDiagnosticsAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterSoftwareDiagnosticsAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterSoftwareDiagnosticsAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterSoftwareDiagnosticsAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeThreadMetricsID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeCurrentHeapFreeID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeCurrentHeapUsedID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeCurrentHeapHighWatermarkID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster ThreadNetworkDiagnostics deprecated attribute names
+    MTRClusterThreadNetworkDiagnosticsAttributeChannelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeChannelID")
+    = 0x00000000,
+    MTRClusterThreadNetworkDiagnosticsAttributeRoutingRoleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRoutingRoleID")
+    = 0x00000001,
+    MTRClusterThreadNetworkDiagnosticsAttributeNetworkNameID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeNetworkNameID")
+    = 0x00000002,
+    MTRClusterThreadNetworkDiagnosticsAttributePanIdID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributePanIdID")
+    = 0x00000003,
+    MTRClusterThreadNetworkDiagnosticsAttributeExtendedPanIdID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeExtendedPanIdID")
+    = 0x00000004,
+    MTRClusterThreadNetworkDiagnosticsAttributeMeshLocalPrefixID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeMeshLocalPrefixID")
+    = 0x00000005,
+    MTRClusterThreadNetworkDiagnosticsAttributeOverrunCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeOverrunCountID")
+    = 0x00000006,
+    MTRClusterThreadNetworkDiagnosticsAttributeNeighborTableListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeNeighborTableListID")
+    = 0x00000007,
+    MTRClusterThreadNetworkDiagnosticsAttributeRouteTableListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRouteTableListID")
+    = 0x00000008,
+    MTRClusterThreadNetworkDiagnosticsAttributePartitionIdID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributePartitionIdID")
+    = 0x00000009,
+    MTRClusterThreadNetworkDiagnosticsAttributeWeightingID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeWeightingID")
+    = 0x0000000A,
+    MTRClusterThreadNetworkDiagnosticsAttributeDataVersionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeDataVersionID")
+    = 0x0000000B,
+    MTRClusterThreadNetworkDiagnosticsAttributeStableDataVersionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeStableDataVersionID")
+    = 0x0000000C,
+    MTRClusterThreadNetworkDiagnosticsAttributeLeaderRouterIdID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeLeaderRouterIdID")
+    = 0x0000000D,
+    MTRClusterThreadNetworkDiagnosticsAttributeDetachedRoleCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeDetachedRoleCountID")
+    = 0x0000000E,
+    MTRClusterThreadNetworkDiagnosticsAttributeChildRoleCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeChildRoleCountID")
+    = 0x0000000F,
+    MTRClusterThreadNetworkDiagnosticsAttributeRouterRoleCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRouterRoleCountID")
+    = 0x00000010,
+    MTRClusterThreadNetworkDiagnosticsAttributeLeaderRoleCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeLeaderRoleCountID")
+    = 0x00000011,
+    MTRClusterThreadNetworkDiagnosticsAttributeAttachAttemptCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeAttachAttemptCountID")
+    = 0x00000012,
+    MTRClusterThreadNetworkDiagnosticsAttributePartitionIdChangeCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributePartitionIdChangeCountID")
+    = 0x00000013,
+    MTRClusterThreadNetworkDiagnosticsAttributeBetterPartitionAttachAttemptCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeBetterPartitionAttachAttemptCountID")
+    = 0x00000014,
+    MTRClusterThreadNetworkDiagnosticsAttributeParentChangeCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeParentChangeCountID")
+    = 0x00000015,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxTotalCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxTotalCountID")
+    = 0x00000016,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxUnicastCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxUnicastCountID")
+    = 0x00000017,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxBroadcastCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxBroadcastCountID")
+    = 0x00000018,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxAckRequestedCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxAckRequestedCountID")
+    = 0x00000019,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxAckedCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxAckedCountID")
+    = 0x0000001A,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxNoAckRequestedCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxNoAckRequestedCountID")
+    = 0x0000001B,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxDataCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxDataCountID")
+    = 0x0000001C,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxDataPollCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxDataPollCountID")
+    = 0x0000001D,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxBeaconCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxBeaconCountID")
+    = 0x0000001E,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxBeaconRequestCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxBeaconRequestCountID")
+    = 0x0000001F,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxOtherCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxOtherCountID")
+    = 0x00000020,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxRetryCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxRetryCountID")
+    = 0x00000021,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxDirectMaxRetryExpiryCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxDirectMaxRetryExpiryCountID")
+    = 0x00000022,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxIndirectMaxRetryExpiryCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxIndirectMaxRetryExpiryCountID")
+    = 0x00000023,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxErrCcaCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxErrCcaCountID")
+    = 0x00000024,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxErrAbortCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxErrAbortCountID")
+    = 0x00000025,
+    MTRClusterThreadNetworkDiagnosticsAttributeTxErrBusyChannelCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxErrBusyChannelCountID")
+    = 0x00000026,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxTotalCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxTotalCountID")
+    = 0x00000027,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxUnicastCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxUnicastCountID")
+    = 0x00000028,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxBroadcastCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxBroadcastCountID")
+    = 0x00000029,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxDataCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxDataCountID")
+    = 0x0000002A,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxDataPollCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxDataPollCountID")
+    = 0x0000002B,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxBeaconCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxBeaconCountID")
+    = 0x0000002C,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxBeaconRequestCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxBeaconRequestCountID")
+    = 0x0000002D,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxOtherCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxOtherCountID")
+    = 0x0000002E,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxAddressFilteredCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxAddressFilteredCountID")
+    = 0x0000002F,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxDestAddrFilteredCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxDestAddrFilteredCountID")
+    = 0x00000030,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxDuplicatedCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxDuplicatedCountID")
+    = 0x00000031,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxErrNoFrameCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrNoFrameCountID")
+    = 0x00000032,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxErrUnknownNeighborCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrUnknownNeighborCountID")
+    = 0x00000033,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxErrInvalidSrcAddrCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrInvalidSrcAddrCountID")
+    = 0x00000034,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxErrSecCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrSecCountID")
+    = 0x00000035,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxErrFcsCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrFcsCountID")
+    = 0x00000036,
+    MTRClusterThreadNetworkDiagnosticsAttributeRxErrOtherCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrOtherCountID")
+    = 0x00000037,
+    MTRClusterThreadNetworkDiagnosticsAttributeActiveTimestampID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeActiveTimestampID")
+    = 0x00000038,
+    MTRClusterThreadNetworkDiagnosticsAttributePendingTimestampID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributePendingTimestampID")
+    = 0x00000039,
+    MTRClusterThreadNetworkDiagnosticsAttributeDelayID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeDelayID")
+    = 0x0000003A,
+    MTRClusterThreadNetworkDiagnosticsAttributeSecurityPolicyID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeSecurityPolicyID")
+    = 0x0000003B,
+    MTRClusterThreadNetworkDiagnosticsAttributeChannelPage0MaskID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeChannelPage0MaskID")
+    = 0x0000003C,
+    MTRClusterThreadNetworkDiagnosticsAttributeOperationalDatasetComponentsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeOperationalDatasetComponentsID")
+    = 0x0000003D,
+    MTRClusterThreadNetworkDiagnosticsAttributeActiveNetworkFaultsListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeActiveNetworkFaultsListID")
+    = 0x0000003E,
+    MTRClusterThreadNetworkDiagnosticsAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterThreadNetworkDiagnosticsAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterThreadNetworkDiagnosticsAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterThreadNetworkDiagnosticsAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterThreadNetworkDiagnosticsAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster ThreadNetworkDiagnostics attributes
-    MTRClusterThreadNetworkDiagnosticsAttributeChannelID = 0x00000000,
-    MTRClusterThreadNetworkDiagnosticsAttributeRoutingRoleID = 0x00000001,
-    MTRClusterThreadNetworkDiagnosticsAttributeNetworkNameID = 0x00000002,
-    MTRClusterThreadNetworkDiagnosticsAttributePanIdID = 0x00000003,
-    MTRClusterThreadNetworkDiagnosticsAttributeExtendedPanIdID = 0x00000004,
-    MTRClusterThreadNetworkDiagnosticsAttributeMeshLocalPrefixID = 0x00000005,
-    MTRClusterThreadNetworkDiagnosticsAttributeOverrunCountID = 0x00000006,
-    MTRClusterThreadNetworkDiagnosticsAttributeNeighborTableListID = 0x00000007,
-    MTRClusterThreadNetworkDiagnosticsAttributeRouteTableListID = 0x00000008,
-    MTRClusterThreadNetworkDiagnosticsAttributePartitionIdID = 0x00000009,
-    MTRClusterThreadNetworkDiagnosticsAttributeWeightingID = 0x0000000A,
-    MTRClusterThreadNetworkDiagnosticsAttributeDataVersionID = 0x0000000B,
-    MTRClusterThreadNetworkDiagnosticsAttributeStableDataVersionID = 0x0000000C,
-    MTRClusterThreadNetworkDiagnosticsAttributeLeaderRouterIdID = 0x0000000D,
-    MTRClusterThreadNetworkDiagnosticsAttributeDetachedRoleCountID = 0x0000000E,
-    MTRClusterThreadNetworkDiagnosticsAttributeChildRoleCountID = 0x0000000F,
-    MTRClusterThreadNetworkDiagnosticsAttributeRouterRoleCountID = 0x00000010,
-    MTRClusterThreadNetworkDiagnosticsAttributeLeaderRoleCountID = 0x00000011,
-    MTRClusterThreadNetworkDiagnosticsAttributeAttachAttemptCountID = 0x00000012,
-    MTRClusterThreadNetworkDiagnosticsAttributePartitionIdChangeCountID = 0x00000013,
-    MTRClusterThreadNetworkDiagnosticsAttributeBetterPartitionAttachAttemptCountID = 0x00000014,
-    MTRClusterThreadNetworkDiagnosticsAttributeParentChangeCountID = 0x00000015,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxTotalCountID = 0x00000016,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxUnicastCountID = 0x00000017,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxBroadcastCountID = 0x00000018,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxAckRequestedCountID = 0x00000019,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxAckedCountID = 0x0000001A,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxNoAckRequestedCountID = 0x0000001B,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxDataCountID = 0x0000001C,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxDataPollCountID = 0x0000001D,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxBeaconCountID = 0x0000001E,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxBeaconRequestCountID = 0x0000001F,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxOtherCountID = 0x00000020,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxRetryCountID = 0x00000021,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxDirectMaxRetryExpiryCountID = 0x00000022,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxIndirectMaxRetryExpiryCountID = 0x00000023,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxErrCcaCountID = 0x00000024,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxErrAbortCountID = 0x00000025,
-    MTRClusterThreadNetworkDiagnosticsAttributeTxErrBusyChannelCountID = 0x00000026,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxTotalCountID = 0x00000027,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxUnicastCountID = 0x00000028,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxBroadcastCountID = 0x00000029,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxDataCountID = 0x0000002A,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxDataPollCountID = 0x0000002B,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxBeaconCountID = 0x0000002C,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxBeaconRequestCountID = 0x0000002D,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxOtherCountID = 0x0000002E,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxAddressFilteredCountID = 0x0000002F,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxDestAddrFilteredCountID = 0x00000030,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxDuplicatedCountID = 0x00000031,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxErrNoFrameCountID = 0x00000032,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxErrUnknownNeighborCountID = 0x00000033,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxErrInvalidSrcAddrCountID = 0x00000034,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxErrSecCountID = 0x00000035,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxErrFcsCountID = 0x00000036,
-    MTRClusterThreadNetworkDiagnosticsAttributeRxErrOtherCountID = 0x00000037,
-    MTRClusterThreadNetworkDiagnosticsAttributeActiveTimestampID = 0x00000038,
-    MTRClusterThreadNetworkDiagnosticsAttributePendingTimestampID = 0x00000039,
-    MTRClusterThreadNetworkDiagnosticsAttributeDelayID = 0x0000003A,
-    MTRClusterThreadNetworkDiagnosticsAttributeSecurityPolicyID = 0x0000003B,
-    MTRClusterThreadNetworkDiagnosticsAttributeChannelPage0MaskID = 0x0000003C,
-    MTRClusterThreadNetworkDiagnosticsAttributeOperationalDatasetComponentsID = 0x0000003D,
-    MTRClusterThreadNetworkDiagnosticsAttributeActiveNetworkFaultsListID = 0x0000003E,
-    MTRClusterThreadNetworkDiagnosticsAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterThreadNetworkDiagnosticsAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterThreadNetworkDiagnosticsAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterThreadNetworkDiagnosticsAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterThreadNetworkDiagnosticsAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeChannelID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRoutingRoleID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeNetworkNameID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributePanIdID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeExtendedPanIdID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeMeshLocalPrefixID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeOverrunCountID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeNeighborTableListID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRouteTableListID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributePartitionIdID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeWeightingID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeDataVersionID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeStableDataVersionID MTR_NEWLY_AVAILABLE = 0x0000000C,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeLeaderRouterIdID MTR_NEWLY_AVAILABLE = 0x0000000D,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeDetachedRoleCountID MTR_NEWLY_AVAILABLE = 0x0000000E,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeChildRoleCountID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRouterRoleCountID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeLeaderRoleCountID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeAttachAttemptCountID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributePartitionIdChangeCountID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeBetterPartitionAttachAttemptCountID MTR_NEWLY_AVAILABLE = 0x00000014,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeParentChangeCountID MTR_NEWLY_AVAILABLE = 0x00000015,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxTotalCountID MTR_NEWLY_AVAILABLE = 0x00000016,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxUnicastCountID MTR_NEWLY_AVAILABLE = 0x00000017,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxBroadcastCountID MTR_NEWLY_AVAILABLE = 0x00000018,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxAckRequestedCountID MTR_NEWLY_AVAILABLE = 0x00000019,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxAckedCountID MTR_NEWLY_AVAILABLE = 0x0000001A,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxNoAckRequestedCountID MTR_NEWLY_AVAILABLE = 0x0000001B,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxDataCountID MTR_NEWLY_AVAILABLE = 0x0000001C,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxDataPollCountID MTR_NEWLY_AVAILABLE = 0x0000001D,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxBeaconCountID MTR_NEWLY_AVAILABLE = 0x0000001E,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxBeaconRequestCountID MTR_NEWLY_AVAILABLE = 0x0000001F,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxOtherCountID MTR_NEWLY_AVAILABLE = 0x00000020,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxRetryCountID MTR_NEWLY_AVAILABLE = 0x00000021,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxDirectMaxRetryExpiryCountID MTR_NEWLY_AVAILABLE = 0x00000022,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxIndirectMaxRetryExpiryCountID MTR_NEWLY_AVAILABLE = 0x00000023,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxErrCcaCountID MTR_NEWLY_AVAILABLE = 0x00000024,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxErrAbortCountID MTR_NEWLY_AVAILABLE = 0x00000025,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxErrBusyChannelCountID MTR_NEWLY_AVAILABLE = 0x00000026,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxTotalCountID MTR_NEWLY_AVAILABLE = 0x00000027,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxUnicastCountID MTR_NEWLY_AVAILABLE = 0x00000028,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxBroadcastCountID MTR_NEWLY_AVAILABLE = 0x00000029,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxDataCountID MTR_NEWLY_AVAILABLE = 0x0000002A,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxDataPollCountID MTR_NEWLY_AVAILABLE = 0x0000002B,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxBeaconCountID MTR_NEWLY_AVAILABLE = 0x0000002C,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxBeaconRequestCountID MTR_NEWLY_AVAILABLE = 0x0000002D,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxOtherCountID MTR_NEWLY_AVAILABLE = 0x0000002E,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxAddressFilteredCountID MTR_NEWLY_AVAILABLE = 0x0000002F,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxDestAddrFilteredCountID MTR_NEWLY_AVAILABLE = 0x00000030,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxDuplicatedCountID MTR_NEWLY_AVAILABLE = 0x00000031,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrNoFrameCountID MTR_NEWLY_AVAILABLE = 0x00000032,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrUnknownNeighborCountID MTR_NEWLY_AVAILABLE = 0x00000033,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrInvalidSrcAddrCountID MTR_NEWLY_AVAILABLE = 0x00000034,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrSecCountID MTR_NEWLY_AVAILABLE = 0x00000035,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrFcsCountID MTR_NEWLY_AVAILABLE = 0x00000036,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrOtherCountID MTR_NEWLY_AVAILABLE = 0x00000037,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeActiveTimestampID MTR_NEWLY_AVAILABLE = 0x00000038,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributePendingTimestampID MTR_NEWLY_AVAILABLE = 0x00000039,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeDelayID MTR_NEWLY_AVAILABLE = 0x0000003A,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeSecurityPolicyID MTR_NEWLY_AVAILABLE = 0x0000003B,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeChannelPage0MaskID MTR_NEWLY_AVAILABLE = 0x0000003C,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeOperationalDatasetComponentsID MTR_NEWLY_AVAILABLE = 0x0000003D,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeActiveNetworkFaultsListID MTR_NEWLY_AVAILABLE = 0x0000003E,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster WiFiNetworkDiagnostics deprecated attribute names
+    MTRClusterWiFiNetworkDiagnosticsAttributeBssidID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeBssidID")
+    = 0x00000000,
+    MTRClusterWiFiNetworkDiagnosticsAttributeSecurityTypeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeSecurityTypeID")
+    = 0x00000001,
+    MTRClusterWiFiNetworkDiagnosticsAttributeWiFiVersionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeWiFiVersionID")
+    = 0x00000002,
+    MTRClusterWiFiNetworkDiagnosticsAttributeChannelNumberID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeChannelNumberID")
+    = 0x00000003,
+    MTRClusterWiFiNetworkDiagnosticsAttributeRssiID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeRssiID")
+    = 0x00000004,
+    MTRClusterWiFiNetworkDiagnosticsAttributeBeaconLostCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeBeaconLostCountID")
+    = 0x00000005,
+    MTRClusterWiFiNetworkDiagnosticsAttributeBeaconRxCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeBeaconRxCountID")
+    = 0x00000006,
+    MTRClusterWiFiNetworkDiagnosticsAttributePacketMulticastRxCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributePacketMulticastRxCountID")
+    = 0x00000007,
+    MTRClusterWiFiNetworkDiagnosticsAttributePacketMulticastTxCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributePacketMulticastTxCountID")
+    = 0x00000008,
+    MTRClusterWiFiNetworkDiagnosticsAttributePacketUnicastRxCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributePacketUnicastRxCountID")
+    = 0x00000009,
+    MTRClusterWiFiNetworkDiagnosticsAttributePacketUnicastTxCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributePacketUnicastTxCountID")
+    = 0x0000000A,
+    MTRClusterWiFiNetworkDiagnosticsAttributeCurrentMaxRateID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeCurrentMaxRateID")
+    = 0x0000000B,
+    MTRClusterWiFiNetworkDiagnosticsAttributeOverrunCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeOverrunCountID")
+    = 0x0000000C,
+    MTRClusterWiFiNetworkDiagnosticsAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterWiFiNetworkDiagnosticsAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterWiFiNetworkDiagnosticsAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterWiFiNetworkDiagnosticsAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterWiFiNetworkDiagnosticsAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster WiFiNetworkDiagnostics attributes
-    MTRClusterWiFiNetworkDiagnosticsAttributeBssidID = 0x00000000,
-    MTRClusterWiFiNetworkDiagnosticsAttributeSecurityTypeID = 0x00000001,
-    MTRClusterWiFiNetworkDiagnosticsAttributeWiFiVersionID = 0x00000002,
-    MTRClusterWiFiNetworkDiagnosticsAttributeChannelNumberID = 0x00000003,
-    MTRClusterWiFiNetworkDiagnosticsAttributeRssiID = 0x00000004,
-    MTRClusterWiFiNetworkDiagnosticsAttributeBeaconLostCountID = 0x00000005,
-    MTRClusterWiFiNetworkDiagnosticsAttributeBeaconRxCountID = 0x00000006,
-    MTRClusterWiFiNetworkDiagnosticsAttributePacketMulticastRxCountID = 0x00000007,
-    MTRClusterWiFiNetworkDiagnosticsAttributePacketMulticastTxCountID = 0x00000008,
-    MTRClusterWiFiNetworkDiagnosticsAttributePacketUnicastRxCountID = 0x00000009,
-    MTRClusterWiFiNetworkDiagnosticsAttributePacketUnicastTxCountID = 0x0000000A,
-    MTRClusterWiFiNetworkDiagnosticsAttributeCurrentMaxRateID = 0x0000000B,
-    MTRClusterWiFiNetworkDiagnosticsAttributeOverrunCountID = 0x0000000C,
-    MTRClusterWiFiNetworkDiagnosticsAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterWiFiNetworkDiagnosticsAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterWiFiNetworkDiagnosticsAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterWiFiNetworkDiagnosticsAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterWiFiNetworkDiagnosticsAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeBssidID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeSecurityTypeID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeWiFiVersionID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeChannelNumberID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeRssiID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeBeaconLostCountID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeBeaconRxCountID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributePacketMulticastRxCountID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributePacketMulticastTxCountID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributePacketUnicastRxCountID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributePacketUnicastTxCountID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeCurrentMaxRateID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeOverrunCountID MTR_NEWLY_AVAILABLE = 0x0000000C,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster EthernetNetworkDiagnostics deprecated attribute names
+    MTRClusterEthernetNetworkDiagnosticsAttributePHYRateID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributePHYRateID")
+    = 0x00000000,
+    MTRClusterEthernetNetworkDiagnosticsAttributeFullDuplexID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeFullDuplexID")
+    = 0x00000001,
+    MTRClusterEthernetNetworkDiagnosticsAttributePacketRxCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributePacketRxCountID")
+    = 0x00000002,
+    MTRClusterEthernetNetworkDiagnosticsAttributePacketTxCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributePacketTxCountID")
+    = 0x00000003,
+    MTRClusterEthernetNetworkDiagnosticsAttributeTxErrCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeTxErrCountID")
+    = 0x00000004,
+    MTRClusterEthernetNetworkDiagnosticsAttributeCollisionCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeCollisionCountID")
+    = 0x00000005,
+    MTRClusterEthernetNetworkDiagnosticsAttributeOverrunCountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeOverrunCountID")
+    = 0x00000006,
+    MTRClusterEthernetNetworkDiagnosticsAttributeCarrierDetectID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeCarrierDetectID")
+    = 0x00000007,
+    MTRClusterEthernetNetworkDiagnosticsAttributeTimeSinceResetID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeTimeSinceResetID")
+    = 0x00000008,
+    MTRClusterEthernetNetworkDiagnosticsAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterEthernetNetworkDiagnosticsAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterEthernetNetworkDiagnosticsAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterEthernetNetworkDiagnosticsAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterEthernetNetworkDiagnosticsAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster EthernetNetworkDiagnostics attributes
-    MTRClusterEthernetNetworkDiagnosticsAttributePHYRateID = 0x00000000,
-    MTRClusterEthernetNetworkDiagnosticsAttributeFullDuplexID = 0x00000001,
-    MTRClusterEthernetNetworkDiagnosticsAttributePacketRxCountID = 0x00000002,
-    MTRClusterEthernetNetworkDiagnosticsAttributePacketTxCountID = 0x00000003,
-    MTRClusterEthernetNetworkDiagnosticsAttributeTxErrCountID = 0x00000004,
-    MTRClusterEthernetNetworkDiagnosticsAttributeCollisionCountID = 0x00000005,
-    MTRClusterEthernetNetworkDiagnosticsAttributeOverrunCountID = 0x00000006,
-    MTRClusterEthernetNetworkDiagnosticsAttributeCarrierDetectID = 0x00000007,
-    MTRClusterEthernetNetworkDiagnosticsAttributeTimeSinceResetID = 0x00000008,
-    MTRClusterEthernetNetworkDiagnosticsAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterEthernetNetworkDiagnosticsAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterEthernetNetworkDiagnosticsAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterEthernetNetworkDiagnosticsAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterEthernetNetworkDiagnosticsAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributePHYRateID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeFullDuplexID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributePacketRxCountID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributePacketTxCountID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeTxErrCountID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeCollisionCountID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeOverrunCountID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeCarrierDetectID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeTimeSinceResetID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster TimeSynchronization deprecated attribute names
+    MTRClusterTimeSynchronizationAttributeUTCTimeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeUTCTimeID")
+    = 0x00000000,
+    MTRClusterTimeSynchronizationAttributeGranularityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeGranularityID")
+    = 0x00000001,
+    MTRClusterTimeSynchronizationAttributeTimeSourceID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeTimeSourceID")
+    = 0x00000002,
+    MTRClusterTimeSynchronizationAttributeTrustedTimeNodeIdID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeTrustedTimeNodeIdID")
+    = 0x00000003,
+    MTRClusterTimeSynchronizationAttributeDefaultNtpID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeDefaultNtpID")
+    = 0x00000004,
+    MTRClusterTimeSynchronizationAttributeTimeZoneID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeTimeZoneID")
+    = 0x00000005,
+    MTRClusterTimeSynchronizationAttributeDstOffsetID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeDstOffsetID")
+    = 0x00000006,
+    MTRClusterTimeSynchronizationAttributeLocalTimeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeLocalTimeID")
+    = 0x00000007,
+    MTRClusterTimeSynchronizationAttributeTimeZoneDatabaseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeTimeZoneDatabaseID")
+    = 0x00000008,
+    MTRClusterTimeSynchronizationAttributeNtpServerPortID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeNtpServerPortID")
+    = 0x00000009,
+    MTRClusterTimeSynchronizationAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterTimeSynchronizationAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterTimeSynchronizationAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterTimeSynchronizationAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterTimeSynchronizationAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTimeSynchronizationAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster TimeSynchronization attributes
-    MTRClusterTimeSynchronizationAttributeUTCTimeID = 0x00000000,
-    MTRClusterTimeSynchronizationAttributeGranularityID = 0x00000001,
-    MTRClusterTimeSynchronizationAttributeTimeSourceID = 0x00000002,
-    MTRClusterTimeSynchronizationAttributeTrustedTimeNodeIdID = 0x00000003,
-    MTRClusterTimeSynchronizationAttributeDefaultNtpID = 0x00000004,
-    MTRClusterTimeSynchronizationAttributeTimeZoneID = 0x00000005,
-    MTRClusterTimeSynchronizationAttributeDstOffsetID = 0x00000006,
-    MTRClusterTimeSynchronizationAttributeLocalTimeID = 0x00000007,
-    MTRClusterTimeSynchronizationAttributeTimeZoneDatabaseID = 0x00000008,
-    MTRClusterTimeSynchronizationAttributeNtpServerPortID = 0x00000009,
-    MTRClusterTimeSynchronizationAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterTimeSynchronizationAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterTimeSynchronizationAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterTimeSynchronizationAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterTimeSynchronizationAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeUTCTimeID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeGranularityID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeTimeSourceID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeTrustedTimeNodeIdID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeDefaultNtpID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeTimeZoneID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeDstOffsetID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeLocalTimeID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeTimeZoneDatabaseID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeNtpServerPortID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterTimeSynchronizationAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster BridgedDeviceBasic deprecated attribute names
+    MTRClusterBridgedDeviceBasicAttributeVendorNameID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeVendorNameID")
+    = 0x00000001,
+    MTRClusterBridgedDeviceBasicAttributeVendorIDID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeVendorIDID")
+    = 0x00000002,
+    MTRClusterBridgedDeviceBasicAttributeProductNameID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeProductNameID")
+    = 0x00000003,
+    MTRClusterBridgedDeviceBasicAttributeNodeLabelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeNodeLabelID")
+    = 0x00000005,
+    MTRClusterBridgedDeviceBasicAttributeHardwareVersionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeHardwareVersionID")
+    = 0x00000007,
+    MTRClusterBridgedDeviceBasicAttributeHardwareVersionStringID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeHardwareVersionStringID")
+    = 0x00000008,
+    MTRClusterBridgedDeviceBasicAttributeSoftwareVersionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeSoftwareVersionID")
+    = 0x00000009,
+    MTRClusterBridgedDeviceBasicAttributeSoftwareVersionStringID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeSoftwareVersionStringID")
+    = 0x0000000A,
+    MTRClusterBridgedDeviceBasicAttributeManufacturingDateID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeManufacturingDateID")
+    = 0x0000000B,
+    MTRClusterBridgedDeviceBasicAttributePartNumberID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributePartNumberID")
+    = 0x0000000C,
+    MTRClusterBridgedDeviceBasicAttributeProductURLID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeProductURLID")
+    = 0x0000000D,
+    MTRClusterBridgedDeviceBasicAttributeProductLabelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeProductLabelID")
+    = 0x0000000E,
+    MTRClusterBridgedDeviceBasicAttributeSerialNumberID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeSerialNumberID")
+    = 0x0000000F,
+    MTRClusterBridgedDeviceBasicAttributeReachableID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeReachableID")
+    = 0x00000011,
+    MTRClusterBridgedDeviceBasicAttributeUniqueIDID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeUniqueIDID")
+    = 0x00000012,
+    MTRClusterBridgedDeviceBasicAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterBridgedDeviceBasicAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterBridgedDeviceBasicAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterBridgedDeviceBasicAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterBridgedDeviceBasicAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster BridgedDeviceBasic attributes
-    MTRClusterBridgedDeviceBasicAttributeVendorNameID = 0x00000001,
-    MTRClusterBridgedDeviceBasicAttributeVendorIDID = 0x00000002,
-    MTRClusterBridgedDeviceBasicAttributeProductNameID = 0x00000003,
-    MTRClusterBridgedDeviceBasicAttributeNodeLabelID = 0x00000005,
-    MTRClusterBridgedDeviceBasicAttributeHardwareVersionID = 0x00000007,
-    MTRClusterBridgedDeviceBasicAttributeHardwareVersionStringID = 0x00000008,
-    MTRClusterBridgedDeviceBasicAttributeSoftwareVersionID = 0x00000009,
-    MTRClusterBridgedDeviceBasicAttributeSoftwareVersionStringID = 0x0000000A,
-    MTRClusterBridgedDeviceBasicAttributeManufacturingDateID = 0x0000000B,
-    MTRClusterBridgedDeviceBasicAttributePartNumberID = 0x0000000C,
-    MTRClusterBridgedDeviceBasicAttributeProductURLID = 0x0000000D,
-    MTRClusterBridgedDeviceBasicAttributeProductLabelID = 0x0000000E,
-    MTRClusterBridgedDeviceBasicAttributeSerialNumberID = 0x0000000F,
-    MTRClusterBridgedDeviceBasicAttributeReachableID = 0x00000011,
-    MTRClusterBridgedDeviceBasicAttributeUniqueIDID = 0x00000012,
-    MTRClusterBridgedDeviceBasicAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterBridgedDeviceBasicAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterBridgedDeviceBasicAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterBridgedDeviceBasicAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterBridgedDeviceBasicAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeVendorNameID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeVendorIDID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeProductNameID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeNodeLabelID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeHardwareVersionID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeHardwareVersionStringID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeSoftwareVersionID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeSoftwareVersionStringID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeManufacturingDateID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributePartNumberID MTR_NEWLY_AVAILABLE = 0x0000000C,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeProductURLID MTR_NEWLY_AVAILABLE = 0x0000000D,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeProductLabelID MTR_NEWLY_AVAILABLE = 0x0000000E,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeSerialNumberID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeReachableID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeUniqueIDID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster Switch deprecated attribute names
+    MTRClusterSwitchAttributeNumberOfPositionsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSwitchAttributeNumberOfPositionsID")
+    = 0x00000000,
+    MTRClusterSwitchAttributeCurrentPositionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSwitchAttributeCurrentPositionID")
+    = 0x00000001,
+    MTRClusterSwitchAttributeMultiPressMaxID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSwitchAttributeMultiPressMaxID")
+    = 0x00000002,
+    MTRClusterSwitchAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSwitchAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterSwitchAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSwitchAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterSwitchAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSwitchAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterSwitchAttributeFeatureMapID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterSwitchAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterSwitchAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterSwitchAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster Switch attributes
-    MTRClusterSwitchAttributeNumberOfPositionsID = 0x00000000,
-    MTRClusterSwitchAttributeCurrentPositionID = 0x00000001,
-    MTRClusterSwitchAttributeMultiPressMaxID = 0x00000002,
-    MTRClusterSwitchAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterSwitchAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterSwitchAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterSwitchAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterSwitchAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterSwitchAttributeNumberOfPositionsID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterSwitchAttributeCurrentPositionID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterSwitchAttributeMultiPressMaxID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterSwitchAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterSwitchAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterSwitchAttributeAttributeListID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterSwitchAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterSwitchAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster AdministratorCommissioning deprecated attribute names
+    MTRClusterAdministratorCommissioningAttributeWindowStatusID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAdministratorCommissioningAttributeWindowStatusID")
+    = 0x00000000,
+    MTRClusterAdministratorCommissioningAttributeAdminFabricIndexID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAdministratorCommissioningAttributeAdminFabricIndexID")
+    = 0x00000001,
+    MTRClusterAdministratorCommissioningAttributeAdminVendorIdID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAdministratorCommissioningAttributeAdminVendorIdID")
+    = 0x00000002,
+    MTRClusterAdministratorCommissioningAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAdministratorCommissioningAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterAdministratorCommissioningAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAdministratorCommissioningAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterAdministratorCommissioningAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAdministratorCommissioningAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterAdministratorCommissioningAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAdministratorCommissioningAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterAdministratorCommissioningAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAdministratorCommissioningAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster AdministratorCommissioning attributes
-    MTRClusterAdministratorCommissioningAttributeWindowStatusID = 0x00000000,
-    MTRClusterAdministratorCommissioningAttributeAdminFabricIndexID = 0x00000001,
-    MTRClusterAdministratorCommissioningAttributeAdminVendorIdID = 0x00000002,
-    MTRClusterAdministratorCommissioningAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterAdministratorCommissioningAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterAdministratorCommissioningAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterAdministratorCommissioningAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterAdministratorCommissioningAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterAdministratorCommissioningAttributeWindowStatusID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterAdministratorCommissioningAttributeAdminFabricIndexID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterAdministratorCommissioningAttributeAdminVendorIdID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterAdministratorCommissioningAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterAdministratorCommissioningAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterAdministratorCommissioningAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterAdministratorCommissioningAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterAdministratorCommissioningAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster OperationalCredentials deprecated attribute names
+    MTRClusterOperationalCredentialsAttributeNOCsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOperationalCredentialsAttributeNOCsID")
+    = 0x00000000,
+    MTRClusterOperationalCredentialsAttributeFabricsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOperationalCredentialsAttributeFabricsID")
+    = 0x00000001,
+    MTRClusterOperationalCredentialsAttributeSupportedFabricsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOperationalCredentialsAttributeSupportedFabricsID")
+    = 0x00000002,
+    MTRClusterOperationalCredentialsAttributeCommissionedFabricsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOperationalCredentialsAttributeCommissionedFabricsID")
+    = 0x00000003,
+    MTRClusterOperationalCredentialsAttributeTrustedRootCertificatesID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOperationalCredentialsAttributeTrustedRootCertificatesID")
+    = 0x00000004,
+    MTRClusterOperationalCredentialsAttributeCurrentFabricIndexID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOperationalCredentialsAttributeCurrentFabricIndexID")
+    = 0x00000005,
+    MTRClusterOperationalCredentialsAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOperationalCredentialsAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterOperationalCredentialsAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOperationalCredentialsAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterOperationalCredentialsAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOperationalCredentialsAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterOperationalCredentialsAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOperationalCredentialsAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterOperationalCredentialsAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOperationalCredentialsAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster OperationalCredentials attributes
-    MTRClusterOperationalCredentialsAttributeNOCsID = 0x00000000,
-    MTRClusterOperationalCredentialsAttributeFabricsID = 0x00000001,
-    MTRClusterOperationalCredentialsAttributeSupportedFabricsID = 0x00000002,
-    MTRClusterOperationalCredentialsAttributeCommissionedFabricsID = 0x00000003,
-    MTRClusterOperationalCredentialsAttributeTrustedRootCertificatesID = 0x00000004,
-    MTRClusterOperationalCredentialsAttributeCurrentFabricIndexID = 0x00000005,
-    MTRClusterOperationalCredentialsAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterOperationalCredentialsAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterOperationalCredentialsAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterOperationalCredentialsAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterOperationalCredentialsAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterOperationalCredentialsAttributeNOCsID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterOperationalCredentialsAttributeFabricsID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterOperationalCredentialsAttributeSupportedFabricsID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterOperationalCredentialsAttributeCommissionedFabricsID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterOperationalCredentialsAttributeTrustedRootCertificatesID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterOperationalCredentialsAttributeCurrentFabricIndexID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterOperationalCredentialsAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterOperationalCredentialsAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterOperationalCredentialsAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterOperationalCredentialsAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterOperationalCredentialsAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster GroupKeyManagement deprecated attribute names
+    MTRClusterGroupKeyManagementAttributeGroupKeyMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGroupKeyManagementAttributeGroupKeyMapID")
+    = 0x00000000,
+    MTRClusterGroupKeyManagementAttributeGroupTableID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGroupKeyManagementAttributeGroupTableID")
+    = 0x00000001,
+    MTRClusterGroupKeyManagementAttributeMaxGroupsPerFabricID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGroupKeyManagementAttributeMaxGroupsPerFabricID")
+    = 0x00000002,
+    MTRClusterGroupKeyManagementAttributeMaxGroupKeysPerFabricID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGroupKeyManagementAttributeMaxGroupKeysPerFabricID")
+    = 0x00000003,
+    MTRClusterGroupKeyManagementAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGroupKeyManagementAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterGroupKeyManagementAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGroupKeyManagementAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterGroupKeyManagementAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGroupKeyManagementAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterGroupKeyManagementAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGroupKeyManagementAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterGroupKeyManagementAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterGroupKeyManagementAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster GroupKeyManagement attributes
-    MTRClusterGroupKeyManagementAttributeGroupKeyMapID = 0x00000000,
-    MTRClusterGroupKeyManagementAttributeGroupTableID = 0x00000001,
-    MTRClusterGroupKeyManagementAttributeMaxGroupsPerFabricID = 0x00000002,
-    MTRClusterGroupKeyManagementAttributeMaxGroupKeysPerFabricID = 0x00000003,
-    MTRClusterGroupKeyManagementAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterGroupKeyManagementAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterGroupKeyManagementAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterGroupKeyManagementAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterGroupKeyManagementAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterGroupKeyManagementAttributeGroupKeyMapID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterGroupKeyManagementAttributeGroupTableID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterGroupKeyManagementAttributeMaxGroupsPerFabricID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterGroupKeyManagementAttributeMaxGroupKeysPerFabricID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterGroupKeyManagementAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterGroupKeyManagementAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterGroupKeyManagementAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterGroupKeyManagementAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterGroupKeyManagementAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster FixedLabel deprecated attribute names
+    MTRClusterFixedLabelAttributeLabelListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFixedLabelAttributeLabelListID")
+    = 0x00000000,
+    MTRClusterFixedLabelAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFixedLabelAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterFixedLabelAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFixedLabelAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterFixedLabelAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFixedLabelAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterFixedLabelAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFixedLabelAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterFixedLabelAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFixedLabelAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster FixedLabel attributes
-    MTRClusterFixedLabelAttributeLabelListID = 0x00000000,
-    MTRClusterFixedLabelAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterFixedLabelAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterFixedLabelAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterFixedLabelAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterFixedLabelAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterFixedLabelAttributeLabelListID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterFixedLabelAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterFixedLabelAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterFixedLabelAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterFixedLabelAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterFixedLabelAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster UserLabel deprecated attribute names
+    MTRClusterUserLabelAttributeLabelListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUserLabelAttributeLabelListID")
+    = 0x00000000,
+    MTRClusterUserLabelAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUserLabelAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterUserLabelAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUserLabelAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterUserLabelAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUserLabelAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterUserLabelAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUserLabelAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterUserLabelAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUserLabelAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster UserLabel attributes
-    MTRClusterUserLabelAttributeLabelListID = 0x00000000,
-    MTRClusterUserLabelAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterUserLabelAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterUserLabelAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterUserLabelAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterUserLabelAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterUserLabelAttributeLabelListID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterUserLabelAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterUserLabelAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterUserLabelAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterUserLabelAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterUserLabelAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster ProxyConfiguration deprecated attribute names
+    MTRClusterProxyConfigurationAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyConfigurationAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterProxyConfigurationAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyConfigurationAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterProxyConfigurationAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyConfigurationAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterProxyConfigurationAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyConfigurationAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterProxyConfigurationAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyConfigurationAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster ProxyConfiguration attributes
-    MTRClusterProxyConfigurationAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterProxyConfigurationAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterProxyConfigurationAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterProxyConfigurationAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterProxyConfigurationAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterProxyConfigurationAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterProxyConfigurationAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterProxyConfigurationAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterProxyConfigurationAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterProxyConfigurationAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster ProxyDiscovery deprecated attribute names
+    MTRClusterProxyDiscoveryAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyDiscoveryAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterProxyDiscoveryAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyDiscoveryAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterProxyDiscoveryAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyDiscoveryAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterProxyDiscoveryAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyDiscoveryAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterProxyDiscoveryAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyDiscoveryAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster ProxyDiscovery attributes
-    MTRClusterProxyDiscoveryAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterProxyDiscoveryAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterProxyDiscoveryAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterProxyDiscoveryAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterProxyDiscoveryAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterProxyDiscoveryAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterProxyDiscoveryAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterProxyDiscoveryAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterProxyDiscoveryAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterProxyDiscoveryAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster ProxyValid deprecated attribute names
+    MTRClusterProxyValidAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyValidAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterProxyValidAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyValidAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterProxyValidAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyValidAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterProxyValidAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyValidAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterProxyValidAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterProxyValidAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster ProxyValid attributes
-    MTRClusterProxyValidAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterProxyValidAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterProxyValidAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterProxyValidAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterProxyValidAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterProxyValidAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterProxyValidAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterProxyValidAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterProxyValidAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterProxyValidAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster BooleanState deprecated attribute names
+    MTRClusterBooleanStateAttributeStateValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBooleanStateAttributeStateValueID")
+    = 0x00000000,
+    MTRClusterBooleanStateAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBooleanStateAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterBooleanStateAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBooleanStateAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterBooleanStateAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBooleanStateAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterBooleanStateAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBooleanStateAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterBooleanStateAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBooleanStateAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster BooleanState attributes
-    MTRClusterBooleanStateAttributeStateValueID = 0x00000000,
-    MTRClusterBooleanStateAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterBooleanStateAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterBooleanStateAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterBooleanStateAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterBooleanStateAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterBooleanStateAttributeStateValueID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterBooleanStateAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterBooleanStateAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterBooleanStateAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterBooleanStateAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterBooleanStateAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster ModeSelect deprecated attribute names
+    MTRClusterModeSelectAttributeDescriptionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterModeSelectAttributeDescriptionID")
+    = 0x00000000,
+    MTRClusterModeSelectAttributeStandardNamespaceID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterModeSelectAttributeStandardNamespaceID")
+    = 0x00000001,
+    MTRClusterModeSelectAttributeSupportedModesID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterModeSelectAttributeSupportedModesID")
+    = 0x00000002,
+    MTRClusterModeSelectAttributeCurrentModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterModeSelectAttributeCurrentModeID")
+    = 0x00000003,
+    MTRClusterModeSelectAttributeStartUpModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterModeSelectAttributeStartUpModeID")
+    = 0x00000004,
+    MTRClusterModeSelectAttributeOnModeID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterModeSelectAttributeOnModeID")
+    = 0x00000005,
+    MTRClusterModeSelectAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterModeSelectAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterModeSelectAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterModeSelectAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterModeSelectAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterModeSelectAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterModeSelectAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterModeSelectAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterModeSelectAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterModeSelectAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster ModeSelect attributes
-    MTRClusterModeSelectAttributeDescriptionID = 0x00000000,
-    MTRClusterModeSelectAttributeStandardNamespaceID = 0x00000001,
-    MTRClusterModeSelectAttributeSupportedModesID = 0x00000002,
-    MTRClusterModeSelectAttributeCurrentModeID = 0x00000003,
-    MTRClusterModeSelectAttributeStartUpModeID = 0x00000004,
-    MTRClusterModeSelectAttributeOnModeID = 0x00000005,
-    MTRClusterModeSelectAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterModeSelectAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterModeSelectAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterModeSelectAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterModeSelectAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterModeSelectAttributeDescriptionID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterModeSelectAttributeStandardNamespaceID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterModeSelectAttributeSupportedModesID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterModeSelectAttributeCurrentModeID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterModeSelectAttributeStartUpModeID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterModeSelectAttributeOnModeID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterModeSelectAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterModeSelectAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterModeSelectAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterModeSelectAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterModeSelectAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster DoorLock deprecated attribute names
+    MTRClusterDoorLockAttributeLockStateID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterDoorLockAttributeLockStateID")
+    = 0x00000000,
+    MTRClusterDoorLockAttributeLockTypeID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterDoorLockAttributeLockTypeID")
+    = 0x00000001,
+    MTRClusterDoorLockAttributeActuatorEnabledID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeActuatorEnabledID")
+    = 0x00000002,
+    MTRClusterDoorLockAttributeDoorStateID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterDoorLockAttributeDoorStateID")
+    = 0x00000003,
+    MTRClusterDoorLockAttributeDoorOpenEventsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeDoorOpenEventsID")
+    = 0x00000004,
+    MTRClusterDoorLockAttributeDoorClosedEventsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeDoorClosedEventsID")
+    = 0x00000005,
+    MTRClusterDoorLockAttributeOpenPeriodID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeOpenPeriodID")
+    = 0x00000006,
+    MTRClusterDoorLockAttributeNumberOfTotalUsersSupportedID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeNumberOfTotalUsersSupportedID")
+    = 0x00000011,
+    MTRClusterDoorLockAttributeNumberOfPINUsersSupportedID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeNumberOfPINUsersSupportedID")
+    = 0x00000012,
+    MTRClusterDoorLockAttributeNumberOfRFIDUsersSupportedID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeNumberOfRFIDUsersSupportedID")
+    = 0x00000013,
+    MTRClusterDoorLockAttributeNumberOfWeekDaySchedulesSupportedPerUserID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeNumberOfWeekDaySchedulesSupportedPerUserID")
+    = 0x00000014,
+    MTRClusterDoorLockAttributeNumberOfYearDaySchedulesSupportedPerUserID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeNumberOfYearDaySchedulesSupportedPerUserID")
+    = 0x00000015,
+    MTRClusterDoorLockAttributeNumberOfHolidaySchedulesSupportedID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeNumberOfHolidaySchedulesSupportedID")
+    = 0x00000016,
+    MTRClusterDoorLockAttributeMaxPINCodeLengthID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeMaxPINCodeLengthID")
+    = 0x00000017,
+    MTRClusterDoorLockAttributeMinPINCodeLengthID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeMinPINCodeLengthID")
+    = 0x00000018,
+    MTRClusterDoorLockAttributeMaxRFIDCodeLengthID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeMaxRFIDCodeLengthID")
+    = 0x00000019,
+    MTRClusterDoorLockAttributeMinRFIDCodeLengthID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeMinRFIDCodeLengthID")
+    = 0x0000001A,
+    MTRClusterDoorLockAttributeCredentialRulesSupportID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeCredentialRulesSupportID")
+    = 0x0000001B,
+    MTRClusterDoorLockAttributeNumberOfCredentialsSupportedPerUserID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeNumberOfCredentialsSupportedPerUserID")
+    = 0x0000001C,
+    MTRClusterDoorLockAttributeLanguageID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterDoorLockAttributeLanguageID")
+    = 0x00000021,
+    MTRClusterDoorLockAttributeLEDSettingsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeLEDSettingsID")
+    = 0x00000022,
+    MTRClusterDoorLockAttributeAutoRelockTimeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeAutoRelockTimeID")
+    = 0x00000023,
+    MTRClusterDoorLockAttributeSoundVolumeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeSoundVolumeID")
+    = 0x00000024,
+    MTRClusterDoorLockAttributeOperatingModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeOperatingModeID")
+    = 0x00000025,
+    MTRClusterDoorLockAttributeSupportedOperatingModesID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeSupportedOperatingModesID")
+    = 0x00000026,
+    MTRClusterDoorLockAttributeDefaultConfigurationRegisterID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeDefaultConfigurationRegisterID")
+    = 0x00000027,
+    MTRClusterDoorLockAttributeEnableLocalProgrammingID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeEnableLocalProgrammingID")
+    = 0x00000028,
+    MTRClusterDoorLockAttributeEnableOneTouchLockingID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeEnableOneTouchLockingID")
+    = 0x00000029,
+    MTRClusterDoorLockAttributeEnableInsideStatusLEDID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeEnableInsideStatusLEDID")
+    = 0x0000002A,
+    MTRClusterDoorLockAttributeEnablePrivacyModeButtonID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeEnablePrivacyModeButtonID")
+    = 0x0000002B,
+    MTRClusterDoorLockAttributeLocalProgrammingFeaturesID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeLocalProgrammingFeaturesID")
+    = 0x0000002C,
+    MTRClusterDoorLockAttributeWrongCodeEntryLimitID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeWrongCodeEntryLimitID")
+    = 0x00000030,
+    MTRClusterDoorLockAttributeUserCodeTemporaryDisableTimeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeUserCodeTemporaryDisableTimeID")
+    = 0x00000031,
+    MTRClusterDoorLockAttributeSendPINOverTheAirID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeSendPINOverTheAirID")
+    = 0x00000032,
+    MTRClusterDoorLockAttributeRequirePINforRemoteOperationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeRequirePINforRemoteOperationID")
+    = 0x00000033,
+    MTRClusterDoorLockAttributeExpiringUserTimeoutID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeExpiringUserTimeoutID")
+    = 0x00000035,
+    MTRClusterDoorLockAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterDoorLockAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterDoorLockAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterDoorLockAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterDoorLockAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterDoorLockAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster DoorLock attributes
-    MTRClusterDoorLockAttributeLockStateID = 0x00000000,
-    MTRClusterDoorLockAttributeLockTypeID = 0x00000001,
-    MTRClusterDoorLockAttributeActuatorEnabledID = 0x00000002,
-    MTRClusterDoorLockAttributeDoorStateID = 0x00000003,
-    MTRClusterDoorLockAttributeDoorOpenEventsID = 0x00000004,
-    MTRClusterDoorLockAttributeDoorClosedEventsID = 0x00000005,
-    MTRClusterDoorLockAttributeOpenPeriodID = 0x00000006,
-    MTRClusterDoorLockAttributeNumberOfTotalUsersSupportedID = 0x00000011,
-    MTRClusterDoorLockAttributeNumberOfPINUsersSupportedID = 0x00000012,
-    MTRClusterDoorLockAttributeNumberOfRFIDUsersSupportedID = 0x00000013,
-    MTRClusterDoorLockAttributeNumberOfWeekDaySchedulesSupportedPerUserID = 0x00000014,
-    MTRClusterDoorLockAttributeNumberOfYearDaySchedulesSupportedPerUserID = 0x00000015,
-    MTRClusterDoorLockAttributeNumberOfHolidaySchedulesSupportedID = 0x00000016,
-    MTRClusterDoorLockAttributeMaxPINCodeLengthID = 0x00000017,
-    MTRClusterDoorLockAttributeMinPINCodeLengthID = 0x00000018,
-    MTRClusterDoorLockAttributeMaxRFIDCodeLengthID = 0x00000019,
-    MTRClusterDoorLockAttributeMinRFIDCodeLengthID = 0x0000001A,
-    MTRClusterDoorLockAttributeCredentialRulesSupportID = 0x0000001B,
-    MTRClusterDoorLockAttributeNumberOfCredentialsSupportedPerUserID = 0x0000001C,
-    MTRClusterDoorLockAttributeLanguageID = 0x00000021,
-    MTRClusterDoorLockAttributeLEDSettingsID = 0x00000022,
-    MTRClusterDoorLockAttributeAutoRelockTimeID = 0x00000023,
-    MTRClusterDoorLockAttributeSoundVolumeID = 0x00000024,
-    MTRClusterDoorLockAttributeOperatingModeID = 0x00000025,
-    MTRClusterDoorLockAttributeSupportedOperatingModesID = 0x00000026,
-    MTRClusterDoorLockAttributeDefaultConfigurationRegisterID = 0x00000027,
-    MTRClusterDoorLockAttributeEnableLocalProgrammingID = 0x00000028,
-    MTRClusterDoorLockAttributeEnableOneTouchLockingID = 0x00000029,
-    MTRClusterDoorLockAttributeEnableInsideStatusLEDID = 0x0000002A,
-    MTRClusterDoorLockAttributeEnablePrivacyModeButtonID = 0x0000002B,
-    MTRClusterDoorLockAttributeLocalProgrammingFeaturesID = 0x0000002C,
-    MTRClusterDoorLockAttributeWrongCodeEntryLimitID = 0x00000030,
-    MTRClusterDoorLockAttributeUserCodeTemporaryDisableTimeID = 0x00000031,
-    MTRClusterDoorLockAttributeSendPINOverTheAirID = 0x00000032,
-    MTRClusterDoorLockAttributeRequirePINforRemoteOperationID = 0x00000033,
-    MTRClusterDoorLockAttributeExpiringUserTimeoutID = 0x00000035,
-    MTRClusterDoorLockAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterDoorLockAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterDoorLockAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterDoorLockAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterDoorLockAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterDoorLockAttributeLockStateID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterDoorLockAttributeLockTypeID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterDoorLockAttributeActuatorEnabledID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterDoorLockAttributeDoorStateID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterDoorLockAttributeDoorOpenEventsID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterDoorLockAttributeDoorClosedEventsID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterDoorLockAttributeOpenPeriodID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterDoorLockAttributeNumberOfTotalUsersSupportedID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRAttributeIDTypeClusterDoorLockAttributeNumberOfPINUsersSupportedID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRAttributeIDTypeClusterDoorLockAttributeNumberOfRFIDUsersSupportedID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRAttributeIDTypeClusterDoorLockAttributeNumberOfWeekDaySchedulesSupportedPerUserID MTR_NEWLY_AVAILABLE = 0x00000014,
+    MTRAttributeIDTypeClusterDoorLockAttributeNumberOfYearDaySchedulesSupportedPerUserID MTR_NEWLY_AVAILABLE = 0x00000015,
+    MTRAttributeIDTypeClusterDoorLockAttributeNumberOfHolidaySchedulesSupportedID MTR_NEWLY_AVAILABLE = 0x00000016,
+    MTRAttributeIDTypeClusterDoorLockAttributeMaxPINCodeLengthID MTR_NEWLY_AVAILABLE = 0x00000017,
+    MTRAttributeIDTypeClusterDoorLockAttributeMinPINCodeLengthID MTR_NEWLY_AVAILABLE = 0x00000018,
+    MTRAttributeIDTypeClusterDoorLockAttributeMaxRFIDCodeLengthID MTR_NEWLY_AVAILABLE = 0x00000019,
+    MTRAttributeIDTypeClusterDoorLockAttributeMinRFIDCodeLengthID MTR_NEWLY_AVAILABLE = 0x0000001A,
+    MTRAttributeIDTypeClusterDoorLockAttributeCredentialRulesSupportID MTR_NEWLY_AVAILABLE = 0x0000001B,
+    MTRAttributeIDTypeClusterDoorLockAttributeNumberOfCredentialsSupportedPerUserID MTR_NEWLY_AVAILABLE = 0x0000001C,
+    MTRAttributeIDTypeClusterDoorLockAttributeLanguageID MTR_NEWLY_AVAILABLE = 0x00000021,
+    MTRAttributeIDTypeClusterDoorLockAttributeLEDSettingsID MTR_NEWLY_AVAILABLE = 0x00000022,
+    MTRAttributeIDTypeClusterDoorLockAttributeAutoRelockTimeID MTR_NEWLY_AVAILABLE = 0x00000023,
+    MTRAttributeIDTypeClusterDoorLockAttributeSoundVolumeID MTR_NEWLY_AVAILABLE = 0x00000024,
+    MTRAttributeIDTypeClusterDoorLockAttributeOperatingModeID MTR_NEWLY_AVAILABLE = 0x00000025,
+    MTRAttributeIDTypeClusterDoorLockAttributeSupportedOperatingModesID MTR_NEWLY_AVAILABLE = 0x00000026,
+    MTRAttributeIDTypeClusterDoorLockAttributeDefaultConfigurationRegisterID MTR_NEWLY_AVAILABLE = 0x00000027,
+    MTRAttributeIDTypeClusterDoorLockAttributeEnableLocalProgrammingID MTR_NEWLY_AVAILABLE = 0x00000028,
+    MTRAttributeIDTypeClusterDoorLockAttributeEnableOneTouchLockingID MTR_NEWLY_AVAILABLE = 0x00000029,
+    MTRAttributeIDTypeClusterDoorLockAttributeEnableInsideStatusLEDID MTR_NEWLY_AVAILABLE = 0x0000002A,
+    MTRAttributeIDTypeClusterDoorLockAttributeEnablePrivacyModeButtonID MTR_NEWLY_AVAILABLE = 0x0000002B,
+    MTRAttributeIDTypeClusterDoorLockAttributeLocalProgrammingFeaturesID MTR_NEWLY_AVAILABLE = 0x0000002C,
+    MTRAttributeIDTypeClusterDoorLockAttributeWrongCodeEntryLimitID MTR_NEWLY_AVAILABLE = 0x00000030,
+    MTRAttributeIDTypeClusterDoorLockAttributeUserCodeTemporaryDisableTimeID MTR_NEWLY_AVAILABLE = 0x00000031,
+    MTRAttributeIDTypeClusterDoorLockAttributeSendPINOverTheAirID MTR_NEWLY_AVAILABLE = 0x00000032,
+    MTRAttributeIDTypeClusterDoorLockAttributeRequirePINforRemoteOperationID MTR_NEWLY_AVAILABLE = 0x00000033,
+    MTRAttributeIDTypeClusterDoorLockAttributeExpiringUserTimeoutID MTR_NEWLY_AVAILABLE = 0x00000035,
+    MTRAttributeIDTypeClusterDoorLockAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterDoorLockAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterDoorLockAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterDoorLockAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterDoorLockAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster WindowCovering deprecated attribute names
+    MTRClusterWindowCoveringAttributeTypeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeTypeID")
+    = 0x00000000,
+    MTRClusterWindowCoveringAttributePhysicalClosedLimitLiftID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributePhysicalClosedLimitLiftID")
+    = 0x00000001,
+    MTRClusterWindowCoveringAttributePhysicalClosedLimitTiltID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributePhysicalClosedLimitTiltID")
+    = 0x00000002,
+    MTRClusterWindowCoveringAttributeCurrentPositionLiftID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionLiftID")
+    = 0x00000003,
+    MTRClusterWindowCoveringAttributeCurrentPositionTiltID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionTiltID")
+    = 0x00000004,
+    MTRClusterWindowCoveringAttributeNumberOfActuationsLiftID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeNumberOfActuationsLiftID")
+    = 0x00000005,
+    MTRClusterWindowCoveringAttributeNumberOfActuationsTiltID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeNumberOfActuationsTiltID")
+    = 0x00000006,
+    MTRClusterWindowCoveringAttributeConfigStatusID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeConfigStatusID")
+    = 0x00000007,
+    MTRClusterWindowCoveringAttributeCurrentPositionLiftPercentageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionLiftPercentageID")
+    = 0x00000008,
+    MTRClusterWindowCoveringAttributeCurrentPositionTiltPercentageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionTiltPercentageID")
+    = 0x00000009,
+    MTRClusterWindowCoveringAttributeOperationalStatusID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeOperationalStatusID")
+    = 0x0000000A,
+    MTRClusterWindowCoveringAttributeTargetPositionLiftPercent100thsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeTargetPositionLiftPercent100thsID")
+    = 0x0000000B,
+    MTRClusterWindowCoveringAttributeTargetPositionTiltPercent100thsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeTargetPositionTiltPercent100thsID")
+    = 0x0000000C,
+    MTRClusterWindowCoveringAttributeEndProductTypeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeEndProductTypeID")
+    = 0x0000000D,
+    MTRClusterWindowCoveringAttributeCurrentPositionLiftPercent100thsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionLiftPercent100thsID")
+    = 0x0000000E,
+    MTRClusterWindowCoveringAttributeCurrentPositionTiltPercent100thsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionTiltPercent100thsID")
+    = 0x0000000F,
+    MTRClusterWindowCoveringAttributeInstalledOpenLimitLiftID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeInstalledOpenLimitLiftID")
+    = 0x00000010,
+    MTRClusterWindowCoveringAttributeInstalledClosedLimitLiftID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeInstalledClosedLimitLiftID")
+    = 0x00000011,
+    MTRClusterWindowCoveringAttributeInstalledOpenLimitTiltID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeInstalledOpenLimitTiltID")
+    = 0x00000012,
+    MTRClusterWindowCoveringAttributeInstalledClosedLimitTiltID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeInstalledClosedLimitTiltID")
+    = 0x00000013,
+    MTRClusterWindowCoveringAttributeModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeModeID")
+    = 0x00000017,
+    MTRClusterWindowCoveringAttributeSafetyStatusID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeSafetyStatusID")
+    = 0x0000001A,
+    MTRClusterWindowCoveringAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterWindowCoveringAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterWindowCoveringAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterWindowCoveringAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterWindowCoveringAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWindowCoveringAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster WindowCovering attributes
-    MTRClusterWindowCoveringAttributeTypeID = 0x00000000,
-    MTRClusterWindowCoveringAttributePhysicalClosedLimitLiftID = 0x00000001,
-    MTRClusterWindowCoveringAttributePhysicalClosedLimitTiltID = 0x00000002,
-    MTRClusterWindowCoveringAttributeCurrentPositionLiftID = 0x00000003,
-    MTRClusterWindowCoveringAttributeCurrentPositionTiltID = 0x00000004,
-    MTRClusterWindowCoveringAttributeNumberOfActuationsLiftID = 0x00000005,
-    MTRClusterWindowCoveringAttributeNumberOfActuationsTiltID = 0x00000006,
-    MTRClusterWindowCoveringAttributeConfigStatusID = 0x00000007,
-    MTRClusterWindowCoveringAttributeCurrentPositionLiftPercentageID = 0x00000008,
-    MTRClusterWindowCoveringAttributeCurrentPositionTiltPercentageID = 0x00000009,
-    MTRClusterWindowCoveringAttributeOperationalStatusID = 0x0000000A,
-    MTRClusterWindowCoveringAttributeTargetPositionLiftPercent100thsID = 0x0000000B,
-    MTRClusterWindowCoveringAttributeTargetPositionTiltPercent100thsID = 0x0000000C,
-    MTRClusterWindowCoveringAttributeEndProductTypeID = 0x0000000D,
-    MTRClusterWindowCoveringAttributeCurrentPositionLiftPercent100thsID = 0x0000000E,
-    MTRClusterWindowCoveringAttributeCurrentPositionTiltPercent100thsID = 0x0000000F,
-    MTRClusterWindowCoveringAttributeInstalledOpenLimitLiftID = 0x00000010,
-    MTRClusterWindowCoveringAttributeInstalledClosedLimitLiftID = 0x00000011,
-    MTRClusterWindowCoveringAttributeInstalledOpenLimitTiltID = 0x00000012,
-    MTRClusterWindowCoveringAttributeInstalledClosedLimitTiltID = 0x00000013,
-    MTRClusterWindowCoveringAttributeModeID = 0x00000017,
-    MTRClusterWindowCoveringAttributeSafetyStatusID = 0x0000001A,
-    MTRClusterWindowCoveringAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterWindowCoveringAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterWindowCoveringAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterWindowCoveringAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterWindowCoveringAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeTypeID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterWindowCoveringAttributePhysicalClosedLimitLiftID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterWindowCoveringAttributePhysicalClosedLimitTiltID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionLiftID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionTiltID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeNumberOfActuationsLiftID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeNumberOfActuationsTiltID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeConfigStatusID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionLiftPercentageID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionTiltPercentageID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeOperationalStatusID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeTargetPositionLiftPercent100thsID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeTargetPositionTiltPercent100thsID MTR_NEWLY_AVAILABLE = 0x0000000C,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeEndProductTypeID MTR_NEWLY_AVAILABLE = 0x0000000D,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionLiftPercent100thsID MTR_NEWLY_AVAILABLE = 0x0000000E,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionTiltPercent100thsID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeInstalledOpenLimitLiftID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeInstalledClosedLimitLiftID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeInstalledOpenLimitTiltID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeInstalledClosedLimitTiltID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeModeID MTR_NEWLY_AVAILABLE = 0x00000017,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeSafetyStatusID MTR_NEWLY_AVAILABLE = 0x0000001A,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterWindowCoveringAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster BarrierControl deprecated attribute names
+    MTRClusterBarrierControlAttributeBarrierMovingStateID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeBarrierMovingStateID")
+    = 0x00000001,
+    MTRClusterBarrierControlAttributeBarrierSafetyStatusID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeBarrierSafetyStatusID")
+    = 0x00000002,
+    MTRClusterBarrierControlAttributeBarrierCapabilitiesID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCapabilitiesID")
+    = 0x00000003,
+    MTRClusterBarrierControlAttributeBarrierOpenEventsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeBarrierOpenEventsID")
+    = 0x00000004,
+    MTRClusterBarrierControlAttributeBarrierCloseEventsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCloseEventsID")
+    = 0x00000005,
+    MTRClusterBarrierControlAttributeBarrierCommandOpenEventsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCommandOpenEventsID")
+    = 0x00000006,
+    MTRClusterBarrierControlAttributeBarrierCommandCloseEventsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCommandCloseEventsID")
+    = 0x00000007,
+    MTRClusterBarrierControlAttributeBarrierOpenPeriodID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeBarrierOpenPeriodID")
+    = 0x00000008,
+    MTRClusterBarrierControlAttributeBarrierClosePeriodID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeBarrierClosePeriodID")
+    = 0x00000009,
+    MTRClusterBarrierControlAttributeBarrierPositionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeBarrierPositionID")
+    = 0x0000000A,
+    MTRClusterBarrierControlAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterBarrierControlAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterBarrierControlAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterBarrierControlAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterBarrierControlAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBarrierControlAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster BarrierControl attributes
-    MTRClusterBarrierControlAttributeBarrierMovingStateID = 0x00000001,
-    MTRClusterBarrierControlAttributeBarrierSafetyStatusID = 0x00000002,
-    MTRClusterBarrierControlAttributeBarrierCapabilitiesID = 0x00000003,
-    MTRClusterBarrierControlAttributeBarrierOpenEventsID = 0x00000004,
-    MTRClusterBarrierControlAttributeBarrierCloseEventsID = 0x00000005,
-    MTRClusterBarrierControlAttributeBarrierCommandOpenEventsID = 0x00000006,
-    MTRClusterBarrierControlAttributeBarrierCommandCloseEventsID = 0x00000007,
-    MTRClusterBarrierControlAttributeBarrierOpenPeriodID = 0x00000008,
-    MTRClusterBarrierControlAttributeBarrierClosePeriodID = 0x00000009,
-    MTRClusterBarrierControlAttributeBarrierPositionID = 0x0000000A,
-    MTRClusterBarrierControlAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterBarrierControlAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterBarrierControlAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterBarrierControlAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterBarrierControlAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterBarrierControlAttributeBarrierMovingStateID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterBarrierControlAttributeBarrierSafetyStatusID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCapabilitiesID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterBarrierControlAttributeBarrierOpenEventsID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCloseEventsID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCommandOpenEventsID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCommandCloseEventsID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterBarrierControlAttributeBarrierOpenPeriodID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterBarrierControlAttributeBarrierClosePeriodID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRAttributeIDTypeClusterBarrierControlAttributeBarrierPositionID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRAttributeIDTypeClusterBarrierControlAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterBarrierControlAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterBarrierControlAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterBarrierControlAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterBarrierControlAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster PumpConfigurationAndControl deprecated attribute names
+    MTRClusterPumpConfigurationAndControlAttributeMaxPressureID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxPressureID")
+    = 0x00000000,
+    MTRClusterPumpConfigurationAndControlAttributeMaxSpeedID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxSpeedID")
+    = 0x00000001,
+    MTRClusterPumpConfigurationAndControlAttributeMaxFlowID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxFlowID")
+    = 0x00000002,
+    MTRClusterPumpConfigurationAndControlAttributeMinConstPressureID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinConstPressureID")
+    = 0x00000003,
+    MTRClusterPumpConfigurationAndControlAttributeMaxConstPressureID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxConstPressureID")
+    = 0x00000004,
+    MTRClusterPumpConfigurationAndControlAttributeMinCompPressureID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinCompPressureID")
+    = 0x00000005,
+    MTRClusterPumpConfigurationAndControlAttributeMaxCompPressureID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxCompPressureID")
+    = 0x00000006,
+    MTRClusterPumpConfigurationAndControlAttributeMinConstSpeedID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinConstSpeedID")
+    = 0x00000007,
+    MTRClusterPumpConfigurationAndControlAttributeMaxConstSpeedID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxConstSpeedID")
+    = 0x00000008,
+    MTRClusterPumpConfigurationAndControlAttributeMinConstFlowID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinConstFlowID")
+    = 0x00000009,
+    MTRClusterPumpConfigurationAndControlAttributeMaxConstFlowID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxConstFlowID")
+    = 0x0000000A,
+    MTRClusterPumpConfigurationAndControlAttributeMinConstTempID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinConstTempID")
+    = 0x0000000B,
+    MTRClusterPumpConfigurationAndControlAttributeMaxConstTempID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxConstTempID")
+    = 0x0000000C,
+    MTRClusterPumpConfigurationAndControlAttributePumpStatusID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributePumpStatusID")
+    = 0x00000010,
+    MTRClusterPumpConfigurationAndControlAttributeEffectiveOperationModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeEffectiveOperationModeID")
+    = 0x00000011,
+    MTRClusterPumpConfigurationAndControlAttributeEffectiveControlModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeEffectiveControlModeID")
+    = 0x00000012,
+    MTRClusterPumpConfigurationAndControlAttributeCapacityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeCapacityID")
+    = 0x00000013,
+    MTRClusterPumpConfigurationAndControlAttributeSpeedID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeSpeedID")
+    = 0x00000014,
+    MTRClusterPumpConfigurationAndControlAttributeLifetimeRunningHoursID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeLifetimeRunningHoursID")
+    = 0x00000015,
+    MTRClusterPumpConfigurationAndControlAttributePowerID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributePowerID")
+    = 0x00000016,
+    MTRClusterPumpConfigurationAndControlAttributeLifetimeEnergyConsumedID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeLifetimeEnergyConsumedID")
+    = 0x00000017,
+    MTRClusterPumpConfigurationAndControlAttributeOperationModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeOperationModeID")
+    = 0x00000020,
+    MTRClusterPumpConfigurationAndControlAttributeControlModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeControlModeID")
+    = 0x00000021,
+    MTRClusterPumpConfigurationAndControlAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterPumpConfigurationAndControlAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterPumpConfigurationAndControlAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterPumpConfigurationAndControlAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterPumpConfigurationAndControlAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster PumpConfigurationAndControl attributes
-    MTRClusterPumpConfigurationAndControlAttributeMaxPressureID = 0x00000000,
-    MTRClusterPumpConfigurationAndControlAttributeMaxSpeedID = 0x00000001,
-    MTRClusterPumpConfigurationAndControlAttributeMaxFlowID = 0x00000002,
-    MTRClusterPumpConfigurationAndControlAttributeMinConstPressureID = 0x00000003,
-    MTRClusterPumpConfigurationAndControlAttributeMaxConstPressureID = 0x00000004,
-    MTRClusterPumpConfigurationAndControlAttributeMinCompPressureID = 0x00000005,
-    MTRClusterPumpConfigurationAndControlAttributeMaxCompPressureID = 0x00000006,
-    MTRClusterPumpConfigurationAndControlAttributeMinConstSpeedID = 0x00000007,
-    MTRClusterPumpConfigurationAndControlAttributeMaxConstSpeedID = 0x00000008,
-    MTRClusterPumpConfigurationAndControlAttributeMinConstFlowID = 0x00000009,
-    MTRClusterPumpConfigurationAndControlAttributeMaxConstFlowID = 0x0000000A,
-    MTRClusterPumpConfigurationAndControlAttributeMinConstTempID = 0x0000000B,
-    MTRClusterPumpConfigurationAndControlAttributeMaxConstTempID = 0x0000000C,
-    MTRClusterPumpConfigurationAndControlAttributePumpStatusID = 0x00000010,
-    MTRClusterPumpConfigurationAndControlAttributeEffectiveOperationModeID = 0x00000011,
-    MTRClusterPumpConfigurationAndControlAttributeEffectiveControlModeID = 0x00000012,
-    MTRClusterPumpConfigurationAndControlAttributeCapacityID = 0x00000013,
-    MTRClusterPumpConfigurationAndControlAttributeSpeedID = 0x00000014,
-    MTRClusterPumpConfigurationAndControlAttributeLifetimeRunningHoursID = 0x00000015,
-    MTRClusterPumpConfigurationAndControlAttributePowerID = 0x00000016,
-    MTRClusterPumpConfigurationAndControlAttributeLifetimeEnergyConsumedID = 0x00000017,
-    MTRClusterPumpConfigurationAndControlAttributeOperationModeID = 0x00000020,
-    MTRClusterPumpConfigurationAndControlAttributeControlModeID = 0x00000021,
-    MTRClusterPumpConfigurationAndControlAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterPumpConfigurationAndControlAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterPumpConfigurationAndControlAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterPumpConfigurationAndControlAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterPumpConfigurationAndControlAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxPressureID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxSpeedID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxFlowID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinConstPressureID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxConstPressureID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinCompPressureID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxCompPressureID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinConstSpeedID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxConstSpeedID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinConstFlowID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxConstFlowID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinConstTempID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxConstTempID MTR_NEWLY_AVAILABLE = 0x0000000C,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributePumpStatusID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeEffectiveOperationModeID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeEffectiveControlModeID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeCapacityID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeSpeedID MTR_NEWLY_AVAILABLE = 0x00000014,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeLifetimeRunningHoursID MTR_NEWLY_AVAILABLE = 0x00000015,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributePowerID MTR_NEWLY_AVAILABLE = 0x00000016,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeLifetimeEnergyConsumedID MTR_NEWLY_AVAILABLE = 0x00000017,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeOperationModeID MTR_NEWLY_AVAILABLE = 0x00000020,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeControlModeID MTR_NEWLY_AVAILABLE = 0x00000021,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster Thermostat deprecated attribute names
+    MTRClusterThermostatAttributeLocalTemperatureID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeLocalTemperatureID")
+    = 0x00000000,
+    MTRClusterThermostatAttributeOutdoorTemperatureID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeOutdoorTemperatureID")
+    = 0x00000001,
+    MTRClusterThermostatAttributeOccupancyID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeOccupancyID")
+    = 0x00000002,
+    MTRClusterThermostatAttributeAbsMinHeatSetpointLimitID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeAbsMinHeatSetpointLimitID")
+    = 0x00000003,
+    MTRClusterThermostatAttributeAbsMaxHeatSetpointLimitID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeAbsMaxHeatSetpointLimitID")
+    = 0x00000004,
+    MTRClusterThermostatAttributeAbsMinCoolSetpointLimitID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeAbsMinCoolSetpointLimitID")
+    = 0x00000005,
+    MTRClusterThermostatAttributeAbsMaxCoolSetpointLimitID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeAbsMaxCoolSetpointLimitID")
+    = 0x00000006,
+    MTRClusterThermostatAttributePICoolingDemandID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributePICoolingDemandID")
+    = 0x00000007,
+    MTRClusterThermostatAttributePIHeatingDemandID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributePIHeatingDemandID")
+    = 0x00000008,
+    MTRClusterThermostatAttributeHVACSystemTypeConfigurationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeHVACSystemTypeConfigurationID")
+    = 0x00000009,
+    MTRClusterThermostatAttributeLocalTemperatureCalibrationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeLocalTemperatureCalibrationID")
+    = 0x00000010,
+    MTRClusterThermostatAttributeOccupiedCoolingSetpointID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeOccupiedCoolingSetpointID")
+    = 0x00000011,
+    MTRClusterThermostatAttributeOccupiedHeatingSetpointID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeOccupiedHeatingSetpointID")
+    = 0x00000012,
+    MTRClusterThermostatAttributeUnoccupiedCoolingSetpointID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedCoolingSetpointID")
+    = 0x00000013,
+    MTRClusterThermostatAttributeUnoccupiedHeatingSetpointID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedHeatingSetpointID")
+    = 0x00000014,
+    MTRClusterThermostatAttributeMinHeatSetpointLimitID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeMinHeatSetpointLimitID")
+    = 0x00000015,
+    MTRClusterThermostatAttributeMaxHeatSetpointLimitID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeMaxHeatSetpointLimitID")
+    = 0x00000016,
+    MTRClusterThermostatAttributeMinCoolSetpointLimitID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeMinCoolSetpointLimitID")
+    = 0x00000017,
+    MTRClusterThermostatAttributeMaxCoolSetpointLimitID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeMaxCoolSetpointLimitID")
+    = 0x00000018,
+    MTRClusterThermostatAttributeMinSetpointDeadBandID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeMinSetpointDeadBandID")
+    = 0x00000019,
+    MTRClusterThermostatAttributeRemoteSensingID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeRemoteSensingID")
+    = 0x0000001A,
+    MTRClusterThermostatAttributeControlSequenceOfOperationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeControlSequenceOfOperationID")
+    = 0x0000001B,
+    MTRClusterThermostatAttributeSystemModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeSystemModeID")
+    = 0x0000001C,
+    MTRClusterThermostatAttributeThermostatRunningModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeThermostatRunningModeID")
+    = 0x0000001E,
+    MTRClusterThermostatAttributeStartOfWeekID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeStartOfWeekID")
+    = 0x00000020,
+    MTRClusterThermostatAttributeNumberOfWeeklyTransitionsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeNumberOfWeeklyTransitionsID")
+    = 0x00000021,
+    MTRClusterThermostatAttributeNumberOfDailyTransitionsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeNumberOfDailyTransitionsID")
+    = 0x00000022,
+    MTRClusterThermostatAttributeTemperatureSetpointHoldID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeTemperatureSetpointHoldID")
+    = 0x00000023,
+    MTRClusterThermostatAttributeTemperatureSetpointHoldDurationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeTemperatureSetpointHoldDurationID")
+    = 0x00000024,
+    MTRClusterThermostatAttributeThermostatProgrammingOperationModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeThermostatProgrammingOperationModeID")
+    = 0x00000025,
+    MTRClusterThermostatAttributeThermostatRunningStateID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeThermostatRunningStateID")
+    = 0x00000029,
+    MTRClusterThermostatAttributeSetpointChangeSourceID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeSetpointChangeSourceID")
+    = 0x00000030,
+    MTRClusterThermostatAttributeSetpointChangeAmountID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeSetpointChangeAmountID")
+    = 0x00000031,
+    MTRClusterThermostatAttributeSetpointChangeSourceTimestampID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeSetpointChangeSourceTimestampID")
+    = 0x00000032,
+    MTRClusterThermostatAttributeOccupiedSetbackID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeOccupiedSetbackID")
+    = 0x00000034,
+    MTRClusterThermostatAttributeOccupiedSetbackMinID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeOccupiedSetbackMinID")
+    = 0x00000035,
+    MTRClusterThermostatAttributeOccupiedSetbackMaxID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeOccupiedSetbackMaxID")
+    = 0x00000036,
+    MTRClusterThermostatAttributeUnoccupiedSetbackID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedSetbackID")
+    = 0x00000037,
+    MTRClusterThermostatAttributeUnoccupiedSetbackMinID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedSetbackMinID")
+    = 0x00000038,
+    MTRClusterThermostatAttributeUnoccupiedSetbackMaxID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedSetbackMaxID")
+    = 0x00000039,
+    MTRClusterThermostatAttributeEmergencyHeatDeltaID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeEmergencyHeatDeltaID")
+    = 0x0000003A,
+    MTRClusterThermostatAttributeACTypeID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterThermostatAttributeACTypeID")
+    = 0x00000040,
+    MTRClusterThermostatAttributeACCapacityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeACCapacityID")
+    = 0x00000041,
+    MTRClusterThermostatAttributeACRefrigerantTypeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeACRefrigerantTypeID")
+    = 0x00000042,
+    MTRClusterThermostatAttributeACCompressorTypeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeACCompressorTypeID")
+    = 0x00000043,
+    MTRClusterThermostatAttributeACErrorCodeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeACErrorCodeID")
+    = 0x00000044,
+    MTRClusterThermostatAttributeACLouverPositionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeACLouverPositionID")
+    = 0x00000045,
+    MTRClusterThermostatAttributeACCoilTemperatureID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeACCoilTemperatureID")
+    = 0x00000046,
+    MTRClusterThermostatAttributeACCapacityformatID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeACCapacityformatID")
+    = 0x00000047,
+    MTRClusterThermostatAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterThermostatAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterThermostatAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterThermostatAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterThermostatAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster Thermostat attributes
-    MTRClusterThermostatAttributeLocalTemperatureID = 0x00000000,
-    MTRClusterThermostatAttributeOutdoorTemperatureID = 0x00000001,
-    MTRClusterThermostatAttributeOccupancyID = 0x00000002,
-    MTRClusterThermostatAttributeAbsMinHeatSetpointLimitID = 0x00000003,
-    MTRClusterThermostatAttributeAbsMaxHeatSetpointLimitID = 0x00000004,
-    MTRClusterThermostatAttributeAbsMinCoolSetpointLimitID = 0x00000005,
-    MTRClusterThermostatAttributeAbsMaxCoolSetpointLimitID = 0x00000006,
-    MTRClusterThermostatAttributePICoolingDemandID = 0x00000007,
-    MTRClusterThermostatAttributePIHeatingDemandID = 0x00000008,
-    MTRClusterThermostatAttributeHVACSystemTypeConfigurationID = 0x00000009,
-    MTRClusterThermostatAttributeLocalTemperatureCalibrationID = 0x00000010,
-    MTRClusterThermostatAttributeOccupiedCoolingSetpointID = 0x00000011,
-    MTRClusterThermostatAttributeOccupiedHeatingSetpointID = 0x00000012,
-    MTRClusterThermostatAttributeUnoccupiedCoolingSetpointID = 0x00000013,
-    MTRClusterThermostatAttributeUnoccupiedHeatingSetpointID = 0x00000014,
-    MTRClusterThermostatAttributeMinHeatSetpointLimitID = 0x00000015,
-    MTRClusterThermostatAttributeMaxHeatSetpointLimitID = 0x00000016,
-    MTRClusterThermostatAttributeMinCoolSetpointLimitID = 0x00000017,
-    MTRClusterThermostatAttributeMaxCoolSetpointLimitID = 0x00000018,
-    MTRClusterThermostatAttributeMinSetpointDeadBandID = 0x00000019,
-    MTRClusterThermostatAttributeRemoteSensingID = 0x0000001A,
-    MTRClusterThermostatAttributeControlSequenceOfOperationID = 0x0000001B,
-    MTRClusterThermostatAttributeSystemModeID = 0x0000001C,
-    MTRClusterThermostatAttributeThermostatRunningModeID = 0x0000001E,
-    MTRClusterThermostatAttributeStartOfWeekID = 0x00000020,
-    MTRClusterThermostatAttributeNumberOfWeeklyTransitionsID = 0x00000021,
-    MTRClusterThermostatAttributeNumberOfDailyTransitionsID = 0x00000022,
-    MTRClusterThermostatAttributeTemperatureSetpointHoldID = 0x00000023,
-    MTRClusterThermostatAttributeTemperatureSetpointHoldDurationID = 0x00000024,
-    MTRClusterThermostatAttributeThermostatProgrammingOperationModeID = 0x00000025,
-    MTRClusterThermostatAttributeThermostatRunningStateID = 0x00000029,
-    MTRClusterThermostatAttributeSetpointChangeSourceID = 0x00000030,
-    MTRClusterThermostatAttributeSetpointChangeAmountID = 0x00000031,
-    MTRClusterThermostatAttributeSetpointChangeSourceTimestampID = 0x00000032,
-    MTRClusterThermostatAttributeOccupiedSetbackID = 0x00000034,
-    MTRClusterThermostatAttributeOccupiedSetbackMinID = 0x00000035,
-    MTRClusterThermostatAttributeOccupiedSetbackMaxID = 0x00000036,
-    MTRClusterThermostatAttributeUnoccupiedSetbackID = 0x00000037,
-    MTRClusterThermostatAttributeUnoccupiedSetbackMinID = 0x00000038,
-    MTRClusterThermostatAttributeUnoccupiedSetbackMaxID = 0x00000039,
-    MTRClusterThermostatAttributeEmergencyHeatDeltaID = 0x0000003A,
-    MTRClusterThermostatAttributeACTypeID = 0x00000040,
-    MTRClusterThermostatAttributeACCapacityID = 0x00000041,
-    MTRClusterThermostatAttributeACRefrigerantTypeID = 0x00000042,
-    MTRClusterThermostatAttributeACCompressorTypeID = 0x00000043,
-    MTRClusterThermostatAttributeACErrorCodeID = 0x00000044,
-    MTRClusterThermostatAttributeACLouverPositionID = 0x00000045,
-    MTRClusterThermostatAttributeACCoilTemperatureID = 0x00000046,
-    MTRClusterThermostatAttributeACCapacityformatID = 0x00000047,
-    MTRClusterThermostatAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterThermostatAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterThermostatAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterThermostatAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterThermostatAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterThermostatAttributeLocalTemperatureID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterThermostatAttributeOutdoorTemperatureID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterThermostatAttributeOccupancyID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterThermostatAttributeAbsMinHeatSetpointLimitID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterThermostatAttributeAbsMaxHeatSetpointLimitID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterThermostatAttributeAbsMinCoolSetpointLimitID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterThermostatAttributeAbsMaxCoolSetpointLimitID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterThermostatAttributePICoolingDemandID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterThermostatAttributePIHeatingDemandID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterThermostatAttributeHVACSystemTypeConfigurationID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRAttributeIDTypeClusterThermostatAttributeLocalTemperatureCalibrationID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRAttributeIDTypeClusterThermostatAttributeOccupiedCoolingSetpointID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRAttributeIDTypeClusterThermostatAttributeOccupiedHeatingSetpointID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedCoolingSetpointID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedHeatingSetpointID MTR_NEWLY_AVAILABLE = 0x00000014,
+    MTRAttributeIDTypeClusterThermostatAttributeMinHeatSetpointLimitID MTR_NEWLY_AVAILABLE = 0x00000015,
+    MTRAttributeIDTypeClusterThermostatAttributeMaxHeatSetpointLimitID MTR_NEWLY_AVAILABLE = 0x00000016,
+    MTRAttributeIDTypeClusterThermostatAttributeMinCoolSetpointLimitID MTR_NEWLY_AVAILABLE = 0x00000017,
+    MTRAttributeIDTypeClusterThermostatAttributeMaxCoolSetpointLimitID MTR_NEWLY_AVAILABLE = 0x00000018,
+    MTRAttributeIDTypeClusterThermostatAttributeMinSetpointDeadBandID MTR_NEWLY_AVAILABLE = 0x00000019,
+    MTRAttributeIDTypeClusterThermostatAttributeRemoteSensingID MTR_NEWLY_AVAILABLE = 0x0000001A,
+    MTRAttributeIDTypeClusterThermostatAttributeControlSequenceOfOperationID MTR_NEWLY_AVAILABLE = 0x0000001B,
+    MTRAttributeIDTypeClusterThermostatAttributeSystemModeID MTR_NEWLY_AVAILABLE = 0x0000001C,
+    MTRAttributeIDTypeClusterThermostatAttributeThermostatRunningModeID MTR_NEWLY_AVAILABLE = 0x0000001E,
+    MTRAttributeIDTypeClusterThermostatAttributeStartOfWeekID MTR_NEWLY_AVAILABLE = 0x00000020,
+    MTRAttributeIDTypeClusterThermostatAttributeNumberOfWeeklyTransitionsID MTR_NEWLY_AVAILABLE = 0x00000021,
+    MTRAttributeIDTypeClusterThermostatAttributeNumberOfDailyTransitionsID MTR_NEWLY_AVAILABLE = 0x00000022,
+    MTRAttributeIDTypeClusterThermostatAttributeTemperatureSetpointHoldID MTR_NEWLY_AVAILABLE = 0x00000023,
+    MTRAttributeIDTypeClusterThermostatAttributeTemperatureSetpointHoldDurationID MTR_NEWLY_AVAILABLE = 0x00000024,
+    MTRAttributeIDTypeClusterThermostatAttributeThermostatProgrammingOperationModeID MTR_NEWLY_AVAILABLE = 0x00000025,
+    MTRAttributeIDTypeClusterThermostatAttributeThermostatRunningStateID MTR_NEWLY_AVAILABLE = 0x00000029,
+    MTRAttributeIDTypeClusterThermostatAttributeSetpointChangeSourceID MTR_NEWLY_AVAILABLE = 0x00000030,
+    MTRAttributeIDTypeClusterThermostatAttributeSetpointChangeAmountID MTR_NEWLY_AVAILABLE = 0x00000031,
+    MTRAttributeIDTypeClusterThermostatAttributeSetpointChangeSourceTimestampID MTR_NEWLY_AVAILABLE = 0x00000032,
+    MTRAttributeIDTypeClusterThermostatAttributeOccupiedSetbackID MTR_NEWLY_AVAILABLE = 0x00000034,
+    MTRAttributeIDTypeClusterThermostatAttributeOccupiedSetbackMinID MTR_NEWLY_AVAILABLE = 0x00000035,
+    MTRAttributeIDTypeClusterThermostatAttributeOccupiedSetbackMaxID MTR_NEWLY_AVAILABLE = 0x00000036,
+    MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedSetbackID MTR_NEWLY_AVAILABLE = 0x00000037,
+    MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedSetbackMinID MTR_NEWLY_AVAILABLE = 0x00000038,
+    MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedSetbackMaxID MTR_NEWLY_AVAILABLE = 0x00000039,
+    MTRAttributeIDTypeClusterThermostatAttributeEmergencyHeatDeltaID MTR_NEWLY_AVAILABLE = 0x0000003A,
+    MTRAttributeIDTypeClusterThermostatAttributeACTypeID MTR_NEWLY_AVAILABLE = 0x00000040,
+    MTRAttributeIDTypeClusterThermostatAttributeACCapacityID MTR_NEWLY_AVAILABLE = 0x00000041,
+    MTRAttributeIDTypeClusterThermostatAttributeACRefrigerantTypeID MTR_NEWLY_AVAILABLE = 0x00000042,
+    MTRAttributeIDTypeClusterThermostatAttributeACCompressorTypeID MTR_NEWLY_AVAILABLE = 0x00000043,
+    MTRAttributeIDTypeClusterThermostatAttributeACErrorCodeID MTR_NEWLY_AVAILABLE = 0x00000044,
+    MTRAttributeIDTypeClusterThermostatAttributeACLouverPositionID MTR_NEWLY_AVAILABLE = 0x00000045,
+    MTRAttributeIDTypeClusterThermostatAttributeACCoilTemperatureID MTR_NEWLY_AVAILABLE = 0x00000046,
+    MTRAttributeIDTypeClusterThermostatAttributeACCapacityformatID MTR_NEWLY_AVAILABLE = 0x00000047,
+    MTRAttributeIDTypeClusterThermostatAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterThermostatAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterThermostatAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterThermostatAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterThermostatAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster FanControl deprecated attribute names
+    MTRClusterFanControlAttributeFanModeID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterFanControlAttributeFanModeID")
+    = 0x00000000,
+    MTRClusterFanControlAttributeFanModeSequenceID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributeFanModeSequenceID")
+    = 0x00000001,
+    MTRClusterFanControlAttributePercentSettingID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributePercentSettingID")
+    = 0x00000002,
+    MTRClusterFanControlAttributePercentCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributePercentCurrentID")
+    = 0x00000003,
+    MTRClusterFanControlAttributeSpeedMaxID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributeSpeedMaxID")
+    = 0x00000004,
+    MTRClusterFanControlAttributeSpeedSettingID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributeSpeedSettingID")
+    = 0x00000005,
+    MTRClusterFanControlAttributeSpeedCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributeSpeedCurrentID")
+    = 0x00000006,
+    MTRClusterFanControlAttributeRockSupportID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributeRockSupportID")
+    = 0x00000007,
+    MTRClusterFanControlAttributeRockSettingID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributeRockSettingID")
+    = 0x00000008,
+    MTRClusterFanControlAttributeWindSupportID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributeWindSupportID")
+    = 0x00000009,
+    MTRClusterFanControlAttributeWindSettingID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributeWindSettingID")
+    = 0x0000000A,
+    MTRClusterFanControlAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterFanControlAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterFanControlAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterFanControlAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterFanControlAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFanControlAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster FanControl attributes
-    MTRClusterFanControlAttributeFanModeID = 0x00000000,
-    MTRClusterFanControlAttributeFanModeSequenceID = 0x00000001,
-    MTRClusterFanControlAttributePercentSettingID = 0x00000002,
-    MTRClusterFanControlAttributePercentCurrentID = 0x00000003,
-    MTRClusterFanControlAttributeSpeedMaxID = 0x00000004,
-    MTRClusterFanControlAttributeSpeedSettingID = 0x00000005,
-    MTRClusterFanControlAttributeSpeedCurrentID = 0x00000006,
-    MTRClusterFanControlAttributeRockSupportID = 0x00000007,
-    MTRClusterFanControlAttributeRockSettingID = 0x00000008,
-    MTRClusterFanControlAttributeWindSupportID = 0x00000009,
-    MTRClusterFanControlAttributeWindSettingID = 0x0000000A,
-    MTRClusterFanControlAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterFanControlAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterFanControlAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterFanControlAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterFanControlAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterFanControlAttributeFanModeID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterFanControlAttributeFanModeSequenceID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterFanControlAttributePercentSettingID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterFanControlAttributePercentCurrentID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterFanControlAttributeSpeedMaxID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterFanControlAttributeSpeedSettingID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterFanControlAttributeSpeedCurrentID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterFanControlAttributeRockSupportID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterFanControlAttributeRockSettingID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterFanControlAttributeWindSupportID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRAttributeIDTypeClusterFanControlAttributeWindSettingID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRAttributeIDTypeClusterFanControlAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterFanControlAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterFanControlAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterFanControlAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterFanControlAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster ThermostatUserInterfaceConfiguration deprecated attribute names
+    MTRClusterThermostatUserInterfaceConfigurationAttributeTemperatureDisplayModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeTemperatureDisplayModeID")
+    = 0x00000000,
+    MTRClusterThermostatUserInterfaceConfigurationAttributeKeypadLockoutID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeKeypadLockoutID")
+    = 0x00000001,
+    MTRClusterThermostatUserInterfaceConfigurationAttributeScheduleProgrammingVisibilityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeScheduleProgrammingVisibilityID")
+    = 0x00000002,
+    MTRClusterThermostatUserInterfaceConfigurationAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterThermostatUserInterfaceConfigurationAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterThermostatUserInterfaceConfigurationAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterThermostatUserInterfaceConfigurationAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterThermostatUserInterfaceConfigurationAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster ThermostatUserInterfaceConfiguration attributes
-    MTRClusterThermostatUserInterfaceConfigurationAttributeTemperatureDisplayModeID = 0x00000000,
-    MTRClusterThermostatUserInterfaceConfigurationAttributeKeypadLockoutID = 0x00000001,
-    MTRClusterThermostatUserInterfaceConfigurationAttributeScheduleProgrammingVisibilityID = 0x00000002,
-    MTRClusterThermostatUserInterfaceConfigurationAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterThermostatUserInterfaceConfigurationAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterThermostatUserInterfaceConfigurationAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterThermostatUserInterfaceConfigurationAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterThermostatUserInterfaceConfigurationAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeTemperatureDisplayModeID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeKeypadLockoutID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeScheduleProgrammingVisibilityID MTR_NEWLY_AVAILABLE
+    = 0x00000002,
+    MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster ColorControl deprecated attribute names
+    MTRClusterColorControlAttributeCurrentHueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeCurrentHueID")
+    = 0x00000000,
+    MTRClusterColorControlAttributeCurrentSaturationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeCurrentSaturationID")
+    = 0x00000001,
+    MTRClusterColorControlAttributeRemainingTimeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeRemainingTimeID")
+    = 0x00000002,
+    MTRClusterColorControlAttributeCurrentXID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeCurrentXID")
+    = 0x00000003,
+    MTRClusterColorControlAttributeCurrentYID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeCurrentYID")
+    = 0x00000004,
+    MTRClusterColorControlAttributeDriftCompensationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeDriftCompensationID")
+    = 0x00000005,
+    MTRClusterColorControlAttributeCompensationTextID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeCompensationTextID")
+    = 0x00000006,
+    MTRClusterColorControlAttributeColorTemperatureMiredsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorTemperatureMiredsID")
+    = 0x00000007,
+    MTRClusterColorControlAttributeColorModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorModeID")
+    = 0x00000008,
+    MTRClusterColorControlAttributeOptionsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeOptionsID")
+    = 0x0000000F,
+    MTRClusterColorControlAttributeNumberOfPrimariesID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeNumberOfPrimariesID")
+    = 0x00000010,
+    MTRClusterColorControlAttributePrimary1XID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary1XID")
+    = 0x00000011,
+    MTRClusterColorControlAttributePrimary1YID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary1YID")
+    = 0x00000012,
+    MTRClusterColorControlAttributePrimary1IntensityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary1IntensityID")
+    = 0x00000013,
+    MTRClusterColorControlAttributePrimary2XID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary2XID")
+    = 0x00000015,
+    MTRClusterColorControlAttributePrimary2YID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary2YID")
+    = 0x00000016,
+    MTRClusterColorControlAttributePrimary2IntensityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary2IntensityID")
+    = 0x00000017,
+    MTRClusterColorControlAttributePrimary3XID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary3XID")
+    = 0x00000019,
+    MTRClusterColorControlAttributePrimary3YID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary3YID")
+    = 0x0000001A,
+    MTRClusterColorControlAttributePrimary3IntensityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary3IntensityID")
+    = 0x0000001B,
+    MTRClusterColorControlAttributePrimary4XID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary4XID")
+    = 0x00000020,
+    MTRClusterColorControlAttributePrimary4YID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary4YID")
+    = 0x00000021,
+    MTRClusterColorControlAttributePrimary4IntensityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary4IntensityID")
+    = 0x00000022,
+    MTRClusterColorControlAttributePrimary5XID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary5XID")
+    = 0x00000024,
+    MTRClusterColorControlAttributePrimary5YID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary5YID")
+    = 0x00000025,
+    MTRClusterColorControlAttributePrimary5IntensityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary5IntensityID")
+    = 0x00000026,
+    MTRClusterColorControlAttributePrimary6XID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary6XID")
+    = 0x00000028,
+    MTRClusterColorControlAttributePrimary6YID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary6YID")
+    = 0x00000029,
+    MTRClusterColorControlAttributePrimary6IntensityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributePrimary6IntensityID")
+    = 0x0000002A,
+    MTRClusterColorControlAttributeWhitePointXID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeWhitePointXID")
+    = 0x00000030,
+    MTRClusterColorControlAttributeWhitePointYID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeWhitePointYID")
+    = 0x00000031,
+    MTRClusterColorControlAttributeColorPointRXID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorPointRXID")
+    = 0x00000032,
+    MTRClusterColorControlAttributeColorPointRYID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorPointRYID")
+    = 0x00000033,
+    MTRClusterColorControlAttributeColorPointRIntensityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorPointRIntensityID")
+    = 0x00000034,
+    MTRClusterColorControlAttributeColorPointGXID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorPointGXID")
+    = 0x00000036,
+    MTRClusterColorControlAttributeColorPointGYID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorPointGYID")
+    = 0x00000037,
+    MTRClusterColorControlAttributeColorPointGIntensityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorPointGIntensityID")
+    = 0x00000038,
+    MTRClusterColorControlAttributeColorPointBXID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorPointBXID")
+    = 0x0000003A,
+    MTRClusterColorControlAttributeColorPointBYID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorPointBYID")
+    = 0x0000003B,
+    MTRClusterColorControlAttributeColorPointBIntensityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorPointBIntensityID")
+    = 0x0000003C,
+    MTRClusterColorControlAttributeEnhancedCurrentHueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeEnhancedCurrentHueID")
+    = 0x00004000,
+    MTRClusterColorControlAttributeEnhancedColorModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeEnhancedColorModeID")
+    = 0x00004001,
+    MTRClusterColorControlAttributeColorLoopActiveID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorLoopActiveID")
+    = 0x00004002,
+    MTRClusterColorControlAttributeColorLoopDirectionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorLoopDirectionID")
+    = 0x00004003,
+    MTRClusterColorControlAttributeColorLoopTimeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorLoopTimeID")
+    = 0x00004004,
+    MTRClusterColorControlAttributeColorLoopStartEnhancedHueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorLoopStartEnhancedHueID")
+    = 0x00004005,
+    MTRClusterColorControlAttributeColorLoopStoredEnhancedHueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorLoopStoredEnhancedHueID")
+    = 0x00004006,
+    MTRClusterColorControlAttributeColorCapabilitiesID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorCapabilitiesID")
+    = 0x0000400A,
+    MTRClusterColorControlAttributeColorTempPhysicalMinMiredsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorTempPhysicalMinMiredsID")
+    = 0x0000400B,
+    MTRClusterColorControlAttributeColorTempPhysicalMaxMiredsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeColorTempPhysicalMaxMiredsID")
+    = 0x0000400C,
+    MTRClusterColorControlAttributeCoupleColorTempToLevelMinMiredsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeCoupleColorTempToLevelMinMiredsID")
+    = 0x0000400D,
+    MTRClusterColorControlAttributeStartUpColorTemperatureMiredsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeStartUpColorTemperatureMiredsID")
+    = 0x00004010,
+    MTRClusterColorControlAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterColorControlAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterColorControlAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterColorControlAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterColorControlAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterColorControlAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster ColorControl attributes
-    MTRClusterColorControlAttributeCurrentHueID = 0x00000000,
-    MTRClusterColorControlAttributeCurrentSaturationID = 0x00000001,
-    MTRClusterColorControlAttributeRemainingTimeID = 0x00000002,
-    MTRClusterColorControlAttributeCurrentXID = 0x00000003,
-    MTRClusterColorControlAttributeCurrentYID = 0x00000004,
-    MTRClusterColorControlAttributeDriftCompensationID = 0x00000005,
-    MTRClusterColorControlAttributeCompensationTextID = 0x00000006,
-    MTRClusterColorControlAttributeColorTemperatureMiredsID = 0x00000007,
-    MTRClusterColorControlAttributeColorModeID = 0x00000008,
-    MTRClusterColorControlAttributeOptionsID = 0x0000000F,
-    MTRClusterColorControlAttributeNumberOfPrimariesID = 0x00000010,
-    MTRClusterColorControlAttributePrimary1XID = 0x00000011,
-    MTRClusterColorControlAttributePrimary1YID = 0x00000012,
-    MTRClusterColorControlAttributePrimary1IntensityID = 0x00000013,
-    MTRClusterColorControlAttributePrimary2XID = 0x00000015,
-    MTRClusterColorControlAttributePrimary2YID = 0x00000016,
-    MTRClusterColorControlAttributePrimary2IntensityID = 0x00000017,
-    MTRClusterColorControlAttributePrimary3XID = 0x00000019,
-    MTRClusterColorControlAttributePrimary3YID = 0x0000001A,
-    MTRClusterColorControlAttributePrimary3IntensityID = 0x0000001B,
-    MTRClusterColorControlAttributePrimary4XID = 0x00000020,
-    MTRClusterColorControlAttributePrimary4YID = 0x00000021,
-    MTRClusterColorControlAttributePrimary4IntensityID = 0x00000022,
-    MTRClusterColorControlAttributePrimary5XID = 0x00000024,
-    MTRClusterColorControlAttributePrimary5YID = 0x00000025,
-    MTRClusterColorControlAttributePrimary5IntensityID = 0x00000026,
-    MTRClusterColorControlAttributePrimary6XID = 0x00000028,
-    MTRClusterColorControlAttributePrimary6YID = 0x00000029,
-    MTRClusterColorControlAttributePrimary6IntensityID = 0x0000002A,
-    MTRClusterColorControlAttributeWhitePointXID = 0x00000030,
-    MTRClusterColorControlAttributeWhitePointYID = 0x00000031,
-    MTRClusterColorControlAttributeColorPointRXID = 0x00000032,
-    MTRClusterColorControlAttributeColorPointRYID = 0x00000033,
-    MTRClusterColorControlAttributeColorPointRIntensityID = 0x00000034,
-    MTRClusterColorControlAttributeColorPointGXID = 0x00000036,
-    MTRClusterColorControlAttributeColorPointGYID = 0x00000037,
-    MTRClusterColorControlAttributeColorPointGIntensityID = 0x00000038,
-    MTRClusterColorControlAttributeColorPointBXID = 0x0000003A,
-    MTRClusterColorControlAttributeColorPointBYID = 0x0000003B,
-    MTRClusterColorControlAttributeColorPointBIntensityID = 0x0000003C,
-    MTRClusterColorControlAttributeEnhancedCurrentHueID = 0x00004000,
-    MTRClusterColorControlAttributeEnhancedColorModeID = 0x00004001,
-    MTRClusterColorControlAttributeColorLoopActiveID = 0x00004002,
-    MTRClusterColorControlAttributeColorLoopDirectionID = 0x00004003,
-    MTRClusterColorControlAttributeColorLoopTimeID = 0x00004004,
-    MTRClusterColorControlAttributeColorLoopStartEnhancedHueID = 0x00004005,
-    MTRClusterColorControlAttributeColorLoopStoredEnhancedHueID = 0x00004006,
-    MTRClusterColorControlAttributeColorCapabilitiesID = 0x0000400A,
-    MTRClusterColorControlAttributeColorTempPhysicalMinMiredsID = 0x0000400B,
-    MTRClusterColorControlAttributeColorTempPhysicalMaxMiredsID = 0x0000400C,
-    MTRClusterColorControlAttributeCoupleColorTempToLevelMinMiredsID = 0x0000400D,
-    MTRClusterColorControlAttributeStartUpColorTemperatureMiredsID = 0x00004010,
-    MTRClusterColorControlAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterColorControlAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterColorControlAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterColorControlAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterColorControlAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterColorControlAttributeCurrentHueID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterColorControlAttributeCurrentSaturationID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterColorControlAttributeRemainingTimeID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterColorControlAttributeCurrentXID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterColorControlAttributeCurrentYID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterColorControlAttributeDriftCompensationID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterColorControlAttributeCompensationTextID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterColorControlAttributeColorTemperatureMiredsID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterColorControlAttributeColorModeID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterColorControlAttributeOptionsID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTRAttributeIDTypeClusterColorControlAttributeNumberOfPrimariesID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary1XID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary1YID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary1IntensityID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary2XID MTR_NEWLY_AVAILABLE = 0x00000015,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary2YID MTR_NEWLY_AVAILABLE = 0x00000016,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary2IntensityID MTR_NEWLY_AVAILABLE = 0x00000017,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary3XID MTR_NEWLY_AVAILABLE = 0x00000019,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary3YID MTR_NEWLY_AVAILABLE = 0x0000001A,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary3IntensityID MTR_NEWLY_AVAILABLE = 0x0000001B,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary4XID MTR_NEWLY_AVAILABLE = 0x00000020,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary4YID MTR_NEWLY_AVAILABLE = 0x00000021,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary4IntensityID MTR_NEWLY_AVAILABLE = 0x00000022,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary5XID MTR_NEWLY_AVAILABLE = 0x00000024,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary5YID MTR_NEWLY_AVAILABLE = 0x00000025,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary5IntensityID MTR_NEWLY_AVAILABLE = 0x00000026,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary6XID MTR_NEWLY_AVAILABLE = 0x00000028,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary6YID MTR_NEWLY_AVAILABLE = 0x00000029,
+    MTRAttributeIDTypeClusterColorControlAttributePrimary6IntensityID MTR_NEWLY_AVAILABLE = 0x0000002A,
+    MTRAttributeIDTypeClusterColorControlAttributeWhitePointXID MTR_NEWLY_AVAILABLE = 0x00000030,
+    MTRAttributeIDTypeClusterColorControlAttributeWhitePointYID MTR_NEWLY_AVAILABLE = 0x00000031,
+    MTRAttributeIDTypeClusterColorControlAttributeColorPointRXID MTR_NEWLY_AVAILABLE = 0x00000032,
+    MTRAttributeIDTypeClusterColorControlAttributeColorPointRYID MTR_NEWLY_AVAILABLE = 0x00000033,
+    MTRAttributeIDTypeClusterColorControlAttributeColorPointRIntensityID MTR_NEWLY_AVAILABLE = 0x00000034,
+    MTRAttributeIDTypeClusterColorControlAttributeColorPointGXID MTR_NEWLY_AVAILABLE = 0x00000036,
+    MTRAttributeIDTypeClusterColorControlAttributeColorPointGYID MTR_NEWLY_AVAILABLE = 0x00000037,
+    MTRAttributeIDTypeClusterColorControlAttributeColorPointGIntensityID MTR_NEWLY_AVAILABLE = 0x00000038,
+    MTRAttributeIDTypeClusterColorControlAttributeColorPointBXID MTR_NEWLY_AVAILABLE = 0x0000003A,
+    MTRAttributeIDTypeClusterColorControlAttributeColorPointBYID MTR_NEWLY_AVAILABLE = 0x0000003B,
+    MTRAttributeIDTypeClusterColorControlAttributeColorPointBIntensityID MTR_NEWLY_AVAILABLE = 0x0000003C,
+    MTRAttributeIDTypeClusterColorControlAttributeEnhancedCurrentHueID MTR_NEWLY_AVAILABLE = 0x00004000,
+    MTRAttributeIDTypeClusterColorControlAttributeEnhancedColorModeID MTR_NEWLY_AVAILABLE = 0x00004001,
+    MTRAttributeIDTypeClusterColorControlAttributeColorLoopActiveID MTR_NEWLY_AVAILABLE = 0x00004002,
+    MTRAttributeIDTypeClusterColorControlAttributeColorLoopDirectionID MTR_NEWLY_AVAILABLE = 0x00004003,
+    MTRAttributeIDTypeClusterColorControlAttributeColorLoopTimeID MTR_NEWLY_AVAILABLE = 0x00004004,
+    MTRAttributeIDTypeClusterColorControlAttributeColorLoopStartEnhancedHueID MTR_NEWLY_AVAILABLE = 0x00004005,
+    MTRAttributeIDTypeClusterColorControlAttributeColorLoopStoredEnhancedHueID MTR_NEWLY_AVAILABLE = 0x00004006,
+    MTRAttributeIDTypeClusterColorControlAttributeColorCapabilitiesID MTR_NEWLY_AVAILABLE = 0x0000400A,
+    MTRAttributeIDTypeClusterColorControlAttributeColorTempPhysicalMinMiredsID MTR_NEWLY_AVAILABLE = 0x0000400B,
+    MTRAttributeIDTypeClusterColorControlAttributeColorTempPhysicalMaxMiredsID MTR_NEWLY_AVAILABLE = 0x0000400C,
+    MTRAttributeIDTypeClusterColorControlAttributeCoupleColorTempToLevelMinMiredsID MTR_NEWLY_AVAILABLE = 0x0000400D,
+    MTRAttributeIDTypeClusterColorControlAttributeStartUpColorTemperatureMiredsID MTR_NEWLY_AVAILABLE = 0x00004010,
+    MTRAttributeIDTypeClusterColorControlAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterColorControlAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterColorControlAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterColorControlAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterColorControlAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster BallastConfiguration deprecated attribute names
+    MTRClusterBallastConfigurationAttributePhysicalMinLevelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributePhysicalMinLevelID")
+    = 0x00000000,
+    MTRClusterBallastConfigurationAttributePhysicalMaxLevelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributePhysicalMaxLevelID")
+    = 0x00000001,
+    MTRClusterBallastConfigurationAttributeBallastStatusID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeBallastStatusID")
+    = 0x00000002,
+    MTRClusterBallastConfigurationAttributeMinLevelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeMinLevelID")
+    = 0x00000010,
+    MTRClusterBallastConfigurationAttributeMaxLevelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeMaxLevelID")
+    = 0x00000011,
+    MTRClusterBallastConfigurationAttributeIntrinsicBalanceFactorID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeIntrinsicBalanceFactorID")
+    = 0x00000014,
+    MTRClusterBallastConfigurationAttributeBallastFactorAdjustmentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeBallastFactorAdjustmentID")
+    = 0x00000015,
+    MTRClusterBallastConfigurationAttributeLampQuantityID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeLampQuantityID")
+    = 0x00000020,
+    MTRClusterBallastConfigurationAttributeLampTypeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeLampTypeID")
+    = 0x00000030,
+    MTRClusterBallastConfigurationAttributeLampManufacturerID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeLampManufacturerID")
+    = 0x00000031,
+    MTRClusterBallastConfigurationAttributeLampRatedHoursID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeLampRatedHoursID")
+    = 0x00000032,
+    MTRClusterBallastConfigurationAttributeLampBurnHoursID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeLampBurnHoursID")
+    = 0x00000033,
+    MTRClusterBallastConfigurationAttributeLampAlarmModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeLampAlarmModeID")
+    = 0x00000034,
+    MTRClusterBallastConfigurationAttributeLampBurnHoursTripPointID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeLampBurnHoursTripPointID")
+    = 0x00000035,
+    MTRClusterBallastConfigurationAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterBallastConfigurationAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterBallastConfigurationAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterBallastConfigurationAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterBallastConfigurationAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterBallastConfigurationAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster BallastConfiguration attributes
-    MTRClusterBallastConfigurationAttributePhysicalMinLevelID = 0x00000000,
-    MTRClusterBallastConfigurationAttributePhysicalMaxLevelID = 0x00000001,
-    MTRClusterBallastConfigurationAttributeBallastStatusID = 0x00000002,
-    MTRClusterBallastConfigurationAttributeMinLevelID = 0x00000010,
-    MTRClusterBallastConfigurationAttributeMaxLevelID = 0x00000011,
-    MTRClusterBallastConfigurationAttributeIntrinsicBalanceFactorID = 0x00000014,
-    MTRClusterBallastConfigurationAttributeBallastFactorAdjustmentID = 0x00000015,
-    MTRClusterBallastConfigurationAttributeLampQuantityID = 0x00000020,
-    MTRClusterBallastConfigurationAttributeLampTypeID = 0x00000030,
-    MTRClusterBallastConfigurationAttributeLampManufacturerID = 0x00000031,
-    MTRClusterBallastConfigurationAttributeLampRatedHoursID = 0x00000032,
-    MTRClusterBallastConfigurationAttributeLampBurnHoursID = 0x00000033,
-    MTRClusterBallastConfigurationAttributeLampAlarmModeID = 0x00000034,
-    MTRClusterBallastConfigurationAttributeLampBurnHoursTripPointID = 0x00000035,
-    MTRClusterBallastConfigurationAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterBallastConfigurationAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterBallastConfigurationAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterBallastConfigurationAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterBallastConfigurationAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributePhysicalMinLevelID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributePhysicalMaxLevelID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeBallastStatusID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeMinLevelID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeMaxLevelID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeIntrinsicBalanceFactorID MTR_NEWLY_AVAILABLE = 0x00000014,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeBallastFactorAdjustmentID MTR_NEWLY_AVAILABLE = 0x00000015,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeLampQuantityID MTR_NEWLY_AVAILABLE = 0x00000020,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeLampTypeID MTR_NEWLY_AVAILABLE = 0x00000030,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeLampManufacturerID MTR_NEWLY_AVAILABLE = 0x00000031,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeLampRatedHoursID MTR_NEWLY_AVAILABLE = 0x00000032,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeLampBurnHoursID MTR_NEWLY_AVAILABLE = 0x00000033,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeLampAlarmModeID MTR_NEWLY_AVAILABLE = 0x00000034,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeLampBurnHoursTripPointID MTR_NEWLY_AVAILABLE = 0x00000035,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterBallastConfigurationAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster IlluminanceMeasurement deprecated attribute names
+    MTRClusterIlluminanceMeasurementAttributeMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeMeasuredValueID")
+    = 0x00000000,
+    MTRClusterIlluminanceMeasurementAttributeMinMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeMinMeasuredValueID")
+    = 0x00000001,
+    MTRClusterIlluminanceMeasurementAttributeMaxMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeMaxMeasuredValueID")
+    = 0x00000002,
+    MTRClusterIlluminanceMeasurementAttributeToleranceID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeToleranceID")
+    = 0x00000003,
+    MTRClusterIlluminanceMeasurementAttributeLightSensorTypeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeLightSensorTypeID")
+    = 0x00000004,
+    MTRClusterIlluminanceMeasurementAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterIlluminanceMeasurementAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterIlluminanceMeasurementAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterIlluminanceMeasurementAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterIlluminanceMeasurementAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster IlluminanceMeasurement attributes
-    MTRClusterIlluminanceMeasurementAttributeMeasuredValueID = 0x00000000,
-    MTRClusterIlluminanceMeasurementAttributeMinMeasuredValueID = 0x00000001,
-    MTRClusterIlluminanceMeasurementAttributeMaxMeasuredValueID = 0x00000002,
-    MTRClusterIlluminanceMeasurementAttributeToleranceID = 0x00000003,
-    MTRClusterIlluminanceMeasurementAttributeLightSensorTypeID = 0x00000004,
-    MTRClusterIlluminanceMeasurementAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterIlluminanceMeasurementAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterIlluminanceMeasurementAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterIlluminanceMeasurementAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterIlluminanceMeasurementAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeMinMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeMaxMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeToleranceID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeLightSensorTypeID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster TemperatureMeasurement deprecated attribute names
+    MTRClusterTemperatureMeasurementAttributeMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTemperatureMeasurementAttributeMeasuredValueID")
+    = 0x00000000,
+    MTRClusterTemperatureMeasurementAttributeMinMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTemperatureMeasurementAttributeMinMeasuredValueID")
+    = 0x00000001,
+    MTRClusterTemperatureMeasurementAttributeMaxMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTemperatureMeasurementAttributeMaxMeasuredValueID")
+    = 0x00000002,
+    MTRClusterTemperatureMeasurementAttributeToleranceID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTemperatureMeasurementAttributeToleranceID")
+    = 0x00000003,
+    MTRClusterTemperatureMeasurementAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTemperatureMeasurementAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterTemperatureMeasurementAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTemperatureMeasurementAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterTemperatureMeasurementAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTemperatureMeasurementAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterTemperatureMeasurementAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTemperatureMeasurementAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterTemperatureMeasurementAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTemperatureMeasurementAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster TemperatureMeasurement attributes
-    MTRClusterTemperatureMeasurementAttributeMeasuredValueID = 0x00000000,
-    MTRClusterTemperatureMeasurementAttributeMinMeasuredValueID = 0x00000001,
-    MTRClusterTemperatureMeasurementAttributeMaxMeasuredValueID = 0x00000002,
-    MTRClusterTemperatureMeasurementAttributeToleranceID = 0x00000003,
-    MTRClusterTemperatureMeasurementAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterTemperatureMeasurementAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterTemperatureMeasurementAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterTemperatureMeasurementAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterTemperatureMeasurementAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterTemperatureMeasurementAttributeMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterTemperatureMeasurementAttributeMinMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterTemperatureMeasurementAttributeMaxMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterTemperatureMeasurementAttributeToleranceID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterTemperatureMeasurementAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterTemperatureMeasurementAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterTemperatureMeasurementAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterTemperatureMeasurementAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterTemperatureMeasurementAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster PressureMeasurement deprecated attribute names
+    MTRClusterPressureMeasurementAttributeMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPressureMeasurementAttributeMeasuredValueID")
+    = 0x00000000,
+    MTRClusterPressureMeasurementAttributeMinMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPressureMeasurementAttributeMinMeasuredValueID")
+    = 0x00000001,
+    MTRClusterPressureMeasurementAttributeMaxMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPressureMeasurementAttributeMaxMeasuredValueID")
+    = 0x00000002,
+    MTRClusterPressureMeasurementAttributeToleranceID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPressureMeasurementAttributeToleranceID")
+    = 0x00000003,
+    MTRClusterPressureMeasurementAttributeScaledValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPressureMeasurementAttributeScaledValueID")
+    = 0x00000010,
+    MTRClusterPressureMeasurementAttributeMinScaledValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPressureMeasurementAttributeMinScaledValueID")
+    = 0x00000011,
+    MTRClusterPressureMeasurementAttributeMaxScaledValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPressureMeasurementAttributeMaxScaledValueID")
+    = 0x00000012,
+    MTRClusterPressureMeasurementAttributeScaledToleranceID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPressureMeasurementAttributeScaledToleranceID")
+    = 0x00000013,
+    MTRClusterPressureMeasurementAttributeScaleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPressureMeasurementAttributeScaleID")
+    = 0x00000014,
+    MTRClusterPressureMeasurementAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPressureMeasurementAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterPressureMeasurementAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPressureMeasurementAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterPressureMeasurementAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPressureMeasurementAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterPressureMeasurementAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPressureMeasurementAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterPressureMeasurementAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterPressureMeasurementAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster PressureMeasurement attributes
-    MTRClusterPressureMeasurementAttributeMeasuredValueID = 0x00000000,
-    MTRClusterPressureMeasurementAttributeMinMeasuredValueID = 0x00000001,
-    MTRClusterPressureMeasurementAttributeMaxMeasuredValueID = 0x00000002,
-    MTRClusterPressureMeasurementAttributeToleranceID = 0x00000003,
-    MTRClusterPressureMeasurementAttributeScaledValueID = 0x00000010,
-    MTRClusterPressureMeasurementAttributeMinScaledValueID = 0x00000011,
-    MTRClusterPressureMeasurementAttributeMaxScaledValueID = 0x00000012,
-    MTRClusterPressureMeasurementAttributeScaledToleranceID = 0x00000013,
-    MTRClusterPressureMeasurementAttributeScaleID = 0x00000014,
-    MTRClusterPressureMeasurementAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterPressureMeasurementAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterPressureMeasurementAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterPressureMeasurementAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterPressureMeasurementAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterPressureMeasurementAttributeMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterPressureMeasurementAttributeMinMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterPressureMeasurementAttributeMaxMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterPressureMeasurementAttributeToleranceID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterPressureMeasurementAttributeScaledValueID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRAttributeIDTypeClusterPressureMeasurementAttributeMinScaledValueID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRAttributeIDTypeClusterPressureMeasurementAttributeMaxScaledValueID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRAttributeIDTypeClusterPressureMeasurementAttributeScaledToleranceID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRAttributeIDTypeClusterPressureMeasurementAttributeScaleID MTR_NEWLY_AVAILABLE = 0x00000014,
+    MTRAttributeIDTypeClusterPressureMeasurementAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterPressureMeasurementAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterPressureMeasurementAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterPressureMeasurementAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterPressureMeasurementAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster FlowMeasurement deprecated attribute names
+    MTRClusterFlowMeasurementAttributeMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFlowMeasurementAttributeMeasuredValueID")
+    = 0x00000000,
+    MTRClusterFlowMeasurementAttributeMinMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFlowMeasurementAttributeMinMeasuredValueID")
+    = 0x00000001,
+    MTRClusterFlowMeasurementAttributeMaxMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFlowMeasurementAttributeMaxMeasuredValueID")
+    = 0x00000002,
+    MTRClusterFlowMeasurementAttributeToleranceID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFlowMeasurementAttributeToleranceID")
+    = 0x00000003,
+    MTRClusterFlowMeasurementAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFlowMeasurementAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterFlowMeasurementAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFlowMeasurementAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterFlowMeasurementAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFlowMeasurementAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterFlowMeasurementAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFlowMeasurementAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterFlowMeasurementAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFlowMeasurementAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster FlowMeasurement attributes
-    MTRClusterFlowMeasurementAttributeMeasuredValueID = 0x00000000,
-    MTRClusterFlowMeasurementAttributeMinMeasuredValueID = 0x00000001,
-    MTRClusterFlowMeasurementAttributeMaxMeasuredValueID = 0x00000002,
-    MTRClusterFlowMeasurementAttributeToleranceID = 0x00000003,
-    MTRClusterFlowMeasurementAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterFlowMeasurementAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterFlowMeasurementAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterFlowMeasurementAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterFlowMeasurementAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterFlowMeasurementAttributeMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterFlowMeasurementAttributeMinMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterFlowMeasurementAttributeMaxMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterFlowMeasurementAttributeToleranceID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterFlowMeasurementAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterFlowMeasurementAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterFlowMeasurementAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterFlowMeasurementAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterFlowMeasurementAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster RelativeHumidityMeasurement deprecated attribute names
+    MTRClusterRelativeHumidityMeasurementAttributeMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeMeasuredValueID")
+    = 0x00000000,
+    MTRClusterRelativeHumidityMeasurementAttributeMinMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeMinMeasuredValueID")
+    = 0x00000001,
+    MTRClusterRelativeHumidityMeasurementAttributeMaxMeasuredValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeMaxMeasuredValueID")
+    = 0x00000002,
+    MTRClusterRelativeHumidityMeasurementAttributeToleranceID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeToleranceID")
+    = 0x00000003,
+    MTRClusterRelativeHumidityMeasurementAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterRelativeHumidityMeasurementAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterRelativeHumidityMeasurementAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterRelativeHumidityMeasurementAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterRelativeHumidityMeasurementAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster RelativeHumidityMeasurement attributes
-    MTRClusterRelativeHumidityMeasurementAttributeMeasuredValueID = 0x00000000,
-    MTRClusterRelativeHumidityMeasurementAttributeMinMeasuredValueID = 0x00000001,
-    MTRClusterRelativeHumidityMeasurementAttributeMaxMeasuredValueID = 0x00000002,
-    MTRClusterRelativeHumidityMeasurementAttributeToleranceID = 0x00000003,
-    MTRClusterRelativeHumidityMeasurementAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterRelativeHumidityMeasurementAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterRelativeHumidityMeasurementAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterRelativeHumidityMeasurementAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterRelativeHumidityMeasurementAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeMinMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeMaxMeasuredValueID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeToleranceID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster OccupancySensing deprecated attribute names
+    MTRClusterOccupancySensingAttributeOccupancyID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributeOccupancyID")
+    = 0x00000000,
+    MTRClusterOccupancySensingAttributeOccupancySensorTypeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributeOccupancySensorTypeID")
+    = 0x00000001,
+    MTRClusterOccupancySensingAttributeOccupancySensorTypeBitmapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributeOccupancySensorTypeBitmapID")
+    = 0x00000002,
+    MTRClusterOccupancySensingAttributePirOccupiedToUnoccupiedDelayID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributePirOccupiedToUnoccupiedDelayID")
+    = 0x00000010,
+    MTRClusterOccupancySensingAttributePirUnoccupiedToOccupiedDelayID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributePirUnoccupiedToOccupiedDelayID")
+    = 0x00000011,
+    MTRClusterOccupancySensingAttributePirUnoccupiedToOccupiedThresholdID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributePirUnoccupiedToOccupiedThresholdID")
+    = 0x00000012,
+    MTRClusterOccupancySensingAttributeUltrasonicOccupiedToUnoccupiedDelayID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicOccupiedToUnoccupiedDelayID")
+    = 0x00000020,
+    MTRClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedDelayID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedDelayID")
+    = 0x00000021,
+    MTRClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedThresholdID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedThresholdID")
+    = 0x00000022,
+    MTRClusterOccupancySensingAttributePhysicalContactOccupiedToUnoccupiedDelayID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributePhysicalContactOccupiedToUnoccupiedDelayID")
+    = 0x00000030,
+    MTRClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedDelayID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedDelayID")
+    = 0x00000031,
+    MTRClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedThresholdID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedThresholdID")
+    = 0x00000032,
+    MTRClusterOccupancySensingAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterOccupancySensingAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterOccupancySensingAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterOccupancySensingAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterOccupancySensingAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterOccupancySensingAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster OccupancySensing attributes
-    MTRClusterOccupancySensingAttributeOccupancyID = 0x00000000,
-    MTRClusterOccupancySensingAttributeOccupancySensorTypeID = 0x00000001,
-    MTRClusterOccupancySensingAttributeOccupancySensorTypeBitmapID = 0x00000002,
-    MTRClusterOccupancySensingAttributePirOccupiedToUnoccupiedDelayID = 0x00000010,
-    MTRClusterOccupancySensingAttributePirUnoccupiedToOccupiedDelayID = 0x00000011,
-    MTRClusterOccupancySensingAttributePirUnoccupiedToOccupiedThresholdID = 0x00000012,
-    MTRClusterOccupancySensingAttributeUltrasonicOccupiedToUnoccupiedDelayID = 0x00000020,
-    MTRClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedDelayID = 0x00000021,
-    MTRClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedThresholdID = 0x00000022,
-    MTRClusterOccupancySensingAttributePhysicalContactOccupiedToUnoccupiedDelayID = 0x00000030,
-    MTRClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedDelayID = 0x00000031,
-    MTRClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedThresholdID = 0x00000032,
-    MTRClusterOccupancySensingAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterOccupancySensingAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterOccupancySensingAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterOccupancySensingAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterOccupancySensingAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterOccupancySensingAttributeOccupancyID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterOccupancySensingAttributeOccupancySensorTypeID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterOccupancySensingAttributeOccupancySensorTypeBitmapID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterOccupancySensingAttributePirOccupiedToUnoccupiedDelayID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRAttributeIDTypeClusterOccupancySensingAttributePirUnoccupiedToOccupiedDelayID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRAttributeIDTypeClusterOccupancySensingAttributePirUnoccupiedToOccupiedThresholdID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicOccupiedToUnoccupiedDelayID MTR_NEWLY_AVAILABLE = 0x00000020,
+    MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedDelayID MTR_NEWLY_AVAILABLE = 0x00000021,
+    MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedThresholdID MTR_NEWLY_AVAILABLE = 0x00000022,
+    MTRAttributeIDTypeClusterOccupancySensingAttributePhysicalContactOccupiedToUnoccupiedDelayID MTR_NEWLY_AVAILABLE = 0x00000030,
+    MTRAttributeIDTypeClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedDelayID MTR_NEWLY_AVAILABLE = 0x00000031,
+    MTRAttributeIDTypeClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedThresholdID MTR_NEWLY_AVAILABLE
+    = 0x00000032,
+    MTRAttributeIDTypeClusterOccupancySensingAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterOccupancySensingAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterOccupancySensingAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterOccupancySensingAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterOccupancySensingAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster WakeOnLan deprecated attribute names
+    MTRClusterWakeOnLanAttributeMACAddressID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWakeOnLanAttributeMACAddressID")
+    = 0x00000000,
+    MTRClusterWakeOnLanAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWakeOnLanAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterWakeOnLanAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWakeOnLanAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterWakeOnLanAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWakeOnLanAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterWakeOnLanAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWakeOnLanAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterWakeOnLanAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterWakeOnLanAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster WakeOnLan attributes
-    MTRClusterWakeOnLanAttributeMACAddressID = 0x00000000,
-    MTRClusterWakeOnLanAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterWakeOnLanAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterWakeOnLanAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterWakeOnLanAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterWakeOnLanAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterWakeOnLanAttributeMACAddressID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterWakeOnLanAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterWakeOnLanAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterWakeOnLanAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterWakeOnLanAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterWakeOnLanAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster Channel deprecated attribute names
+    MTRClusterChannelAttributeChannelListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterChannelAttributeChannelListID")
+    = 0x00000000,
+    MTRClusterChannelAttributeLineupID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterChannelAttributeLineupID")
+    = 0x00000001,
+    MTRClusterChannelAttributeCurrentChannelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterChannelAttributeCurrentChannelID")
+    = 0x00000002,
+    MTRClusterChannelAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterChannelAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterChannelAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterChannelAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterChannelAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterChannelAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterChannelAttributeFeatureMapID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterChannelAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterChannelAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterChannelAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster Channel attributes
-    MTRClusterChannelAttributeChannelListID = 0x00000000,
-    MTRClusterChannelAttributeLineupID = 0x00000001,
-    MTRClusterChannelAttributeCurrentChannelID = 0x00000002,
-    MTRClusterChannelAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterChannelAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterChannelAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterChannelAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterChannelAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterChannelAttributeChannelListID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterChannelAttributeLineupID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterChannelAttributeCurrentChannelID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterChannelAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterChannelAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterChannelAttributeAttributeListID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterChannelAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterChannelAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster TargetNavigator deprecated attribute names
+    MTRClusterTargetNavigatorAttributeTargetListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTargetNavigatorAttributeTargetListID")
+    = 0x00000000,
+    MTRClusterTargetNavigatorAttributeCurrentTargetID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTargetNavigatorAttributeCurrentTargetID")
+    = 0x00000001,
+    MTRClusterTargetNavigatorAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTargetNavigatorAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterTargetNavigatorAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTargetNavigatorAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterTargetNavigatorAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTargetNavigatorAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterTargetNavigatorAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTargetNavigatorAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterTargetNavigatorAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterTargetNavigatorAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster TargetNavigator attributes
-    MTRClusterTargetNavigatorAttributeTargetListID = 0x00000000,
-    MTRClusterTargetNavigatorAttributeCurrentTargetID = 0x00000001,
-    MTRClusterTargetNavigatorAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterTargetNavigatorAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterTargetNavigatorAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterTargetNavigatorAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterTargetNavigatorAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterTargetNavigatorAttributeTargetListID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterTargetNavigatorAttributeCurrentTargetID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterTargetNavigatorAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterTargetNavigatorAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterTargetNavigatorAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterTargetNavigatorAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterTargetNavigatorAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster MediaPlayback deprecated attribute names
+    MTRClusterMediaPlaybackAttributeCurrentStateID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaPlaybackAttributeCurrentStateID")
+    = 0x00000000,
+    MTRClusterMediaPlaybackAttributeStartTimeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaPlaybackAttributeStartTimeID")
+    = 0x00000001,
+    MTRClusterMediaPlaybackAttributeDurationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaPlaybackAttributeDurationID")
+    = 0x00000002,
+    MTRClusterMediaPlaybackAttributeSampledPositionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaPlaybackAttributeSampledPositionID")
+    = 0x00000003,
+    MTRClusterMediaPlaybackAttributePlaybackSpeedID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaPlaybackAttributePlaybackSpeedID")
+    = 0x00000004,
+    MTRClusterMediaPlaybackAttributeSeekRangeEndID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaPlaybackAttributeSeekRangeEndID")
+    = 0x00000005,
+    MTRClusterMediaPlaybackAttributeSeekRangeStartID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaPlaybackAttributeSeekRangeStartID")
+    = 0x00000006,
+    MTRClusterMediaPlaybackAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaPlaybackAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterMediaPlaybackAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaPlaybackAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterMediaPlaybackAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaPlaybackAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterMediaPlaybackAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaPlaybackAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterMediaPlaybackAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaPlaybackAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster MediaPlayback attributes
-    MTRClusterMediaPlaybackAttributeCurrentStateID = 0x00000000,
-    MTRClusterMediaPlaybackAttributeStartTimeID = 0x00000001,
-    MTRClusterMediaPlaybackAttributeDurationID = 0x00000002,
-    MTRClusterMediaPlaybackAttributeSampledPositionID = 0x00000003,
-    MTRClusterMediaPlaybackAttributePlaybackSpeedID = 0x00000004,
-    MTRClusterMediaPlaybackAttributeSeekRangeEndID = 0x00000005,
-    MTRClusterMediaPlaybackAttributeSeekRangeStartID = 0x00000006,
-    MTRClusterMediaPlaybackAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterMediaPlaybackAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterMediaPlaybackAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterMediaPlaybackAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterMediaPlaybackAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterMediaPlaybackAttributeCurrentStateID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterMediaPlaybackAttributeStartTimeID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterMediaPlaybackAttributeDurationID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterMediaPlaybackAttributeSampledPositionID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterMediaPlaybackAttributePlaybackSpeedID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterMediaPlaybackAttributeSeekRangeEndID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterMediaPlaybackAttributeSeekRangeStartID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterMediaPlaybackAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterMediaPlaybackAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterMediaPlaybackAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterMediaPlaybackAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterMediaPlaybackAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster MediaInput deprecated attribute names
+    MTRClusterMediaInputAttributeInputListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaInputAttributeInputListID")
+    = 0x00000000,
+    MTRClusterMediaInputAttributeCurrentInputID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaInputAttributeCurrentInputID")
+    = 0x00000001,
+    MTRClusterMediaInputAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaInputAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterMediaInputAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaInputAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterMediaInputAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaInputAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterMediaInputAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaInputAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterMediaInputAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterMediaInputAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster MediaInput attributes
-    MTRClusterMediaInputAttributeInputListID = 0x00000000,
-    MTRClusterMediaInputAttributeCurrentInputID = 0x00000001,
-    MTRClusterMediaInputAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterMediaInputAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterMediaInputAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterMediaInputAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterMediaInputAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterMediaInputAttributeInputListID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterMediaInputAttributeCurrentInputID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterMediaInputAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterMediaInputAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterMediaInputAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterMediaInputAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterMediaInputAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster LowPower deprecated attribute names
+    MTRClusterLowPowerAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLowPowerAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterLowPowerAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLowPowerAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterLowPowerAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLowPowerAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterLowPowerAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLowPowerAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterLowPowerAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterLowPowerAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster LowPower attributes
-    MTRClusterLowPowerAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterLowPowerAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterLowPowerAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterLowPowerAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterLowPowerAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterLowPowerAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterLowPowerAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterLowPowerAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterLowPowerAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterLowPowerAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster KeypadInput deprecated attribute names
+    MTRClusterKeypadInputAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterKeypadInputAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterKeypadInputAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterKeypadInputAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterKeypadInputAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterKeypadInputAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterKeypadInputAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterKeypadInputAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterKeypadInputAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterKeypadInputAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster KeypadInput attributes
-    MTRClusterKeypadInputAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterKeypadInputAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterKeypadInputAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterKeypadInputAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterKeypadInputAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterKeypadInputAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterKeypadInputAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterKeypadInputAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterKeypadInputAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterKeypadInputAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster ContentLauncher deprecated attribute names
+    MTRClusterContentLauncherAttributeAcceptHeaderID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterContentLauncherAttributeAcceptHeaderID")
+    = 0x00000000,
+    MTRClusterContentLauncherAttributeSupportedStreamingProtocolsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterContentLauncherAttributeSupportedStreamingProtocolsID")
+    = 0x00000001,
+    MTRClusterContentLauncherAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterContentLauncherAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterContentLauncherAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterContentLauncherAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterContentLauncherAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterContentLauncherAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterContentLauncherAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterContentLauncherAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterContentLauncherAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterContentLauncherAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster ContentLauncher attributes
-    MTRClusterContentLauncherAttributeAcceptHeaderID = 0x00000000,
-    MTRClusterContentLauncherAttributeSupportedStreamingProtocolsID = 0x00000001,
-    MTRClusterContentLauncherAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterContentLauncherAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterContentLauncherAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterContentLauncherAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterContentLauncherAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterContentLauncherAttributeAcceptHeaderID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterContentLauncherAttributeSupportedStreamingProtocolsID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterContentLauncherAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterContentLauncherAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterContentLauncherAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterContentLauncherAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterContentLauncherAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster AudioOutput deprecated attribute names
+    MTRClusterAudioOutputAttributeOutputListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAudioOutputAttributeOutputListID")
+    = 0x00000000,
+    MTRClusterAudioOutputAttributeCurrentOutputID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAudioOutputAttributeCurrentOutputID")
+    = 0x00000001,
+    MTRClusterAudioOutputAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAudioOutputAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterAudioOutputAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAudioOutputAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterAudioOutputAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAudioOutputAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterAudioOutputAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAudioOutputAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterAudioOutputAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAudioOutputAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster AudioOutput attributes
-    MTRClusterAudioOutputAttributeOutputListID = 0x00000000,
-    MTRClusterAudioOutputAttributeCurrentOutputID = 0x00000001,
-    MTRClusterAudioOutputAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterAudioOutputAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterAudioOutputAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterAudioOutputAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterAudioOutputAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterAudioOutputAttributeOutputListID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterAudioOutputAttributeCurrentOutputID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterAudioOutputAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterAudioOutputAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterAudioOutputAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterAudioOutputAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterAudioOutputAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster ApplicationLauncher deprecated attribute names
+    MTRClusterApplicationLauncherAttributeCatalogListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationLauncherAttributeCatalogListID")
+    = 0x00000000,
+    MTRClusterApplicationLauncherAttributeCurrentAppID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationLauncherAttributeCurrentAppID")
+    = 0x00000001,
+    MTRClusterApplicationLauncherAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationLauncherAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterApplicationLauncherAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationLauncherAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterApplicationLauncherAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationLauncherAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterApplicationLauncherAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationLauncherAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterApplicationLauncherAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationLauncherAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster ApplicationLauncher attributes
-    MTRClusterApplicationLauncherAttributeCatalogListID = 0x00000000,
-    MTRClusterApplicationLauncherAttributeCurrentAppID = 0x00000001,
-    MTRClusterApplicationLauncherAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterApplicationLauncherAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterApplicationLauncherAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterApplicationLauncherAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterApplicationLauncherAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterApplicationLauncherAttributeCatalogListID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterApplicationLauncherAttributeCurrentAppID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterApplicationLauncherAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterApplicationLauncherAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterApplicationLauncherAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterApplicationLauncherAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterApplicationLauncherAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster ApplicationBasic deprecated attribute names
+    MTRClusterApplicationBasicAttributeVendorNameID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationBasicAttributeVendorNameID")
+    = 0x00000000,
+    MTRClusterApplicationBasicAttributeVendorIDID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationBasicAttributeVendorIDID")
+    = 0x00000001,
+    MTRClusterApplicationBasicAttributeApplicationNameID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationBasicAttributeApplicationNameID")
+    = 0x00000002,
+    MTRClusterApplicationBasicAttributeProductIDID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationBasicAttributeProductIDID")
+    = 0x00000003,
+    MTRClusterApplicationBasicAttributeApplicationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationBasicAttributeApplicationID")
+    = 0x00000004,
+    MTRClusterApplicationBasicAttributeStatusID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationBasicAttributeStatusID")
+    = 0x00000005,
+    MTRClusterApplicationBasicAttributeApplicationVersionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationBasicAttributeApplicationVersionID")
+    = 0x00000006,
+    MTRClusterApplicationBasicAttributeAllowedVendorListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationBasicAttributeAllowedVendorListID")
+    = 0x00000007,
+    MTRClusterApplicationBasicAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationBasicAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterApplicationBasicAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationBasicAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterApplicationBasicAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationBasicAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterApplicationBasicAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationBasicAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterApplicationBasicAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterApplicationBasicAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster ApplicationBasic attributes
-    MTRClusterApplicationBasicAttributeVendorNameID = 0x00000000,
-    MTRClusterApplicationBasicAttributeVendorIDID = 0x00000001,
-    MTRClusterApplicationBasicAttributeApplicationNameID = 0x00000002,
-    MTRClusterApplicationBasicAttributeProductIDID = 0x00000003,
-    MTRClusterApplicationBasicAttributeApplicationID = 0x00000004,
-    MTRClusterApplicationBasicAttributeStatusID = 0x00000005,
-    MTRClusterApplicationBasicAttributeApplicationVersionID = 0x00000006,
-    MTRClusterApplicationBasicAttributeAllowedVendorListID = 0x00000007,
-    MTRClusterApplicationBasicAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterApplicationBasicAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterApplicationBasicAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterApplicationBasicAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterApplicationBasicAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterApplicationBasicAttributeVendorNameID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterApplicationBasicAttributeVendorIDID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterApplicationBasicAttributeApplicationNameID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterApplicationBasicAttributeProductIDID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterApplicationBasicAttributeApplicationID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterApplicationBasicAttributeStatusID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterApplicationBasicAttributeApplicationVersionID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterApplicationBasicAttributeAllowedVendorListID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterApplicationBasicAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterApplicationBasicAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterApplicationBasicAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterApplicationBasicAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterApplicationBasicAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster AccountLogin deprecated attribute names
+    MTRClusterAccountLoginAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAccountLoginAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterAccountLoginAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAccountLoginAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterAccountLoginAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAccountLoginAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterAccountLoginAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAccountLoginAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterAccountLoginAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterAccountLoginAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster AccountLogin attributes
-    MTRClusterAccountLoginAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterAccountLoginAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterAccountLoginAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterAccountLoginAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterAccountLoginAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterAccountLoginAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterAccountLoginAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterAccountLoginAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterAccountLoginAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterAccountLoginAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster ElectricalMeasurement deprecated attribute names
+    MTRClusterElectricalMeasurementAttributeMeasurementTypeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasurementTypeID")
+    = 0x00000000,
+    MTRClusterElectricalMeasurementAttributeDcVoltageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageID")
+    = 0x00000100,
+    MTRClusterElectricalMeasurementAttributeDcVoltageMinID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageMinID")
+    = 0x00000101,
+    MTRClusterElectricalMeasurementAttributeDcVoltageMaxID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageMaxID")
+    = 0x00000102,
+    MTRClusterElectricalMeasurementAttributeDcCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentID")
+    = 0x00000103,
+    MTRClusterElectricalMeasurementAttributeDcCurrentMinID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentMinID")
+    = 0x00000104,
+    MTRClusterElectricalMeasurementAttributeDcCurrentMaxID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentMaxID")
+    = 0x00000105,
+    MTRClusterElectricalMeasurementAttributeDcPowerID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerID")
+    = 0x00000106,
+    MTRClusterElectricalMeasurementAttributeDcPowerMinID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerMinID")
+    = 0x00000107,
+    MTRClusterElectricalMeasurementAttributeDcPowerMaxID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerMaxID")
+    = 0x00000108,
+    MTRClusterElectricalMeasurementAttributeDcVoltageMultiplierID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageMultiplierID")
+    = 0x00000200,
+    MTRClusterElectricalMeasurementAttributeDcVoltageDivisorID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageDivisorID")
+    = 0x00000201,
+    MTRClusterElectricalMeasurementAttributeDcCurrentMultiplierID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentMultiplierID")
+    = 0x00000202,
+    MTRClusterElectricalMeasurementAttributeDcCurrentDivisorID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentDivisorID")
+    = 0x00000203,
+    MTRClusterElectricalMeasurementAttributeDcPowerMultiplierID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerMultiplierID")
+    = 0x00000204,
+    MTRClusterElectricalMeasurementAttributeDcPowerDivisorID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerDivisorID")
+    = 0x00000205,
+    MTRClusterElectricalMeasurementAttributeAcFrequencyID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyID")
+    = 0x00000300,
+    MTRClusterElectricalMeasurementAttributeAcFrequencyMinID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyMinID")
+    = 0x00000301,
+    MTRClusterElectricalMeasurementAttributeAcFrequencyMaxID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyMaxID")
+    = 0x00000302,
+    MTRClusterElectricalMeasurementAttributeNeutralCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeNeutralCurrentID")
+    = 0x00000303,
+    MTRClusterElectricalMeasurementAttributeTotalActivePowerID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeTotalActivePowerID")
+    = 0x00000304,
+    MTRClusterElectricalMeasurementAttributeTotalReactivePowerID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeTotalReactivePowerID")
+    = 0x00000305,
+    MTRClusterElectricalMeasurementAttributeTotalApparentPowerID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeTotalApparentPowerID")
+    = 0x00000306,
+    MTRClusterElectricalMeasurementAttributeMeasured1stHarmonicCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured1stHarmonicCurrentID")
+    = 0x00000307,
+    MTRClusterElectricalMeasurementAttributeMeasured3rdHarmonicCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured3rdHarmonicCurrentID")
+    = 0x00000308,
+    MTRClusterElectricalMeasurementAttributeMeasured5thHarmonicCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured5thHarmonicCurrentID")
+    = 0x00000309,
+    MTRClusterElectricalMeasurementAttributeMeasured7thHarmonicCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured7thHarmonicCurrentID")
+    = 0x0000030A,
+    MTRClusterElectricalMeasurementAttributeMeasured9thHarmonicCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured9thHarmonicCurrentID")
+    = 0x0000030B,
+    MTRClusterElectricalMeasurementAttributeMeasured11thHarmonicCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured11thHarmonicCurrentID")
+    = 0x0000030C,
+    MTRClusterElectricalMeasurementAttributeMeasuredPhase1stHarmonicCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase1stHarmonicCurrentID")
+    = 0x0000030D,
+    MTRClusterElectricalMeasurementAttributeMeasuredPhase3rdHarmonicCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase3rdHarmonicCurrentID")
+    = 0x0000030E,
+    MTRClusterElectricalMeasurementAttributeMeasuredPhase5thHarmonicCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase5thHarmonicCurrentID")
+    = 0x0000030F,
+    MTRClusterElectricalMeasurementAttributeMeasuredPhase7thHarmonicCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase7thHarmonicCurrentID")
+    = 0x00000310,
+    MTRClusterElectricalMeasurementAttributeMeasuredPhase9thHarmonicCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase9thHarmonicCurrentID")
+    = 0x00000311,
+    MTRClusterElectricalMeasurementAttributeMeasuredPhase11thHarmonicCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase11thHarmonicCurrentID")
+    = 0x00000312,
+    MTRClusterElectricalMeasurementAttributeAcFrequencyMultiplierID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyMultiplierID")
+    = 0x00000400,
+    MTRClusterElectricalMeasurementAttributeAcFrequencyDivisorID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyDivisorID")
+    = 0x00000401,
+    MTRClusterElectricalMeasurementAttributePowerMultiplierID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerMultiplierID")
+    = 0x00000402,
+    MTRClusterElectricalMeasurementAttributePowerDivisorID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerDivisorID")
+    = 0x00000403,
+    MTRClusterElectricalMeasurementAttributeHarmonicCurrentMultiplierID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeHarmonicCurrentMultiplierID")
+    = 0x00000404,
+    MTRClusterElectricalMeasurementAttributePhaseHarmonicCurrentMultiplierID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributePhaseHarmonicCurrentMultiplierID")
+    = 0x00000405,
+    MTRClusterElectricalMeasurementAttributeInstantaneousVoltageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousVoltageID")
+    = 0x00000500,
+    MTRClusterElectricalMeasurementAttributeInstantaneousLineCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousLineCurrentID")
+    = 0x00000501,
+    MTRClusterElectricalMeasurementAttributeInstantaneousActiveCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousActiveCurrentID")
+    = 0x00000502,
+    MTRClusterElectricalMeasurementAttributeInstantaneousReactiveCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousReactiveCurrentID")
+    = 0x00000503,
+    MTRClusterElectricalMeasurementAttributeInstantaneousPowerID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousPowerID")
+    = 0x00000504,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageID")
+    = 0x00000505,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageMinID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMinID")
+    = 0x00000506,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageMaxID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMaxID")
+    = 0x00000507,
+    MTRClusterElectricalMeasurementAttributeRmsCurrentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentID")
+    = 0x00000508,
+    MTRClusterElectricalMeasurementAttributeRmsCurrentMinID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMinID")
+    = 0x00000509,
+    MTRClusterElectricalMeasurementAttributeRmsCurrentMaxID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMaxID")
+    = 0x0000050A,
+    MTRClusterElectricalMeasurementAttributeActivePowerID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerID")
+    = 0x0000050B,
+    MTRClusterElectricalMeasurementAttributeActivePowerMinID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMinID")
+    = 0x0000050C,
+    MTRClusterElectricalMeasurementAttributeActivePowerMaxID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMaxID")
+    = 0x0000050D,
+    MTRClusterElectricalMeasurementAttributeReactivePowerID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactivePowerID")
+    = 0x0000050E,
+    MTRClusterElectricalMeasurementAttributeApparentPowerID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeApparentPowerID")
+    = 0x0000050F,
+    MTRClusterElectricalMeasurementAttributePowerFactorID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerFactorID")
+    = 0x00000510,
+    MTRClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodID")
+    = 0x00000511,
+    MTRClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterID")
+    = 0x00000513,
+    MTRClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodID")
+    = 0x00000514,
+    MTRClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodID")
+    = 0x00000515,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageSagPeriodID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSagPeriodID")
+    = 0x00000516,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodID")
+    = 0x00000517,
+    MTRClusterElectricalMeasurementAttributeAcVoltageMultiplierID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcVoltageMultiplierID")
+    = 0x00000600,
+    MTRClusterElectricalMeasurementAttributeAcVoltageDivisorID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcVoltageDivisorID")
+    = 0x00000601,
+    MTRClusterElectricalMeasurementAttributeAcCurrentMultiplierID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcCurrentMultiplierID")
+    = 0x00000602,
+    MTRClusterElectricalMeasurementAttributeAcCurrentDivisorID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcCurrentDivisorID")
+    = 0x00000603,
+    MTRClusterElectricalMeasurementAttributeAcPowerMultiplierID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcPowerMultiplierID")
+    = 0x00000604,
+    MTRClusterElectricalMeasurementAttributeAcPowerDivisorID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcPowerDivisorID")
+    = 0x00000605,
+    MTRClusterElectricalMeasurementAttributeOverloadAlarmsMaskID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeOverloadAlarmsMaskID")
+    = 0x00000700,
+    MTRClusterElectricalMeasurementAttributeVoltageOverloadID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeVoltageOverloadID")
+    = 0x00000701,
+    MTRClusterElectricalMeasurementAttributeCurrentOverloadID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeCurrentOverloadID")
+    = 0x00000702,
+    MTRClusterElectricalMeasurementAttributeAcOverloadAlarmsMaskID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcOverloadAlarmsMaskID")
+    = 0x00000800,
+    MTRClusterElectricalMeasurementAttributeAcVoltageOverloadID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcVoltageOverloadID")
+    = 0x00000801,
+    MTRClusterElectricalMeasurementAttributeAcCurrentOverloadID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcCurrentOverloadID")
+    = 0x00000802,
+    MTRClusterElectricalMeasurementAttributeAcActivePowerOverloadID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcActivePowerOverloadID")
+    = 0x00000803,
+    MTRClusterElectricalMeasurementAttributeAcReactivePowerOverloadID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcReactivePowerOverloadID")
+    = 0x00000804,
+    MTRClusterElectricalMeasurementAttributeAverageRmsOverVoltageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsOverVoltageID")
+    = 0x00000805,
+    MTRClusterElectricalMeasurementAttributeAverageRmsUnderVoltageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsUnderVoltageID")
+    = 0x00000806,
+    MTRClusterElectricalMeasurementAttributeRmsExtremeOverVoltageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeOverVoltageID")
+    = 0x00000807,
+    MTRClusterElectricalMeasurementAttributeRmsExtremeUnderVoltageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeUnderVoltageID")
+    = 0x00000808,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageSagID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSagID")
+    = 0x00000809,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageSwellID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSwellID")
+    = 0x0000080A,
+    MTRClusterElectricalMeasurementAttributeLineCurrentPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeLineCurrentPhaseBID")
+    = 0x00000901,
+    MTRClusterElectricalMeasurementAttributeActiveCurrentPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeActiveCurrentPhaseBID")
+    = 0x00000902,
+    MTRClusterElectricalMeasurementAttributeReactiveCurrentPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactiveCurrentPhaseBID")
+    = 0x00000903,
+    MTRClusterElectricalMeasurementAttributeRmsVoltagePhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltagePhaseBID")
+    = 0x00000905,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageMinPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMinPhaseBID")
+    = 0x00000906,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageMaxPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMaxPhaseBID")
+    = 0x00000907,
+    MTRClusterElectricalMeasurementAttributeRmsCurrentPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentPhaseBID")
+    = 0x00000908,
+    MTRClusterElectricalMeasurementAttributeRmsCurrentMinPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMinPhaseBID")
+    = 0x00000909,
+    MTRClusterElectricalMeasurementAttributeRmsCurrentMaxPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMaxPhaseBID")
+    = 0x0000090A,
+    MTRClusterElectricalMeasurementAttributeActivePowerPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerPhaseBID")
+    = 0x0000090B,
+    MTRClusterElectricalMeasurementAttributeActivePowerMinPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMinPhaseBID")
+    = 0x0000090C,
+    MTRClusterElectricalMeasurementAttributeActivePowerMaxPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMaxPhaseBID")
+    = 0x0000090D,
+    MTRClusterElectricalMeasurementAttributeReactivePowerPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactivePowerPhaseBID")
+    = 0x0000090E,
+    MTRClusterElectricalMeasurementAttributeApparentPowerPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeApparentPowerPhaseBID")
+    = 0x0000090F,
+    MTRClusterElectricalMeasurementAttributePowerFactorPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerFactorPhaseBID")
+    = 0x00000910,
+    MTRClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodPhaseBID")
+    = 0x00000911,
+    MTRClusterElectricalMeasurementAttributeAverageRmsOverVoltageCounterPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsOverVoltageCounterPhaseBID")
+    = 0x00000912,
+    MTRClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterPhaseBID")
+    = 0x00000913,
+    MTRClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodPhaseBID")
+    = 0x00000914,
+    MTRClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodPhaseBID")
+    = 0x00000915,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageSagPeriodPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSagPeriodPhaseBID")
+    = 0x00000916,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodPhaseBID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodPhaseBID")
+    = 0x00000917,
+    MTRClusterElectricalMeasurementAttributeLineCurrentPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeLineCurrentPhaseCID")
+    = 0x00000A01,
+    MTRClusterElectricalMeasurementAttributeActiveCurrentPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeActiveCurrentPhaseCID")
+    = 0x00000A02,
+    MTRClusterElectricalMeasurementAttributeReactiveCurrentPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactiveCurrentPhaseCID")
+    = 0x00000A03,
+    MTRClusterElectricalMeasurementAttributeRmsVoltagePhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltagePhaseCID")
+    = 0x00000A05,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageMinPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMinPhaseCID")
+    = 0x00000A06,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageMaxPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMaxPhaseCID")
+    = 0x00000A07,
+    MTRClusterElectricalMeasurementAttributeRmsCurrentPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentPhaseCID")
+    = 0x00000A08,
+    MTRClusterElectricalMeasurementAttributeRmsCurrentMinPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMinPhaseCID")
+    = 0x00000A09,
+    MTRClusterElectricalMeasurementAttributeRmsCurrentMaxPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMaxPhaseCID")
+    = 0x00000A0A,
+    MTRClusterElectricalMeasurementAttributeActivePowerPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerPhaseCID")
+    = 0x00000A0B,
+    MTRClusterElectricalMeasurementAttributeActivePowerMinPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMinPhaseCID")
+    = 0x00000A0C,
+    MTRClusterElectricalMeasurementAttributeActivePowerMaxPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMaxPhaseCID")
+    = 0x00000A0D,
+    MTRClusterElectricalMeasurementAttributeReactivePowerPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactivePowerPhaseCID")
+    = 0x00000A0E,
+    MTRClusterElectricalMeasurementAttributeApparentPowerPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeApparentPowerPhaseCID")
+    = 0x00000A0F,
+    MTRClusterElectricalMeasurementAttributePowerFactorPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerFactorPhaseCID")
+    = 0x00000A10,
+    MTRClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodPhaseCID")
+    = 0x00000A11,
+    MTRClusterElectricalMeasurementAttributeAverageRmsOverVoltageCounterPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsOverVoltageCounterPhaseCID")
+    = 0x00000A12,
+    MTRClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterPhaseCID")
+    = 0x00000A13,
+    MTRClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodPhaseCID")
+    = 0x00000A14,
+    MTRClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodPhaseCID")
+    = 0x00000A15,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageSagPeriodPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSagPeriodPhaseCID")
+    = 0x00000A16,
+    MTRClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodPhaseCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodPhaseCID")
+    = 0x00000A17,
+    MTRClusterElectricalMeasurementAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterElectricalMeasurementAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterElectricalMeasurementAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterElectricalMeasurementAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterElectricalMeasurementAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterElectricalMeasurementAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster ElectricalMeasurement attributes
-    MTRClusterElectricalMeasurementAttributeMeasurementTypeID = 0x00000000,
-    MTRClusterElectricalMeasurementAttributeDcVoltageID = 0x00000100,
-    MTRClusterElectricalMeasurementAttributeDcVoltageMinID = 0x00000101,
-    MTRClusterElectricalMeasurementAttributeDcVoltageMaxID = 0x00000102,
-    MTRClusterElectricalMeasurementAttributeDcCurrentID = 0x00000103,
-    MTRClusterElectricalMeasurementAttributeDcCurrentMinID = 0x00000104,
-    MTRClusterElectricalMeasurementAttributeDcCurrentMaxID = 0x00000105,
-    MTRClusterElectricalMeasurementAttributeDcPowerID = 0x00000106,
-    MTRClusterElectricalMeasurementAttributeDcPowerMinID = 0x00000107,
-    MTRClusterElectricalMeasurementAttributeDcPowerMaxID = 0x00000108,
-    MTRClusterElectricalMeasurementAttributeDcVoltageMultiplierID = 0x00000200,
-    MTRClusterElectricalMeasurementAttributeDcVoltageDivisorID = 0x00000201,
-    MTRClusterElectricalMeasurementAttributeDcCurrentMultiplierID = 0x00000202,
-    MTRClusterElectricalMeasurementAttributeDcCurrentDivisorID = 0x00000203,
-    MTRClusterElectricalMeasurementAttributeDcPowerMultiplierID = 0x00000204,
-    MTRClusterElectricalMeasurementAttributeDcPowerDivisorID = 0x00000205,
-    MTRClusterElectricalMeasurementAttributeAcFrequencyID = 0x00000300,
-    MTRClusterElectricalMeasurementAttributeAcFrequencyMinID = 0x00000301,
-    MTRClusterElectricalMeasurementAttributeAcFrequencyMaxID = 0x00000302,
-    MTRClusterElectricalMeasurementAttributeNeutralCurrentID = 0x00000303,
-    MTRClusterElectricalMeasurementAttributeTotalActivePowerID = 0x00000304,
-    MTRClusterElectricalMeasurementAttributeTotalReactivePowerID = 0x00000305,
-    MTRClusterElectricalMeasurementAttributeTotalApparentPowerID = 0x00000306,
-    MTRClusterElectricalMeasurementAttributeMeasured1stHarmonicCurrentID = 0x00000307,
-    MTRClusterElectricalMeasurementAttributeMeasured3rdHarmonicCurrentID = 0x00000308,
-    MTRClusterElectricalMeasurementAttributeMeasured5thHarmonicCurrentID = 0x00000309,
-    MTRClusterElectricalMeasurementAttributeMeasured7thHarmonicCurrentID = 0x0000030A,
-    MTRClusterElectricalMeasurementAttributeMeasured9thHarmonicCurrentID = 0x0000030B,
-    MTRClusterElectricalMeasurementAttributeMeasured11thHarmonicCurrentID = 0x0000030C,
-    MTRClusterElectricalMeasurementAttributeMeasuredPhase1stHarmonicCurrentID = 0x0000030D,
-    MTRClusterElectricalMeasurementAttributeMeasuredPhase3rdHarmonicCurrentID = 0x0000030E,
-    MTRClusterElectricalMeasurementAttributeMeasuredPhase5thHarmonicCurrentID = 0x0000030F,
-    MTRClusterElectricalMeasurementAttributeMeasuredPhase7thHarmonicCurrentID = 0x00000310,
-    MTRClusterElectricalMeasurementAttributeMeasuredPhase9thHarmonicCurrentID = 0x00000311,
-    MTRClusterElectricalMeasurementAttributeMeasuredPhase11thHarmonicCurrentID = 0x00000312,
-    MTRClusterElectricalMeasurementAttributeAcFrequencyMultiplierID = 0x00000400,
-    MTRClusterElectricalMeasurementAttributeAcFrequencyDivisorID = 0x00000401,
-    MTRClusterElectricalMeasurementAttributePowerMultiplierID = 0x00000402,
-    MTRClusterElectricalMeasurementAttributePowerDivisorID = 0x00000403,
-    MTRClusterElectricalMeasurementAttributeHarmonicCurrentMultiplierID = 0x00000404,
-    MTRClusterElectricalMeasurementAttributePhaseHarmonicCurrentMultiplierID = 0x00000405,
-    MTRClusterElectricalMeasurementAttributeInstantaneousVoltageID = 0x00000500,
-    MTRClusterElectricalMeasurementAttributeInstantaneousLineCurrentID = 0x00000501,
-    MTRClusterElectricalMeasurementAttributeInstantaneousActiveCurrentID = 0x00000502,
-    MTRClusterElectricalMeasurementAttributeInstantaneousReactiveCurrentID = 0x00000503,
-    MTRClusterElectricalMeasurementAttributeInstantaneousPowerID = 0x00000504,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageID = 0x00000505,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageMinID = 0x00000506,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageMaxID = 0x00000507,
-    MTRClusterElectricalMeasurementAttributeRmsCurrentID = 0x00000508,
-    MTRClusterElectricalMeasurementAttributeRmsCurrentMinID = 0x00000509,
-    MTRClusterElectricalMeasurementAttributeRmsCurrentMaxID = 0x0000050A,
-    MTRClusterElectricalMeasurementAttributeActivePowerID = 0x0000050B,
-    MTRClusterElectricalMeasurementAttributeActivePowerMinID = 0x0000050C,
-    MTRClusterElectricalMeasurementAttributeActivePowerMaxID = 0x0000050D,
-    MTRClusterElectricalMeasurementAttributeReactivePowerID = 0x0000050E,
-    MTRClusterElectricalMeasurementAttributeApparentPowerID = 0x0000050F,
-    MTRClusterElectricalMeasurementAttributePowerFactorID = 0x00000510,
-    MTRClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodID = 0x00000511,
-    MTRClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterID = 0x00000513,
-    MTRClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodID = 0x00000514,
-    MTRClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodID = 0x00000515,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageSagPeriodID = 0x00000516,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodID = 0x00000517,
-    MTRClusterElectricalMeasurementAttributeAcVoltageMultiplierID = 0x00000600,
-    MTRClusterElectricalMeasurementAttributeAcVoltageDivisorID = 0x00000601,
-    MTRClusterElectricalMeasurementAttributeAcCurrentMultiplierID = 0x00000602,
-    MTRClusterElectricalMeasurementAttributeAcCurrentDivisorID = 0x00000603,
-    MTRClusterElectricalMeasurementAttributeAcPowerMultiplierID = 0x00000604,
-    MTRClusterElectricalMeasurementAttributeAcPowerDivisorID = 0x00000605,
-    MTRClusterElectricalMeasurementAttributeOverloadAlarmsMaskID = 0x00000700,
-    MTRClusterElectricalMeasurementAttributeVoltageOverloadID = 0x00000701,
-    MTRClusterElectricalMeasurementAttributeCurrentOverloadID = 0x00000702,
-    MTRClusterElectricalMeasurementAttributeAcOverloadAlarmsMaskID = 0x00000800,
-    MTRClusterElectricalMeasurementAttributeAcVoltageOverloadID = 0x00000801,
-    MTRClusterElectricalMeasurementAttributeAcCurrentOverloadID = 0x00000802,
-    MTRClusterElectricalMeasurementAttributeAcActivePowerOverloadID = 0x00000803,
-    MTRClusterElectricalMeasurementAttributeAcReactivePowerOverloadID = 0x00000804,
-    MTRClusterElectricalMeasurementAttributeAverageRmsOverVoltageID = 0x00000805,
-    MTRClusterElectricalMeasurementAttributeAverageRmsUnderVoltageID = 0x00000806,
-    MTRClusterElectricalMeasurementAttributeRmsExtremeOverVoltageID = 0x00000807,
-    MTRClusterElectricalMeasurementAttributeRmsExtremeUnderVoltageID = 0x00000808,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageSagID = 0x00000809,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageSwellID = 0x0000080A,
-    MTRClusterElectricalMeasurementAttributeLineCurrentPhaseBID = 0x00000901,
-    MTRClusterElectricalMeasurementAttributeActiveCurrentPhaseBID = 0x00000902,
-    MTRClusterElectricalMeasurementAttributeReactiveCurrentPhaseBID = 0x00000903,
-    MTRClusterElectricalMeasurementAttributeRmsVoltagePhaseBID = 0x00000905,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageMinPhaseBID = 0x00000906,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageMaxPhaseBID = 0x00000907,
-    MTRClusterElectricalMeasurementAttributeRmsCurrentPhaseBID = 0x00000908,
-    MTRClusterElectricalMeasurementAttributeRmsCurrentMinPhaseBID = 0x00000909,
-    MTRClusterElectricalMeasurementAttributeRmsCurrentMaxPhaseBID = 0x0000090A,
-    MTRClusterElectricalMeasurementAttributeActivePowerPhaseBID = 0x0000090B,
-    MTRClusterElectricalMeasurementAttributeActivePowerMinPhaseBID = 0x0000090C,
-    MTRClusterElectricalMeasurementAttributeActivePowerMaxPhaseBID = 0x0000090D,
-    MTRClusterElectricalMeasurementAttributeReactivePowerPhaseBID = 0x0000090E,
-    MTRClusterElectricalMeasurementAttributeApparentPowerPhaseBID = 0x0000090F,
-    MTRClusterElectricalMeasurementAttributePowerFactorPhaseBID = 0x00000910,
-    MTRClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodPhaseBID = 0x00000911,
-    MTRClusterElectricalMeasurementAttributeAverageRmsOverVoltageCounterPhaseBID = 0x00000912,
-    MTRClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterPhaseBID = 0x00000913,
-    MTRClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodPhaseBID = 0x00000914,
-    MTRClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodPhaseBID = 0x00000915,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageSagPeriodPhaseBID = 0x00000916,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodPhaseBID = 0x00000917,
-    MTRClusterElectricalMeasurementAttributeLineCurrentPhaseCID = 0x00000A01,
-    MTRClusterElectricalMeasurementAttributeActiveCurrentPhaseCID = 0x00000A02,
-    MTRClusterElectricalMeasurementAttributeReactiveCurrentPhaseCID = 0x00000A03,
-    MTRClusterElectricalMeasurementAttributeRmsVoltagePhaseCID = 0x00000A05,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageMinPhaseCID = 0x00000A06,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageMaxPhaseCID = 0x00000A07,
-    MTRClusterElectricalMeasurementAttributeRmsCurrentPhaseCID = 0x00000A08,
-    MTRClusterElectricalMeasurementAttributeRmsCurrentMinPhaseCID = 0x00000A09,
-    MTRClusterElectricalMeasurementAttributeRmsCurrentMaxPhaseCID = 0x00000A0A,
-    MTRClusterElectricalMeasurementAttributeActivePowerPhaseCID = 0x00000A0B,
-    MTRClusterElectricalMeasurementAttributeActivePowerMinPhaseCID = 0x00000A0C,
-    MTRClusterElectricalMeasurementAttributeActivePowerMaxPhaseCID = 0x00000A0D,
-    MTRClusterElectricalMeasurementAttributeReactivePowerPhaseCID = 0x00000A0E,
-    MTRClusterElectricalMeasurementAttributeApparentPowerPhaseCID = 0x00000A0F,
-    MTRClusterElectricalMeasurementAttributePowerFactorPhaseCID = 0x00000A10,
-    MTRClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodPhaseCID = 0x00000A11,
-    MTRClusterElectricalMeasurementAttributeAverageRmsOverVoltageCounterPhaseCID = 0x00000A12,
-    MTRClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterPhaseCID = 0x00000A13,
-    MTRClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodPhaseCID = 0x00000A14,
-    MTRClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodPhaseCID = 0x00000A15,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageSagPeriodPhaseCID = 0x00000A16,
-    MTRClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodPhaseCID = 0x00000A17,
-    MTRClusterElectricalMeasurementAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterElectricalMeasurementAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterElectricalMeasurementAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterElectricalMeasurementAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterElectricalMeasurementAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasurementTypeID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageID MTR_NEWLY_AVAILABLE = 0x00000100,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageMinID MTR_NEWLY_AVAILABLE = 0x00000101,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageMaxID MTR_NEWLY_AVAILABLE = 0x00000102,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentID MTR_NEWLY_AVAILABLE = 0x00000103,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentMinID MTR_NEWLY_AVAILABLE = 0x00000104,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentMaxID MTR_NEWLY_AVAILABLE = 0x00000105,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerID MTR_NEWLY_AVAILABLE = 0x00000106,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerMinID MTR_NEWLY_AVAILABLE = 0x00000107,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerMaxID MTR_NEWLY_AVAILABLE = 0x00000108,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageMultiplierID MTR_NEWLY_AVAILABLE = 0x00000200,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageDivisorID MTR_NEWLY_AVAILABLE = 0x00000201,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentMultiplierID MTR_NEWLY_AVAILABLE = 0x00000202,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentDivisorID MTR_NEWLY_AVAILABLE = 0x00000203,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerMultiplierID MTR_NEWLY_AVAILABLE = 0x00000204,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerDivisorID MTR_NEWLY_AVAILABLE = 0x00000205,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyID MTR_NEWLY_AVAILABLE = 0x00000300,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyMinID MTR_NEWLY_AVAILABLE = 0x00000301,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyMaxID MTR_NEWLY_AVAILABLE = 0x00000302,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeNeutralCurrentID MTR_NEWLY_AVAILABLE = 0x00000303,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeTotalActivePowerID MTR_NEWLY_AVAILABLE = 0x00000304,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeTotalReactivePowerID MTR_NEWLY_AVAILABLE = 0x00000305,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeTotalApparentPowerID MTR_NEWLY_AVAILABLE = 0x00000306,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured1stHarmonicCurrentID MTR_NEWLY_AVAILABLE = 0x00000307,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured3rdHarmonicCurrentID MTR_NEWLY_AVAILABLE = 0x00000308,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured5thHarmonicCurrentID MTR_NEWLY_AVAILABLE = 0x00000309,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured7thHarmonicCurrentID MTR_NEWLY_AVAILABLE = 0x0000030A,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured9thHarmonicCurrentID MTR_NEWLY_AVAILABLE = 0x0000030B,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured11thHarmonicCurrentID MTR_NEWLY_AVAILABLE = 0x0000030C,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase1stHarmonicCurrentID MTR_NEWLY_AVAILABLE = 0x0000030D,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase3rdHarmonicCurrentID MTR_NEWLY_AVAILABLE = 0x0000030E,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase5thHarmonicCurrentID MTR_NEWLY_AVAILABLE = 0x0000030F,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase7thHarmonicCurrentID MTR_NEWLY_AVAILABLE = 0x00000310,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase9thHarmonicCurrentID MTR_NEWLY_AVAILABLE = 0x00000311,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase11thHarmonicCurrentID MTR_NEWLY_AVAILABLE = 0x00000312,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyMultiplierID MTR_NEWLY_AVAILABLE = 0x00000400,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyDivisorID MTR_NEWLY_AVAILABLE = 0x00000401,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerMultiplierID MTR_NEWLY_AVAILABLE = 0x00000402,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerDivisorID MTR_NEWLY_AVAILABLE = 0x00000403,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeHarmonicCurrentMultiplierID MTR_NEWLY_AVAILABLE = 0x00000404,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributePhaseHarmonicCurrentMultiplierID MTR_NEWLY_AVAILABLE = 0x00000405,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousVoltageID MTR_NEWLY_AVAILABLE = 0x00000500,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousLineCurrentID MTR_NEWLY_AVAILABLE = 0x00000501,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousActiveCurrentID MTR_NEWLY_AVAILABLE = 0x00000502,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousReactiveCurrentID MTR_NEWLY_AVAILABLE = 0x00000503,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousPowerID MTR_NEWLY_AVAILABLE = 0x00000504,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageID MTR_NEWLY_AVAILABLE = 0x00000505,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMinID MTR_NEWLY_AVAILABLE = 0x00000506,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMaxID MTR_NEWLY_AVAILABLE = 0x00000507,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentID MTR_NEWLY_AVAILABLE = 0x00000508,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMinID MTR_NEWLY_AVAILABLE = 0x00000509,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMaxID MTR_NEWLY_AVAILABLE = 0x0000050A,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerID MTR_NEWLY_AVAILABLE = 0x0000050B,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMinID MTR_NEWLY_AVAILABLE = 0x0000050C,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMaxID MTR_NEWLY_AVAILABLE = 0x0000050D,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactivePowerID MTR_NEWLY_AVAILABLE = 0x0000050E,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeApparentPowerID MTR_NEWLY_AVAILABLE = 0x0000050F,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerFactorID MTR_NEWLY_AVAILABLE = 0x00000510,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodID MTR_NEWLY_AVAILABLE = 0x00000511,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterID MTR_NEWLY_AVAILABLE = 0x00000513,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodID MTR_NEWLY_AVAILABLE = 0x00000514,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodID MTR_NEWLY_AVAILABLE = 0x00000515,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSagPeriodID MTR_NEWLY_AVAILABLE = 0x00000516,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodID MTR_NEWLY_AVAILABLE = 0x00000517,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcVoltageMultiplierID MTR_NEWLY_AVAILABLE = 0x00000600,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcVoltageDivisorID MTR_NEWLY_AVAILABLE = 0x00000601,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcCurrentMultiplierID MTR_NEWLY_AVAILABLE = 0x00000602,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcCurrentDivisorID MTR_NEWLY_AVAILABLE = 0x00000603,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcPowerMultiplierID MTR_NEWLY_AVAILABLE = 0x00000604,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcPowerDivisorID MTR_NEWLY_AVAILABLE = 0x00000605,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeOverloadAlarmsMaskID MTR_NEWLY_AVAILABLE = 0x00000700,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeVoltageOverloadID MTR_NEWLY_AVAILABLE = 0x00000701,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeCurrentOverloadID MTR_NEWLY_AVAILABLE = 0x00000702,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcOverloadAlarmsMaskID MTR_NEWLY_AVAILABLE = 0x00000800,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcVoltageOverloadID MTR_NEWLY_AVAILABLE = 0x00000801,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcCurrentOverloadID MTR_NEWLY_AVAILABLE = 0x00000802,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcActivePowerOverloadID MTR_NEWLY_AVAILABLE = 0x00000803,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcReactivePowerOverloadID MTR_NEWLY_AVAILABLE = 0x00000804,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsOverVoltageID MTR_NEWLY_AVAILABLE = 0x00000805,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsUnderVoltageID MTR_NEWLY_AVAILABLE = 0x00000806,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeOverVoltageID MTR_NEWLY_AVAILABLE = 0x00000807,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeUnderVoltageID MTR_NEWLY_AVAILABLE = 0x00000808,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSagID MTR_NEWLY_AVAILABLE = 0x00000809,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSwellID MTR_NEWLY_AVAILABLE = 0x0000080A,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeLineCurrentPhaseBID MTR_NEWLY_AVAILABLE = 0x00000901,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeActiveCurrentPhaseBID MTR_NEWLY_AVAILABLE = 0x00000902,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactiveCurrentPhaseBID MTR_NEWLY_AVAILABLE = 0x00000903,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltagePhaseBID MTR_NEWLY_AVAILABLE = 0x00000905,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMinPhaseBID MTR_NEWLY_AVAILABLE = 0x00000906,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMaxPhaseBID MTR_NEWLY_AVAILABLE = 0x00000907,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentPhaseBID MTR_NEWLY_AVAILABLE = 0x00000908,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMinPhaseBID MTR_NEWLY_AVAILABLE = 0x00000909,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMaxPhaseBID MTR_NEWLY_AVAILABLE = 0x0000090A,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerPhaseBID MTR_NEWLY_AVAILABLE = 0x0000090B,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMinPhaseBID MTR_NEWLY_AVAILABLE = 0x0000090C,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMaxPhaseBID MTR_NEWLY_AVAILABLE = 0x0000090D,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactivePowerPhaseBID MTR_NEWLY_AVAILABLE = 0x0000090E,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeApparentPowerPhaseBID MTR_NEWLY_AVAILABLE = 0x0000090F,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerFactorPhaseBID MTR_NEWLY_AVAILABLE = 0x00000910,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodPhaseBID MTR_NEWLY_AVAILABLE
+    = 0x00000911,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsOverVoltageCounterPhaseBID MTR_NEWLY_AVAILABLE = 0x00000912,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterPhaseBID MTR_NEWLY_AVAILABLE = 0x00000913,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodPhaseBID MTR_NEWLY_AVAILABLE = 0x00000914,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodPhaseBID MTR_NEWLY_AVAILABLE = 0x00000915,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSagPeriodPhaseBID MTR_NEWLY_AVAILABLE = 0x00000916,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodPhaseBID MTR_NEWLY_AVAILABLE = 0x00000917,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeLineCurrentPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A01,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeActiveCurrentPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A02,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactiveCurrentPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A03,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltagePhaseCID MTR_NEWLY_AVAILABLE = 0x00000A05,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMinPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A06,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMaxPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A07,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A08,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMinPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A09,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMaxPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A0A,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A0B,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMinPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A0C,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMaxPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A0D,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactivePowerPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A0E,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeApparentPowerPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A0F,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerFactorPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A10,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodPhaseCID MTR_NEWLY_AVAILABLE
+    = 0x00000A11,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsOverVoltageCounterPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A12,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A13,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A14,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A15,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSagPeriodPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A16,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodPhaseCID MTR_NEWLY_AVAILABLE = 0x00000A17,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterElectricalMeasurementAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
 
-    // Cluster UnitTesting attributes
-    MTRClusterUnitTestingAttributeBooleanID MTR_NEWLY_AVAILABLE = 0x00000000,
-    MTRClusterUnitTestingAttributeBitmap8ID MTR_NEWLY_AVAILABLE = 0x00000001,
-    MTRClusterUnitTestingAttributeBitmap16ID MTR_NEWLY_AVAILABLE = 0x00000002,
-    MTRClusterUnitTestingAttributeBitmap32ID MTR_NEWLY_AVAILABLE = 0x00000003,
-    MTRClusterUnitTestingAttributeBitmap64ID MTR_NEWLY_AVAILABLE = 0x00000004,
-    MTRClusterUnitTestingAttributeInt8uID MTR_NEWLY_AVAILABLE = 0x00000005,
-    MTRClusterUnitTestingAttributeInt16uID MTR_NEWLY_AVAILABLE = 0x00000006,
-    MTRClusterUnitTestingAttributeInt24uID MTR_NEWLY_AVAILABLE = 0x00000007,
-    MTRClusterUnitTestingAttributeInt32uID MTR_NEWLY_AVAILABLE = 0x00000008,
-    MTRClusterUnitTestingAttributeInt40uID MTR_NEWLY_AVAILABLE = 0x00000009,
-    MTRClusterUnitTestingAttributeInt48uID MTR_NEWLY_AVAILABLE = 0x0000000A,
-    MTRClusterUnitTestingAttributeInt56uID MTR_NEWLY_AVAILABLE = 0x0000000B,
-    MTRClusterUnitTestingAttributeInt64uID MTR_NEWLY_AVAILABLE = 0x0000000C,
-    MTRClusterUnitTestingAttributeInt8sID MTR_NEWLY_AVAILABLE = 0x0000000D,
-    MTRClusterUnitTestingAttributeInt16sID MTR_NEWLY_AVAILABLE = 0x0000000E,
-    MTRClusterUnitTestingAttributeInt24sID MTR_NEWLY_AVAILABLE = 0x0000000F,
-    MTRClusterUnitTestingAttributeInt32sID MTR_NEWLY_AVAILABLE = 0x00000010,
-    MTRClusterUnitTestingAttributeInt40sID MTR_NEWLY_AVAILABLE = 0x00000011,
-    MTRClusterUnitTestingAttributeInt48sID MTR_NEWLY_AVAILABLE = 0x00000012,
-    MTRClusterUnitTestingAttributeInt56sID MTR_NEWLY_AVAILABLE = 0x00000013,
-    MTRClusterUnitTestingAttributeInt64sID MTR_NEWLY_AVAILABLE = 0x00000014,
-    MTRClusterUnitTestingAttributeEnum8ID MTR_NEWLY_AVAILABLE = 0x00000015,
-    MTRClusterUnitTestingAttributeEnum16ID MTR_NEWLY_AVAILABLE = 0x00000016,
-    MTRClusterUnitTestingAttributeFloatSingleID MTR_NEWLY_AVAILABLE = 0x00000017,
-    MTRClusterUnitTestingAttributeFloatDoubleID MTR_NEWLY_AVAILABLE = 0x00000018,
-    MTRClusterUnitTestingAttributeOctetStringID MTR_NEWLY_AVAILABLE = 0x00000019,
-    MTRClusterUnitTestingAttributeListInt8uID MTR_NEWLY_AVAILABLE = 0x0000001A,
-    MTRClusterUnitTestingAttributeListOctetStringID MTR_NEWLY_AVAILABLE = 0x0000001B,
-    MTRClusterUnitTestingAttributeListStructOctetStringID MTR_NEWLY_AVAILABLE = 0x0000001C,
-    MTRClusterUnitTestingAttributeLongOctetStringID MTR_NEWLY_AVAILABLE = 0x0000001D,
-    MTRClusterUnitTestingAttributeCharStringID MTR_NEWLY_AVAILABLE = 0x0000001E,
-    MTRClusterUnitTestingAttributeLongCharStringID MTR_NEWLY_AVAILABLE = 0x0000001F,
-    MTRClusterUnitTestingAttributeEpochUsID MTR_NEWLY_AVAILABLE = 0x00000020,
-    MTRClusterUnitTestingAttributeEpochSID MTR_NEWLY_AVAILABLE = 0x00000021,
-    MTRClusterUnitTestingAttributeVendorIdID MTR_NEWLY_AVAILABLE = 0x00000022,
-    MTRClusterUnitTestingAttributeListNullablesAndOptionalsStructID MTR_NEWLY_AVAILABLE = 0x00000023,
-    MTRClusterUnitTestingAttributeEnumAttrID MTR_NEWLY_AVAILABLE = 0x00000024,
-    MTRClusterUnitTestingAttributeStructAttrID MTR_NEWLY_AVAILABLE = 0x00000025,
-    MTRClusterUnitTestingAttributeRangeRestrictedInt8uID MTR_NEWLY_AVAILABLE = 0x00000026,
-    MTRClusterUnitTestingAttributeRangeRestrictedInt8sID MTR_NEWLY_AVAILABLE = 0x00000027,
-    MTRClusterUnitTestingAttributeRangeRestrictedInt16uID MTR_NEWLY_AVAILABLE = 0x00000028,
-    MTRClusterUnitTestingAttributeRangeRestrictedInt16sID MTR_NEWLY_AVAILABLE = 0x00000029,
-    MTRClusterUnitTestingAttributeListLongOctetStringID MTR_NEWLY_AVAILABLE = 0x0000002A,
-    MTRClusterUnitTestingAttributeListFabricScopedID MTR_NEWLY_AVAILABLE = 0x0000002B,
-    MTRClusterUnitTestingAttributeTimedWriteBooleanID MTR_NEWLY_AVAILABLE = 0x00000030,
-    MTRClusterUnitTestingAttributeGeneralErrorBooleanID MTR_NEWLY_AVAILABLE = 0x00000031,
-    MTRClusterUnitTestingAttributeClusterErrorBooleanID MTR_NEWLY_AVAILABLE = 0x00000032,
-    MTRClusterUnitTestingAttributeUnsupportedID MTR_NEWLY_AVAILABLE = 0x000000FF,
-    MTRClusterUnitTestingAttributeNullableBooleanID MTR_NEWLY_AVAILABLE = 0x00004000,
-    MTRClusterUnitTestingAttributeNullableBitmap8ID MTR_NEWLY_AVAILABLE = 0x00004001,
-    MTRClusterUnitTestingAttributeNullableBitmap16ID MTR_NEWLY_AVAILABLE = 0x00004002,
-    MTRClusterUnitTestingAttributeNullableBitmap32ID MTR_NEWLY_AVAILABLE = 0x00004003,
-    MTRClusterUnitTestingAttributeNullableBitmap64ID MTR_NEWLY_AVAILABLE = 0x00004004,
-    MTRClusterUnitTestingAttributeNullableInt8uID MTR_NEWLY_AVAILABLE = 0x00004005,
-    MTRClusterUnitTestingAttributeNullableInt16uID MTR_NEWLY_AVAILABLE = 0x00004006,
-    MTRClusterUnitTestingAttributeNullableInt24uID MTR_NEWLY_AVAILABLE = 0x00004007,
-    MTRClusterUnitTestingAttributeNullableInt32uID MTR_NEWLY_AVAILABLE = 0x00004008,
-    MTRClusterUnitTestingAttributeNullableInt40uID MTR_NEWLY_AVAILABLE = 0x00004009,
-    MTRClusterUnitTestingAttributeNullableInt48uID MTR_NEWLY_AVAILABLE = 0x0000400A,
-    MTRClusterUnitTestingAttributeNullableInt56uID MTR_NEWLY_AVAILABLE = 0x0000400B,
-    MTRClusterUnitTestingAttributeNullableInt64uID MTR_NEWLY_AVAILABLE = 0x0000400C,
-    MTRClusterUnitTestingAttributeNullableInt8sID MTR_NEWLY_AVAILABLE = 0x0000400D,
-    MTRClusterUnitTestingAttributeNullableInt16sID MTR_NEWLY_AVAILABLE = 0x0000400E,
-    MTRClusterUnitTestingAttributeNullableInt24sID MTR_NEWLY_AVAILABLE = 0x0000400F,
-    MTRClusterUnitTestingAttributeNullableInt32sID MTR_NEWLY_AVAILABLE = 0x00004010,
-    MTRClusterUnitTestingAttributeNullableInt40sID MTR_NEWLY_AVAILABLE = 0x00004011,
-    MTRClusterUnitTestingAttributeNullableInt48sID MTR_NEWLY_AVAILABLE = 0x00004012,
-    MTRClusterUnitTestingAttributeNullableInt56sID MTR_NEWLY_AVAILABLE = 0x00004013,
-    MTRClusterUnitTestingAttributeNullableInt64sID MTR_NEWLY_AVAILABLE = 0x00004014,
-    MTRClusterUnitTestingAttributeNullableEnum8ID MTR_NEWLY_AVAILABLE = 0x00004015,
-    MTRClusterUnitTestingAttributeNullableEnum16ID MTR_NEWLY_AVAILABLE = 0x00004016,
-    MTRClusterUnitTestingAttributeNullableFloatSingleID MTR_NEWLY_AVAILABLE = 0x00004017,
-    MTRClusterUnitTestingAttributeNullableFloatDoubleID MTR_NEWLY_AVAILABLE = 0x00004018,
-    MTRClusterUnitTestingAttributeNullableOctetStringID MTR_NEWLY_AVAILABLE = 0x00004019,
-    MTRClusterUnitTestingAttributeNullableCharStringID MTR_NEWLY_AVAILABLE = 0x0000401E,
-    MTRClusterUnitTestingAttributeNullableEnumAttrID MTR_NEWLY_AVAILABLE = 0x00004024,
-    MTRClusterUnitTestingAttributeNullableStructID MTR_NEWLY_AVAILABLE = 0x00004025,
-    MTRClusterUnitTestingAttributeNullableRangeRestrictedInt8uID MTR_NEWLY_AVAILABLE = 0x00004026,
-    MTRClusterUnitTestingAttributeNullableRangeRestrictedInt8sID MTR_NEWLY_AVAILABLE = 0x00004027,
-    MTRClusterUnitTestingAttributeNullableRangeRestrictedInt16uID MTR_NEWLY_AVAILABLE = 0x00004028,
-    MTRClusterUnitTestingAttributeNullableRangeRestrictedInt16sID MTR_NEWLY_AVAILABLE = 0x00004029,
-    MTRClusterUnitTestingAttributeWriteOnlyInt8uID MTR_NEWLY_AVAILABLE = 0x0000402A,
-    MTRClusterUnitTestingAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterUnitTestingAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterUnitTestingAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterUnitTestingAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterUnitTestingAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
-
-    // Cluster TestCluster attributes
-    MTRClusterTestClusterAttributeBooleanID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeBooleanID") = 0x00000000,
-    MTRClusterTestClusterAttributeBitmap8ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeBitmap8ID") = 0x00000001,
-    MTRClusterTestClusterAttributeBitmap16ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeBitmap16ID")
+    // Cluster TestCluster deprecated attribute names
+    MTRClusterTestClusterAttributeBooleanID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeBooleanID")
+    = 0x00000000,
+    MTRClusterTestClusterAttributeBitmap8ID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeBitmap8ID")
+    = 0x00000001,
+    MTRClusterTestClusterAttributeBitmap16ID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeBitmap16ID")
     = 0x00000002,
-    MTRClusterTestClusterAttributeBitmap32ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeBitmap32ID")
+    MTRClusterTestClusterAttributeBitmap32ID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeBitmap32ID")
     = 0x00000003,
-    MTRClusterTestClusterAttributeBitmap64ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeBitmap64ID")
+    MTRClusterTestClusterAttributeBitmap64ID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeBitmap64ID")
     = 0x00000004,
-    MTRClusterTestClusterAttributeInt8uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt8uID") = 0x00000005,
-    MTRClusterTestClusterAttributeInt16uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt16uID") = 0x00000006,
-    MTRClusterTestClusterAttributeInt24uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt24uID") = 0x00000007,
-    MTRClusterTestClusterAttributeInt32uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt32uID") = 0x00000008,
-    MTRClusterTestClusterAttributeInt40uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt40uID") = 0x00000009,
-    MTRClusterTestClusterAttributeInt48uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt48uID") = 0x0000000A,
-    MTRClusterTestClusterAttributeInt56uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt56uID") = 0x0000000B,
-    MTRClusterTestClusterAttributeInt64uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt64uID") = 0x0000000C,
-    MTRClusterTestClusterAttributeInt8sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt8sID") = 0x0000000D,
-    MTRClusterTestClusterAttributeInt16sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt16sID") = 0x0000000E,
-    MTRClusterTestClusterAttributeInt24sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt24sID") = 0x0000000F,
-    MTRClusterTestClusterAttributeInt32sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt32sID") = 0x00000010,
-    MTRClusterTestClusterAttributeInt40sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt40sID") = 0x00000011,
-    MTRClusterTestClusterAttributeInt48sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt48sID") = 0x00000012,
-    MTRClusterTestClusterAttributeInt56sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt56sID") = 0x00000013,
-    MTRClusterTestClusterAttributeInt64sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeInt64sID") = 0x00000014,
-    MTRClusterTestClusterAttributeEnum8ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeEnum8ID") = 0x00000015,
-    MTRClusterTestClusterAttributeEnum16ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeEnum16ID") = 0x00000016,
-    MTRClusterTestClusterAttributeFloatSingleID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeFloatSingleID")
+    MTRClusterTestClusterAttributeInt8uID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt8uID")
+    = 0x00000005,
+    MTRClusterTestClusterAttributeInt16uID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt16uID")
+    = 0x00000006,
+    MTRClusterTestClusterAttributeInt24uID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt24uID")
+    = 0x00000007,
+    MTRClusterTestClusterAttributeInt32uID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt32uID")
+    = 0x00000008,
+    MTRClusterTestClusterAttributeInt40uID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt40uID")
+    = 0x00000009,
+    MTRClusterTestClusterAttributeInt48uID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt48uID")
+    = 0x0000000A,
+    MTRClusterTestClusterAttributeInt56uID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt56uID")
+    = 0x0000000B,
+    MTRClusterTestClusterAttributeInt64uID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt64uID")
+    = 0x0000000C,
+    MTRClusterTestClusterAttributeInt8sID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt8sID")
+    = 0x0000000D,
+    MTRClusterTestClusterAttributeInt16sID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt16sID")
+    = 0x0000000E,
+    MTRClusterTestClusterAttributeInt24sID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt24sID")
+    = 0x0000000F,
+    MTRClusterTestClusterAttributeInt32sID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt32sID")
+    = 0x00000010,
+    MTRClusterTestClusterAttributeInt40sID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt40sID")
+    = 0x00000011,
+    MTRClusterTestClusterAttributeInt48sID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt48sID")
+    = 0x00000012,
+    MTRClusterTestClusterAttributeInt56sID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt56sID")
+    = 0x00000013,
+    MTRClusterTestClusterAttributeInt64sID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeInt64sID")
+    = 0x00000014,
+    MTRClusterTestClusterAttributeEnum8ID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeEnum8ID")
+    = 0x00000015,
+    MTRClusterTestClusterAttributeEnum16ID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeEnum16ID")
+    = 0x00000016,
+    MTRClusterTestClusterAttributeFloatSingleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeFloatSingleID")
     = 0x00000017,
-    MTRClusterTestClusterAttributeFloatDoubleID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeFloatDoubleID")
+    MTRClusterTestClusterAttributeFloatDoubleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeFloatDoubleID")
     = 0x00000018,
-    MTRClusterTestClusterAttributeOctetStringID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeOctetStringID")
+    MTRClusterTestClusterAttributeOctetStringID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeOctetStringID")
     = 0x00000019,
-    MTRClusterTestClusterAttributeListInt8uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeListInt8uID")
+    MTRClusterTestClusterAttributeListInt8uID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeListInt8uID")
     = 0x0000001A,
     MTRClusterTestClusterAttributeListOctetStringID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeListOctetStringID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeListOctetStringID")
     = 0x0000001B,
     MTRClusterTestClusterAttributeListStructOctetStringID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeListStructOctetStringID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeListStructOctetStringID")
     = 0x0000001C,
     MTRClusterTestClusterAttributeLongOctetStringID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeLongOctetStringID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeLongOctetStringID")
     = 0x0000001D,
-    MTRClusterTestClusterAttributeCharStringID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeCharStringID")
+    MTRClusterTestClusterAttributeCharStringID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeCharStringID")
     = 0x0000001E,
-    MTRClusterTestClusterAttributeLongCharStringID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeLongCharStringID")
+    MTRClusterTestClusterAttributeLongCharStringID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeLongCharStringID")
     = 0x0000001F,
-    MTRClusterTestClusterAttributeEpochUsID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeEpochUsID") = 0x00000020,
-    MTRClusterTestClusterAttributeEpochSID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeEpochSID") = 0x00000021,
-    MTRClusterTestClusterAttributeVendorIdID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeVendorIdID")
+    MTRClusterTestClusterAttributeEpochUsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeEpochUsID")
+    = 0x00000020,
+    MTRClusterTestClusterAttributeEpochSID MTR_NEWLY_DEPRECATED("Please use MTRAttributeIDTypeClusterUnitTestingAttributeEpochSID")
+    = 0x00000021,
+    MTRClusterTestClusterAttributeVendorIdID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeVendorIdID")
     = 0x00000022,
     MTRClusterTestClusterAttributeListNullablesAndOptionalsStructID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeListNullablesAndOptionalsStructID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeListNullablesAndOptionalsStructID")
     = 0x00000023,
-    MTRClusterTestClusterAttributeEnumAttrID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeEnumAttrID")
+    MTRClusterTestClusterAttributeEnumAttrID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeEnumAttrID")
     = 0x00000024,
-    MTRClusterTestClusterAttributeStructAttrID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeStructAttrID")
+    MTRClusterTestClusterAttributeStructAttrID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeStructAttrID")
     = 0x00000025,
     MTRClusterTestClusterAttributeRangeRestrictedInt8uID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeRangeRestrictedInt8uID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt8uID")
     = 0x00000026,
     MTRClusterTestClusterAttributeRangeRestrictedInt8sID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeRangeRestrictedInt8sID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt8sID")
     = 0x00000027,
     MTRClusterTestClusterAttributeRangeRestrictedInt16uID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeRangeRestrictedInt16uID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt16uID")
     = 0x00000028,
     MTRClusterTestClusterAttributeRangeRestrictedInt16sID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeRangeRestrictedInt16sID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt16sID")
     = 0x00000029,
     MTRClusterTestClusterAttributeListLongOctetStringID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeListLongOctetStringID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeListLongOctetStringID")
     = 0x0000002A,
     MTRClusterTestClusterAttributeListFabricScopedID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeListFabricScopedID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeListFabricScopedID")
     = 0x0000002B,
     MTRClusterTestClusterAttributeTimedWriteBooleanID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeTimedWriteBooleanID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeTimedWriteBooleanID")
     = 0x00000030,
     MTRClusterTestClusterAttributeGeneralErrorBooleanID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeGeneralErrorBooleanID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeGeneralErrorBooleanID")
     = 0x00000031,
     MTRClusterTestClusterAttributeClusterErrorBooleanID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeClusterErrorBooleanID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeClusterErrorBooleanID")
     = 0x00000032,
-    MTRClusterTestClusterAttributeUnsupportedID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeUnsupportedID")
+    MTRClusterTestClusterAttributeUnsupportedID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeUnsupportedID")
     = 0x000000FF,
     MTRClusterTestClusterAttributeNullableBooleanID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeNullableBooleanID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableBooleanID")
     = 0x00004000,
     MTRClusterTestClusterAttributeNullableBitmap8ID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeNullableBitmap8ID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap8ID")
     = 0x00004001,
     MTRClusterTestClusterAttributeNullableBitmap16ID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeNullableBitmap16ID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap16ID")
     = 0x00004002,
     MTRClusterTestClusterAttributeNullableBitmap32ID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeNullableBitmap32ID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap32ID")
     = 0x00004003,
     MTRClusterTestClusterAttributeNullableBitmap64ID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeNullableBitmap64ID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap64ID")
     = 0x00004004,
-    MTRClusterTestClusterAttributeNullableInt8uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt8uID")
+    MTRClusterTestClusterAttributeNullableInt8uID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt8uID")
     = 0x00004005,
-    MTRClusterTestClusterAttributeNullableInt16uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt16uID")
+    MTRClusterTestClusterAttributeNullableInt16uID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt16uID")
     = 0x00004006,
-    MTRClusterTestClusterAttributeNullableInt24uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt24uID")
+    MTRClusterTestClusterAttributeNullableInt24uID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt24uID")
     = 0x00004007,
-    MTRClusterTestClusterAttributeNullableInt32uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt32uID")
+    MTRClusterTestClusterAttributeNullableInt32uID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt32uID")
     = 0x00004008,
-    MTRClusterTestClusterAttributeNullableInt40uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt40uID")
+    MTRClusterTestClusterAttributeNullableInt40uID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt40uID")
     = 0x00004009,
-    MTRClusterTestClusterAttributeNullableInt48uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt48uID")
+    MTRClusterTestClusterAttributeNullableInt48uID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt48uID")
     = 0x0000400A,
-    MTRClusterTestClusterAttributeNullableInt56uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt56uID")
+    MTRClusterTestClusterAttributeNullableInt56uID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt56uID")
     = 0x0000400B,
-    MTRClusterTestClusterAttributeNullableInt64uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt64uID")
+    MTRClusterTestClusterAttributeNullableInt64uID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt64uID")
     = 0x0000400C,
-    MTRClusterTestClusterAttributeNullableInt8sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt8sID")
+    MTRClusterTestClusterAttributeNullableInt8sID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt8sID")
     = 0x0000400D,
-    MTRClusterTestClusterAttributeNullableInt16sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt16sID")
+    MTRClusterTestClusterAttributeNullableInt16sID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt16sID")
     = 0x0000400E,
-    MTRClusterTestClusterAttributeNullableInt24sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt24sID")
+    MTRClusterTestClusterAttributeNullableInt24sID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt24sID")
     = 0x0000400F,
-    MTRClusterTestClusterAttributeNullableInt32sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt32sID")
+    MTRClusterTestClusterAttributeNullableInt32sID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt32sID")
     = 0x00004010,
-    MTRClusterTestClusterAttributeNullableInt40sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt40sID")
+    MTRClusterTestClusterAttributeNullableInt40sID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt40sID")
     = 0x00004011,
-    MTRClusterTestClusterAttributeNullableInt48sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt48sID")
+    MTRClusterTestClusterAttributeNullableInt48sID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt48sID")
     = 0x00004012,
-    MTRClusterTestClusterAttributeNullableInt56sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt56sID")
+    MTRClusterTestClusterAttributeNullableInt56sID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt56sID")
     = 0x00004013,
-    MTRClusterTestClusterAttributeNullableInt64sID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableInt64sID")
+    MTRClusterTestClusterAttributeNullableInt64sID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt64sID")
     = 0x00004014,
-    MTRClusterTestClusterAttributeNullableEnum8ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableEnum8ID")
+    MTRClusterTestClusterAttributeNullableEnum8ID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableEnum8ID")
     = 0x00004015,
-    MTRClusterTestClusterAttributeNullableEnum16ID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableEnum16ID")
+    MTRClusterTestClusterAttributeNullableEnum16ID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableEnum16ID")
     = 0x00004016,
     MTRClusterTestClusterAttributeNullableFloatSingleID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeNullableFloatSingleID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableFloatSingleID")
     = 0x00004017,
     MTRClusterTestClusterAttributeNullableFloatDoubleID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeNullableFloatDoubleID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableFloatDoubleID")
     = 0x00004018,
     MTRClusterTestClusterAttributeNullableOctetStringID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeNullableOctetStringID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableOctetStringID")
     = 0x00004019,
     MTRClusterTestClusterAttributeNullableCharStringID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeNullableCharStringID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableCharStringID")
     = 0x0000401E,
     MTRClusterTestClusterAttributeNullableEnumAttrID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeNullableEnumAttrID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableEnumAttrID")
     = 0x00004024,
-    MTRClusterTestClusterAttributeNullableStructID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeNullableStructID")
+    MTRClusterTestClusterAttributeNullableStructID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableStructID")
     = 0x00004025,
     MTRClusterTestClusterAttributeNullableRangeRestrictedInt8uID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeNullableRangeRestrictedInt8uID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt8uID")
     = 0x00004026,
     MTRClusterTestClusterAttributeNullableRangeRestrictedInt8sID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeNullableRangeRestrictedInt8sID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt8sID")
     = 0x00004027,
     MTRClusterTestClusterAttributeNullableRangeRestrictedInt16uID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeNullableRangeRestrictedInt16uID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt16uID")
     = 0x00004028,
     MTRClusterTestClusterAttributeNullableRangeRestrictedInt16sID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingAttributeNullableRangeRestrictedInt16sID")
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt16sID")
     = 0x00004029,
-    MTRClusterTestClusterAttributeWriteOnlyInt8uID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingAttributeWriteOnlyInt8uID")
+    MTRClusterTestClusterAttributeWriteOnlyInt8uID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeWriteOnlyInt8uID")
     = 0x0000402A,
-    MTRClusterTestClusterAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterTestClusterAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterTestClusterAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterTestClusterAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterTestClusterAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRClusterTestClusterAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterTestClusterAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterTestClusterAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterTestClusterAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterTestClusterAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterUnitTestingAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
+
+    // Cluster UnitTesting attributes
+    MTRAttributeIDTypeClusterUnitTestingAttributeBooleanID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterUnitTestingAttributeBitmap8ID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterUnitTestingAttributeBitmap16ID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRAttributeIDTypeClusterUnitTestingAttributeBitmap32ID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRAttributeIDTypeClusterUnitTestingAttributeBitmap64ID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt8uID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt16uID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt24uID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt32uID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt40uID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt48uID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt56uID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt64uID MTR_NEWLY_AVAILABLE = 0x0000000C,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt8sID MTR_NEWLY_AVAILABLE = 0x0000000D,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt16sID MTR_NEWLY_AVAILABLE = 0x0000000E,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt24sID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt32sID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt40sID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt48sID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt56sID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRAttributeIDTypeClusterUnitTestingAttributeInt64sID MTR_NEWLY_AVAILABLE = 0x00000014,
+    MTRAttributeIDTypeClusterUnitTestingAttributeEnum8ID MTR_NEWLY_AVAILABLE = 0x00000015,
+    MTRAttributeIDTypeClusterUnitTestingAttributeEnum16ID MTR_NEWLY_AVAILABLE = 0x00000016,
+    MTRAttributeIDTypeClusterUnitTestingAttributeFloatSingleID MTR_NEWLY_AVAILABLE = 0x00000017,
+    MTRAttributeIDTypeClusterUnitTestingAttributeFloatDoubleID MTR_NEWLY_AVAILABLE = 0x00000018,
+    MTRAttributeIDTypeClusterUnitTestingAttributeOctetStringID MTR_NEWLY_AVAILABLE = 0x00000019,
+    MTRAttributeIDTypeClusterUnitTestingAttributeListInt8uID MTR_NEWLY_AVAILABLE = 0x0000001A,
+    MTRAttributeIDTypeClusterUnitTestingAttributeListOctetStringID MTR_NEWLY_AVAILABLE = 0x0000001B,
+    MTRAttributeIDTypeClusterUnitTestingAttributeListStructOctetStringID MTR_NEWLY_AVAILABLE = 0x0000001C,
+    MTRAttributeIDTypeClusterUnitTestingAttributeLongOctetStringID MTR_NEWLY_AVAILABLE = 0x0000001D,
+    MTRAttributeIDTypeClusterUnitTestingAttributeCharStringID MTR_NEWLY_AVAILABLE = 0x0000001E,
+    MTRAttributeIDTypeClusterUnitTestingAttributeLongCharStringID MTR_NEWLY_AVAILABLE = 0x0000001F,
+    MTRAttributeIDTypeClusterUnitTestingAttributeEpochUsID MTR_NEWLY_AVAILABLE = 0x00000020,
+    MTRAttributeIDTypeClusterUnitTestingAttributeEpochSID MTR_NEWLY_AVAILABLE = 0x00000021,
+    MTRAttributeIDTypeClusterUnitTestingAttributeVendorIdID MTR_NEWLY_AVAILABLE = 0x00000022,
+    MTRAttributeIDTypeClusterUnitTestingAttributeListNullablesAndOptionalsStructID MTR_NEWLY_AVAILABLE = 0x00000023,
+    MTRAttributeIDTypeClusterUnitTestingAttributeEnumAttrID MTR_NEWLY_AVAILABLE = 0x00000024,
+    MTRAttributeIDTypeClusterUnitTestingAttributeStructAttrID MTR_NEWLY_AVAILABLE = 0x00000025,
+    MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt8uID MTR_NEWLY_AVAILABLE = 0x00000026,
+    MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt8sID MTR_NEWLY_AVAILABLE = 0x00000027,
+    MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt16uID MTR_NEWLY_AVAILABLE = 0x00000028,
+    MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt16sID MTR_NEWLY_AVAILABLE = 0x00000029,
+    MTRAttributeIDTypeClusterUnitTestingAttributeListLongOctetStringID MTR_NEWLY_AVAILABLE = 0x0000002A,
+    MTRAttributeIDTypeClusterUnitTestingAttributeListFabricScopedID MTR_NEWLY_AVAILABLE = 0x0000002B,
+    MTRAttributeIDTypeClusterUnitTestingAttributeTimedWriteBooleanID MTR_NEWLY_AVAILABLE = 0x00000030,
+    MTRAttributeIDTypeClusterUnitTestingAttributeGeneralErrorBooleanID MTR_NEWLY_AVAILABLE = 0x00000031,
+    MTRAttributeIDTypeClusterUnitTestingAttributeClusterErrorBooleanID MTR_NEWLY_AVAILABLE = 0x00000032,
+    MTRAttributeIDTypeClusterUnitTestingAttributeUnsupportedID MTR_NEWLY_AVAILABLE = 0x000000FF,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableBooleanID MTR_NEWLY_AVAILABLE = 0x00004000,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap8ID MTR_NEWLY_AVAILABLE = 0x00004001,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap16ID MTR_NEWLY_AVAILABLE = 0x00004002,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap32ID MTR_NEWLY_AVAILABLE = 0x00004003,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap64ID MTR_NEWLY_AVAILABLE = 0x00004004,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt8uID MTR_NEWLY_AVAILABLE = 0x00004005,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt16uID MTR_NEWLY_AVAILABLE = 0x00004006,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt24uID MTR_NEWLY_AVAILABLE = 0x00004007,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt32uID MTR_NEWLY_AVAILABLE = 0x00004008,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt40uID MTR_NEWLY_AVAILABLE = 0x00004009,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt48uID MTR_NEWLY_AVAILABLE = 0x0000400A,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt56uID MTR_NEWLY_AVAILABLE = 0x0000400B,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt64uID MTR_NEWLY_AVAILABLE = 0x0000400C,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt8sID MTR_NEWLY_AVAILABLE = 0x0000400D,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt16sID MTR_NEWLY_AVAILABLE = 0x0000400E,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt24sID MTR_NEWLY_AVAILABLE = 0x0000400F,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt32sID MTR_NEWLY_AVAILABLE = 0x00004010,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt40sID MTR_NEWLY_AVAILABLE = 0x00004011,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt48sID MTR_NEWLY_AVAILABLE = 0x00004012,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt56sID MTR_NEWLY_AVAILABLE = 0x00004013,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt64sID MTR_NEWLY_AVAILABLE = 0x00004014,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableEnum8ID MTR_NEWLY_AVAILABLE = 0x00004015,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableEnum16ID MTR_NEWLY_AVAILABLE = 0x00004016,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableFloatSingleID MTR_NEWLY_AVAILABLE = 0x00004017,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableFloatDoubleID MTR_NEWLY_AVAILABLE = 0x00004018,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableOctetStringID MTR_NEWLY_AVAILABLE = 0x00004019,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableCharStringID MTR_NEWLY_AVAILABLE = 0x0000401E,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableEnumAttrID MTR_NEWLY_AVAILABLE = 0x00004024,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableStructID MTR_NEWLY_AVAILABLE = 0x00004025,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt8uID MTR_NEWLY_AVAILABLE = 0x00004026,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt8sID MTR_NEWLY_AVAILABLE = 0x00004027,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt16uID MTR_NEWLY_AVAILABLE = 0x00004028,
+    MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt16sID MTR_NEWLY_AVAILABLE = 0x00004029,
+    MTRAttributeIDTypeClusterUnitTestingAttributeWriteOnlyInt8uID MTR_NEWLY_AVAILABLE = 0x0000402A,
+    MTRAttributeIDTypeClusterUnitTestingAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterUnitTestingAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterUnitTestingAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterUnitTestingAttributeFeatureMapID MTR_NEWLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterUnitTestingAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+
+    // Cluster FaultInjection deprecated attribute names
+    MTRClusterFaultInjectionAttributeGeneratedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFaultInjectionAttributeGeneratedCommandListID")
+    = MTRClusterGlobalAttributeGeneratedCommandListID,
+    MTRClusterFaultInjectionAttributeAcceptedCommandListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFaultInjectionAttributeAcceptedCommandListID")
+    = MTRClusterGlobalAttributeAcceptedCommandListID,
+    MTRClusterFaultInjectionAttributeAttributeListID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFaultInjectionAttributeAttributeListID")
+    = MTRClusterGlobalAttributeAttributeListID,
+    MTRClusterFaultInjectionAttributeFeatureMapID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFaultInjectionAttributeFeatureMapID")
+    = MTRClusterGlobalAttributeFeatureMapID,
+    MTRClusterFaultInjectionAttributeClusterRevisionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRAttributeIDTypeClusterFaultInjectionAttributeClusterRevisionID")
+    = MTRClusterGlobalAttributeClusterRevisionID,
 
     // Cluster FaultInjection attributes
-    MTRClusterFaultInjectionAttributeGeneratedCommandListID = MTRClusterGlobalAttributeGeneratedCommandListID,
-    MTRClusterFaultInjectionAttributeAcceptedCommandListID = MTRClusterGlobalAttributeAcceptedCommandListID,
-    MTRClusterFaultInjectionAttributeAttributeListID = MTRClusterGlobalAttributeAttributeListID,
-    MTRClusterFaultInjectionAttributeFeatureMapID = MTRClusterGlobalAttributeFeatureMapID,
-    MTRClusterFaultInjectionAttributeClusterRevisionID = MTRClusterGlobalAttributeClusterRevisionID,
+    MTRAttributeIDTypeClusterFaultInjectionAttributeGeneratedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterFaultInjectionAttributeAcceptedCommandListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterFaultInjectionAttributeAttributeListID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterFaultInjectionAttributeFeatureMapID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterFaultInjectionAttributeClusterRevisionID MTR_NEWLY_AVAILABLE
+    = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
 
 };
 
 #pragma mark - Commands IDs
 
-typedef NS_ENUM(uint32_t, MTRClusterCommandIDType) {
+typedef NS_ENUM(uint32_t, MTRCommandIDType) {
+
+    // Cluster Identify deprecated command id names
+    MTRClusterIdentifyCommandIdentifyID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterIdentifyCommandIdentifyID")
+    = 0x00000000,
+    MTRClusterIdentifyCommandTriggerEffectID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterIdentifyCommandTriggerEffectID")
+    = 0x00000040,
 
     // Cluster Identify commands
-    MTRClusterIdentifyCommandIdentifyID = 0x00000000,
-    MTRClusterIdentifyCommandTriggerEffectID = 0x00000040,
+    MTRCommandIDTypeClusterIdentifyCommandIdentifyID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterIdentifyCommandTriggerEffectID MTR_NEWLY_AVAILABLE = 0x00000040,
+
+    // Cluster Groups deprecated command id names
+    MTRClusterGroupsCommandAddGroupID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterGroupsCommandAddGroupID")
+    = 0x00000000,
+    MTRClusterGroupsCommandAddGroupResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGroupsCommandAddGroupResponseID")
+    = 0x00000000,
+    MTRClusterGroupsCommandViewGroupID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterGroupsCommandViewGroupID")
+    = 0x00000001,
+    MTRClusterGroupsCommandViewGroupResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGroupsCommandViewGroupResponseID")
+    = 0x00000001,
+    MTRClusterGroupsCommandGetGroupMembershipID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGroupsCommandGetGroupMembershipID")
+    = 0x00000002,
+    MTRClusterGroupsCommandGetGroupMembershipResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGroupsCommandGetGroupMembershipResponseID")
+    = 0x00000002,
+    MTRClusterGroupsCommandRemoveGroupID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterGroupsCommandRemoveGroupID")
+    = 0x00000003,
+    MTRClusterGroupsCommandRemoveGroupResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGroupsCommandRemoveGroupResponseID")
+    = 0x00000003,
+    MTRClusterGroupsCommandRemoveAllGroupsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGroupsCommandRemoveAllGroupsID")
+    = 0x00000004,
+    MTRClusterGroupsCommandAddGroupIfIdentifyingID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGroupsCommandAddGroupIfIdentifyingID")
+    = 0x00000005,
 
     // Cluster Groups commands
-    MTRClusterGroupsCommandAddGroupID = 0x00000000,
-    MTRClusterGroupsCommandAddGroupResponseID = 0x00000000,
-    MTRClusterGroupsCommandViewGroupID = 0x00000001,
-    MTRClusterGroupsCommandViewGroupResponseID = 0x00000001,
-    MTRClusterGroupsCommandGetGroupMembershipID = 0x00000002,
-    MTRClusterGroupsCommandGetGroupMembershipResponseID = 0x00000002,
-    MTRClusterGroupsCommandRemoveGroupID = 0x00000003,
-    MTRClusterGroupsCommandRemoveGroupResponseID = 0x00000003,
-    MTRClusterGroupsCommandRemoveAllGroupsID = 0x00000004,
-    MTRClusterGroupsCommandAddGroupIfIdentifyingID = 0x00000005,
+    MTRCommandIDTypeClusterGroupsCommandAddGroupID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterGroupsCommandAddGroupResponseID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterGroupsCommandViewGroupID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterGroupsCommandViewGroupResponseID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterGroupsCommandGetGroupMembershipID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterGroupsCommandGetGroupMembershipResponseID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterGroupsCommandRemoveGroupID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterGroupsCommandRemoveGroupResponseID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterGroupsCommandRemoveAllGroupsID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRCommandIDTypeClusterGroupsCommandAddGroupIfIdentifyingID MTR_NEWLY_AVAILABLE = 0x00000005,
+
+    // Cluster Scenes deprecated command id names
+    MTRClusterScenesCommandAddSceneID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterScenesCommandAddSceneID")
+    = 0x00000000,
+    MTRClusterScenesCommandAddSceneResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterScenesCommandAddSceneResponseID")
+    = 0x00000000,
+    MTRClusterScenesCommandViewSceneID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterScenesCommandViewSceneID")
+    = 0x00000001,
+    MTRClusterScenesCommandViewSceneResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterScenesCommandViewSceneResponseID")
+    = 0x00000001,
+    MTRClusterScenesCommandRemoveSceneID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterScenesCommandRemoveSceneID")
+    = 0x00000002,
+    MTRClusterScenesCommandRemoveSceneResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterScenesCommandRemoveSceneResponseID")
+    = 0x00000002,
+    MTRClusterScenesCommandRemoveAllScenesID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterScenesCommandRemoveAllScenesID")
+    = 0x00000003,
+    MTRClusterScenesCommandRemoveAllScenesResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterScenesCommandRemoveAllScenesResponseID")
+    = 0x00000003,
+    MTRClusterScenesCommandStoreSceneID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterScenesCommandStoreSceneID")
+    = 0x00000004,
+    MTRClusterScenesCommandStoreSceneResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterScenesCommandStoreSceneResponseID")
+    = 0x00000004,
+    MTRClusterScenesCommandRecallSceneID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterScenesCommandRecallSceneID")
+    = 0x00000005,
+    MTRClusterScenesCommandGetSceneMembershipID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterScenesCommandGetSceneMembershipID")
+    = 0x00000006,
+    MTRClusterScenesCommandGetSceneMembershipResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterScenesCommandGetSceneMembershipResponseID")
+    = 0x00000006,
+    MTRClusterScenesCommandEnhancedAddSceneID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterScenesCommandEnhancedAddSceneID")
+    = 0x00000040,
+    MTRClusterScenesCommandEnhancedAddSceneResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterScenesCommandEnhancedAddSceneResponseID")
+    = 0x00000040,
+    MTRClusterScenesCommandEnhancedViewSceneID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterScenesCommandEnhancedViewSceneID")
+    = 0x00000041,
+    MTRClusterScenesCommandEnhancedViewSceneResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterScenesCommandEnhancedViewSceneResponseID")
+    = 0x00000041,
+    MTRClusterScenesCommandCopySceneID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterScenesCommandCopySceneID")
+    = 0x00000042,
+    MTRClusterScenesCommandCopySceneResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterScenesCommandCopySceneResponseID")
+    = 0x00000042,
 
     // Cluster Scenes commands
-    MTRClusterScenesCommandAddSceneID = 0x00000000,
-    MTRClusterScenesCommandAddSceneResponseID = 0x00000000,
-    MTRClusterScenesCommandViewSceneID = 0x00000001,
-    MTRClusterScenesCommandViewSceneResponseID = 0x00000001,
-    MTRClusterScenesCommandRemoveSceneID = 0x00000002,
-    MTRClusterScenesCommandRemoveSceneResponseID = 0x00000002,
-    MTRClusterScenesCommandRemoveAllScenesID = 0x00000003,
-    MTRClusterScenesCommandRemoveAllScenesResponseID = 0x00000003,
-    MTRClusterScenesCommandStoreSceneID = 0x00000004,
-    MTRClusterScenesCommandStoreSceneResponseID = 0x00000004,
-    MTRClusterScenesCommandRecallSceneID = 0x00000005,
-    MTRClusterScenesCommandGetSceneMembershipID = 0x00000006,
-    MTRClusterScenesCommandGetSceneMembershipResponseID = 0x00000006,
-    MTRClusterScenesCommandEnhancedAddSceneID = 0x00000040,
-    MTRClusterScenesCommandEnhancedAddSceneResponseID = 0x00000040,
-    MTRClusterScenesCommandEnhancedViewSceneID = 0x00000041,
-    MTRClusterScenesCommandEnhancedViewSceneResponseID = 0x00000041,
-    MTRClusterScenesCommandCopySceneID = 0x00000042,
-    MTRClusterScenesCommandCopySceneResponseID = 0x00000042,
+    MTRCommandIDTypeClusterScenesCommandAddSceneID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterScenesCommandAddSceneResponseID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterScenesCommandViewSceneID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterScenesCommandViewSceneResponseID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterScenesCommandRemoveSceneID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterScenesCommandRemoveSceneResponseID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterScenesCommandRemoveAllScenesID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterScenesCommandRemoveAllScenesResponseID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterScenesCommandStoreSceneID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRCommandIDTypeClusterScenesCommandStoreSceneResponseID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRCommandIDTypeClusterScenesCommandRecallSceneID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRCommandIDTypeClusterScenesCommandGetSceneMembershipID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRCommandIDTypeClusterScenesCommandGetSceneMembershipResponseID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRCommandIDTypeClusterScenesCommandEnhancedAddSceneID MTR_NEWLY_AVAILABLE = 0x00000040,
+    MTRCommandIDTypeClusterScenesCommandEnhancedAddSceneResponseID MTR_NEWLY_AVAILABLE = 0x00000040,
+    MTRCommandIDTypeClusterScenesCommandEnhancedViewSceneID MTR_NEWLY_AVAILABLE = 0x00000041,
+    MTRCommandIDTypeClusterScenesCommandEnhancedViewSceneResponseID MTR_NEWLY_AVAILABLE = 0x00000041,
+    MTRCommandIDTypeClusterScenesCommandCopySceneID MTR_NEWLY_AVAILABLE = 0x00000042,
+    MTRCommandIDTypeClusterScenesCommandCopySceneResponseID MTR_NEWLY_AVAILABLE = 0x00000042,
+
+    // Cluster OnOff deprecated command id names
+    MTRClusterOnOffCommandOffID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterOnOffCommandOffID") = 0x00000000,
+    MTRClusterOnOffCommandOnID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterOnOffCommandOnID") = 0x00000001,
+    MTRClusterOnOffCommandToggleID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterOnOffCommandToggleID") = 0x00000002,
+    MTRClusterOnOffCommandOffWithEffectID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterOnOffCommandOffWithEffectID")
+    = 0x00000040,
+    MTRClusterOnOffCommandOnWithRecallGlobalSceneID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOnOffCommandOnWithRecallGlobalSceneID")
+    = 0x00000041,
+    MTRClusterOnOffCommandOnWithTimedOffID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterOnOffCommandOnWithTimedOffID")
+    = 0x00000042,
 
     // Cluster OnOff commands
-    MTRClusterOnOffCommandOffID = 0x00000000,
-    MTRClusterOnOffCommandOnID = 0x00000001,
-    MTRClusterOnOffCommandToggleID = 0x00000002,
-    MTRClusterOnOffCommandOffWithEffectID = 0x00000040,
-    MTRClusterOnOffCommandOnWithRecallGlobalSceneID = 0x00000041,
-    MTRClusterOnOffCommandOnWithTimedOffID = 0x00000042,
+    MTRCommandIDTypeClusterOnOffCommandOffID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterOnOffCommandOnID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterOnOffCommandToggleID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterOnOffCommandOffWithEffectID MTR_NEWLY_AVAILABLE = 0x00000040,
+    MTRCommandIDTypeClusterOnOffCommandOnWithRecallGlobalSceneID MTR_NEWLY_AVAILABLE = 0x00000041,
+    MTRCommandIDTypeClusterOnOffCommandOnWithTimedOffID MTR_NEWLY_AVAILABLE = 0x00000042,
+
+    // Cluster LevelControl deprecated command id names
+    MTRClusterLevelControlCommandMoveToLevelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterLevelControlCommandMoveToLevelID")
+    = 0x00000000,
+    MTRClusterLevelControlCommandMoveID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterLevelControlCommandMoveID")
+    = 0x00000001,
+    MTRClusterLevelControlCommandStepID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterLevelControlCommandStepID")
+    = 0x00000002,
+    MTRClusterLevelControlCommandStopID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterLevelControlCommandStopID")
+    = 0x00000003,
+    MTRClusterLevelControlCommandMoveToLevelWithOnOffID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterLevelControlCommandMoveToLevelWithOnOffID")
+    = 0x00000004,
+    MTRClusterLevelControlCommandMoveWithOnOffID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterLevelControlCommandMoveWithOnOffID")
+    = 0x00000005,
+    MTRClusterLevelControlCommandStepWithOnOffID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterLevelControlCommandStepWithOnOffID")
+    = 0x00000006,
+    MTRClusterLevelControlCommandStopWithOnOffID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterLevelControlCommandStopWithOnOffID")
+    = 0x00000007,
+    MTRClusterLevelControlCommandMoveToClosestFrequencyID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterLevelControlCommandMoveToClosestFrequencyID")
+    = 0x00000008,
 
     // Cluster LevelControl commands
-    MTRClusterLevelControlCommandMoveToLevelID = 0x00000000,
-    MTRClusterLevelControlCommandMoveID = 0x00000001,
-    MTRClusterLevelControlCommandStepID = 0x00000002,
-    MTRClusterLevelControlCommandStopID = 0x00000003,
-    MTRClusterLevelControlCommandMoveToLevelWithOnOffID = 0x00000004,
-    MTRClusterLevelControlCommandMoveWithOnOffID = 0x00000005,
-    MTRClusterLevelControlCommandStepWithOnOffID = 0x00000006,
-    MTRClusterLevelControlCommandStopWithOnOffID = 0x00000007,
-    MTRClusterLevelControlCommandMoveToClosestFrequencyID = 0x00000008,
+    MTRCommandIDTypeClusterLevelControlCommandMoveToLevelID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterLevelControlCommandMoveID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterLevelControlCommandStepID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterLevelControlCommandStopID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterLevelControlCommandMoveToLevelWithOnOffID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRCommandIDTypeClusterLevelControlCommandMoveWithOnOffID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRCommandIDTypeClusterLevelControlCommandStepWithOnOffID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRCommandIDTypeClusterLevelControlCommandStopWithOnOffID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRCommandIDTypeClusterLevelControlCommandMoveToClosestFrequencyID MTR_NEWLY_AVAILABLE = 0x00000008,
+
+    // Cluster Actions deprecated command id names
+    MTRClusterActionsCommandInstantActionID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterActionsCommandInstantActionID")
+    = 0x00000000,
+    MTRClusterActionsCommandInstantActionWithTransitionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterActionsCommandInstantActionWithTransitionID")
+    = 0x00000001,
+    MTRClusterActionsCommandStartActionID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterActionsCommandStartActionID")
+    = 0x00000002,
+    MTRClusterActionsCommandStartActionWithDurationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterActionsCommandStartActionWithDurationID")
+    = 0x00000003,
+    MTRClusterActionsCommandStopActionID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterActionsCommandStopActionID")
+    = 0x00000004,
+    MTRClusterActionsCommandPauseActionID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterActionsCommandPauseActionID")
+    = 0x00000005,
+    MTRClusterActionsCommandPauseActionWithDurationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterActionsCommandPauseActionWithDurationID")
+    = 0x00000006,
+    MTRClusterActionsCommandResumeActionID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterActionsCommandResumeActionID")
+    = 0x00000007,
+    MTRClusterActionsCommandEnableActionID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterActionsCommandEnableActionID")
+    = 0x00000008,
+    MTRClusterActionsCommandEnableActionWithDurationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterActionsCommandEnableActionWithDurationID")
+    = 0x00000009,
+    MTRClusterActionsCommandDisableActionID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterActionsCommandDisableActionID")
+    = 0x0000000A,
+    MTRClusterActionsCommandDisableActionWithDurationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterActionsCommandDisableActionWithDurationID")
+    = 0x0000000B,
 
     // Cluster Actions commands
-    MTRClusterActionsCommandInstantActionID = 0x00000000,
-    MTRClusterActionsCommandInstantActionWithTransitionID = 0x00000001,
-    MTRClusterActionsCommandStartActionID = 0x00000002,
-    MTRClusterActionsCommandStartActionWithDurationID = 0x00000003,
-    MTRClusterActionsCommandStopActionID = 0x00000004,
-    MTRClusterActionsCommandPauseActionID = 0x00000005,
-    MTRClusterActionsCommandPauseActionWithDurationID = 0x00000006,
-    MTRClusterActionsCommandResumeActionID = 0x00000007,
-    MTRClusterActionsCommandEnableActionID = 0x00000008,
-    MTRClusterActionsCommandEnableActionWithDurationID = 0x00000009,
-    MTRClusterActionsCommandDisableActionID = 0x0000000A,
-    MTRClusterActionsCommandDisableActionWithDurationID = 0x0000000B,
+    MTRCommandIDTypeClusterActionsCommandInstantActionID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterActionsCommandInstantActionWithTransitionID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterActionsCommandStartActionID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterActionsCommandStartActionWithDurationID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterActionsCommandStopActionID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRCommandIDTypeClusterActionsCommandPauseActionID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRCommandIDTypeClusterActionsCommandPauseActionWithDurationID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRCommandIDTypeClusterActionsCommandResumeActionID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRCommandIDTypeClusterActionsCommandEnableActionID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRCommandIDTypeClusterActionsCommandEnableActionWithDurationID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRCommandIDTypeClusterActionsCommandDisableActionID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRCommandIDTypeClusterActionsCommandDisableActionWithDurationID MTR_NEWLY_AVAILABLE = 0x0000000B,
+
+    // Cluster Basic deprecated command id names
+    MTRClusterBasicCommandMfgSpecificPingID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterBasicCommandMfgSpecificPingID")
+    = 0x10020000,
 
     // Cluster Basic commands
-    MTRClusterBasicCommandMfgSpecificPingID = 0x10020000,
+    MTRCommandIDTypeClusterBasicCommandMfgSpecificPingID MTR_NEWLY_AVAILABLE = 0x10020000,
+
+    // Cluster OtaSoftwareUpdateProvider deprecated command id names
+    MTRClusterOtaSoftwareUpdateProviderCommandQueryImageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandQueryImageID")
+    = 0x00000000,
+    MTRClusterOtaSoftwareUpdateProviderCommandQueryImageResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandQueryImageResponseID")
+    = 0x00000001,
+    MTRClusterOtaSoftwareUpdateProviderCommandApplyUpdateRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandApplyUpdateRequestID")
+    = 0x00000002,
+    MTRClusterOtaSoftwareUpdateProviderCommandApplyUpdateResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandApplyUpdateResponseID")
+    = 0x00000003,
+    MTRClusterOtaSoftwareUpdateProviderCommandNotifyUpdateAppliedID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandNotifyUpdateAppliedID")
+    = 0x00000004,
 
     // Cluster OtaSoftwareUpdateProvider commands
-    MTRClusterOtaSoftwareUpdateProviderCommandQueryImageID = 0x00000000,
-    MTRClusterOtaSoftwareUpdateProviderCommandQueryImageResponseID = 0x00000001,
-    MTRClusterOtaSoftwareUpdateProviderCommandApplyUpdateRequestID = 0x00000002,
-    MTRClusterOtaSoftwareUpdateProviderCommandApplyUpdateResponseID = 0x00000003,
-    MTRClusterOtaSoftwareUpdateProviderCommandNotifyUpdateAppliedID = 0x00000004,
+    MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandQueryImageID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandQueryImageResponseID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandApplyUpdateRequestID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandApplyUpdateResponseID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandNotifyUpdateAppliedID MTR_NEWLY_AVAILABLE = 0x00000004,
+
+    // Cluster OtaSoftwareUpdateRequestor deprecated command id names
+    MTRClusterOtaSoftwareUpdateRequestorCommandAnnounceOtaProviderID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOtaSoftwareUpdateRequestorCommandAnnounceOtaProviderID")
+    = 0x00000000,
 
     // Cluster OtaSoftwareUpdateRequestor commands
-    MTRClusterOtaSoftwareUpdateRequestorCommandAnnounceOtaProviderID = 0x00000000,
+    MTRCommandIDTypeClusterOtaSoftwareUpdateRequestorCommandAnnounceOtaProviderID MTR_NEWLY_AVAILABLE = 0x00000000,
+
+    // Cluster GeneralCommissioning deprecated command id names
+    MTRClusterGeneralCommissioningCommandArmFailSafeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGeneralCommissioningCommandArmFailSafeID")
+    = 0x00000000,
+    MTRClusterGeneralCommissioningCommandArmFailSafeResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGeneralCommissioningCommandArmFailSafeResponseID")
+    = 0x00000001,
+    MTRClusterGeneralCommissioningCommandSetRegulatoryConfigID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGeneralCommissioningCommandSetRegulatoryConfigID")
+    = 0x00000002,
+    MTRClusterGeneralCommissioningCommandSetRegulatoryConfigResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGeneralCommissioningCommandSetRegulatoryConfigResponseID")
+    = 0x00000003,
+    MTRClusterGeneralCommissioningCommandCommissioningCompleteID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGeneralCommissioningCommandCommissioningCompleteID")
+    = 0x00000004,
+    MTRClusterGeneralCommissioningCommandCommissioningCompleteResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGeneralCommissioningCommandCommissioningCompleteResponseID")
+    = 0x00000005,
 
     // Cluster GeneralCommissioning commands
-    MTRClusterGeneralCommissioningCommandArmFailSafeID = 0x00000000,
-    MTRClusterGeneralCommissioningCommandArmFailSafeResponseID = 0x00000001,
-    MTRClusterGeneralCommissioningCommandSetRegulatoryConfigID = 0x00000002,
-    MTRClusterGeneralCommissioningCommandSetRegulatoryConfigResponseID = 0x00000003,
-    MTRClusterGeneralCommissioningCommandCommissioningCompleteID = 0x00000004,
-    MTRClusterGeneralCommissioningCommandCommissioningCompleteResponseID = 0x00000005,
+    MTRCommandIDTypeClusterGeneralCommissioningCommandArmFailSafeID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterGeneralCommissioningCommandArmFailSafeResponseID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterGeneralCommissioningCommandSetRegulatoryConfigID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterGeneralCommissioningCommandSetRegulatoryConfigResponseID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterGeneralCommissioningCommandCommissioningCompleteID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRCommandIDTypeClusterGeneralCommissioningCommandCommissioningCompleteResponseID MTR_NEWLY_AVAILABLE = 0x00000005,
+
+    // Cluster NetworkCommissioning deprecated command id names
+    MTRClusterNetworkCommissioningCommandScanNetworksID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterNetworkCommissioningCommandScanNetworksID")
+    = 0x00000000,
+    MTRClusterNetworkCommissioningCommandScanNetworksResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterNetworkCommissioningCommandScanNetworksResponseID")
+    = 0x00000001,
+    MTRClusterNetworkCommissioningCommandAddOrUpdateWiFiNetworkID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterNetworkCommissioningCommandAddOrUpdateWiFiNetworkID")
+    = 0x00000002,
+    MTRClusterNetworkCommissioningCommandAddOrUpdateThreadNetworkID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterNetworkCommissioningCommandAddOrUpdateThreadNetworkID")
+    = 0x00000003,
+    MTRClusterNetworkCommissioningCommandRemoveNetworkID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterNetworkCommissioningCommandRemoveNetworkID")
+    = 0x00000004,
+    MTRClusterNetworkCommissioningCommandNetworkConfigResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterNetworkCommissioningCommandNetworkConfigResponseID")
+    = 0x00000005,
+    MTRClusterNetworkCommissioningCommandConnectNetworkID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterNetworkCommissioningCommandConnectNetworkID")
+    = 0x00000006,
+    MTRClusterNetworkCommissioningCommandConnectNetworkResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterNetworkCommissioningCommandConnectNetworkResponseID")
+    = 0x00000007,
+    MTRClusterNetworkCommissioningCommandReorderNetworkID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterNetworkCommissioningCommandReorderNetworkID")
+    = 0x00000008,
 
     // Cluster NetworkCommissioning commands
-    MTRClusterNetworkCommissioningCommandScanNetworksID = 0x00000000,
-    MTRClusterNetworkCommissioningCommandScanNetworksResponseID = 0x00000001,
-    MTRClusterNetworkCommissioningCommandAddOrUpdateWiFiNetworkID = 0x00000002,
-    MTRClusterNetworkCommissioningCommandAddOrUpdateThreadNetworkID = 0x00000003,
-    MTRClusterNetworkCommissioningCommandRemoveNetworkID = 0x00000004,
-    MTRClusterNetworkCommissioningCommandNetworkConfigResponseID = 0x00000005,
-    MTRClusterNetworkCommissioningCommandConnectNetworkID = 0x00000006,
-    MTRClusterNetworkCommissioningCommandConnectNetworkResponseID = 0x00000007,
-    MTRClusterNetworkCommissioningCommandReorderNetworkID = 0x00000008,
+    MTRCommandIDTypeClusterNetworkCommissioningCommandScanNetworksID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterNetworkCommissioningCommandScanNetworksResponseID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterNetworkCommissioningCommandAddOrUpdateWiFiNetworkID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterNetworkCommissioningCommandAddOrUpdateThreadNetworkID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterNetworkCommissioningCommandRemoveNetworkID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRCommandIDTypeClusterNetworkCommissioningCommandNetworkConfigResponseID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRCommandIDTypeClusterNetworkCommissioningCommandConnectNetworkID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRCommandIDTypeClusterNetworkCommissioningCommandConnectNetworkResponseID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRCommandIDTypeClusterNetworkCommissioningCommandReorderNetworkID MTR_NEWLY_AVAILABLE = 0x00000008,
+
+    // Cluster DiagnosticLogs deprecated command id names
+    MTRClusterDiagnosticLogsCommandRetrieveLogsRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDiagnosticLogsCommandRetrieveLogsRequestID")
+    = 0x00000000,
+    MTRClusterDiagnosticLogsCommandRetrieveLogsResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDiagnosticLogsCommandRetrieveLogsResponseID")
+    = 0x00000001,
 
     // Cluster DiagnosticLogs commands
-    MTRClusterDiagnosticLogsCommandRetrieveLogsRequestID = 0x00000000,
-    MTRClusterDiagnosticLogsCommandRetrieveLogsResponseID = 0x00000001,
+    MTRCommandIDTypeClusterDiagnosticLogsCommandRetrieveLogsRequestID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterDiagnosticLogsCommandRetrieveLogsResponseID MTR_NEWLY_AVAILABLE = 0x00000001,
+
+    // Cluster GeneralDiagnostics deprecated command id names
+    MTRClusterGeneralDiagnosticsCommandTestEventTriggerID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGeneralDiagnosticsCommandTestEventTriggerID")
+    = 0x00000000,
 
     // Cluster GeneralDiagnostics commands
-    MTRClusterGeneralDiagnosticsCommandTestEventTriggerID = 0x00000000,
+    MTRCommandIDTypeClusterGeneralDiagnosticsCommandTestEventTriggerID MTR_NEWLY_AVAILABLE = 0x00000000,
+
+    // Cluster SoftwareDiagnostics deprecated command id names
+    MTRClusterSoftwareDiagnosticsCommandResetWatermarksID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterSoftwareDiagnosticsCommandResetWatermarksID")
+    = 0x00000000,
 
     // Cluster SoftwareDiagnostics commands
-    MTRClusterSoftwareDiagnosticsCommandResetWatermarksID = 0x00000000,
+    MTRCommandIDTypeClusterSoftwareDiagnosticsCommandResetWatermarksID MTR_NEWLY_AVAILABLE = 0x00000000,
+
+    // Cluster ThreadNetworkDiagnostics deprecated command id names
+    MTRClusterThreadNetworkDiagnosticsCommandResetCountsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterThreadNetworkDiagnosticsCommandResetCountsID")
+    = 0x00000000,
 
     // Cluster ThreadNetworkDiagnostics commands
-    MTRClusterThreadNetworkDiagnosticsCommandResetCountsID = 0x00000000,
+    MTRCommandIDTypeClusterThreadNetworkDiagnosticsCommandResetCountsID MTR_NEWLY_AVAILABLE = 0x00000000,
+
+    // Cluster WiFiNetworkDiagnostics deprecated command id names
+    MTRClusterWiFiNetworkDiagnosticsCommandResetCountsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterWiFiNetworkDiagnosticsCommandResetCountsID")
+    = 0x00000000,
 
     // Cluster WiFiNetworkDiagnostics commands
-    MTRClusterWiFiNetworkDiagnosticsCommandResetCountsID = 0x00000000,
+    MTRCommandIDTypeClusterWiFiNetworkDiagnosticsCommandResetCountsID MTR_NEWLY_AVAILABLE = 0x00000000,
+
+    // Cluster EthernetNetworkDiagnostics deprecated command id names
+    MTRClusterEthernetNetworkDiagnosticsCommandResetCountsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterEthernetNetworkDiagnosticsCommandResetCountsID")
+    = 0x00000000,
 
     // Cluster EthernetNetworkDiagnostics commands
-    MTRClusterEthernetNetworkDiagnosticsCommandResetCountsID = 0x00000000,
+    MTRCommandIDTypeClusterEthernetNetworkDiagnosticsCommandResetCountsID MTR_NEWLY_AVAILABLE = 0x00000000,
+
+    // Cluster TimeSynchronization deprecated command id names
+    MTRClusterTimeSynchronizationCommandSetUtcTimeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterTimeSynchronizationCommandSetUtcTimeID")
+    = 0x00000000,
 
     // Cluster TimeSynchronization commands
-    MTRClusterTimeSynchronizationCommandSetUtcTimeID = 0x00000000,
+    MTRCommandIDTypeClusterTimeSynchronizationCommandSetUtcTimeID MTR_NEWLY_AVAILABLE = 0x00000000,
+
+    // Cluster AdministratorCommissioning deprecated command id names
+    MTRClusterAdministratorCommissioningCommandOpenCommissioningWindowID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterAdministratorCommissioningCommandOpenCommissioningWindowID")
+    = 0x00000000,
+    MTRClusterAdministratorCommissioningCommandOpenBasicCommissioningWindowID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterAdministratorCommissioningCommandOpenBasicCommissioningWindowID")
+    = 0x00000001,
+    MTRClusterAdministratorCommissioningCommandRevokeCommissioningID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterAdministratorCommissioningCommandRevokeCommissioningID")
+    = 0x00000002,
 
     // Cluster AdministratorCommissioning commands
-    MTRClusterAdministratorCommissioningCommandOpenCommissioningWindowID = 0x00000000,
-    MTRClusterAdministratorCommissioningCommandOpenBasicCommissioningWindowID = 0x00000001,
-    MTRClusterAdministratorCommissioningCommandRevokeCommissioningID = 0x00000002,
+    MTRCommandIDTypeClusterAdministratorCommissioningCommandOpenCommissioningWindowID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterAdministratorCommissioningCommandOpenBasicCommissioningWindowID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterAdministratorCommissioningCommandRevokeCommissioningID MTR_NEWLY_AVAILABLE = 0x00000002,
+
+    // Cluster OperationalCredentials deprecated command id names
+    MTRClusterOperationalCredentialsCommandAttestationRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOperationalCredentialsCommandAttestationRequestID")
+    = 0x00000000,
+    MTRClusterOperationalCredentialsCommandAttestationResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOperationalCredentialsCommandAttestationResponseID")
+    = 0x00000001,
+    MTRClusterOperationalCredentialsCommandCertificateChainRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOperationalCredentialsCommandCertificateChainRequestID")
+    = 0x00000002,
+    MTRClusterOperationalCredentialsCommandCertificateChainResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOperationalCredentialsCommandCertificateChainResponseID")
+    = 0x00000003,
+    MTRClusterOperationalCredentialsCommandCSRRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOperationalCredentialsCommandCSRRequestID")
+    = 0x00000004,
+    MTRClusterOperationalCredentialsCommandCSRResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOperationalCredentialsCommandCSRResponseID")
+    = 0x00000005,
+    MTRClusterOperationalCredentialsCommandAddNOCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOperationalCredentialsCommandAddNOCID")
+    = 0x00000006,
+    MTRClusterOperationalCredentialsCommandUpdateNOCID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOperationalCredentialsCommandUpdateNOCID")
+    = 0x00000007,
+    MTRClusterOperationalCredentialsCommandNOCResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOperationalCredentialsCommandNOCResponseID")
+    = 0x00000008,
+    MTRClusterOperationalCredentialsCommandUpdateFabricLabelID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOperationalCredentialsCommandUpdateFabricLabelID")
+    = 0x00000009,
+    MTRClusterOperationalCredentialsCommandRemoveFabricID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOperationalCredentialsCommandRemoveFabricID")
+    = 0x0000000A,
+    MTRClusterOperationalCredentialsCommandAddTrustedRootCertificateID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterOperationalCredentialsCommandAddTrustedRootCertificateID")
+    = 0x0000000B,
 
     // Cluster OperationalCredentials commands
-    MTRClusterOperationalCredentialsCommandAttestationRequestID = 0x00000000,
-    MTRClusterOperationalCredentialsCommandAttestationResponseID = 0x00000001,
-    MTRClusterOperationalCredentialsCommandCertificateChainRequestID = 0x00000002,
-    MTRClusterOperationalCredentialsCommandCertificateChainResponseID = 0x00000003,
-    MTRClusterOperationalCredentialsCommandCSRRequestID = 0x00000004,
-    MTRClusterOperationalCredentialsCommandCSRResponseID = 0x00000005,
-    MTRClusterOperationalCredentialsCommandAddNOCID = 0x00000006,
-    MTRClusterOperationalCredentialsCommandUpdateNOCID = 0x00000007,
-    MTRClusterOperationalCredentialsCommandNOCResponseID = 0x00000008,
-    MTRClusterOperationalCredentialsCommandUpdateFabricLabelID = 0x00000009,
-    MTRClusterOperationalCredentialsCommandRemoveFabricID = 0x0000000A,
-    MTRClusterOperationalCredentialsCommandAddTrustedRootCertificateID = 0x0000000B,
+    MTRCommandIDTypeClusterOperationalCredentialsCommandAttestationRequestID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterOperationalCredentialsCommandAttestationResponseID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterOperationalCredentialsCommandCertificateChainRequestID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterOperationalCredentialsCommandCertificateChainResponseID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterOperationalCredentialsCommandCSRRequestID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRCommandIDTypeClusterOperationalCredentialsCommandCSRResponseID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRCommandIDTypeClusterOperationalCredentialsCommandAddNOCID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRCommandIDTypeClusterOperationalCredentialsCommandUpdateNOCID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRCommandIDTypeClusterOperationalCredentialsCommandNOCResponseID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRCommandIDTypeClusterOperationalCredentialsCommandUpdateFabricLabelID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRCommandIDTypeClusterOperationalCredentialsCommandRemoveFabricID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRCommandIDTypeClusterOperationalCredentialsCommandAddTrustedRootCertificateID MTR_NEWLY_AVAILABLE = 0x0000000B,
+
+    // Cluster GroupKeyManagement deprecated command id names
+    MTRClusterGroupKeyManagementCommandKeySetWriteID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGroupKeyManagementCommandKeySetWriteID")
+    = 0x00000000,
+    MTRClusterGroupKeyManagementCommandKeySetReadID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGroupKeyManagementCommandKeySetReadID")
+    = 0x00000001,
+    MTRClusterGroupKeyManagementCommandKeySetReadResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGroupKeyManagementCommandKeySetReadResponseID")
+    = 0x00000002,
+    MTRClusterGroupKeyManagementCommandKeySetRemoveID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGroupKeyManagementCommandKeySetRemoveID")
+    = 0x00000003,
+    MTRClusterGroupKeyManagementCommandKeySetReadAllIndicesID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGroupKeyManagementCommandKeySetReadAllIndicesID")
+    = 0x00000004,
+    MTRClusterGroupKeyManagementCommandKeySetReadAllIndicesResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterGroupKeyManagementCommandKeySetReadAllIndicesResponseID")
+    = 0x00000005,
 
     // Cluster GroupKeyManagement commands
-    MTRClusterGroupKeyManagementCommandKeySetWriteID = 0x00000000,
-    MTRClusterGroupKeyManagementCommandKeySetReadID = 0x00000001,
-    MTRClusterGroupKeyManagementCommandKeySetReadResponseID = 0x00000002,
-    MTRClusterGroupKeyManagementCommandKeySetRemoveID = 0x00000003,
-    MTRClusterGroupKeyManagementCommandKeySetReadAllIndicesID = 0x00000004,
-    MTRClusterGroupKeyManagementCommandKeySetReadAllIndicesResponseID = 0x00000005,
+    MTRCommandIDTypeClusterGroupKeyManagementCommandKeySetWriteID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterGroupKeyManagementCommandKeySetReadID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterGroupKeyManagementCommandKeySetReadResponseID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterGroupKeyManagementCommandKeySetRemoveID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterGroupKeyManagementCommandKeySetReadAllIndicesID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRCommandIDTypeClusterGroupKeyManagementCommandKeySetReadAllIndicesResponseID MTR_NEWLY_AVAILABLE = 0x00000005,
+
+    // Cluster ModeSelect deprecated command id names
+    MTRClusterModeSelectCommandChangeToModeID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterModeSelectCommandChangeToModeID")
+    = 0x00000000,
 
     // Cluster ModeSelect commands
-    MTRClusterModeSelectCommandChangeToModeID = 0x00000000,
+    MTRCommandIDTypeClusterModeSelectCommandChangeToModeID MTR_NEWLY_AVAILABLE = 0x00000000,
+
+    // Cluster DoorLock deprecated command id names
+    MTRClusterDoorLockCommandLockDoorID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterDoorLockCommandLockDoorID")
+    = 0x00000000,
+    MTRClusterDoorLockCommandUnlockDoorID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterDoorLockCommandUnlockDoorID")
+    = 0x00000001,
+    MTRClusterDoorLockCommandUnlockWithTimeoutID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandUnlockWithTimeoutID")
+    = 0x00000003,
+    MTRClusterDoorLockCommandSetWeekDayScheduleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandSetWeekDayScheduleID")
+    = 0x0000000B,
+    MTRClusterDoorLockCommandGetWeekDayScheduleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandGetWeekDayScheduleID")
+    = 0x0000000C,
+    MTRClusterDoorLockCommandGetWeekDayScheduleResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandGetWeekDayScheduleResponseID")
+    = 0x0000000C,
+    MTRClusterDoorLockCommandClearWeekDayScheduleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandClearWeekDayScheduleID")
+    = 0x0000000D,
+    MTRClusterDoorLockCommandSetYearDayScheduleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandSetYearDayScheduleID")
+    = 0x0000000E,
+    MTRClusterDoorLockCommandGetYearDayScheduleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandGetYearDayScheduleID")
+    = 0x0000000F,
+    MTRClusterDoorLockCommandGetYearDayScheduleResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandGetYearDayScheduleResponseID")
+    = 0x0000000F,
+    MTRClusterDoorLockCommandClearYearDayScheduleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandClearYearDayScheduleID")
+    = 0x00000010,
+    MTRClusterDoorLockCommandSetHolidayScheduleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandSetHolidayScheduleID")
+    = 0x00000011,
+    MTRClusterDoorLockCommandGetHolidayScheduleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandGetHolidayScheduleID")
+    = 0x00000012,
+    MTRClusterDoorLockCommandGetHolidayScheduleResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandGetHolidayScheduleResponseID")
+    = 0x00000012,
+    MTRClusterDoorLockCommandClearHolidayScheduleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandClearHolidayScheduleID")
+    = 0x00000013,
+    MTRClusterDoorLockCommandSetUserID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterDoorLockCommandSetUserID")
+    = 0x0000001A,
+    MTRClusterDoorLockCommandGetUserID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterDoorLockCommandGetUserID")
+    = 0x0000001B,
+    MTRClusterDoorLockCommandGetUserResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandGetUserResponseID")
+    = 0x0000001C,
+    MTRClusterDoorLockCommandClearUserID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterDoorLockCommandClearUserID")
+    = 0x0000001D,
+    MTRClusterDoorLockCommandSetCredentialID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandSetCredentialID")
+    = 0x00000022,
+    MTRClusterDoorLockCommandSetCredentialResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandSetCredentialResponseID")
+    = 0x00000023,
+    MTRClusterDoorLockCommandGetCredentialStatusID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandGetCredentialStatusID")
+    = 0x00000024,
+    MTRClusterDoorLockCommandGetCredentialStatusResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandGetCredentialStatusResponseID")
+    = 0x00000025,
+    MTRClusterDoorLockCommandClearCredentialID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterDoorLockCommandClearCredentialID")
+    = 0x00000026,
 
     // Cluster DoorLock commands
-    MTRClusterDoorLockCommandLockDoorID = 0x00000000,
-    MTRClusterDoorLockCommandUnlockDoorID = 0x00000001,
-    MTRClusterDoorLockCommandUnlockWithTimeoutID = 0x00000003,
-    MTRClusterDoorLockCommandSetWeekDayScheduleID = 0x0000000B,
-    MTRClusterDoorLockCommandGetWeekDayScheduleID = 0x0000000C,
-    MTRClusterDoorLockCommandGetWeekDayScheduleResponseID = 0x0000000C,
-    MTRClusterDoorLockCommandClearWeekDayScheduleID = 0x0000000D,
-    MTRClusterDoorLockCommandSetYearDayScheduleID = 0x0000000E,
-    MTRClusterDoorLockCommandGetYearDayScheduleID = 0x0000000F,
-    MTRClusterDoorLockCommandGetYearDayScheduleResponseID = 0x0000000F,
-    MTRClusterDoorLockCommandClearYearDayScheduleID = 0x00000010,
-    MTRClusterDoorLockCommandSetHolidayScheduleID = 0x00000011,
-    MTRClusterDoorLockCommandGetHolidayScheduleID = 0x00000012,
-    MTRClusterDoorLockCommandGetHolidayScheduleResponseID = 0x00000012,
-    MTRClusterDoorLockCommandClearHolidayScheduleID = 0x00000013,
-    MTRClusterDoorLockCommandSetUserID = 0x0000001A,
-    MTRClusterDoorLockCommandGetUserID = 0x0000001B,
-    MTRClusterDoorLockCommandGetUserResponseID = 0x0000001C,
-    MTRClusterDoorLockCommandClearUserID = 0x0000001D,
-    MTRClusterDoorLockCommandSetCredentialID = 0x00000022,
-    MTRClusterDoorLockCommandSetCredentialResponseID = 0x00000023,
-    MTRClusterDoorLockCommandGetCredentialStatusID = 0x00000024,
-    MTRClusterDoorLockCommandGetCredentialStatusResponseID = 0x00000025,
-    MTRClusterDoorLockCommandClearCredentialID = 0x00000026,
+    MTRCommandIDTypeClusterDoorLockCommandLockDoorID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterDoorLockCommandUnlockDoorID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterDoorLockCommandUnlockWithTimeoutID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterDoorLockCommandSetWeekDayScheduleID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTRCommandIDTypeClusterDoorLockCommandGetWeekDayScheduleID MTR_NEWLY_AVAILABLE = 0x0000000C,
+    MTRCommandIDTypeClusterDoorLockCommandGetWeekDayScheduleResponseID MTR_NEWLY_AVAILABLE = 0x0000000C,
+    MTRCommandIDTypeClusterDoorLockCommandClearWeekDayScheduleID MTR_NEWLY_AVAILABLE = 0x0000000D,
+    MTRCommandIDTypeClusterDoorLockCommandSetYearDayScheduleID MTR_NEWLY_AVAILABLE = 0x0000000E,
+    MTRCommandIDTypeClusterDoorLockCommandGetYearDayScheduleID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTRCommandIDTypeClusterDoorLockCommandGetYearDayScheduleResponseID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTRCommandIDTypeClusterDoorLockCommandClearYearDayScheduleID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRCommandIDTypeClusterDoorLockCommandSetHolidayScheduleID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRCommandIDTypeClusterDoorLockCommandGetHolidayScheduleID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRCommandIDTypeClusterDoorLockCommandGetHolidayScheduleResponseID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRCommandIDTypeClusterDoorLockCommandClearHolidayScheduleID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRCommandIDTypeClusterDoorLockCommandSetUserID MTR_NEWLY_AVAILABLE = 0x0000001A,
+    MTRCommandIDTypeClusterDoorLockCommandGetUserID MTR_NEWLY_AVAILABLE = 0x0000001B,
+    MTRCommandIDTypeClusterDoorLockCommandGetUserResponseID MTR_NEWLY_AVAILABLE = 0x0000001C,
+    MTRCommandIDTypeClusterDoorLockCommandClearUserID MTR_NEWLY_AVAILABLE = 0x0000001D,
+    MTRCommandIDTypeClusterDoorLockCommandSetCredentialID MTR_NEWLY_AVAILABLE = 0x00000022,
+    MTRCommandIDTypeClusterDoorLockCommandSetCredentialResponseID MTR_NEWLY_AVAILABLE = 0x00000023,
+    MTRCommandIDTypeClusterDoorLockCommandGetCredentialStatusID MTR_NEWLY_AVAILABLE = 0x00000024,
+    MTRCommandIDTypeClusterDoorLockCommandGetCredentialStatusResponseID MTR_NEWLY_AVAILABLE = 0x00000025,
+    MTRCommandIDTypeClusterDoorLockCommandClearCredentialID MTR_NEWLY_AVAILABLE = 0x00000026,
+
+    // Cluster WindowCovering deprecated command id names
+    MTRClusterWindowCoveringCommandUpOrOpenID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterWindowCoveringCommandUpOrOpenID")
+    = 0x00000000,
+    MTRClusterWindowCoveringCommandDownOrCloseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterWindowCoveringCommandDownOrCloseID")
+    = 0x00000001,
+    MTRClusterWindowCoveringCommandStopMotionID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterWindowCoveringCommandStopMotionID")
+    = 0x00000002,
+    MTRClusterWindowCoveringCommandGoToLiftValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterWindowCoveringCommandGoToLiftValueID")
+    = 0x00000004,
+    MTRClusterWindowCoveringCommandGoToLiftPercentageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterWindowCoveringCommandGoToLiftPercentageID")
+    = 0x00000005,
+    MTRClusterWindowCoveringCommandGoToTiltValueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterWindowCoveringCommandGoToTiltValueID")
+    = 0x00000007,
+    MTRClusterWindowCoveringCommandGoToTiltPercentageID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterWindowCoveringCommandGoToTiltPercentageID")
+    = 0x00000008,
 
     // Cluster WindowCovering commands
-    MTRClusterWindowCoveringCommandUpOrOpenID = 0x00000000,
-    MTRClusterWindowCoveringCommandDownOrCloseID = 0x00000001,
-    MTRClusterWindowCoveringCommandStopMotionID = 0x00000002,
-    MTRClusterWindowCoveringCommandGoToLiftValueID = 0x00000004,
-    MTRClusterWindowCoveringCommandGoToLiftPercentageID = 0x00000005,
-    MTRClusterWindowCoveringCommandGoToTiltValueID = 0x00000007,
-    MTRClusterWindowCoveringCommandGoToTiltPercentageID = 0x00000008,
+    MTRCommandIDTypeClusterWindowCoveringCommandUpOrOpenID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterWindowCoveringCommandDownOrCloseID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterWindowCoveringCommandStopMotionID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterWindowCoveringCommandGoToLiftValueID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRCommandIDTypeClusterWindowCoveringCommandGoToLiftPercentageID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRCommandIDTypeClusterWindowCoveringCommandGoToTiltValueID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRCommandIDTypeClusterWindowCoveringCommandGoToTiltPercentageID MTR_NEWLY_AVAILABLE = 0x00000008,
+
+    // Cluster BarrierControl deprecated command id names
+    MTRClusterBarrierControlCommandBarrierControlGoToPercentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterBarrierControlCommandBarrierControlGoToPercentID")
+    = 0x00000000,
+    MTRClusterBarrierControlCommandBarrierControlStopID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterBarrierControlCommandBarrierControlStopID")
+    = 0x00000001,
 
     // Cluster BarrierControl commands
-    MTRClusterBarrierControlCommandBarrierControlGoToPercentID = 0x00000000,
-    MTRClusterBarrierControlCommandBarrierControlStopID = 0x00000001,
+    MTRCommandIDTypeClusterBarrierControlCommandBarrierControlGoToPercentID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterBarrierControlCommandBarrierControlStopID MTR_NEWLY_AVAILABLE = 0x00000001,
+
+    // Cluster Thermostat deprecated command id names
+    MTRClusterThermostatCommandSetpointRaiseLowerID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterThermostatCommandSetpointRaiseLowerID")
+    = 0x00000000,
+    MTRClusterThermostatCommandGetWeeklyScheduleResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterThermostatCommandGetWeeklyScheduleResponseID")
+    = 0x00000000,
+    MTRClusterThermostatCommandSetWeeklyScheduleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterThermostatCommandSetWeeklyScheduleID")
+    = 0x00000001,
+    MTRClusterThermostatCommandGetWeeklyScheduleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterThermostatCommandGetWeeklyScheduleID")
+    = 0x00000002,
+    MTRClusterThermostatCommandClearWeeklyScheduleID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterThermostatCommandClearWeeklyScheduleID")
+    = 0x00000003,
 
     // Cluster Thermostat commands
-    MTRClusterThermostatCommandSetpointRaiseLowerID = 0x00000000,
-    MTRClusterThermostatCommandGetWeeklyScheduleResponseID = 0x00000000,
-    MTRClusterThermostatCommandSetWeeklyScheduleID = 0x00000001,
-    MTRClusterThermostatCommandGetWeeklyScheduleID = 0x00000002,
-    MTRClusterThermostatCommandClearWeeklyScheduleID = 0x00000003,
+    MTRCommandIDTypeClusterThermostatCommandSetpointRaiseLowerID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterThermostatCommandGetWeeklyScheduleResponseID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterThermostatCommandSetWeeklyScheduleID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterThermostatCommandGetWeeklyScheduleID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterThermostatCommandClearWeeklyScheduleID MTR_NEWLY_AVAILABLE = 0x00000003,
+
+    // Cluster ColorControl deprecated command id names
+    MTRClusterColorControlCommandMoveToHueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandMoveToHueID")
+    = 0x00000000,
+    MTRClusterColorControlCommandMoveHueID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterColorControlCommandMoveHueID")
+    = 0x00000001,
+    MTRClusterColorControlCommandStepHueID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterColorControlCommandStepHueID")
+    = 0x00000002,
+    MTRClusterColorControlCommandMoveToSaturationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandMoveToSaturationID")
+    = 0x00000003,
+    MTRClusterColorControlCommandMoveSaturationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandMoveSaturationID")
+    = 0x00000004,
+    MTRClusterColorControlCommandStepSaturationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandStepSaturationID")
+    = 0x00000005,
+    MTRClusterColorControlCommandMoveToHueAndSaturationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandMoveToHueAndSaturationID")
+    = 0x00000006,
+    MTRClusterColorControlCommandMoveToColorID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandMoveToColorID")
+    = 0x00000007,
+    MTRClusterColorControlCommandMoveColorID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandMoveColorID")
+    = 0x00000008,
+    MTRClusterColorControlCommandStepColorID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandStepColorID")
+    = 0x00000009,
+    MTRClusterColorControlCommandMoveToColorTemperatureID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandMoveToColorTemperatureID")
+    = 0x0000000A,
+    MTRClusterColorControlCommandEnhancedMoveToHueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandEnhancedMoveToHueID")
+    = 0x00000040,
+    MTRClusterColorControlCommandEnhancedMoveHueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandEnhancedMoveHueID")
+    = 0x00000041,
+    MTRClusterColorControlCommandEnhancedStepHueID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandEnhancedStepHueID")
+    = 0x00000042,
+    MTRClusterColorControlCommandEnhancedMoveToHueAndSaturationID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandEnhancedMoveToHueAndSaturationID")
+    = 0x00000043,
+    MTRClusterColorControlCommandColorLoopSetID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandColorLoopSetID")
+    = 0x00000044,
+    MTRClusterColorControlCommandStopMoveStepID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandStopMoveStepID")
+    = 0x00000047,
+    MTRClusterColorControlCommandMoveColorTemperatureID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandMoveColorTemperatureID")
+    = 0x0000004B,
+    MTRClusterColorControlCommandStepColorTemperatureID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterColorControlCommandStepColorTemperatureID")
+    = 0x0000004C,
 
     // Cluster ColorControl commands
-    MTRClusterColorControlCommandMoveToHueID = 0x00000000,
-    MTRClusterColorControlCommandMoveHueID = 0x00000001,
-    MTRClusterColorControlCommandStepHueID = 0x00000002,
-    MTRClusterColorControlCommandMoveToSaturationID = 0x00000003,
-    MTRClusterColorControlCommandMoveSaturationID = 0x00000004,
-    MTRClusterColorControlCommandStepSaturationID = 0x00000005,
-    MTRClusterColorControlCommandMoveToHueAndSaturationID = 0x00000006,
-    MTRClusterColorControlCommandMoveToColorID = 0x00000007,
-    MTRClusterColorControlCommandMoveColorID = 0x00000008,
-    MTRClusterColorControlCommandStepColorID = 0x00000009,
-    MTRClusterColorControlCommandMoveToColorTemperatureID = 0x0000000A,
-    MTRClusterColorControlCommandEnhancedMoveToHueID = 0x00000040,
-    MTRClusterColorControlCommandEnhancedMoveHueID = 0x00000041,
-    MTRClusterColorControlCommandEnhancedStepHueID = 0x00000042,
-    MTRClusterColorControlCommandEnhancedMoveToHueAndSaturationID = 0x00000043,
-    MTRClusterColorControlCommandColorLoopSetID = 0x00000044,
-    MTRClusterColorControlCommandStopMoveStepID = 0x00000047,
-    MTRClusterColorControlCommandMoveColorTemperatureID = 0x0000004B,
-    MTRClusterColorControlCommandStepColorTemperatureID = 0x0000004C,
+    MTRCommandIDTypeClusterColorControlCommandMoveToHueID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterColorControlCommandMoveHueID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterColorControlCommandStepHueID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterColorControlCommandMoveToSaturationID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterColorControlCommandMoveSaturationID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRCommandIDTypeClusterColorControlCommandStepSaturationID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRCommandIDTypeClusterColorControlCommandMoveToHueAndSaturationID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRCommandIDTypeClusterColorControlCommandMoveToColorID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRCommandIDTypeClusterColorControlCommandMoveColorID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRCommandIDTypeClusterColorControlCommandStepColorID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRCommandIDTypeClusterColorControlCommandMoveToColorTemperatureID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRCommandIDTypeClusterColorControlCommandEnhancedMoveToHueID MTR_NEWLY_AVAILABLE = 0x00000040,
+    MTRCommandIDTypeClusterColorControlCommandEnhancedMoveHueID MTR_NEWLY_AVAILABLE = 0x00000041,
+    MTRCommandIDTypeClusterColorControlCommandEnhancedStepHueID MTR_NEWLY_AVAILABLE = 0x00000042,
+    MTRCommandIDTypeClusterColorControlCommandEnhancedMoveToHueAndSaturationID MTR_NEWLY_AVAILABLE = 0x00000043,
+    MTRCommandIDTypeClusterColorControlCommandColorLoopSetID MTR_NEWLY_AVAILABLE = 0x00000044,
+    MTRCommandIDTypeClusterColorControlCommandStopMoveStepID MTR_NEWLY_AVAILABLE = 0x00000047,
+    MTRCommandIDTypeClusterColorControlCommandMoveColorTemperatureID MTR_NEWLY_AVAILABLE = 0x0000004B,
+    MTRCommandIDTypeClusterColorControlCommandStepColorTemperatureID MTR_NEWLY_AVAILABLE = 0x0000004C,
+
+    // Cluster Channel deprecated command id names
+    MTRClusterChannelCommandChangeChannelID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterChannelCommandChangeChannelID")
+    = 0x00000000,
+    MTRClusterChannelCommandChangeChannelResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterChannelCommandChangeChannelResponseID")
+    = 0x00000001,
+    MTRClusterChannelCommandChangeChannelByNumberID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterChannelCommandChangeChannelByNumberID")
+    = 0x00000002,
+    MTRClusterChannelCommandSkipChannelID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterChannelCommandSkipChannelID")
+    = 0x00000003,
 
     // Cluster Channel commands
-    MTRClusterChannelCommandChangeChannelID = 0x00000000,
-    MTRClusterChannelCommandChangeChannelResponseID = 0x00000001,
-    MTRClusterChannelCommandChangeChannelByNumberID = 0x00000002,
-    MTRClusterChannelCommandSkipChannelID = 0x00000003,
+    MTRCommandIDTypeClusterChannelCommandChangeChannelID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterChannelCommandChangeChannelResponseID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterChannelCommandChangeChannelByNumberID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterChannelCommandSkipChannelID MTR_NEWLY_AVAILABLE = 0x00000003,
+
+    // Cluster TargetNavigator deprecated command id names
+    MTRClusterTargetNavigatorCommandNavigateTargetID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterTargetNavigatorCommandNavigateTargetID")
+    = 0x00000000,
+    MTRClusterTargetNavigatorCommandNavigateTargetResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterTargetNavigatorCommandNavigateTargetResponseID")
+    = 0x00000001,
 
     // Cluster TargetNavigator commands
-    MTRClusterTargetNavigatorCommandNavigateTargetID = 0x00000000,
-    MTRClusterTargetNavigatorCommandNavigateTargetResponseID = 0x00000001,
+    MTRCommandIDTypeClusterTargetNavigatorCommandNavigateTargetID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterTargetNavigatorCommandNavigateTargetResponseID MTR_NEWLY_AVAILABLE = 0x00000001,
+
+    // Cluster MediaPlayback deprecated command id names
+    MTRClusterMediaPlaybackCommandPlayID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterMediaPlaybackCommandPlayID")
+    = 0x00000000,
+    MTRClusterMediaPlaybackCommandPauseID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterMediaPlaybackCommandPauseID")
+    = 0x00000001,
+    MTRClusterMediaPlaybackCommandStopPlaybackID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterMediaPlaybackCommandStopPlaybackID")
+    = 0x00000002,
+    MTRClusterMediaPlaybackCommandStartOverID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterMediaPlaybackCommandStartOverID")
+    = 0x00000003,
+    MTRClusterMediaPlaybackCommandPreviousID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterMediaPlaybackCommandPreviousID")
+    = 0x00000004,
+    MTRClusterMediaPlaybackCommandNextID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterMediaPlaybackCommandNextID")
+    = 0x00000005,
+    MTRClusterMediaPlaybackCommandRewindID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterMediaPlaybackCommandRewindID")
+    = 0x00000006,
+    MTRClusterMediaPlaybackCommandFastForwardID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterMediaPlaybackCommandFastForwardID")
+    = 0x00000007,
+    MTRClusterMediaPlaybackCommandSkipForwardID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterMediaPlaybackCommandSkipForwardID")
+    = 0x00000008,
+    MTRClusterMediaPlaybackCommandSkipBackwardID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterMediaPlaybackCommandSkipBackwardID")
+    = 0x00000009,
+    MTRClusterMediaPlaybackCommandPlaybackResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterMediaPlaybackCommandPlaybackResponseID")
+    = 0x0000000A,
+    MTRClusterMediaPlaybackCommandSeekID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterMediaPlaybackCommandSeekID")
+    = 0x0000000B,
 
     // Cluster MediaPlayback commands
-    MTRClusterMediaPlaybackCommandPlayID = 0x00000000,
-    MTRClusterMediaPlaybackCommandPauseID = 0x00000001,
-    MTRClusterMediaPlaybackCommandStopPlaybackID = 0x00000002,
-    MTRClusterMediaPlaybackCommandStartOverID = 0x00000003,
-    MTRClusterMediaPlaybackCommandPreviousID = 0x00000004,
-    MTRClusterMediaPlaybackCommandNextID = 0x00000005,
-    MTRClusterMediaPlaybackCommandRewindID = 0x00000006,
-    MTRClusterMediaPlaybackCommandFastForwardID = 0x00000007,
-    MTRClusterMediaPlaybackCommandSkipForwardID = 0x00000008,
-    MTRClusterMediaPlaybackCommandSkipBackwardID = 0x00000009,
-    MTRClusterMediaPlaybackCommandPlaybackResponseID = 0x0000000A,
-    MTRClusterMediaPlaybackCommandSeekID = 0x0000000B,
+    MTRCommandIDTypeClusterMediaPlaybackCommandPlayID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterMediaPlaybackCommandPauseID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterMediaPlaybackCommandStopPlaybackID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterMediaPlaybackCommandStartOverID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterMediaPlaybackCommandPreviousID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRCommandIDTypeClusterMediaPlaybackCommandNextID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRCommandIDTypeClusterMediaPlaybackCommandRewindID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRCommandIDTypeClusterMediaPlaybackCommandFastForwardID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRCommandIDTypeClusterMediaPlaybackCommandSkipForwardID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRCommandIDTypeClusterMediaPlaybackCommandSkipBackwardID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRCommandIDTypeClusterMediaPlaybackCommandPlaybackResponseID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRCommandIDTypeClusterMediaPlaybackCommandSeekID MTR_NEWLY_AVAILABLE = 0x0000000B,
+
+    // Cluster MediaInput deprecated command id names
+    MTRClusterMediaInputCommandSelectInputID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterMediaInputCommandSelectInputID")
+    = 0x00000000,
+    MTRClusterMediaInputCommandShowInputStatusID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterMediaInputCommandShowInputStatusID")
+    = 0x00000001,
+    MTRClusterMediaInputCommandHideInputStatusID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterMediaInputCommandHideInputStatusID")
+    = 0x00000002,
+    MTRClusterMediaInputCommandRenameInputID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterMediaInputCommandRenameInputID")
+    = 0x00000003,
 
     // Cluster MediaInput commands
-    MTRClusterMediaInputCommandSelectInputID = 0x00000000,
-    MTRClusterMediaInputCommandShowInputStatusID = 0x00000001,
-    MTRClusterMediaInputCommandHideInputStatusID = 0x00000002,
-    MTRClusterMediaInputCommandRenameInputID = 0x00000003,
+    MTRCommandIDTypeClusterMediaInputCommandSelectInputID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterMediaInputCommandShowInputStatusID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterMediaInputCommandHideInputStatusID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterMediaInputCommandRenameInputID MTR_NEWLY_AVAILABLE = 0x00000003,
+
+    // Cluster LowPower deprecated command id names
+    MTRClusterLowPowerCommandSleepID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterLowPowerCommandSleepID") = 0x00000000,
 
     // Cluster LowPower commands
-    MTRClusterLowPowerCommandSleepID = 0x00000000,
+    MTRCommandIDTypeClusterLowPowerCommandSleepID MTR_NEWLY_AVAILABLE = 0x00000000,
+
+    // Cluster KeypadInput deprecated command id names
+    MTRClusterKeypadInputCommandSendKeyID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterKeypadInputCommandSendKeyID")
+    = 0x00000000,
+    MTRClusterKeypadInputCommandSendKeyResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterKeypadInputCommandSendKeyResponseID")
+    = 0x00000001,
 
     // Cluster KeypadInput commands
-    MTRClusterKeypadInputCommandSendKeyID = 0x00000000,
-    MTRClusterKeypadInputCommandSendKeyResponseID = 0x00000001,
+    MTRCommandIDTypeClusterKeypadInputCommandSendKeyID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterKeypadInputCommandSendKeyResponseID MTR_NEWLY_AVAILABLE = 0x00000001,
+
+    // Cluster ContentLauncher deprecated command id names
+    MTRClusterContentLauncherCommandLaunchContentID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterContentLauncherCommandLaunchContentID")
+    = 0x00000000,
+    MTRClusterContentLauncherCommandLaunchURLID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterContentLauncherCommandLaunchURLID")
+    = 0x00000001,
+    MTRClusterContentLauncherCommandLaunchResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterContentLauncherCommandLaunchResponseID")
+    = 0x00000002,
 
     // Cluster ContentLauncher commands
-    MTRClusterContentLauncherCommandLaunchContentID = 0x00000000,
-    MTRClusterContentLauncherCommandLaunchURLID = 0x00000001,
-    MTRClusterContentLauncherCommandLaunchResponseID = 0x00000002,
+    MTRCommandIDTypeClusterContentLauncherCommandLaunchContentID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterContentLauncherCommandLaunchURLID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterContentLauncherCommandLaunchResponseID MTR_NEWLY_AVAILABLE = 0x00000002,
+
+    // Cluster AudioOutput deprecated command id names
+    MTRClusterAudioOutputCommandSelectOutputID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterAudioOutputCommandSelectOutputID")
+    = 0x00000000,
+    MTRClusterAudioOutputCommandRenameOutputID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterAudioOutputCommandRenameOutputID")
+    = 0x00000001,
 
     // Cluster AudioOutput commands
-    MTRClusterAudioOutputCommandSelectOutputID = 0x00000000,
-    MTRClusterAudioOutputCommandRenameOutputID = 0x00000001,
+    MTRCommandIDTypeClusterAudioOutputCommandSelectOutputID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterAudioOutputCommandRenameOutputID MTR_NEWLY_AVAILABLE = 0x00000001,
+
+    // Cluster ApplicationLauncher deprecated command id names
+    MTRClusterApplicationLauncherCommandLaunchAppID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterApplicationLauncherCommandLaunchAppID")
+    = 0x00000000,
+    MTRClusterApplicationLauncherCommandStopAppID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterApplicationLauncherCommandStopAppID")
+    = 0x00000001,
+    MTRClusterApplicationLauncherCommandHideAppID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterApplicationLauncherCommandHideAppID")
+    = 0x00000002,
+    MTRClusterApplicationLauncherCommandLauncherResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterApplicationLauncherCommandLauncherResponseID")
+    = 0x00000003,
 
     // Cluster ApplicationLauncher commands
-    MTRClusterApplicationLauncherCommandLaunchAppID = 0x00000000,
-    MTRClusterApplicationLauncherCommandStopAppID = 0x00000001,
-    MTRClusterApplicationLauncherCommandHideAppID = 0x00000002,
-    MTRClusterApplicationLauncherCommandLauncherResponseID = 0x00000003,
+    MTRCommandIDTypeClusterApplicationLauncherCommandLaunchAppID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterApplicationLauncherCommandStopAppID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterApplicationLauncherCommandHideAppID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterApplicationLauncherCommandLauncherResponseID MTR_NEWLY_AVAILABLE = 0x00000003,
+
+    // Cluster AccountLogin deprecated command id names
+    MTRClusterAccountLoginCommandGetSetupPINID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterAccountLoginCommandGetSetupPINID")
+    = 0x00000000,
+    MTRClusterAccountLoginCommandGetSetupPINResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterAccountLoginCommandGetSetupPINResponseID")
+    = 0x00000001,
+    MTRClusterAccountLoginCommandLoginID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterAccountLoginCommandLoginID")
+    = 0x00000002,
+    MTRClusterAccountLoginCommandLogoutID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterAccountLoginCommandLogoutID")
+    = 0x00000003,
 
     // Cluster AccountLogin commands
-    MTRClusterAccountLoginCommandGetSetupPINID = 0x00000000,
-    MTRClusterAccountLoginCommandGetSetupPINResponseID = 0x00000001,
-    MTRClusterAccountLoginCommandLoginID = 0x00000002,
-    MTRClusterAccountLoginCommandLogoutID = 0x00000003,
+    MTRCommandIDTypeClusterAccountLoginCommandGetSetupPINID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterAccountLoginCommandGetSetupPINResponseID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterAccountLoginCommandLoginID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterAccountLoginCommandLogoutID MTR_NEWLY_AVAILABLE = 0x00000003,
+
+    // Cluster ElectricalMeasurement deprecated command id names
+    MTRClusterElectricalMeasurementCommandGetProfileInfoResponseCommandID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterElectricalMeasurementCommandGetProfileInfoResponseCommandID")
+    = 0x00000000,
+    MTRClusterElectricalMeasurementCommandGetProfileInfoCommandID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterElectricalMeasurementCommandGetProfileInfoCommandID")
+    = 0x00000000,
+    MTRClusterElectricalMeasurementCommandGetMeasurementProfileResponseCommandID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterElectricalMeasurementCommandGetMeasurementProfileResponseCommandID")
+    = 0x00000001,
+    MTRClusterElectricalMeasurementCommandGetMeasurementProfileCommandID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterElectricalMeasurementCommandGetMeasurementProfileCommandID")
+    = 0x00000001,
 
     // Cluster ElectricalMeasurement commands
-    MTRClusterElectricalMeasurementCommandGetProfileInfoResponseCommandID = 0x00000000,
-    MTRClusterElectricalMeasurementCommandGetProfileInfoCommandID = 0x00000000,
-    MTRClusterElectricalMeasurementCommandGetMeasurementProfileResponseCommandID = 0x00000001,
-    MTRClusterElectricalMeasurementCommandGetMeasurementProfileCommandID = 0x00000001,
+    MTRCommandIDTypeClusterElectricalMeasurementCommandGetProfileInfoResponseCommandID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterElectricalMeasurementCommandGetProfileInfoCommandID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterElectricalMeasurementCommandGetMeasurementProfileResponseCommandID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterElectricalMeasurementCommandGetMeasurementProfileCommandID MTR_NEWLY_AVAILABLE = 0x00000001,
 
-    // Cluster UnitTesting commands
-    MTRClusterUnitTestingCommandTestID MTR_NEWLY_AVAILABLE = 0x00000000,
-    MTRClusterUnitTestingCommandTestSpecificResponseID MTR_NEWLY_AVAILABLE = 0x00000000,
-    MTRClusterUnitTestingCommandTestNotHandledID MTR_NEWLY_AVAILABLE = 0x00000001,
-    MTRClusterUnitTestingCommandTestAddArgumentsResponseID MTR_NEWLY_AVAILABLE = 0x00000001,
-    MTRClusterUnitTestingCommandTestSpecificID MTR_NEWLY_AVAILABLE = 0x00000002,
-    MTRClusterUnitTestingCommandTestSimpleArgumentResponseID MTR_NEWLY_AVAILABLE = 0x00000002,
-    MTRClusterUnitTestingCommandTestUnknownCommandID MTR_NEWLY_AVAILABLE = 0x00000003,
-    MTRClusterUnitTestingCommandTestStructArrayArgumentResponseID MTR_NEWLY_AVAILABLE = 0x00000003,
-    MTRClusterUnitTestingCommandTestAddArgumentsID MTR_NEWLY_AVAILABLE = 0x00000004,
-    MTRClusterUnitTestingCommandTestListInt8UReverseResponseID MTR_NEWLY_AVAILABLE = 0x00000004,
-    MTRClusterUnitTestingCommandTestSimpleArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000005,
-    MTRClusterUnitTestingCommandTestEnumsResponseID MTR_NEWLY_AVAILABLE = 0x00000005,
-    MTRClusterUnitTestingCommandTestStructArrayArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000006,
-    MTRClusterUnitTestingCommandTestNullableOptionalResponseID MTR_NEWLY_AVAILABLE = 0x00000006,
-    MTRClusterUnitTestingCommandTestStructArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000007,
-    MTRClusterUnitTestingCommandTestComplexNullableOptionalResponseID MTR_NEWLY_AVAILABLE = 0x00000007,
-    MTRClusterUnitTestingCommandTestNestedStructArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000008,
-    MTRClusterUnitTestingCommandBooleanResponseID MTR_NEWLY_AVAILABLE = 0x00000008,
-    MTRClusterUnitTestingCommandTestListStructArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000009,
-    MTRClusterUnitTestingCommandSimpleStructResponseID MTR_NEWLY_AVAILABLE = 0x00000009,
-    MTRClusterUnitTestingCommandTestListInt8UArgumentRequestID MTR_NEWLY_AVAILABLE = 0x0000000A,
-    MTRClusterUnitTestingCommandTestEmitTestEventResponseID MTR_NEWLY_AVAILABLE = 0x0000000A,
-    MTRClusterUnitTestingCommandTestNestedStructListArgumentRequestID MTR_NEWLY_AVAILABLE = 0x0000000B,
-    MTRClusterUnitTestingCommandTestEmitTestFabricScopedEventResponseID MTR_NEWLY_AVAILABLE = 0x0000000B,
-    MTRClusterUnitTestingCommandTestListNestedStructListArgumentRequestID MTR_NEWLY_AVAILABLE = 0x0000000C,
-    MTRClusterUnitTestingCommandTestListInt8UReverseRequestID MTR_NEWLY_AVAILABLE = 0x0000000D,
-    MTRClusterUnitTestingCommandTestEnumsRequestID MTR_NEWLY_AVAILABLE = 0x0000000E,
-    MTRClusterUnitTestingCommandTestNullableOptionalRequestID MTR_NEWLY_AVAILABLE = 0x0000000F,
-    MTRClusterUnitTestingCommandTestComplexNullableOptionalRequestID MTR_NEWLY_AVAILABLE = 0x00000010,
-    MTRClusterUnitTestingCommandSimpleStructEchoRequestID MTR_NEWLY_AVAILABLE = 0x00000011,
-    MTRClusterUnitTestingCommandTimedInvokeRequestID MTR_NEWLY_AVAILABLE = 0x00000012,
-    MTRClusterUnitTestingCommandTestSimpleOptionalArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000013,
-    MTRClusterUnitTestingCommandTestEmitTestEventRequestID MTR_NEWLY_AVAILABLE = 0x00000014,
-    MTRClusterUnitTestingCommandTestEmitTestFabricScopedEventRequestID MTR_NEWLY_AVAILABLE = 0x00000015,
-
-    // Cluster TestCluster commands
-    MTRClusterTestClusterCommandTestID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingCommandTestID") = 0x00000000,
-    MTRClusterTestClusterCommandTestSpecificResponseID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestSpecificResponseID")
+    // Cluster TestCluster deprecated command id names
+    MTRClusterTestClusterCommandTestID MTR_NEWLY_DEPRECATED("Please use MTRCommandIDTypeClusterUnitTestingCommandTestID")
     = 0x00000000,
-    MTRClusterTestClusterCommandTestNotHandledID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingCommandTestNotHandledID")
+    MTRClusterTestClusterCommandTestSpecificResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestSpecificResponseID")
+    = 0x00000000,
+    MTRClusterTestClusterCommandTestNotHandledID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestNotHandledID")
     = 0x00000001,
     MTRClusterTestClusterCommandTestAddArgumentsResponseID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestAddArgumentsResponseID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestAddArgumentsResponseID")
     = 0x00000001,
-    MTRClusterTestClusterCommandTestSpecificID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingCommandTestSpecificID")
+    MTRClusterTestClusterCommandTestSpecificID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestSpecificID")
     = 0x00000002,
     MTRClusterTestClusterCommandTestSimpleArgumentResponseID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestSimpleArgumentResponseID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestSimpleArgumentResponseID")
     = 0x00000002,
     MTRClusterTestClusterCommandTestUnknownCommandID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestUnknownCommandID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestUnknownCommandID")
     = 0x00000003,
     MTRClusterTestClusterCommandTestStructArrayArgumentResponseID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestStructArrayArgumentResponseID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestStructArrayArgumentResponseID")
     = 0x00000003,
-    MTRClusterTestClusterCommandTestAddArgumentsID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingCommandTestAddArgumentsID")
+    MTRClusterTestClusterCommandTestAddArgumentsID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestAddArgumentsID")
     = 0x00000004,
     MTRClusterTestClusterCommandTestListInt8UReverseResponseID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestListInt8UReverseResponseID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestListInt8UReverseResponseID")
     = 0x00000004,
     MTRClusterTestClusterCommandTestSimpleArgumentRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestSimpleArgumentRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestSimpleArgumentRequestID")
     = 0x00000005,
     MTRClusterTestClusterCommandTestEnumsResponseID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestEnumsResponseID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestEnumsResponseID")
     = 0x00000005,
     MTRClusterTestClusterCommandTestStructArrayArgumentRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestStructArrayArgumentRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestStructArrayArgumentRequestID")
     = 0x00000006,
     MTRClusterTestClusterCommandTestNullableOptionalResponseID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestNullableOptionalResponseID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestNullableOptionalResponseID")
     = 0x00000006,
     MTRClusterTestClusterCommandTestStructArgumentRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestStructArgumentRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestStructArgumentRequestID")
     = 0x00000007,
     MTRClusterTestClusterCommandTestComplexNullableOptionalResponseID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestComplexNullableOptionalResponseID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestComplexNullableOptionalResponseID")
     = 0x00000007,
     MTRClusterTestClusterCommandTestNestedStructArgumentRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestNestedStructArgumentRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestNestedStructArgumentRequestID")
     = 0x00000008,
-    MTRClusterTestClusterCommandBooleanResponseID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingCommandBooleanResponseID")
+    MTRClusterTestClusterCommandBooleanResponseID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandBooleanResponseID")
     = 0x00000008,
     MTRClusterTestClusterCommandTestListStructArgumentRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestListStructArgumentRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestListStructArgumentRequestID")
     = 0x00000009,
     MTRClusterTestClusterCommandSimpleStructResponseID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandSimpleStructResponseID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandSimpleStructResponseID")
     = 0x00000009,
     MTRClusterTestClusterCommandTestListInt8UArgumentRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestListInt8UArgumentRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestListInt8UArgumentRequestID")
     = 0x0000000A,
     MTRClusterTestClusterCommandTestEmitTestEventResponseID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestEmitTestEventResponseID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestEmitTestEventResponseID")
     = 0x0000000A,
     MTRClusterTestClusterCommandTestNestedStructListArgumentRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestNestedStructListArgumentRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestNestedStructListArgumentRequestID")
     = 0x0000000B,
     MTRClusterTestClusterCommandTestEmitTestFabricScopedEventResponseID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestEmitTestFabricScopedEventResponseID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestEmitTestFabricScopedEventResponseID")
     = 0x0000000B,
     MTRClusterTestClusterCommandTestListNestedStructListArgumentRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestListNestedStructListArgumentRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestListNestedStructListArgumentRequestID")
     = 0x0000000C,
     MTRClusterTestClusterCommandTestListInt8UReverseRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestListInt8UReverseRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestListInt8UReverseRequestID")
     = 0x0000000D,
-    MTRClusterTestClusterCommandTestEnumsRequestID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingCommandTestEnumsRequestID")
+    MTRClusterTestClusterCommandTestEnumsRequestID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestEnumsRequestID")
     = 0x0000000E,
     MTRClusterTestClusterCommandTestNullableOptionalRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestNullableOptionalRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestNullableOptionalRequestID")
     = 0x0000000F,
     MTRClusterTestClusterCommandTestComplexNullableOptionalRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestComplexNullableOptionalRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestComplexNullableOptionalRequestID")
     = 0x00000010,
     MTRClusterTestClusterCommandSimpleStructEchoRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandSimpleStructEchoRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandSimpleStructEchoRequestID")
     = 0x00000011,
     MTRClusterTestClusterCommandTimedInvokeRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTimedInvokeRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTimedInvokeRequestID")
     = 0x00000012,
     MTRClusterTestClusterCommandTestSimpleOptionalArgumentRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestSimpleOptionalArgumentRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestSimpleOptionalArgumentRequestID")
     = 0x00000013,
     MTRClusterTestClusterCommandTestEmitTestEventRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestEmitTestEventRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestEmitTestEventRequestID")
     = 0x00000014,
     MTRClusterTestClusterCommandTestEmitTestFabricScopedEventRequestID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingCommandTestEmitTestFabricScopedEventRequestID")
+        "Please use MTRCommandIDTypeClusterUnitTestingCommandTestEmitTestFabricScopedEventRequestID")
     = 0x00000015,
 
+    // Cluster UnitTesting commands
+    MTRCommandIDTypeClusterUnitTestingCommandTestID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterUnitTestingCommandTestSpecificResponseID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterUnitTestingCommandTestNotHandledID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterUnitTestingCommandTestAddArgumentsResponseID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTRCommandIDTypeClusterUnitTestingCommandTestSpecificID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterUnitTestingCommandTestSimpleArgumentResponseID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTRCommandIDTypeClusterUnitTestingCommandTestUnknownCommandID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterUnitTestingCommandTestStructArrayArgumentResponseID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTRCommandIDTypeClusterUnitTestingCommandTestAddArgumentsID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRCommandIDTypeClusterUnitTestingCommandTestListInt8UReverseResponseID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTRCommandIDTypeClusterUnitTestingCommandTestSimpleArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRCommandIDTypeClusterUnitTestingCommandTestEnumsResponseID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTRCommandIDTypeClusterUnitTestingCommandTestStructArrayArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRCommandIDTypeClusterUnitTestingCommandTestNullableOptionalResponseID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTRCommandIDTypeClusterUnitTestingCommandTestStructArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRCommandIDTypeClusterUnitTestingCommandTestComplexNullableOptionalResponseID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTRCommandIDTypeClusterUnitTestingCommandTestNestedStructArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRCommandIDTypeClusterUnitTestingCommandBooleanResponseID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTRCommandIDTypeClusterUnitTestingCommandTestListStructArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRCommandIDTypeClusterUnitTestingCommandSimpleStructResponseID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTRCommandIDTypeClusterUnitTestingCommandTestListInt8UArgumentRequestID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRCommandIDTypeClusterUnitTestingCommandTestEmitTestEventResponseID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTRCommandIDTypeClusterUnitTestingCommandTestNestedStructListArgumentRequestID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTRCommandIDTypeClusterUnitTestingCommandTestEmitTestFabricScopedEventResponseID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTRCommandIDTypeClusterUnitTestingCommandTestListNestedStructListArgumentRequestID MTR_NEWLY_AVAILABLE = 0x0000000C,
+    MTRCommandIDTypeClusterUnitTestingCommandTestListInt8UReverseRequestID MTR_NEWLY_AVAILABLE = 0x0000000D,
+    MTRCommandIDTypeClusterUnitTestingCommandTestEnumsRequestID MTR_NEWLY_AVAILABLE = 0x0000000E,
+    MTRCommandIDTypeClusterUnitTestingCommandTestNullableOptionalRequestID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTRCommandIDTypeClusterUnitTestingCommandTestComplexNullableOptionalRequestID MTR_NEWLY_AVAILABLE = 0x00000010,
+    MTRCommandIDTypeClusterUnitTestingCommandSimpleStructEchoRequestID MTR_NEWLY_AVAILABLE = 0x00000011,
+    MTRCommandIDTypeClusterUnitTestingCommandTimedInvokeRequestID MTR_NEWLY_AVAILABLE = 0x00000012,
+    MTRCommandIDTypeClusterUnitTestingCommandTestSimpleOptionalArgumentRequestID MTR_NEWLY_AVAILABLE = 0x00000013,
+    MTRCommandIDTypeClusterUnitTestingCommandTestEmitTestEventRequestID MTR_NEWLY_AVAILABLE = 0x00000014,
+    MTRCommandIDTypeClusterUnitTestingCommandTestEmitTestFabricScopedEventRequestID MTR_NEWLY_AVAILABLE = 0x00000015,
+
+    // Cluster FaultInjection deprecated command id names
+    MTRClusterFaultInjectionCommandFailAtFaultID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterFaultInjectionCommandFailAtFaultID")
+    = 0x00000000,
+    MTRClusterFaultInjectionCommandFailRandomlyAtFaultID MTR_NEWLY_DEPRECATED(
+        "Please use MTRCommandIDTypeClusterFaultInjectionCommandFailRandomlyAtFaultID")
+    = 0x00000001,
+
     // Cluster FaultInjection commands
-    MTRClusterFaultInjectionCommandFailAtFaultID = 0x00000000,
-    MTRClusterFaultInjectionCommandFailRandomlyAtFaultID = 0x00000001,
+    MTRCommandIDTypeClusterFaultInjectionCommandFailAtFaultID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTRCommandIDTypeClusterFaultInjectionCommandFailRandomlyAtFaultID MTR_NEWLY_AVAILABLE = 0x00000001,
 
 };
 
 #pragma mark - Events IDs
 
-typedef NS_ENUM(uint32_t, MTRClusterEventIDType) {
+typedef NS_ENUM(uint32_t, MTREventIDType) {
+
+    // Cluster AccessControl deprecated event names
+    MTRClusterAccessControlEventAccessControlEntryChangedID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterAccessControlEventAccessControlEntryChangedID")
+    = 0x00000000,
+    MTRClusterAccessControlEventAccessControlExtensionChangedID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterAccessControlEventAccessControlExtensionChangedID")
+    = 0x00000001,
 
     // Cluster AccessControl events
-    MTRClusterAccessControlEventAccessControlEntryChangedID = 0x00000000,
-    MTRClusterAccessControlEventAccessControlExtensionChangedID = 0x00000001,
+    MTREventIDTypeClusterAccessControlEventAccessControlEntryChangedID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTREventIDTypeClusterAccessControlEventAccessControlExtensionChangedID MTR_NEWLY_AVAILABLE = 0x00000001,
+
+    // Cluster Actions deprecated event names
+    MTRClusterActionsEventStateChangedID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterActionsEventStateChangedID")
+    = 0x00000000,
+    MTRClusterActionsEventActionFailedID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterActionsEventActionFailedID")
+    = 0x00000001,
 
     // Cluster Actions events
-    MTRClusterActionsEventStateChangedID = 0x00000000,
-    MTRClusterActionsEventActionFailedID = 0x00000001,
+    MTREventIDTypeClusterActionsEventStateChangedID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTREventIDTypeClusterActionsEventActionFailedID MTR_NEWLY_AVAILABLE = 0x00000001,
+
+    // Cluster Basic deprecated event names
+    MTRClusterBasicEventStartUpID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterBasicEventStartUpID") = 0x00000000,
+    MTRClusterBasicEventShutDownID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterBasicEventShutDownID") = 0x00000001,
+    MTRClusterBasicEventLeaveID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterBasicEventLeaveID") = 0x00000002,
+    MTRClusterBasicEventReachableChangedID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterBasicEventReachableChangedID")
+    = 0x00000003,
 
     // Cluster Basic events
-    MTRClusterBasicEventStartUpID = 0x00000000,
-    MTRClusterBasicEventShutDownID = 0x00000001,
-    MTRClusterBasicEventLeaveID = 0x00000002,
-    MTRClusterBasicEventReachableChangedID = 0x00000003,
+    MTREventIDTypeClusterBasicEventStartUpID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTREventIDTypeClusterBasicEventShutDownID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTREventIDTypeClusterBasicEventLeaveID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTREventIDTypeClusterBasicEventReachableChangedID MTR_NEWLY_AVAILABLE = 0x00000003,
+
+    // Cluster OtaSoftwareUpdateRequestor deprecated event names
+    MTRClusterOtaSoftwareUpdateRequestorEventStateTransitionID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterOtaSoftwareUpdateRequestorEventStateTransitionID")
+    = 0x00000000,
+    MTRClusterOtaSoftwareUpdateRequestorEventVersionAppliedID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterOtaSoftwareUpdateRequestorEventVersionAppliedID")
+    = 0x00000001,
+    MTRClusterOtaSoftwareUpdateRequestorEventDownloadErrorID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterOtaSoftwareUpdateRequestorEventDownloadErrorID")
+    = 0x00000002,
 
     // Cluster OtaSoftwareUpdateRequestor events
-    MTRClusterOtaSoftwareUpdateRequestorEventStateTransitionID = 0x00000000,
-    MTRClusterOtaSoftwareUpdateRequestorEventVersionAppliedID = 0x00000001,
-    MTRClusterOtaSoftwareUpdateRequestorEventDownloadErrorID = 0x00000002,
+    MTREventIDTypeClusterOtaSoftwareUpdateRequestorEventStateTransitionID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTREventIDTypeClusterOtaSoftwareUpdateRequestorEventVersionAppliedID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTREventIDTypeClusterOtaSoftwareUpdateRequestorEventDownloadErrorID MTR_NEWLY_AVAILABLE = 0x00000002,
+
+    // Cluster GeneralDiagnostics deprecated event names
+    MTRClusterGeneralDiagnosticsEventHardwareFaultChangeID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterGeneralDiagnosticsEventHardwareFaultChangeID")
+    = 0x00000000,
+    MTRClusterGeneralDiagnosticsEventRadioFaultChangeID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterGeneralDiagnosticsEventRadioFaultChangeID")
+    = 0x00000001,
+    MTRClusterGeneralDiagnosticsEventNetworkFaultChangeID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterGeneralDiagnosticsEventNetworkFaultChangeID")
+    = 0x00000002,
+    MTRClusterGeneralDiagnosticsEventBootReasonID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterGeneralDiagnosticsEventBootReasonID")
+    = 0x00000003,
 
     // Cluster GeneralDiagnostics events
-    MTRClusterGeneralDiagnosticsEventHardwareFaultChangeID = 0x00000000,
-    MTRClusterGeneralDiagnosticsEventRadioFaultChangeID = 0x00000001,
-    MTRClusterGeneralDiagnosticsEventNetworkFaultChangeID = 0x00000002,
-    MTRClusterGeneralDiagnosticsEventBootReasonID = 0x00000003,
+    MTREventIDTypeClusterGeneralDiagnosticsEventHardwareFaultChangeID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTREventIDTypeClusterGeneralDiagnosticsEventRadioFaultChangeID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTREventIDTypeClusterGeneralDiagnosticsEventNetworkFaultChangeID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTREventIDTypeClusterGeneralDiagnosticsEventBootReasonID MTR_NEWLY_AVAILABLE = 0x00000003,
+
+    // Cluster SoftwareDiagnostics deprecated event names
+    MTRClusterSoftwareDiagnosticsEventSoftwareFaultID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterSoftwareDiagnosticsEventSoftwareFaultID")
+    = 0x00000000,
 
     // Cluster SoftwareDiagnostics events
-    MTRClusterSoftwareDiagnosticsEventSoftwareFaultID = 0x00000000,
+    MTREventIDTypeClusterSoftwareDiagnosticsEventSoftwareFaultID MTR_NEWLY_AVAILABLE = 0x00000000,
+
+    // Cluster ThreadNetworkDiagnostics deprecated event names
+    MTRClusterThreadNetworkDiagnosticsEventConnectionStatusID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterThreadNetworkDiagnosticsEventConnectionStatusID")
+    = 0x00000000,
+    MTRClusterThreadNetworkDiagnosticsEventNetworkFaultChangeID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterThreadNetworkDiagnosticsEventNetworkFaultChangeID")
+    = 0x00000001,
 
     // Cluster ThreadNetworkDiagnostics events
-    MTRClusterThreadNetworkDiagnosticsEventConnectionStatusID = 0x00000000,
-    MTRClusterThreadNetworkDiagnosticsEventNetworkFaultChangeID = 0x00000001,
+    MTREventIDTypeClusterThreadNetworkDiagnosticsEventConnectionStatusID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTREventIDTypeClusterThreadNetworkDiagnosticsEventNetworkFaultChangeID MTR_NEWLY_AVAILABLE = 0x00000001,
+
+    // Cluster WiFiNetworkDiagnostics deprecated event names
+    MTRClusterWiFiNetworkDiagnosticsEventDisconnectionID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterWiFiNetworkDiagnosticsEventDisconnectionID")
+    = 0x00000000,
+    MTRClusterWiFiNetworkDiagnosticsEventAssociationFailureID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterWiFiNetworkDiagnosticsEventAssociationFailureID")
+    = 0x00000001,
+    MTRClusterWiFiNetworkDiagnosticsEventConnectionStatusID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterWiFiNetworkDiagnosticsEventConnectionStatusID")
+    = 0x00000002,
 
     // Cluster WiFiNetworkDiagnostics events
-    MTRClusterWiFiNetworkDiagnosticsEventDisconnectionID = 0x00000000,
-    MTRClusterWiFiNetworkDiagnosticsEventAssociationFailureID = 0x00000001,
-    MTRClusterWiFiNetworkDiagnosticsEventConnectionStatusID = 0x00000002,
+    MTREventIDTypeClusterWiFiNetworkDiagnosticsEventDisconnectionID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTREventIDTypeClusterWiFiNetworkDiagnosticsEventAssociationFailureID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTREventIDTypeClusterWiFiNetworkDiagnosticsEventConnectionStatusID MTR_NEWLY_AVAILABLE = 0x00000002,
+
+    // Cluster BridgedDeviceBasic deprecated event names
+    MTRClusterBridgedDeviceBasicEventStartUpID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterBridgedDeviceBasicEventStartUpID")
+    = 0x00000000,
+    MTRClusterBridgedDeviceBasicEventShutDownID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterBridgedDeviceBasicEventShutDownID")
+    = 0x00000001,
+    MTRClusterBridgedDeviceBasicEventLeaveID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterBridgedDeviceBasicEventLeaveID")
+    = 0x00000002,
+    MTRClusterBridgedDeviceBasicEventReachableChangedID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterBridgedDeviceBasicEventReachableChangedID")
+    = 0x00000003,
 
     // Cluster BridgedDeviceBasic events
-    MTRClusterBridgedDeviceBasicEventStartUpID = 0x00000000,
-    MTRClusterBridgedDeviceBasicEventShutDownID = 0x00000001,
-    MTRClusterBridgedDeviceBasicEventLeaveID = 0x00000002,
-    MTRClusterBridgedDeviceBasicEventReachableChangedID = 0x00000003,
+    MTREventIDTypeClusterBridgedDeviceBasicEventStartUpID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTREventIDTypeClusterBridgedDeviceBasicEventShutDownID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTREventIDTypeClusterBridgedDeviceBasicEventLeaveID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTREventIDTypeClusterBridgedDeviceBasicEventReachableChangedID MTR_NEWLY_AVAILABLE = 0x00000003,
+
+    // Cluster Switch deprecated event names
+    MTRClusterSwitchEventSwitchLatchedID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterSwitchEventSwitchLatchedID")
+    = 0x00000000,
+    MTRClusterSwitchEventInitialPressID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterSwitchEventInitialPressID")
+    = 0x00000001,
+    MTRClusterSwitchEventLongPressID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterSwitchEventLongPressID") = 0x00000002,
+    MTRClusterSwitchEventShortReleaseID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterSwitchEventShortReleaseID")
+    = 0x00000003,
+    MTRClusterSwitchEventLongReleaseID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterSwitchEventLongReleaseID")
+    = 0x00000004,
+    MTRClusterSwitchEventMultiPressOngoingID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterSwitchEventMultiPressOngoingID")
+    = 0x00000005,
+    MTRClusterSwitchEventMultiPressCompleteID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterSwitchEventMultiPressCompleteID")
+    = 0x00000006,
 
     // Cluster Switch events
-    MTRClusterSwitchEventSwitchLatchedID = 0x00000000,
-    MTRClusterSwitchEventInitialPressID = 0x00000001,
-    MTRClusterSwitchEventLongPressID = 0x00000002,
-    MTRClusterSwitchEventShortReleaseID = 0x00000003,
-    MTRClusterSwitchEventLongReleaseID = 0x00000004,
-    MTRClusterSwitchEventMultiPressOngoingID = 0x00000005,
-    MTRClusterSwitchEventMultiPressCompleteID = 0x00000006,
+    MTREventIDTypeClusterSwitchEventSwitchLatchedID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTREventIDTypeClusterSwitchEventInitialPressID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTREventIDTypeClusterSwitchEventLongPressID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTREventIDTypeClusterSwitchEventShortReleaseID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTREventIDTypeClusterSwitchEventLongReleaseID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTREventIDTypeClusterSwitchEventMultiPressOngoingID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTREventIDTypeClusterSwitchEventMultiPressCompleteID MTR_NEWLY_AVAILABLE = 0x00000006,
+
+    // Cluster BooleanState deprecated event names
+    MTRClusterBooleanStateEventStateChangeID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterBooleanStateEventStateChangeID")
+    = 0x00000000,
 
     // Cluster BooleanState events
-    MTRClusterBooleanStateEventStateChangeID = 0x00000000,
+    MTREventIDTypeClusterBooleanStateEventStateChangeID MTR_NEWLY_AVAILABLE = 0x00000000,
+
+    // Cluster DoorLock deprecated event names
+    MTRClusterDoorLockEventDoorLockAlarmID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterDoorLockEventDoorLockAlarmID")
+    = 0x00000000,
+    MTRClusterDoorLockEventDoorStateChangeID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterDoorLockEventDoorStateChangeID")
+    = 0x00000001,
+    MTRClusterDoorLockEventLockOperationID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterDoorLockEventLockOperationID")
+    = 0x00000002,
+    MTRClusterDoorLockEventLockOperationErrorID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterDoorLockEventLockOperationErrorID")
+    = 0x00000003,
+    MTRClusterDoorLockEventLockUserChangeID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterDoorLockEventLockUserChangeID")
+    = 0x00000004,
 
     // Cluster DoorLock events
-    MTRClusterDoorLockEventDoorLockAlarmID = 0x00000000,
-    MTRClusterDoorLockEventDoorStateChangeID = 0x00000001,
-    MTRClusterDoorLockEventLockOperationID = 0x00000002,
-    MTRClusterDoorLockEventLockOperationErrorID = 0x00000003,
-    MTRClusterDoorLockEventLockUserChangeID = 0x00000004,
+    MTREventIDTypeClusterDoorLockEventDoorLockAlarmID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTREventIDTypeClusterDoorLockEventDoorStateChangeID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTREventIDTypeClusterDoorLockEventLockOperationID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTREventIDTypeClusterDoorLockEventLockOperationErrorID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTREventIDTypeClusterDoorLockEventLockUserChangeID MTR_NEWLY_AVAILABLE = 0x00000004,
+
+    // Cluster PumpConfigurationAndControl deprecated event names
+    MTRClusterPumpConfigurationAndControlEventSupplyVoltageLowID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventSupplyVoltageLowID")
+    = 0x00000000,
+    MTRClusterPumpConfigurationAndControlEventSupplyVoltageHighID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventSupplyVoltageHighID")
+    = 0x00000001,
+    MTRClusterPumpConfigurationAndControlEventPowerMissingPhaseID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventPowerMissingPhaseID")
+    = 0x00000002,
+    MTRClusterPumpConfigurationAndControlEventSystemPressureLowID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventSystemPressureLowID")
+    = 0x00000003,
+    MTRClusterPumpConfigurationAndControlEventSystemPressureHighID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventSystemPressureHighID")
+    = 0x00000004,
+    MTRClusterPumpConfigurationAndControlEventDryRunningID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventDryRunningID")
+    = 0x00000005,
+    MTRClusterPumpConfigurationAndControlEventMotorTemperatureHighID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventMotorTemperatureHighID")
+    = 0x00000006,
+    MTRClusterPumpConfigurationAndControlEventPumpMotorFatalFailureID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventPumpMotorFatalFailureID")
+    = 0x00000007,
+    MTRClusterPumpConfigurationAndControlEventElectronicTemperatureHighID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventElectronicTemperatureHighID")
+    = 0x00000008,
+    MTRClusterPumpConfigurationAndControlEventPumpBlockedID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventPumpBlockedID")
+    = 0x00000009,
+    MTRClusterPumpConfigurationAndControlEventSensorFailureID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventSensorFailureID")
+    = 0x0000000A,
+    MTRClusterPumpConfigurationAndControlEventElectronicNonFatalFailureID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventElectronicNonFatalFailureID")
+    = 0x0000000B,
+    MTRClusterPumpConfigurationAndControlEventElectronicFatalFailureID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventElectronicFatalFailureID")
+    = 0x0000000C,
+    MTRClusterPumpConfigurationAndControlEventGeneralFaultID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventGeneralFaultID")
+    = 0x0000000D,
+    MTRClusterPumpConfigurationAndControlEventLeakageID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventLeakageID")
+    = 0x0000000E,
+    MTRClusterPumpConfigurationAndControlEventAirDetectionID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventAirDetectionID")
+    = 0x0000000F,
+    MTRClusterPumpConfigurationAndControlEventTurbineOperationID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterPumpConfigurationAndControlEventTurbineOperationID")
+    = 0x00000010,
 
     // Cluster PumpConfigurationAndControl events
-    MTRClusterPumpConfigurationAndControlEventSupplyVoltageLowID = 0x00000000,
-    MTRClusterPumpConfigurationAndControlEventSupplyVoltageHighID = 0x00000001,
-    MTRClusterPumpConfigurationAndControlEventPowerMissingPhaseID = 0x00000002,
-    MTRClusterPumpConfigurationAndControlEventSystemPressureLowID = 0x00000003,
-    MTRClusterPumpConfigurationAndControlEventSystemPressureHighID = 0x00000004,
-    MTRClusterPumpConfigurationAndControlEventDryRunningID = 0x00000005,
-    MTRClusterPumpConfigurationAndControlEventMotorTemperatureHighID = 0x00000006,
-    MTRClusterPumpConfigurationAndControlEventPumpMotorFatalFailureID = 0x00000007,
-    MTRClusterPumpConfigurationAndControlEventElectronicTemperatureHighID = 0x00000008,
-    MTRClusterPumpConfigurationAndControlEventPumpBlockedID = 0x00000009,
-    MTRClusterPumpConfigurationAndControlEventSensorFailureID = 0x0000000A,
-    MTRClusterPumpConfigurationAndControlEventElectronicNonFatalFailureID = 0x0000000B,
-    MTRClusterPumpConfigurationAndControlEventElectronicFatalFailureID = 0x0000000C,
-    MTRClusterPumpConfigurationAndControlEventGeneralFaultID = 0x0000000D,
-    MTRClusterPumpConfigurationAndControlEventLeakageID = 0x0000000E,
-    MTRClusterPumpConfigurationAndControlEventAirDetectionID = 0x0000000F,
-    MTRClusterPumpConfigurationAndControlEventTurbineOperationID = 0x00000010,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventSupplyVoltageLowID MTR_NEWLY_AVAILABLE = 0x00000000,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventSupplyVoltageHighID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventPowerMissingPhaseID MTR_NEWLY_AVAILABLE = 0x00000002,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventSystemPressureLowID MTR_NEWLY_AVAILABLE = 0x00000003,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventSystemPressureHighID MTR_NEWLY_AVAILABLE = 0x00000004,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventDryRunningID MTR_NEWLY_AVAILABLE = 0x00000005,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventMotorTemperatureHighID MTR_NEWLY_AVAILABLE = 0x00000006,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventPumpMotorFatalFailureID MTR_NEWLY_AVAILABLE = 0x00000007,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventElectronicTemperatureHighID MTR_NEWLY_AVAILABLE = 0x00000008,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventPumpBlockedID MTR_NEWLY_AVAILABLE = 0x00000009,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventSensorFailureID MTR_NEWLY_AVAILABLE = 0x0000000A,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventElectronicNonFatalFailureID MTR_NEWLY_AVAILABLE = 0x0000000B,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventElectronicFatalFailureID MTR_NEWLY_AVAILABLE = 0x0000000C,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventGeneralFaultID MTR_NEWLY_AVAILABLE = 0x0000000D,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventLeakageID MTR_NEWLY_AVAILABLE = 0x0000000E,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventAirDetectionID MTR_NEWLY_AVAILABLE = 0x0000000F,
+    MTREventIDTypeClusterPumpConfigurationAndControlEventTurbineOperationID MTR_NEWLY_AVAILABLE = 0x00000010,
+
+    // Cluster TestCluster deprecated event names
+    MTRClusterTestClusterEventTestEventID MTR_NEWLY_DEPRECATED("Please use MTREventIDTypeClusterUnitTestingEventTestEventID")
+    = 0x00000001,
+    MTRClusterTestClusterEventTestFabricScopedEventID MTR_NEWLY_DEPRECATED(
+        "Please use MTREventIDTypeClusterUnitTestingEventTestFabricScopedEventID")
+    = 0x00000002,
 
     // Cluster UnitTesting events
-    MTRClusterUnitTestingEventTestEventID MTR_NEWLY_AVAILABLE = 0x00000001,
-    MTRClusterUnitTestingEventTestFabricScopedEventID MTR_NEWLY_AVAILABLE = 0x00000002,
-
-    // Cluster TestCluster events
-    MTRClusterTestClusterEventTestEventID MTR_NEWLY_DEPRECATED("Please use MTRClusterUnitTestingEventTestEventID") = 0x00000001,
-    MTRClusterTestClusterEventTestFabricScopedEventID MTR_NEWLY_DEPRECATED(
-        "Please use MTRClusterUnitTestingEventTestFabricScopedEventID")
-    = 0x00000002,
+    MTREventIDTypeClusterUnitTestingEventTestEventID MTR_NEWLY_AVAILABLE = 0x00000001,
+    MTREventIDTypeClusterUnitTestingEventTestFabricScopedEventID MTR_NEWLY_AVAILABLE = 0x00000002,
 
 };

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
@@ -159,8 +159,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeIdentifyTimeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIdentifyID)
-                                        attributeID:@(MTRClusterIdentifyAttributeIdentifyTimeID)
+                                          clusterID:@(MTRClusterIDTypeIdentifyID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIdentifyAttributeIdentifyTimeID)
                                              params:params];
 }
 
@@ -176,8 +176,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterIdentifyID)
-                                  attributeID:@(MTRClusterIdentifyAttributeIdentifyTimeID)
+                                    clusterID:@(MTRClusterIDTypeIdentifyID)
+                                  attributeID:@(MTRAttributeIDTypeClusterIdentifyAttributeIdentifyTimeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -186,48 +186,48 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeIdentifyTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIdentifyID)
-                                        attributeID:@(MTRClusterIdentifyAttributeIdentifyTypeID)
+                                          clusterID:@(MTRClusterIDTypeIdentifyID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIdentifyAttributeIdentifyTypeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIdentifyID)
-                                        attributeID:@(MTRClusterIdentifyAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeIdentifyID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIdentifyAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIdentifyID)
-                                        attributeID:@(MTRClusterIdentifyAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeIdentifyID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIdentifyAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIdentifyID)
-                                        attributeID:@(MTRClusterIdentifyAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeIdentifyID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIdentifyAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIdentifyID)
-                                        attributeID:@(MTRClusterIdentifyAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeIdentifyID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIdentifyAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIdentifyID)
-                                        attributeID:@(MTRClusterIdentifyAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeIdentifyID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIdentifyAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -590,48 +590,48 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNameSupportWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupsID)
-                                        attributeID:@(MTRClusterGroupsAttributeNameSupportID)
+                                          clusterID:@(MTRClusterIDTypeGroupsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupsAttributeNameSupportID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupsID)
-                                        attributeID:@(MTRClusterGroupsAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeGroupsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupsAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupsID)
-                                        attributeID:@(MTRClusterGroupsAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeGroupsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupsAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupsID)
-                                        attributeID:@(MTRClusterGroupsAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeGroupsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupsAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupsID)
-                                        attributeID:@(MTRClusterGroupsAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeGroupsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupsAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupsID)
-                                        attributeID:@(MTRClusterGroupsAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeGroupsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupsAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -1380,88 +1380,88 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeSceneCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterScenesID)
-                                        attributeID:@(MTRClusterScenesAttributeSceneCountID)
+                                          clusterID:@(MTRClusterIDTypeScenesID)
+                                        attributeID:@(MTRAttributeIDTypeClusterScenesAttributeSceneCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentSceneWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterScenesID)
-                                        attributeID:@(MTRClusterScenesAttributeCurrentSceneID)
+                                          clusterID:@(MTRClusterIDTypeScenesID)
+                                        attributeID:@(MTRAttributeIDTypeClusterScenesAttributeCurrentSceneID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentGroupWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterScenesID)
-                                        attributeID:@(MTRClusterScenesAttributeCurrentGroupID)
+                                          clusterID:@(MTRClusterIDTypeScenesID)
+                                        attributeID:@(MTRAttributeIDTypeClusterScenesAttributeCurrentGroupID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSceneValidWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterScenesID)
-                                        attributeID:@(MTRClusterScenesAttributeSceneValidID)
+                                          clusterID:@(MTRClusterIDTypeScenesID)
+                                        attributeID:@(MTRAttributeIDTypeClusterScenesAttributeSceneValidID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNameSupportWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterScenesID)
-                                        attributeID:@(MTRClusterScenesAttributeNameSupportID)
+                                          clusterID:@(MTRClusterIDTypeScenesID)
+                                        attributeID:@(MTRAttributeIDTypeClusterScenesAttributeNameSupportID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLastConfiguredByWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterScenesID)
-                                        attributeID:@(MTRClusterScenesAttributeLastConfiguredByID)
+                                          clusterID:@(MTRClusterIDTypeScenesID)
+                                        attributeID:@(MTRAttributeIDTypeClusterScenesAttributeLastConfiguredByID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterScenesID)
-                                        attributeID:@(MTRClusterScenesAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeScenesID)
+                                        attributeID:@(MTRAttributeIDTypeClusterScenesAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterScenesID)
-                                        attributeID:@(MTRClusterScenesAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeScenesID)
+                                        attributeID:@(MTRAttributeIDTypeClusterScenesAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterScenesID)
-                                        attributeID:@(MTRClusterScenesAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeScenesID)
+                                        attributeID:@(MTRAttributeIDTypeClusterScenesAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterScenesID)
-                                        attributeID:@(MTRClusterScenesAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeScenesID)
+                                        attributeID:@(MTRAttributeIDTypeClusterScenesAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterScenesID)
-                                        attributeID:@(MTRClusterScenesAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeScenesID)
+                                        attributeID:@(MTRAttributeIDTypeClusterScenesAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -1955,24 +1955,24 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOnOffWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffID)
-                                        attributeID:@(MTRClusterOnOffAttributeOnOffID)
+                                          clusterID:@(MTRClusterIDTypeOnOffID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeOnOffID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGlobalSceneControlWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffID)
-                                        attributeID:@(MTRClusterOnOffAttributeGlobalSceneControlID)
+                                          clusterID:@(MTRClusterIDTypeOnOffID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeGlobalSceneControlID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOnTimeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffID)
-                                        attributeID:@(MTRClusterOnOffAttributeOnTimeID)
+                                          clusterID:@(MTRClusterIDTypeOnOffID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeOnTimeID)
                                              params:params];
 }
 
@@ -1988,8 +1988,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterOnOffID)
-                                  attributeID:@(MTRClusterOnOffAttributeOnTimeID)
+                                    clusterID:@(MTRClusterIDTypeOnOffID)
+                                  attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeOnTimeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -1998,8 +1998,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOffWaitTimeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffID)
-                                        attributeID:@(MTRClusterOnOffAttributeOffWaitTimeID)
+                                          clusterID:@(MTRClusterIDTypeOnOffID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeOffWaitTimeID)
                                              params:params];
 }
 
@@ -2015,8 +2015,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterOnOffID)
-                                  attributeID:@(MTRClusterOnOffAttributeOffWaitTimeID)
+                                    clusterID:@(MTRClusterIDTypeOnOffID)
+                                  attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeOffWaitTimeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -2025,8 +2025,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeStartUpOnOffWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffID)
-                                        attributeID:@(MTRClusterOnOffAttributeStartUpOnOffID)
+                                          clusterID:@(MTRClusterIDTypeOnOffID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeStartUpOnOffID)
                                              params:params];
 }
 
@@ -2042,8 +2042,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterOnOffID)
-                                  attributeID:@(MTRClusterOnOffAttributeStartUpOnOffID)
+                                    clusterID:@(MTRClusterIDTypeOnOffID)
+                                  attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeStartUpOnOffID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -2052,40 +2052,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffID)
-                                        attributeID:@(MTRClusterOnOffAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeOnOffID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffID)
-                                        attributeID:@(MTRClusterOnOffAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeOnOffID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffID)
-                                        attributeID:@(MTRClusterOnOffAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeOnOffID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffID)
-                                        attributeID:@(MTRClusterOnOffAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeOnOffID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffID)
-                                        attributeID:@(MTRClusterOnOffAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeOnOffID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -2214,16 +2214,16 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeSwitchTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffSwitchConfigurationID)
-                                        attributeID:@(MTRClusterOnOffSwitchConfigurationAttributeSwitchTypeID)
+                                          clusterID:@(MTRClusterIDTypeOnOffSwitchConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeSwitchTypeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSwitchActionsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffSwitchConfigurationID)
-                                        attributeID:@(MTRClusterOnOffSwitchConfigurationAttributeSwitchActionsID)
+                                          clusterID:@(MTRClusterIDTypeOnOffSwitchConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeSwitchActionsID)
                                              params:params];
 }
 
@@ -2239,8 +2239,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterOnOffSwitchConfigurationID)
-                                  attributeID:@(MTRClusterOnOffSwitchConfigurationAttributeSwitchActionsID)
+                                    clusterID:@(MTRClusterIDTypeOnOffSwitchConfigurationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeSwitchActionsID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -2248,41 +2248,43 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffSwitchConfigurationID)
-                                        attributeID:@(MTRClusterOnOffSwitchConfigurationAttributeGeneratedCommandListID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeOnOffSwitchConfigurationID)
+                                     attributeID:@(MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeGeneratedCommandListID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffSwitchConfigurationID)
-                                        attributeID:@(MTRClusterOnOffSwitchConfigurationAttributeAcceptedCommandListID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeOnOffSwitchConfigurationID)
+                                     attributeID:@(MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeAcceptedCommandListID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffSwitchConfigurationID)
-                                        attributeID:@(MTRClusterOnOffSwitchConfigurationAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeOnOffSwitchConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffSwitchConfigurationID)
-                                        attributeID:@(MTRClusterOnOffSwitchConfigurationAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeOnOffSwitchConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOnOffSwitchConfigurationID)
-                                        attributeID:@(MTRClusterOnOffSwitchConfigurationAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeOnOffSwitchConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOnOffSwitchConfigurationAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -2812,64 +2814,64 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeCurrentLevelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeCurrentLevelID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeCurrentLevelID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRemainingTimeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeRemainingTimeID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeRemainingTimeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinLevelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeMinLevelID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeMinLevelID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxLevelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeMaxLevelID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeMaxLevelID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentFrequencyWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeCurrentFrequencyID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeCurrentFrequencyID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinFrequencyWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeMinFrequencyID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeMinFrequencyID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxFrequencyWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeMaxFrequencyID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeMaxFrequencyID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOptionsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeOptionsID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeOptionsID)
                                              params:params];
 }
 
@@ -2885,8 +2887,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterLevelControlID)
-                                  attributeID:@(MTRClusterLevelControlAttributeOptionsID)
+                                    clusterID:@(MTRClusterIDTypeLevelControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeOptionsID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -2895,8 +2897,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOnOffTransitionTimeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeOnOffTransitionTimeID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeOnOffTransitionTimeID)
                                              params:params];
 }
 
@@ -2912,8 +2914,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterLevelControlID)
-                                  attributeID:@(MTRClusterLevelControlAttributeOnOffTransitionTimeID)
+                                    clusterID:@(MTRClusterIDTypeLevelControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeOnOffTransitionTimeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -2922,8 +2924,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOnLevelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeOnLevelID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeOnLevelID)
                                              params:params];
 }
 
@@ -2939,8 +2941,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterLevelControlID)
-                                  attributeID:@(MTRClusterLevelControlAttributeOnLevelID)
+                                    clusterID:@(MTRClusterIDTypeLevelControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeOnLevelID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -2949,8 +2951,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOnTransitionTimeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeOnTransitionTimeID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeOnTransitionTimeID)
                                              params:params];
 }
 
@@ -2966,8 +2968,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterLevelControlID)
-                                  attributeID:@(MTRClusterLevelControlAttributeOnTransitionTimeID)
+                                    clusterID:@(MTRClusterIDTypeLevelControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeOnTransitionTimeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -2976,8 +2978,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOffTransitionTimeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeOffTransitionTimeID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeOffTransitionTimeID)
                                              params:params];
 }
 
@@ -2993,8 +2995,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterLevelControlID)
-                                  attributeID:@(MTRClusterLevelControlAttributeOffTransitionTimeID)
+                                    clusterID:@(MTRClusterIDTypeLevelControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeOffTransitionTimeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -3003,8 +3005,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeDefaultMoveRateWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeDefaultMoveRateID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeDefaultMoveRateID)
                                              params:params];
 }
 
@@ -3020,8 +3022,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterLevelControlID)
-                                  attributeID:@(MTRClusterLevelControlAttributeDefaultMoveRateID)
+                                    clusterID:@(MTRClusterIDTypeLevelControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeDefaultMoveRateID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -3030,8 +3032,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeStartUpCurrentLevelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeStartUpCurrentLevelID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeStartUpCurrentLevelID)
                                              params:params];
 }
 
@@ -3047,8 +3049,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterLevelControlID)
-                                  attributeID:@(MTRClusterLevelControlAttributeStartUpCurrentLevelID)
+                                    clusterID:@(MTRClusterIDTypeLevelControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeStartUpCurrentLevelID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -3057,40 +3059,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLevelControlID)
-                                        attributeID:@(MTRClusterLevelControlAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeLevelControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLevelControlAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -3213,8 +3215,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeActiveTextWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBinaryInputBasicID)
-                                        attributeID:@(MTRClusterBinaryInputBasicAttributeActiveTextID)
+                                          clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeActiveTextID)
                                              params:params];
 }
 
@@ -3230,8 +3232,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBinaryInputBasicID)
-                                  attributeID:@(MTRClusterBinaryInputBasicAttributeActiveTextID)
+                                    clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeActiveTextID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -3240,8 +3242,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeDescriptionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBinaryInputBasicID)
-                                        attributeID:@(MTRClusterBinaryInputBasicAttributeDescriptionID)
+                                          clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeDescriptionID)
                                              params:params];
 }
 
@@ -3257,8 +3259,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBinaryInputBasicID)
-                                  attributeID:@(MTRClusterBinaryInputBasicAttributeDescriptionID)
+                                    clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeDescriptionID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -3267,8 +3269,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInactiveTextWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBinaryInputBasicID)
-                                        attributeID:@(MTRClusterBinaryInputBasicAttributeInactiveTextID)
+                                          clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeInactiveTextID)
                                              params:params];
 }
 
@@ -3284,8 +3286,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBinaryInputBasicID)
-                                  attributeID:@(MTRClusterBinaryInputBasicAttributeInactiveTextID)
+                                    clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeInactiveTextID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -3294,8 +3296,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOutOfServiceWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBinaryInputBasicID)
-                                        attributeID:@(MTRClusterBinaryInputBasicAttributeOutOfServiceID)
+                                          clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeOutOfServiceID)
                                              params:params];
 }
 
@@ -3311,8 +3313,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBinaryInputBasicID)
-                                  attributeID:@(MTRClusterBinaryInputBasicAttributeOutOfServiceID)
+                                    clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeOutOfServiceID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -3321,16 +3323,16 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributePolarityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBinaryInputBasicID)
-                                        attributeID:@(MTRClusterBinaryInputBasicAttributePolarityID)
+                                          clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributePolarityID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePresentValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBinaryInputBasicID)
-                                        attributeID:@(MTRClusterBinaryInputBasicAttributePresentValueID)
+                                          clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributePresentValueID)
                                              params:params];
 }
 
@@ -3346,8 +3348,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBinaryInputBasicID)
-                                  attributeID:@(MTRClusterBinaryInputBasicAttributePresentValueID)
+                                    clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributePresentValueID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -3356,8 +3358,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeReliabilityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBinaryInputBasicID)
-                                        attributeID:@(MTRClusterBinaryInputBasicAttributeReliabilityID)
+                                          clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeReliabilityID)
                                              params:params];
 }
 
@@ -3373,8 +3375,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBinaryInputBasicID)
-                                  attributeID:@(MTRClusterBinaryInputBasicAttributeReliabilityID)
+                                    clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeReliabilityID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -3383,56 +3385,56 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeStatusFlagsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBinaryInputBasicID)
-                                        attributeID:@(MTRClusterBinaryInputBasicAttributeStatusFlagsID)
+                                          clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeStatusFlagsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeApplicationTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBinaryInputBasicID)
-                                        attributeID:@(MTRClusterBinaryInputBasicAttributeApplicationTypeID)
+                                          clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeApplicationTypeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBinaryInputBasicID)
-                                        attributeID:@(MTRClusterBinaryInputBasicAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBinaryInputBasicID)
-                                        attributeID:@(MTRClusterBinaryInputBasicAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBinaryInputBasicID)
-                                        attributeID:@(MTRClusterBinaryInputBasicAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBinaryInputBasicID)
-                                        attributeID:@(MTRClusterBinaryInputBasicAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBinaryInputBasicID)
-                                        attributeID:@(MTRClusterBinaryInputBasicAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeBinaryInputBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBinaryInputBasicAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -3465,72 +3467,72 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeDeviceListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDescriptorID)
-                                        attributeID:@(MTRClusterDescriptorAttributeDeviceTypeListID)
+                                          clusterID:@(MTRClusterIDTypeDescriptorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDescriptorAttributeDeviceTypeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeServerListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDescriptorID)
-                                        attributeID:@(MTRClusterDescriptorAttributeServerListID)
+                                          clusterID:@(MTRClusterIDTypeDescriptorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDescriptorAttributeServerListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClientListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDescriptorID)
-                                        attributeID:@(MTRClusterDescriptorAttributeClientListID)
+                                          clusterID:@(MTRClusterIDTypeDescriptorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDescriptorAttributeClientListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePartsListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDescriptorID)
-                                        attributeID:@(MTRClusterDescriptorAttributePartsListID)
+                                          clusterID:@(MTRClusterIDTypeDescriptorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDescriptorAttributePartsListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDescriptorID)
-                                        attributeID:@(MTRClusterDescriptorAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeDescriptorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDescriptorAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDescriptorID)
-                                        attributeID:@(MTRClusterDescriptorAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeDescriptorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDescriptorAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDescriptorID)
-                                        attributeID:@(MTRClusterDescriptorAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeDescriptorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDescriptorAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDescriptorID)
-                                        attributeID:@(MTRClusterDescriptorAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeDescriptorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDescriptorAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDescriptorID)
-                                        attributeID:@(MTRClusterDescriptorAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeDescriptorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDescriptorAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -3563,8 +3565,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBindingWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBindingID)
-                                        attributeID:@(MTRClusterBindingAttributeBindingID)
+                                          clusterID:@(MTRClusterIDTypeBindingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBindingAttributeBindingID)
                                              params:params];
 }
 
@@ -3580,8 +3582,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBindingID)
-                                  attributeID:@(MTRClusterBindingAttributeBindingID)
+                                    clusterID:@(MTRClusterIDTypeBindingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBindingAttributeBindingID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -3590,40 +3592,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBindingID)
-                                        attributeID:@(MTRClusterBindingAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeBindingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBindingAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBindingID)
-                                        attributeID:@(MTRClusterBindingAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeBindingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBindingAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBindingID)
-                                        attributeID:@(MTRClusterBindingAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeBindingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBindingAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBindingID)
-                                        attributeID:@(MTRClusterBindingAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeBindingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBindingAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBindingID)
-                                        attributeID:@(MTRClusterBindingAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeBindingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBindingAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -3656,8 +3658,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeAclWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccessControlID)
-                                        attributeID:@(MTRClusterAccessControlAttributeAclID)
+                                          clusterID:@(MTRClusterIDTypeAccessControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeAclID)
                                              params:params];
 }
 
@@ -3673,8 +3675,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterAccessControlID)
-                                  attributeID:@(MTRClusterAccessControlAttributeAclID)
+                                    clusterID:@(MTRClusterIDTypeAccessControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeAclID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -3683,8 +3685,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeExtensionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccessControlID)
-                                        attributeID:@(MTRClusterAccessControlAttributeExtensionID)
+                                          clusterID:@(MTRClusterIDTypeAccessControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeExtensionID)
                                              params:params];
 }
 
@@ -3700,8 +3702,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterAccessControlID)
-                                  attributeID:@(MTRClusterAccessControlAttributeExtensionID)
+                                    clusterID:@(MTRClusterIDTypeAccessControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeExtensionID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -3709,65 +3711,67 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeSubjectsPerAccessControlEntryWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccessControlID)
-                                        attributeID:@(MTRClusterAccessControlAttributeSubjectsPerAccessControlEntryID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeAccessControlID)
+                                     attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeSubjectsPerAccessControlEntryID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTargetsPerAccessControlEntryWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccessControlID)
-                                        attributeID:@(MTRClusterAccessControlAttributeTargetsPerAccessControlEntryID)
+                                          clusterID:@(MTRClusterIDTypeAccessControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeTargetsPerAccessControlEntryID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAccessControlEntriesPerFabricWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccessControlID)
-                                        attributeID:@(MTRClusterAccessControlAttributeAccessControlEntriesPerFabricID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeAccessControlID)
+                                     attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeAccessControlEntriesPerFabricID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccessControlID)
-                                        attributeID:@(MTRClusterAccessControlAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeAccessControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccessControlID)
-                                        attributeID:@(MTRClusterAccessControlAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeAccessControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccessControlID)
-                                        attributeID:@(MTRClusterAccessControlAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeAccessControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccessControlID)
-                                        attributeID:@(MTRClusterAccessControlAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeAccessControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccessControlID)
-                                        attributeID:@(MTRClusterAccessControlAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeAccessControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -4441,64 +4445,64 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeActionListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterActionsID)
-                                        attributeID:@(MTRClusterActionsAttributeActionListID)
+                                          clusterID:@(MTRClusterIDTypeActionsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterActionsAttributeActionListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeEndpointListsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterActionsID)
-                                        attributeID:@(MTRClusterActionsAttributeEndpointListsID)
+                                          clusterID:@(MTRClusterIDTypeActionsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterActionsAttributeEndpointListsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSetupURLWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterActionsID)
-                                        attributeID:@(MTRClusterActionsAttributeSetupURLID)
+                                          clusterID:@(MTRClusterIDTypeActionsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterActionsAttributeSetupURLID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterActionsID)
-                                        attributeID:@(MTRClusterActionsAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeActionsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterActionsAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterActionsID)
-                                        attributeID:@(MTRClusterActionsAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeActionsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterActionsAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterActionsID)
-                                        attributeID:@(MTRClusterActionsAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeActionsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterActionsAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterActionsID)
-                                        attributeID:@(MTRClusterActionsAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeActionsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterActionsAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterActionsID)
-                                        attributeID:@(MTRClusterActionsAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeActionsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterActionsAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -4708,48 +4712,48 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeDataModelRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeDataModelRevisionID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeDataModelRevisionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeVendorNameWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeVendorNameID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeVendorNameID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeVendorIDWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeVendorIDID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeVendorIDID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeProductNameWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeProductNameID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeProductNameID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeProductIDWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeProductIDID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeProductIDID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNodeLabelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeNodeLabelID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeNodeLabelID)
                                              params:params];
 }
 
@@ -4765,8 +4769,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBasicID)
-                                  attributeID:@(MTRClusterBasicAttributeNodeLabelID)
+                                    clusterID:@(MTRClusterIDTypeBasicID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBasicAttributeNodeLabelID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -4775,8 +4779,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLocationWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeLocationID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeLocationID)
                                              params:params];
 }
 
@@ -4792,8 +4796,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBasicID)
-                                  attributeID:@(MTRClusterBasicAttributeLocationID)
+                                    clusterID:@(MTRClusterIDTypeBasicID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBasicAttributeLocationID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -4802,80 +4806,80 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeHardwareVersionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeHardwareVersionID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeHardwareVersionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeHardwareVersionStringWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeHardwareVersionStringID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeHardwareVersionStringID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSoftwareVersionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeSoftwareVersionID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeSoftwareVersionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSoftwareVersionStringWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeSoftwareVersionStringID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeSoftwareVersionStringID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeManufacturingDateWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeManufacturingDateID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeManufacturingDateID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePartNumberWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributePartNumberID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributePartNumberID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeProductURLWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeProductURLID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeProductURLID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeProductLabelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeProductLabelID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeProductLabelID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSerialNumberWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeSerialNumberID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeSerialNumberID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLocalConfigDisabledWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeLocalConfigDisabledID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeLocalConfigDisabledID)
                                              params:params];
 }
 
@@ -4891,8 +4895,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBasicID)
-                                  attributeID:@(MTRClusterBasicAttributeLocalConfigDisabledID)
+                                    clusterID:@(MTRClusterIDTypeBasicID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBasicAttributeLocalConfigDisabledID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -4901,64 +4905,64 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeReachableWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeReachableID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeReachableID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeUniqueIDWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeUniqueIDID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeUniqueIDID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCapabilityMinimaWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeCapabilityMinimaID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeCapabilityMinimaID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBasicID)
-                                        attributeID:@(MTRClusterBasicAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBasicAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -5194,41 +5198,43 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOtaSoftwareUpdateProviderID)
-                                        attributeID:@(MTRClusterOtaSoftwareUpdateProviderAttributeGeneratedCommandListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateProviderID)
+                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeGeneratedCommandListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOtaSoftwareUpdateProviderID)
-                                        attributeID:@(MTRClusterOtaSoftwareUpdateProviderAttributeAcceptedCommandListID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateProviderID)
+                                     attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeAcceptedCommandListID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOtaSoftwareUpdateProviderID)
-                                        attributeID:@(MTRClusterOtaSoftwareUpdateProviderAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateProviderID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOtaSoftwareUpdateProviderID)
-                                        attributeID:@(MTRClusterOtaSoftwareUpdateProviderAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateProviderID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOtaSoftwareUpdateProviderID)
-                                        attributeID:@(MTRClusterOtaSoftwareUpdateProviderAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateProviderID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -5359,10 +5365,11 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeDefaultOtaProvidersWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOtaSoftwareUpdateRequestorID)
-                                        attributeID:@(MTRClusterOtaSoftwareUpdateRequestorAttributeDefaultOtaProvidersID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
+                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeDefaultOtaProvidersID)
+                             params:params];
 }
 
 - (void)writeAttributeDefaultOtaProvidersWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -5377,8 +5384,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterOtaSoftwareUpdateRequestorID)
-                                  attributeID:@(MTRClusterOtaSoftwareUpdateRequestorAttributeDefaultOtaProvidersID)
+                                    clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
+                                  attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeDefaultOtaProvidersID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -5387,64 +5394,67 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeUpdatePossibleWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOtaSoftwareUpdateRequestorID)
-                                        attributeID:@(MTRClusterOtaSoftwareUpdateRequestorAttributeUpdatePossibleID)
+                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdatePossibleID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeUpdateStateWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOtaSoftwareUpdateRequestorID)
-                                        attributeID:@(MTRClusterOtaSoftwareUpdateRequestorAttributeUpdateStateID)
+                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdateStateID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeUpdateStateProgressWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOtaSoftwareUpdateRequestorID)
-                                        attributeID:@(MTRClusterOtaSoftwareUpdateRequestorAttributeUpdateStateProgressID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
+                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdateStateProgressID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOtaSoftwareUpdateRequestorID)
-                                        attributeID:@(MTRClusterOtaSoftwareUpdateRequestorAttributeGeneratedCommandListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
+                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeGeneratedCommandListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOtaSoftwareUpdateRequestorID)
-                                        attributeID:@(MTRClusterOtaSoftwareUpdateRequestorAttributeAcceptedCommandListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
+                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeAcceptedCommandListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOtaSoftwareUpdateRequestorID)
-                                        attributeID:@(MTRClusterOtaSoftwareUpdateRequestorAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOtaSoftwareUpdateRequestorID)
-                                        attributeID:@(MTRClusterOtaSoftwareUpdateRequestorAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOtaSoftwareUpdateRequestorID)
-                                        attributeID:@(MTRClusterOtaSoftwareUpdateRequestorAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -5487,8 +5497,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeActiveLocaleWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLocalizationConfigurationID)
-                                        attributeID:@(MTRClusterLocalizationConfigurationAttributeActiveLocaleID)
+                                          clusterID:@(MTRClusterIDTypeLocalizationConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLocalizationConfigurationAttributeActiveLocaleID)
                                              params:params];
 }
 
@@ -5504,8 +5514,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterLocalizationConfigurationID)
-                                  attributeID:@(MTRClusterLocalizationConfigurationAttributeActiveLocaleID)
+                                    clusterID:@(MTRClusterIDTypeLocalizationConfigurationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterLocalizationConfigurationAttributeActiveLocaleID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -5514,48 +5524,50 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeSupportedLocalesWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLocalizationConfigurationID)
-                                        attributeID:@(MTRClusterLocalizationConfigurationAttributeSupportedLocalesID)
+                                          clusterID:@(MTRClusterIDTypeLocalizationConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLocalizationConfigurationAttributeSupportedLocalesID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLocalizationConfigurationID)
-                                        attributeID:@(MTRClusterLocalizationConfigurationAttributeGeneratedCommandListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeLocalizationConfigurationID)
+                        attributeID:@(MTRAttributeIDTypeClusterLocalizationConfigurationAttributeGeneratedCommandListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLocalizationConfigurationID)
-                                        attributeID:@(MTRClusterLocalizationConfigurationAttributeAcceptedCommandListID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeLocalizationConfigurationID)
+                                     attributeID:@(MTRAttributeIDTypeClusterLocalizationConfigurationAttributeAcceptedCommandListID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLocalizationConfigurationID)
-                                        attributeID:@(MTRClusterLocalizationConfigurationAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeLocalizationConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLocalizationConfigurationAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLocalizationConfigurationID)
-                                        attributeID:@(MTRClusterLocalizationConfigurationAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeLocalizationConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLocalizationConfigurationAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLocalizationConfigurationID)
-                                        attributeID:@(MTRClusterLocalizationConfigurationAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeLocalizationConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLocalizationConfigurationAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -5588,8 +5600,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeHourFormatWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTimeFormatLocalizationID)
-                                        attributeID:@(MTRClusterTimeFormatLocalizationAttributeHourFormatID)
+                                          clusterID:@(MTRClusterIDTypeTimeFormatLocalizationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeHourFormatID)
                                              params:params];
 }
 
@@ -5605,8 +5617,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterTimeFormatLocalizationID)
-                                  attributeID:@(MTRClusterTimeFormatLocalizationAttributeHourFormatID)
+                                    clusterID:@(MTRClusterIDTypeTimeFormatLocalizationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeHourFormatID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -5615,8 +5627,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeActiveCalendarTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTimeFormatLocalizationID)
-                                        attributeID:@(MTRClusterTimeFormatLocalizationAttributeActiveCalendarTypeID)
+                                          clusterID:@(MTRClusterIDTypeTimeFormatLocalizationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeActiveCalendarTypeID)
                                              params:params];
 }
 
@@ -5632,8 +5644,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterTimeFormatLocalizationID)
-                                  attributeID:@(MTRClusterTimeFormatLocalizationAttributeActiveCalendarTypeID)
+                                    clusterID:@(MTRClusterIDTypeTimeFormatLocalizationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeActiveCalendarTypeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -5641,49 +5653,51 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeSupportedCalendarTypesWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTimeFormatLocalizationID)
-                                        attributeID:@(MTRClusterTimeFormatLocalizationAttributeSupportedCalendarTypesID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeTimeFormatLocalizationID)
+                                     attributeID:@(MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeSupportedCalendarTypesID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTimeFormatLocalizationID)
-                                        attributeID:@(MTRClusterTimeFormatLocalizationAttributeGeneratedCommandListID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeTimeFormatLocalizationID)
+                                     attributeID:@(MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeGeneratedCommandListID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTimeFormatLocalizationID)
-                                        attributeID:@(MTRClusterTimeFormatLocalizationAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeTimeFormatLocalizationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTimeFormatLocalizationID)
-                                        attributeID:@(MTRClusterTimeFormatLocalizationAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeTimeFormatLocalizationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTimeFormatLocalizationID)
-                                        attributeID:@(MTRClusterTimeFormatLocalizationAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeTimeFormatLocalizationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTimeFormatLocalizationID)
-                                        attributeID:@(MTRClusterTimeFormatLocalizationAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeTimeFormatLocalizationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTimeFormatLocalizationAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -5716,8 +5730,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeTemperatureUnitWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitLocalizationID)
-                                        attributeID:@(MTRClusterUnitLocalizationAttributeTemperatureUnitID)
+                                          clusterID:@(MTRClusterIDTypeUnitLocalizationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitLocalizationAttributeTemperatureUnitID)
                                              params:params];
 }
 
@@ -5733,8 +5747,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitLocalizationID)
-                                  attributeID:@(MTRClusterUnitLocalizationAttributeTemperatureUnitID)
+                                    clusterID:@(MTRClusterIDTypeUnitLocalizationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitLocalizationAttributeTemperatureUnitID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -5743,40 +5757,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitLocalizationID)
-                                        attributeID:@(MTRClusterUnitLocalizationAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeUnitLocalizationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitLocalizationAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitLocalizationID)
-                                        attributeID:@(MTRClusterUnitLocalizationAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeUnitLocalizationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitLocalizationAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitLocalizationID)
-                                        attributeID:@(MTRClusterUnitLocalizationAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeUnitLocalizationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitLocalizationAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitLocalizationID)
-                                        attributeID:@(MTRClusterUnitLocalizationAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeUnitLocalizationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitLocalizationAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitLocalizationID)
-                                        attributeID:@(MTRClusterUnitLocalizationAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeUnitLocalizationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitLocalizationAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -5809,48 +5823,50 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeSourcesWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceConfigurationID)
-                                        attributeID:@(MTRClusterPowerSourceConfigurationAttributeSourcesID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeSourcesID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceConfigurationID)
-                                        attributeID:@(MTRClusterPowerSourceConfigurationAttributeGeneratedCommandListID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypePowerSourceConfigurationID)
+                                     attributeID:@(MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeGeneratedCommandListID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceConfigurationID)
-                                        attributeID:@(MTRClusterPowerSourceConfigurationAttributeAcceptedCommandListID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypePowerSourceConfigurationID)
+                                     attributeID:@(MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeAcceptedCommandListID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceConfigurationID)
-                                        attributeID:@(MTRClusterPowerSourceConfigurationAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceConfigurationID)
-                                        attributeID:@(MTRClusterPowerSourceConfigurationAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceConfigurationID)
-                                        attributeID:@(MTRClusterPowerSourceConfigurationAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceConfigurationAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -5883,288 +5899,288 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeStatusWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeStatusID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeStatusID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOrderWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeOrderID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeOrderID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDescriptionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeDescriptionID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeDescriptionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeWiredAssessedInputVoltageWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeWiredAssessedInputVoltageID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeWiredAssessedInputVoltageID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeWiredAssessedInputFrequencyWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeWiredAssessedInputFrequencyID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeWiredAssessedInputFrequencyID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeWiredCurrentTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeWiredCurrentTypeID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeWiredCurrentTypeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeWiredAssessedCurrentWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeWiredAssessedCurrentID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeWiredAssessedCurrentID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeWiredNominalVoltageWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeWiredNominalVoltageID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeWiredNominalVoltageID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeWiredMaximumCurrentWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeWiredMaximumCurrentID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeWiredMaximumCurrentID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeWiredPresentWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeWiredPresentID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeWiredPresentID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActiveWiredFaultsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeActiveWiredFaultsID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeActiveWiredFaultsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatVoltageWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatVoltageID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatVoltageID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatPercentRemainingWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatPercentRemainingID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatPercentRemainingID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatTimeRemainingWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatTimeRemainingID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatTimeRemainingID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatChargeLevelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatChargeLevelID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatChargeLevelID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatReplacementNeededWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatReplacementNeededID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatReplacementNeededID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatReplaceabilityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatReplaceabilityID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatReplaceabilityID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatPresentWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatPresentID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatPresentID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActiveBatFaultsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeActiveBatFaultsID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeActiveBatFaultsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatReplacementDescriptionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatReplacementDescriptionID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatReplacementDescriptionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatCommonDesignationWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatCommonDesignationID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatCommonDesignationID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatANSIDesignationWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatANSIDesignationID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatANSIDesignationID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatIECDesignationWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatIECDesignationID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatIECDesignationID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatApprovedChemistryWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatApprovedChemistryID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatApprovedChemistryID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatCapacityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatCapacityID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatCapacityID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatQuantityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatQuantityID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatQuantityID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatChargeStateWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatChargeStateID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatChargeStateID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatTimeToFullChargeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatTimeToFullChargeID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatTimeToFullChargeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatFunctionalWhileChargingWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatFunctionalWhileChargingID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatFunctionalWhileChargingID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBatChargingCurrentWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeBatChargingCurrentID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeBatChargingCurrentID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActiveBatChargeFaultsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeActiveBatChargeFaultsID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeActiveBatChargeFaultsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPowerSourceID)
-                                        attributeID:@(MTRClusterPowerSourceAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypePowerSourceID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPowerSourceAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -6352,8 +6368,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBreadcrumbWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralCommissioningID)
-                                        attributeID:@(MTRClusterGeneralCommissioningAttributeBreadcrumbID)
+                                          clusterID:@(MTRClusterIDTypeGeneralCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralCommissioningAttributeBreadcrumbID)
                                              params:params];
 }
 
@@ -6369,8 +6385,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterGeneralCommissioningID)
-                                  attributeID:@(MTRClusterGeneralCommissioningAttributeBreadcrumbID)
+                                    clusterID:@(MTRClusterIDTypeGeneralCommissioningID)
+                                  attributeID:@(MTRAttributeIDTypeClusterGeneralCommissioningAttributeBreadcrumbID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -6378,73 +6394,75 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeBasicCommissioningInfoWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralCommissioningID)
-                                        attributeID:@(MTRClusterGeneralCommissioningAttributeBasicCommissioningInfoID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeGeneralCommissioningID)
+                                     attributeID:@(MTRAttributeIDTypeClusterGeneralCommissioningAttributeBasicCommissioningInfoID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRegulatoryConfigWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralCommissioningID)
-                                        attributeID:@(MTRClusterGeneralCommissioningAttributeRegulatoryConfigID)
+                                          clusterID:@(MTRClusterIDTypeGeneralCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralCommissioningAttributeRegulatoryConfigID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLocationCapabilityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralCommissioningID)
-                                        attributeID:@(MTRClusterGeneralCommissioningAttributeLocationCapabilityID)
+                                          clusterID:@(MTRClusterIDTypeGeneralCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralCommissioningAttributeLocationCapabilityID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSupportsConcurrentConnectionWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralCommissioningID)
-                                        attributeID:@(MTRClusterGeneralCommissioningAttributeSupportsConcurrentConnectionID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeGeneralCommissioningID)
+                        attributeID:@(MTRAttributeIDTypeClusterGeneralCommissioningAttributeSupportsConcurrentConnectionID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralCommissioningID)
-                                        attributeID:@(MTRClusterGeneralCommissioningAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeGeneralCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralCommissioningAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralCommissioningID)
-                                        attributeID:@(MTRClusterGeneralCommissioningAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeGeneralCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralCommissioningAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralCommissioningID)
-                                        attributeID:@(MTRClusterGeneralCommissioningAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeGeneralCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralCommissioningAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralCommissioningID)
-                                        attributeID:@(MTRClusterGeneralCommissioningAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeGeneralCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralCommissioningAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralCommissioningID)
-                                        attributeID:@(MTRClusterGeneralCommissioningAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeGeneralCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralCommissioningAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -6849,40 +6867,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMaxNetworksWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterNetworkCommissioningID)
-                                        attributeID:@(MTRClusterNetworkCommissioningAttributeMaxNetworksID)
+                                          clusterID:@(MTRClusterIDTypeNetworkCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterNetworkCommissioningAttributeMaxNetworksID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNetworksWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterNetworkCommissioningID)
-                                        attributeID:@(MTRClusterNetworkCommissioningAttributeNetworksID)
+                                          clusterID:@(MTRClusterIDTypeNetworkCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterNetworkCommissioningAttributeNetworksID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeScanMaxTimeSecondsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterNetworkCommissioningID)
-                                        attributeID:@(MTRClusterNetworkCommissioningAttributeScanMaxTimeSecondsID)
+                                          clusterID:@(MTRClusterIDTypeNetworkCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterNetworkCommissioningAttributeScanMaxTimeSecondsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeConnectMaxTimeSecondsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterNetworkCommissioningID)
-                                        attributeID:@(MTRClusterNetworkCommissioningAttributeConnectMaxTimeSecondsID)
+                                          clusterID:@(MTRClusterIDTypeNetworkCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterNetworkCommissioningAttributeConnectMaxTimeSecondsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeInterfaceEnabledWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterNetworkCommissioningID)
-                                        attributeID:@(MTRClusterNetworkCommissioningAttributeInterfaceEnabledID)
+                                          clusterID:@(MTRClusterIDTypeNetworkCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterNetworkCommissioningAttributeInterfaceEnabledID)
                                              params:params];
 }
 
@@ -6898,8 +6916,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterNetworkCommissioningID)
-                                  attributeID:@(MTRClusterNetworkCommissioningAttributeInterfaceEnabledID)
+                                    clusterID:@(MTRClusterIDTypeNetworkCommissioningID)
+                                  attributeID:@(MTRAttributeIDTypeClusterNetworkCommissioningAttributeInterfaceEnabledID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -6908,64 +6926,64 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLastNetworkingStatusWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterNetworkCommissioningID)
-                                        attributeID:@(MTRClusterNetworkCommissioningAttributeLastNetworkingStatusID)
+                                          clusterID:@(MTRClusterIDTypeNetworkCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterNetworkCommissioningAttributeLastNetworkingStatusID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLastNetworkIDWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterNetworkCommissioningID)
-                                        attributeID:@(MTRClusterNetworkCommissioningAttributeLastNetworkIDID)
+                                          clusterID:@(MTRClusterIDTypeNetworkCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterNetworkCommissioningAttributeLastNetworkIDID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLastConnectErrorValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterNetworkCommissioningID)
-                                        attributeID:@(MTRClusterNetworkCommissioningAttributeLastConnectErrorValueID)
+                                          clusterID:@(MTRClusterIDTypeNetworkCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterNetworkCommissioningAttributeLastConnectErrorValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterNetworkCommissioningID)
-                                        attributeID:@(MTRClusterNetworkCommissioningAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeNetworkCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterNetworkCommissioningAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterNetworkCommissioningID)
-                                        attributeID:@(MTRClusterNetworkCommissioningAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeNetworkCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterNetworkCommissioningAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterNetworkCommissioningID)
-                                        attributeID:@(MTRClusterNetworkCommissioningAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeNetworkCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterNetworkCommissioningAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterNetworkCommissioningID)
-                                        attributeID:@(MTRClusterNetworkCommissioningAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeNetworkCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterNetworkCommissioningAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterNetworkCommissioningID)
-                                        attributeID:@(MTRClusterNetworkCommissioningAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeNetworkCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterNetworkCommissioningAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -7141,40 +7159,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDiagnosticLogsID)
-                                        attributeID:@(MTRClusterDiagnosticLogsAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeDiagnosticLogsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDiagnosticLogsAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDiagnosticLogsID)
-                                        attributeID:@(MTRClusterDiagnosticLogsAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeDiagnosticLogsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDiagnosticLogsAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDiagnosticLogsID)
-                                        attributeID:@(MTRClusterDiagnosticLogsAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeDiagnosticLogsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDiagnosticLogsAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDiagnosticLogsID)
-                                        attributeID:@(MTRClusterDiagnosticLogsAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeDiagnosticLogsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDiagnosticLogsAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDiagnosticLogsID)
-                                        attributeID:@(MTRClusterDiagnosticLogsAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeDiagnosticLogsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDiagnosticLogsAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -7272,112 +7290,113 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNetworkInterfacesWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralDiagnosticsID)
-                                        attributeID:@(MTRClusterGeneralDiagnosticsAttributeNetworkInterfacesID)
+                                          clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeNetworkInterfacesID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRebootCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralDiagnosticsID)
-                                        attributeID:@(MTRClusterGeneralDiagnosticsAttributeRebootCountID)
+                                          clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeRebootCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeUpTimeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralDiagnosticsID)
-                                        attributeID:@(MTRClusterGeneralDiagnosticsAttributeUpTimeID)
+                                          clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeUpTimeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTotalOperationalHoursWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralDiagnosticsID)
-                                        attributeID:@(MTRClusterGeneralDiagnosticsAttributeTotalOperationalHoursID)
+                                          clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeTotalOperationalHoursID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBootReasonsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralDiagnosticsID)
-                                        attributeID:@(MTRClusterGeneralDiagnosticsAttributeBootReasonsID)
+                                          clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeBootReasonsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActiveHardwareFaultsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralDiagnosticsID)
-                                        attributeID:@(MTRClusterGeneralDiagnosticsAttributeActiveHardwareFaultsID)
+                                          clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeActiveHardwareFaultsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActiveRadioFaultsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralDiagnosticsID)
-                                        attributeID:@(MTRClusterGeneralDiagnosticsAttributeActiveRadioFaultsID)
+                                          clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeActiveRadioFaultsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActiveNetworkFaultsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralDiagnosticsID)
-                                        attributeID:@(MTRClusterGeneralDiagnosticsAttributeActiveNetworkFaultsID)
+                                          clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeActiveNetworkFaultsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTestEventTriggersEnabledWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralDiagnosticsID)
-                                        attributeID:@(MTRClusterGeneralDiagnosticsAttributeTestEventTriggersEnabledID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                     attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeTestEventTriggersEnabledID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralDiagnosticsID)
-                                        attributeID:@(MTRClusterGeneralDiagnosticsAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralDiagnosticsID)
-                                        attributeID:@(MTRClusterGeneralDiagnosticsAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralDiagnosticsID)
-                                        attributeID:@(MTRClusterGeneralDiagnosticsAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralDiagnosticsID)
-                                        attributeID:@(MTRClusterGeneralDiagnosticsAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGeneralDiagnosticsID)
-                                        attributeID:@(MTRClusterGeneralDiagnosticsAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -7477,72 +7496,73 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeThreadMetricsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSoftwareDiagnosticsID)
-                                        attributeID:@(MTRClusterSoftwareDiagnosticsAttributeThreadMetricsID)
+                                          clusterID:@(MTRClusterIDTypeSoftwareDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeThreadMetricsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentHeapFreeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSoftwareDiagnosticsID)
-                                        attributeID:@(MTRClusterSoftwareDiagnosticsAttributeCurrentHeapFreeID)
+                                          clusterID:@(MTRClusterIDTypeSoftwareDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeCurrentHeapFreeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentHeapUsedWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSoftwareDiagnosticsID)
-                                        attributeID:@(MTRClusterSoftwareDiagnosticsAttributeCurrentHeapUsedID)
+                                          clusterID:@(MTRClusterIDTypeSoftwareDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeCurrentHeapUsedID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentHeapHighWatermarkWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSoftwareDiagnosticsID)
-                                        attributeID:@(MTRClusterSoftwareDiagnosticsAttributeCurrentHeapHighWatermarkID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeSoftwareDiagnosticsID)
+                                     attributeID:@(MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeCurrentHeapHighWatermarkID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSoftwareDiagnosticsID)
-                                        attributeID:@(MTRClusterSoftwareDiagnosticsAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeSoftwareDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSoftwareDiagnosticsID)
-                                        attributeID:@(MTRClusterSoftwareDiagnosticsAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeSoftwareDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSoftwareDiagnosticsID)
-                                        attributeID:@(MTRClusterSoftwareDiagnosticsAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeSoftwareDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSoftwareDiagnosticsID)
-                                        attributeID:@(MTRClusterSoftwareDiagnosticsAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeSoftwareDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSoftwareDiagnosticsID)
-                                        attributeID:@(MTRClusterSoftwareDiagnosticsAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeSoftwareDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSoftwareDiagnosticsAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -7651,545 +7671,562 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeChannelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeChannelID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeChannelID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRoutingRoleWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRoutingRoleID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRoutingRoleID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNetworkNameWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeNetworkNameID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeNetworkNameID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePanIdWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributePanIdID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributePanIdID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeExtendedPanIdWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeExtendedPanIdID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeExtendedPanIdID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMeshLocalPrefixWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeMeshLocalPrefixID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeMeshLocalPrefixID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOverrunCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeOverrunCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeOverrunCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNeighborTableListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeNeighborTableListID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeNeighborTableListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRouteTableListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRouteTableListID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRouteTableListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePartitionIdWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributePartitionIdID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributePartitionIdID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeWeightingWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeWeightingID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeWeightingID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDataVersionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeDataVersionID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeDataVersionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeStableDataVersionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeStableDataVersionID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeStableDataVersionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLeaderRouterIdWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeLeaderRouterIdID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeLeaderRouterIdID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDetachedRoleCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeDetachedRoleCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeDetachedRoleCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeChildRoleCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeChildRoleCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeChildRoleCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRouterRoleCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRouterRoleCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRouterRoleCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLeaderRoleCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeLeaderRoleCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeLeaderRoleCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttachAttemptCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeAttachAttemptCountID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                     attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeAttachAttemptCountID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePartitionIdChangeCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributePartitionIdChangeCountID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributePartitionIdChangeCountID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBetterPartitionAttachAttemptCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return
-        [self.device readAttributeWithEndpointID:@(_endpoint)
-                                       clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                     attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeBetterPartitionAttachAttemptCountID)
-                                          params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeBetterPartitionAttachAttemptCountID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeParentChangeCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeParentChangeCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeParentChangeCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxTotalCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxTotalCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxTotalCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxUnicastCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxUnicastCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxUnicastCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxBroadcastCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxBroadcastCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxBroadcastCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxAckRequestedCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxAckRequestedCountID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                     attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxAckRequestedCountID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxAckedCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxAckedCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxAckedCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxNoAckRequestedCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxNoAckRequestedCountID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxNoAckRequestedCountID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxDataCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxDataCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxDataCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxDataPollCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxDataPollCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxDataPollCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxBeaconCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxBeaconCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxBeaconCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxBeaconRequestCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxBeaconRequestCountID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                     attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxBeaconRequestCountID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxOtherCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxOtherCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxOtherCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxRetryCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxRetryCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxRetryCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxDirectMaxRetryExpiryCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxDirectMaxRetryExpiryCountID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxDirectMaxRetryExpiryCountID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxIndirectMaxRetryExpiryCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxIndirectMaxRetryExpiryCountID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxIndirectMaxRetryExpiryCountID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxErrCcaCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxErrCcaCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxErrCcaCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxErrAbortCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxErrAbortCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxErrAbortCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxErrBusyChannelCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeTxErrBusyChannelCountID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeTxErrBusyChannelCountID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxTotalCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxTotalCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxTotalCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxUnicastCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxUnicastCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxUnicastCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxBroadcastCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxBroadcastCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxBroadcastCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxDataCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxDataCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxDataCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxDataPollCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxDataPollCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxDataPollCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxBeaconCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxBeaconCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxBeaconCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxBeaconRequestCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxBeaconRequestCountID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                     attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxBeaconRequestCountID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxOtherCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxOtherCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxOtherCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxAddressFilteredCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxAddressFilteredCountID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxAddressFilteredCountID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxDestAddrFilteredCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxDestAddrFilteredCountID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxDestAddrFilteredCountID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxDuplicatedCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxDuplicatedCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxDuplicatedCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxErrNoFrameCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxErrNoFrameCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrNoFrameCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxErrUnknownNeighborCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxErrUnknownNeighborCountID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrUnknownNeighborCountID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxErrInvalidSrcAddrCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxErrInvalidSrcAddrCountID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrInvalidSrcAddrCountID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxErrSecCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxErrSecCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrSecCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxErrFcsCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxErrFcsCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrFcsCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRxErrOtherCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeRxErrOtherCountID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeRxErrOtherCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActiveTimestampWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeActiveTimestampID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeActiveTimestampID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePendingTimestampWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributePendingTimestampID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributePendingTimestampID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDelayWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeDelayID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeDelayID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSecurityPolicyWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeSecurityPolicyID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeSecurityPolicyID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeChannelPage0MaskWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeChannelPage0MaskID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeChannelPage0MaskID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOperationalDatasetComponentsWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeOperationalDatasetComponentsID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeOperationalDatasetComponentsID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActiveNetworkFaultsListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeActiveNetworkFaultsListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeActiveNetworkFaultsListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeGeneratedCommandListID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                     attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeGeneratedCommandListID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeAcceptedCommandListID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                     attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeAcceptedCommandListID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThreadNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterThreadNetworkDiagnosticsAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeThreadNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThreadNetworkDiagnosticsAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -8298,144 +8335,149 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBssidWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributeBssidID)
+                                          clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeBssidID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSecurityTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributeSecurityTypeID)
+                                          clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeSecurityTypeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeWiFiVersionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributeWiFiVersionID)
+                                          clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeWiFiVersionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeChannelNumberWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributeChannelNumberID)
+                                          clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeChannelNumberID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRssiWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributeRssiID)
+                                          clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeRssiID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBeaconLostCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributeBeaconLostCountID)
+                                          clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeBeaconLostCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBeaconRxCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributeBeaconRxCountID)
+                                          clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeBeaconRxCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePacketMulticastRxCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributePacketMulticastRxCountID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                     attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributePacketMulticastRxCountID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePacketMulticastTxCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributePacketMulticastTxCountID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                     attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributePacketMulticastTxCountID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePacketUnicastRxCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributePacketUnicastRxCountID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                     attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributePacketUnicastRxCountID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePacketUnicastTxCountWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributePacketUnicastTxCountID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                     attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributePacketUnicastTxCountID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentMaxRateWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributeCurrentMaxRateID)
+                                          clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeCurrentMaxRateID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOverrunCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributeOverrunCountID)
+                                          clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeOverrunCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributeGeneratedCommandListID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                     attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeGeneratedCommandListID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWiFiNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterWiFiNetworkDiagnosticsAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeWiFiNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkDiagnosticsAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -8544,112 +8586,114 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributePHYRateWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterEthernetNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterEthernetNetworkDiagnosticsAttributePHYRateID)
+                                          clusterID:@(MTRClusterIDTypeEthernetNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributePHYRateID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFullDuplexWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterEthernetNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterEthernetNetworkDiagnosticsAttributeFullDuplexID)
+                                          clusterID:@(MTRClusterIDTypeEthernetNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeFullDuplexID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePacketRxCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterEthernetNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterEthernetNetworkDiagnosticsAttributePacketRxCountID)
+                                          clusterID:@(MTRClusterIDTypeEthernetNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributePacketRxCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePacketTxCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterEthernetNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterEthernetNetworkDiagnosticsAttributePacketTxCountID)
+                                          clusterID:@(MTRClusterIDTypeEthernetNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributePacketTxCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTxErrCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterEthernetNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterEthernetNetworkDiagnosticsAttributeTxErrCountID)
+                                          clusterID:@(MTRClusterIDTypeEthernetNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeTxErrCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCollisionCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterEthernetNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterEthernetNetworkDiagnosticsAttributeCollisionCountID)
+                                          clusterID:@(MTRClusterIDTypeEthernetNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeCollisionCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOverrunCountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterEthernetNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterEthernetNetworkDiagnosticsAttributeOverrunCountID)
+                                          clusterID:@(MTRClusterIDTypeEthernetNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeOverrunCountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCarrierDetectWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterEthernetNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterEthernetNetworkDiagnosticsAttributeCarrierDetectID)
+                                          clusterID:@(MTRClusterIDTypeEthernetNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeCarrierDetectID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTimeSinceResetWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterEthernetNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterEthernetNetworkDiagnosticsAttributeTimeSinceResetID)
+                                          clusterID:@(MTRClusterIDTypeEthernetNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeTimeSinceResetID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterEthernetNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterEthernetNetworkDiagnosticsAttributeGeneratedCommandListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeEthernetNetworkDiagnosticsID)
+                        attributeID:@(MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeGeneratedCommandListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterEthernetNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterEthernetNetworkDiagnosticsAttributeAcceptedCommandListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeEthernetNetworkDiagnosticsID)
+                        attributeID:@(MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeAcceptedCommandListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterEthernetNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterEthernetNetworkDiagnosticsAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeEthernetNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterEthernetNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterEthernetNetworkDiagnosticsAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeEthernetNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterEthernetNetworkDiagnosticsID)
-                                        attributeID:@(MTRClusterEthernetNetworkDiagnosticsAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeEthernetNetworkDiagnosticsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterEthernetNetworkDiagnosticsAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -8701,32 +8745,32 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeVendorNameWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeVendorNameID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeVendorNameID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeVendorIDWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeVendorIDID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeVendorIDID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeProductNameWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeProductNameID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeProductNameID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNodeLabelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeNodeLabelID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeNodeLabelID)
                                              params:params];
 }
 
@@ -8742,8 +8786,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                  attributeID:@(MTRClusterBridgedDeviceBasicAttributeNodeLabelID)
+                                    clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeNodeLabelID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -8752,128 +8796,128 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeHardwareVersionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeHardwareVersionID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeHardwareVersionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeHardwareVersionStringWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeHardwareVersionStringID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeHardwareVersionStringID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSoftwareVersionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeSoftwareVersionID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeSoftwareVersionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSoftwareVersionStringWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeSoftwareVersionStringID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeSoftwareVersionStringID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeManufacturingDateWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeManufacturingDateID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeManufacturingDateID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePartNumberWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributePartNumberID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributePartNumberID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeProductURLWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeProductURLID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeProductURLID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeProductLabelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeProductLabelID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeProductLabelID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSerialNumberWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeSerialNumberID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeSerialNumberID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeReachableWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeReachableID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeReachableID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeUniqueIDWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeUniqueIDID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeUniqueIDID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBridgedDeviceBasicID)
-                                        attributeID:@(MTRClusterBridgedDeviceBasicAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeBridgedDeviceBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBridgedDeviceBasicAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -8906,64 +8950,64 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNumberOfPositionsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSwitchID)
-                                        attributeID:@(MTRClusterSwitchAttributeNumberOfPositionsID)
+                                          clusterID:@(MTRClusterIDTypeSwitchID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSwitchAttributeNumberOfPositionsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentPositionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSwitchID)
-                                        attributeID:@(MTRClusterSwitchAttributeCurrentPositionID)
+                                          clusterID:@(MTRClusterIDTypeSwitchID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSwitchAttributeCurrentPositionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMultiPressMaxWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSwitchID)
-                                        attributeID:@(MTRClusterSwitchAttributeMultiPressMaxID)
+                                          clusterID:@(MTRClusterIDTypeSwitchID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSwitchAttributeMultiPressMaxID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSwitchID)
-                                        attributeID:@(MTRClusterSwitchAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeSwitchID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSwitchAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSwitchID)
-                                        attributeID:@(MTRClusterSwitchAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeSwitchID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSwitchAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSwitchID)
-                                        attributeID:@(MTRClusterSwitchAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeSwitchID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSwitchAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSwitchID)
-                                        attributeID:@(MTRClusterSwitchAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeSwitchID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSwitchAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterSwitchID)
-                                        attributeID:@(MTRClusterSwitchAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeSwitchID)
+                                        attributeID:@(MTRAttributeIDTypeClusterSwitchAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -9164,64 +9208,67 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeWindowStatusWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAdministratorCommissioningID)
-                                        attributeID:@(MTRClusterAdministratorCommissioningAttributeWindowStatusID)
+                                          clusterID:@(MTRClusterIDTypeAdministratorCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAdministratorCommissioningAttributeWindowStatusID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAdminFabricIndexWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAdministratorCommissioningID)
-                                        attributeID:@(MTRClusterAdministratorCommissioningAttributeAdminFabricIndexID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeAdministratorCommissioningID)
+                                     attributeID:@(MTRAttributeIDTypeClusterAdministratorCommissioningAttributeAdminFabricIndexID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAdminVendorIdWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAdministratorCommissioningID)
-                                        attributeID:@(MTRClusterAdministratorCommissioningAttributeAdminVendorIdID)
+                                          clusterID:@(MTRClusterIDTypeAdministratorCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAdministratorCommissioningAttributeAdminVendorIdID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAdministratorCommissioningID)
-                                        attributeID:@(MTRClusterAdministratorCommissioningAttributeGeneratedCommandListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeAdministratorCommissioningID)
+                        attributeID:@(MTRAttributeIDTypeClusterAdministratorCommissioningAttributeGeneratedCommandListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAdministratorCommissioningID)
-                                        attributeID:@(MTRClusterAdministratorCommissioningAttributeAcceptedCommandListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeAdministratorCommissioningID)
+                        attributeID:@(MTRAttributeIDTypeClusterAdministratorCommissioningAttributeAcceptedCommandListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAdministratorCommissioningID)
-                                        attributeID:@(MTRClusterAdministratorCommissioningAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeAdministratorCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAdministratorCommissioningAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAdministratorCommissioningID)
-                                        attributeID:@(MTRClusterAdministratorCommissioningAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeAdministratorCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAdministratorCommissioningAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAdministratorCommissioningID)
-                                        attributeID:@(MTRClusterAdministratorCommissioningAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeAdministratorCommissioningID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAdministratorCommissioningAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -9680,88 +9727,90 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNOCsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOperationalCredentialsID)
-                                        attributeID:@(MTRClusterOperationalCredentialsAttributeNOCsID)
+                                          clusterID:@(MTRClusterIDTypeOperationalCredentialsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOperationalCredentialsAttributeNOCsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFabricsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOperationalCredentialsID)
-                                        attributeID:@(MTRClusterOperationalCredentialsAttributeFabricsID)
+                                          clusterID:@(MTRClusterIDTypeOperationalCredentialsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOperationalCredentialsAttributeFabricsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSupportedFabricsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOperationalCredentialsID)
-                                        attributeID:@(MTRClusterOperationalCredentialsAttributeSupportedFabricsID)
+                                          clusterID:@(MTRClusterIDTypeOperationalCredentialsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOperationalCredentialsAttributeSupportedFabricsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCommissionedFabricsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOperationalCredentialsID)
-                                        attributeID:@(MTRClusterOperationalCredentialsAttributeCommissionedFabricsID)
+                                          clusterID:@(MTRClusterIDTypeOperationalCredentialsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOperationalCredentialsAttributeCommissionedFabricsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTrustedRootCertificatesWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOperationalCredentialsID)
-                                        attributeID:@(MTRClusterOperationalCredentialsAttributeTrustedRootCertificatesID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeOperationalCredentialsID)
+                        attributeID:@(MTRAttributeIDTypeClusterOperationalCredentialsAttributeTrustedRootCertificatesID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentFabricIndexWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOperationalCredentialsID)
-                                        attributeID:@(MTRClusterOperationalCredentialsAttributeCurrentFabricIndexID)
+                                          clusterID:@(MTRClusterIDTypeOperationalCredentialsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOperationalCredentialsAttributeCurrentFabricIndexID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOperationalCredentialsID)
-                                        attributeID:@(MTRClusterOperationalCredentialsAttributeGeneratedCommandListID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeOperationalCredentialsID)
+                                     attributeID:@(MTRAttributeIDTypeClusterOperationalCredentialsAttributeGeneratedCommandListID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOperationalCredentialsID)
-                                        attributeID:@(MTRClusterOperationalCredentialsAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeOperationalCredentialsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOperationalCredentialsAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOperationalCredentialsID)
-                                        attributeID:@(MTRClusterOperationalCredentialsAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeOperationalCredentialsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOperationalCredentialsAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOperationalCredentialsID)
-                                        attributeID:@(MTRClusterOperationalCredentialsAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeOperationalCredentialsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOperationalCredentialsAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOperationalCredentialsID)
-                                        attributeID:@(MTRClusterOperationalCredentialsAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeOperationalCredentialsID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOperationalCredentialsAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -10158,8 +10207,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGroupKeyMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupKeyManagementID)
-                                        attributeID:@(MTRClusterGroupKeyManagementAttributeGroupKeyMapID)
+                                          clusterID:@(MTRClusterIDTypeGroupKeyManagementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupKeyManagementAttributeGroupKeyMapID)
                                              params:params];
 }
 
@@ -10175,8 +10224,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterGroupKeyManagementID)
-                                  attributeID:@(MTRClusterGroupKeyManagementAttributeGroupKeyMapID)
+                                    clusterID:@(MTRClusterIDTypeGroupKeyManagementID)
+                                  attributeID:@(MTRAttributeIDTypeClusterGroupKeyManagementAttributeGroupKeyMapID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -10185,64 +10234,64 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGroupTableWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupKeyManagementID)
-                                        attributeID:@(MTRClusterGroupKeyManagementAttributeGroupTableID)
+                                          clusterID:@(MTRClusterIDTypeGroupKeyManagementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupKeyManagementAttributeGroupTableID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxGroupsPerFabricWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupKeyManagementID)
-                                        attributeID:@(MTRClusterGroupKeyManagementAttributeMaxGroupsPerFabricID)
+                                          clusterID:@(MTRClusterIDTypeGroupKeyManagementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupKeyManagementAttributeMaxGroupsPerFabricID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxGroupKeysPerFabricWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupKeyManagementID)
-                                        attributeID:@(MTRClusterGroupKeyManagementAttributeMaxGroupKeysPerFabricID)
+                                          clusterID:@(MTRClusterIDTypeGroupKeyManagementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupKeyManagementAttributeMaxGroupKeysPerFabricID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupKeyManagementID)
-                                        attributeID:@(MTRClusterGroupKeyManagementAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeGroupKeyManagementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupKeyManagementAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupKeyManagementID)
-                                        attributeID:@(MTRClusterGroupKeyManagementAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeGroupKeyManagementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupKeyManagementAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupKeyManagementID)
-                                        attributeID:@(MTRClusterGroupKeyManagementAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeGroupKeyManagementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupKeyManagementAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupKeyManagementID)
-                                        attributeID:@(MTRClusterGroupKeyManagementAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeGroupKeyManagementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupKeyManagementAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterGroupKeyManagementID)
-                                        attributeID:@(MTRClusterGroupKeyManagementAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeGroupKeyManagementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterGroupKeyManagementAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -10325,48 +10374,48 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLabelListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFixedLabelID)
-                                        attributeID:@(MTRClusterFixedLabelAttributeLabelListID)
+                                          clusterID:@(MTRClusterIDTypeFixedLabelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFixedLabelAttributeLabelListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFixedLabelID)
-                                        attributeID:@(MTRClusterFixedLabelAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeFixedLabelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFixedLabelAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFixedLabelID)
-                                        attributeID:@(MTRClusterFixedLabelAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeFixedLabelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFixedLabelAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFixedLabelID)
-                                        attributeID:@(MTRClusterFixedLabelAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeFixedLabelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFixedLabelAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFixedLabelID)
-                                        attributeID:@(MTRClusterFixedLabelAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeFixedLabelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFixedLabelAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFixedLabelID)
-                                        attributeID:@(MTRClusterFixedLabelAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeFixedLabelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFixedLabelAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -10399,8 +10448,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLabelListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUserLabelID)
-                                        attributeID:@(MTRClusterUserLabelAttributeLabelListID)
+                                          clusterID:@(MTRClusterIDTypeUserLabelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUserLabelAttributeLabelListID)
                                              params:params];
 }
 
@@ -10416,8 +10465,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUserLabelID)
-                                  attributeID:@(MTRClusterUserLabelAttributeLabelListID)
+                                    clusterID:@(MTRClusterIDTypeUserLabelID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUserLabelAttributeLabelListID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -10426,40 +10475,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUserLabelID)
-                                        attributeID:@(MTRClusterUserLabelAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeUserLabelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUserLabelAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUserLabelID)
-                                        attributeID:@(MTRClusterUserLabelAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeUserLabelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUserLabelAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUserLabelID)
-                                        attributeID:@(MTRClusterUserLabelAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeUserLabelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUserLabelAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUserLabelID)
-                                        attributeID:@(MTRClusterUserLabelAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeUserLabelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUserLabelAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUserLabelID)
-                                        attributeID:@(MTRClusterUserLabelAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeUserLabelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUserLabelAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -10492,48 +10541,48 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeStateValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBooleanStateID)
-                                        attributeID:@(MTRClusterBooleanStateAttributeStateValueID)
+                                          clusterID:@(MTRClusterIDTypeBooleanStateID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBooleanStateAttributeStateValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBooleanStateID)
-                                        attributeID:@(MTRClusterBooleanStateAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeBooleanStateID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBooleanStateAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBooleanStateID)
-                                        attributeID:@(MTRClusterBooleanStateAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeBooleanStateID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBooleanStateAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBooleanStateID)
-                                        attributeID:@(MTRClusterBooleanStateAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeBooleanStateID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBooleanStateAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBooleanStateID)
-                                        attributeID:@(MTRClusterBooleanStateAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeBooleanStateID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBooleanStateAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBooleanStateID)
-                                        attributeID:@(MTRClusterBooleanStateAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeBooleanStateID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBooleanStateAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -10615,40 +10664,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeDescriptionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterModeSelectID)
-                                        attributeID:@(MTRClusterModeSelectAttributeDescriptionID)
+                                          clusterID:@(MTRClusterIDTypeModeSelectID)
+                                        attributeID:@(MTRAttributeIDTypeClusterModeSelectAttributeDescriptionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeStandardNamespaceWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterModeSelectID)
-                                        attributeID:@(MTRClusterModeSelectAttributeStandardNamespaceID)
+                                          clusterID:@(MTRClusterIDTypeModeSelectID)
+                                        attributeID:@(MTRAttributeIDTypeClusterModeSelectAttributeStandardNamespaceID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSupportedModesWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterModeSelectID)
-                                        attributeID:@(MTRClusterModeSelectAttributeSupportedModesID)
+                                          clusterID:@(MTRClusterIDTypeModeSelectID)
+                                        attributeID:@(MTRAttributeIDTypeClusterModeSelectAttributeSupportedModesID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentModeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterModeSelectID)
-                                        attributeID:@(MTRClusterModeSelectAttributeCurrentModeID)
+                                          clusterID:@(MTRClusterIDTypeModeSelectID)
+                                        attributeID:@(MTRAttributeIDTypeClusterModeSelectAttributeCurrentModeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeStartUpModeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterModeSelectID)
-                                        attributeID:@(MTRClusterModeSelectAttributeStartUpModeID)
+                                          clusterID:@(MTRClusterIDTypeModeSelectID)
+                                        attributeID:@(MTRAttributeIDTypeClusterModeSelectAttributeStartUpModeID)
                                              params:params];
 }
 
@@ -10664,8 +10713,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterModeSelectID)
-                                  attributeID:@(MTRClusterModeSelectAttributeStartUpModeID)
+                                    clusterID:@(MTRClusterIDTypeModeSelectID)
+                                  attributeID:@(MTRAttributeIDTypeClusterModeSelectAttributeStartUpModeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -10674,8 +10723,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOnModeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterModeSelectID)
-                                        attributeID:@(MTRClusterModeSelectAttributeOnModeID)
+                                          clusterID:@(MTRClusterIDTypeModeSelectID)
+                                        attributeID:@(MTRAttributeIDTypeClusterModeSelectAttributeOnModeID)
                                              params:params];
 }
 
@@ -10691,8 +10740,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterModeSelectID)
-                                  attributeID:@(MTRClusterModeSelectAttributeOnModeID)
+                                    clusterID:@(MTRClusterIDTypeModeSelectID)
+                                  attributeID:@(MTRAttributeIDTypeClusterModeSelectAttributeOnModeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -10701,40 +10750,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterModeSelectID)
-                                        attributeID:@(MTRClusterModeSelectAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeModeSelectID)
+                                        attributeID:@(MTRAttributeIDTypeClusterModeSelectAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterModeSelectID)
-                                        attributeID:@(MTRClusterModeSelectAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeModeSelectID)
+                                        attributeID:@(MTRAttributeIDTypeClusterModeSelectAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterModeSelectID)
-                                        attributeID:@(MTRClusterModeSelectAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeModeSelectID)
+                                        attributeID:@(MTRAttributeIDTypeClusterModeSelectAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterModeSelectID)
-                                        attributeID:@(MTRClusterModeSelectAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeModeSelectID)
+                                        attributeID:@(MTRAttributeIDTypeClusterModeSelectAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterModeSelectID)
-                                        attributeID:@(MTRClusterModeSelectAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeModeSelectID)
+                                        attributeID:@(MTRAttributeIDTypeClusterModeSelectAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -11763,40 +11812,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLockStateWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeLockStateID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeLockStateID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLockTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeLockTypeID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeLockTypeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActuatorEnabledWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeActuatorEnabledID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeActuatorEnabledID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDoorStateWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeDoorStateID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeDoorStateID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDoorOpenEventsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeDoorOpenEventsID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeDoorOpenEventsID)
                                              params:params];
 }
 
@@ -11812,8 +11861,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeDoorOpenEventsID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeDoorOpenEventsID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -11822,8 +11871,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeDoorClosedEventsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeDoorClosedEventsID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeDoorClosedEventsID)
                                              params:params];
 }
 
@@ -11839,8 +11888,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeDoorClosedEventsID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeDoorClosedEventsID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -11849,8 +11898,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOpenPeriodWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeOpenPeriodID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeOpenPeriodID)
                                              params:params];
 }
 
@@ -11866,8 +11915,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeOpenPeriodID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeOpenPeriodID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -11876,104 +11925,107 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNumberOfTotalUsersSupportedWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeNumberOfTotalUsersSupportedID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeNumberOfTotalUsersSupportedID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNumberOfPINUsersSupportedWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeNumberOfPINUsersSupportedID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeNumberOfPINUsersSupportedID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNumberOfRFIDUsersSupportedWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeNumberOfRFIDUsersSupportedID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeNumberOfRFIDUsersSupportedID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNumberOfWeekDaySchedulesSupportedPerUserWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeNumberOfWeekDaySchedulesSupportedPerUserID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeNumberOfWeekDaySchedulesSupportedPerUserID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNumberOfYearDaySchedulesSupportedPerUserWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeNumberOfYearDaySchedulesSupportedPerUserID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeNumberOfYearDaySchedulesSupportedPerUserID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNumberOfHolidaySchedulesSupportedWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeNumberOfHolidaySchedulesSupportedID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeNumberOfHolidaySchedulesSupportedID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxPINCodeLengthWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeMaxPINCodeLengthID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeMaxPINCodeLengthID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinPINCodeLengthWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeMinPINCodeLengthID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeMinPINCodeLengthID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxRFIDCodeLengthWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeMaxRFIDCodeLengthID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeMaxRFIDCodeLengthID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinRFIDCodeLengthWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeMinRFIDCodeLengthID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeMinRFIDCodeLengthID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCredentialRulesSupportWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeCredentialRulesSupportID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeCredentialRulesSupportID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNumberOfCredentialsSupportedPerUserWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeNumberOfCredentialsSupportedPerUserID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeDoorLockID)
+                                     attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeNumberOfCredentialsSupportedPerUserID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLanguageWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeLanguageID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeLanguageID)
                                              params:params];
 }
 
@@ -11989,8 +12041,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeLanguageID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeLanguageID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -11999,8 +12051,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLEDSettingsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeLEDSettingsID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeLEDSettingsID)
                                              params:params];
 }
 
@@ -12016,8 +12068,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeLEDSettingsID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeLEDSettingsID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -12026,8 +12078,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeAutoRelockTimeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeAutoRelockTimeID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeAutoRelockTimeID)
                                              params:params];
 }
 
@@ -12043,8 +12095,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeAutoRelockTimeID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeAutoRelockTimeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -12053,8 +12105,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeSoundVolumeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeSoundVolumeID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeSoundVolumeID)
                                              params:params];
 }
 
@@ -12070,8 +12122,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeSoundVolumeID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeSoundVolumeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -12080,8 +12132,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOperatingModeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeOperatingModeID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeOperatingModeID)
                                              params:params];
 }
 
@@ -12097,8 +12149,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeOperatingModeID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeOperatingModeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -12107,24 +12159,24 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeSupportedOperatingModesWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeSupportedOperatingModesID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeSupportedOperatingModesID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDefaultConfigurationRegisterWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeDefaultConfigurationRegisterID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeDefaultConfigurationRegisterID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeEnableLocalProgrammingWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeEnableLocalProgrammingID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeEnableLocalProgrammingID)
                                              params:params];
 }
 
@@ -12142,8 +12194,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeEnableLocalProgrammingID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeEnableLocalProgrammingID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -12152,8 +12204,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeEnableOneTouchLockingWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeEnableOneTouchLockingID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeEnableOneTouchLockingID)
                                              params:params];
 }
 
@@ -12171,8 +12223,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeEnableOneTouchLockingID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeEnableOneTouchLockingID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -12181,8 +12233,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeEnableInsideStatusLEDWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeEnableInsideStatusLEDID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeEnableInsideStatusLEDID)
                                              params:params];
 }
 
@@ -12200,8 +12252,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeEnableInsideStatusLEDID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeEnableInsideStatusLEDID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -12210,8 +12262,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeEnablePrivacyModeButtonWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeEnablePrivacyModeButtonID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeEnablePrivacyModeButtonID)
                                              params:params];
 }
 
@@ -12229,8 +12281,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeEnablePrivacyModeButtonID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeEnablePrivacyModeButtonID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -12239,8 +12291,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLocalProgrammingFeaturesWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeLocalProgrammingFeaturesID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeLocalProgrammingFeaturesID)
                                              params:params];
 }
 
@@ -12258,8 +12310,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeLocalProgrammingFeaturesID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeLocalProgrammingFeaturesID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -12268,8 +12320,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeWrongCodeEntryLimitWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeWrongCodeEntryLimitID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeWrongCodeEntryLimitID)
                                              params:params];
 }
 
@@ -12285,8 +12337,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeWrongCodeEntryLimitID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeWrongCodeEntryLimitID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -12295,8 +12347,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeUserCodeTemporaryDisableTimeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeUserCodeTemporaryDisableTimeID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeUserCodeTemporaryDisableTimeID)
                                              params:params];
 }
 
@@ -12314,8 +12366,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeUserCodeTemporaryDisableTimeID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeUserCodeTemporaryDisableTimeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -12324,8 +12376,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeSendPINOverTheAirWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeSendPINOverTheAirID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeSendPINOverTheAirID)
                                              params:params];
 }
 
@@ -12341,8 +12393,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeSendPINOverTheAirID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeSendPINOverTheAirID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -12351,8 +12403,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeRequirePINforRemoteOperationWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeRequirePINforRemoteOperationID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeRequirePINforRemoteOperationID)
                                              params:params];
 }
 
@@ -12370,8 +12422,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeRequirePINforRemoteOperationID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeRequirePINforRemoteOperationID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -12380,8 +12432,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeExpiringUserTimeoutWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeExpiringUserTimeoutID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeExpiringUserTimeoutID)
                                              params:params];
 }
 
@@ -12397,8 +12449,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterDoorLockID)
-                                  attributeID:@(MTRClusterDoorLockAttributeExpiringUserTimeoutID)
+                                    clusterID:@(MTRClusterIDTypeDoorLockID)
+                                  attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeExpiringUserTimeoutID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -12407,40 +12459,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterDoorLockID)
-                                        attributeID:@(MTRClusterDoorLockAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeDoorLockID)
+                                        attributeID:@(MTRAttributeIDTypeClusterDoorLockAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -13045,168 +13097,174 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeTypeID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeTypeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePhysicalClosedLimitLiftWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributePhysicalClosedLimitLiftID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributePhysicalClosedLimitLiftID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePhysicalClosedLimitTiltWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributePhysicalClosedLimitTiltID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributePhysicalClosedLimitTiltID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentPositionLiftWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeCurrentPositionLiftID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionLiftID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentPositionTiltWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeCurrentPositionTiltID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionTiltID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNumberOfActuationsLiftWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeNumberOfActuationsLiftID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeNumberOfActuationsLiftID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNumberOfActuationsTiltWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeNumberOfActuationsTiltID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeNumberOfActuationsTiltID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeConfigStatusWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeConfigStatusID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeConfigStatusID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentPositionLiftPercentageWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeCurrentPositionLiftPercentageID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                     attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionLiftPercentageID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentPositionTiltPercentageWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeCurrentPositionTiltPercentageID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                     attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionTiltPercentageID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOperationalStatusWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeOperationalStatusID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeOperationalStatusID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTargetPositionLiftPercent100thsWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeTargetPositionLiftPercent100thsID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeTargetPositionLiftPercent100thsID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTargetPositionTiltPercent100thsWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeTargetPositionTiltPercent100thsID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeTargetPositionTiltPercent100thsID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeEndProductTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeEndProductTypeID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeEndProductTypeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentPositionLiftPercent100thsWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeCurrentPositionLiftPercent100thsID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionLiftPercent100thsID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentPositionTiltPercent100thsWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeCurrentPositionTiltPercent100thsID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeCurrentPositionTiltPercent100thsID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeInstalledOpenLimitLiftWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeInstalledOpenLimitLiftID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeInstalledOpenLimitLiftID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeInstalledClosedLimitLiftWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeInstalledClosedLimitLiftID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeInstalledClosedLimitLiftID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeInstalledOpenLimitTiltWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeInstalledOpenLimitTiltID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeInstalledOpenLimitTiltID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeInstalledClosedLimitTiltWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeInstalledClosedLimitTiltID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeInstalledClosedLimitTiltID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeModeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeModeID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeModeID)
                                              params:params];
 }
 
@@ -13222,8 +13280,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterWindowCoveringID)
-                                  attributeID:@(MTRClusterWindowCoveringAttributeModeID)
+                                    clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                  attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeModeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -13232,48 +13290,48 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeSafetyStatusWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeSafetyStatusID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeSafetyStatusID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWindowCoveringID)
-                                        attributeID:@(MTRClusterWindowCoveringAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeWindowCoveringID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWindowCoveringAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -13509,32 +13567,32 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBarrierMovingStateWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeBarrierMovingStateID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierMovingStateID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBarrierSafetyStatusWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeBarrierSafetyStatusID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierSafetyStatusID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBarrierCapabilitiesWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeBarrierCapabilitiesID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCapabilitiesID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBarrierOpenEventsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeBarrierOpenEventsID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierOpenEventsID)
                                              params:params];
 }
 
@@ -13550,8 +13608,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBarrierControlID)
-                                  attributeID:@(MTRClusterBarrierControlAttributeBarrierOpenEventsID)
+                                    clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierOpenEventsID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -13560,8 +13618,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBarrierCloseEventsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeBarrierCloseEventsID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCloseEventsID)
                                              params:params];
 }
 
@@ -13577,8 +13635,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBarrierControlID)
-                                  attributeID:@(MTRClusterBarrierControlAttributeBarrierCloseEventsID)
+                                    clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCloseEventsID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -13587,8 +13645,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBarrierCommandOpenEventsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeBarrierCommandOpenEventsID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCommandOpenEventsID)
                                              params:params];
 }
 
@@ -13606,8 +13664,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBarrierControlID)
-                                  attributeID:@(MTRClusterBarrierControlAttributeBarrierCommandOpenEventsID)
+                                    clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCommandOpenEventsID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -13616,8 +13674,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBarrierCommandCloseEventsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeBarrierCommandCloseEventsID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCommandCloseEventsID)
                                              params:params];
 }
 
@@ -13635,8 +13693,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBarrierControlID)
-                                  attributeID:@(MTRClusterBarrierControlAttributeBarrierCommandCloseEventsID)
+                                    clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierCommandCloseEventsID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -13645,8 +13703,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBarrierOpenPeriodWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeBarrierOpenPeriodID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierOpenPeriodID)
                                              params:params];
 }
 
@@ -13662,8 +13720,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBarrierControlID)
-                                  attributeID:@(MTRClusterBarrierControlAttributeBarrierOpenPeriodID)
+                                    clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierOpenPeriodID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -13672,8 +13730,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBarrierClosePeriodWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeBarrierClosePeriodID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierClosePeriodID)
                                              params:params];
 }
 
@@ -13689,8 +13747,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBarrierControlID)
-                                  attributeID:@(MTRClusterBarrierControlAttributeBarrierClosePeriodID)
+                                    clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierClosePeriodID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -13699,48 +13757,48 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBarrierPositionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeBarrierPositionID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeBarrierPositionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBarrierControlID)
-                                        attributeID:@(MTRClusterBarrierControlAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeBarrierControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBarrierControlAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -13802,153 +13860,160 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMaxPressureWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeMaxPressureID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxPressureID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxSpeedWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeMaxSpeedID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxSpeedID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxFlowWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeMaxFlowID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxFlowID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinConstPressureWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeMinConstPressureID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                     attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinConstPressureID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxConstPressureWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeMaxConstPressureID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                     attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxConstPressureID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinCompPressureWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeMinCompPressureID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                     attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinCompPressureID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxCompPressureWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeMaxCompPressureID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                     attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxCompPressureID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinConstSpeedWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeMinConstSpeedID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinConstSpeedID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxConstSpeedWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeMaxConstSpeedID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxConstSpeedID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinConstFlowWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeMinConstFlowID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinConstFlowID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxConstFlowWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeMaxConstFlowID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxConstFlowID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinConstTempWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeMinConstTempID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMinConstTempID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxConstTempWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeMaxConstTempID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeMaxConstTempID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePumpStatusWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributePumpStatusID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributePumpStatusID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeEffectiveOperationModeWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeEffectiveOperationModeID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeEffectiveOperationModeID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeEffectiveControlModeWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeEffectiveControlModeID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeEffectiveControlModeID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCapacityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeCapacityID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeCapacityID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSpeedWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeSpeedID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeSpeedID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLifetimeRunningHoursWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeLifetimeRunningHoursID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeLifetimeRunningHoursID)
+                             params:params];
 }
 
 - (void)writeAttributeLifetimeRunningHoursWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -13963,8 +14028,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                  attributeID:@(MTRClusterPumpConfigurationAndControlAttributeLifetimeRunningHoursID)
+                                    clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeLifetimeRunningHoursID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -13973,17 +14038,18 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributePowerWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributePowerID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributePowerID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLifetimeEnergyConsumedWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeLifetimeEnergyConsumedID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeLifetimeEnergyConsumedID)
+                             params:params];
 }
 
 - (void)writeAttributeLifetimeEnergyConsumedWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -13999,19 +14065,20 @@ using chip::SessionHandle;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                  attributeID:@(MTRClusterPumpConfigurationAndControlAttributeLifetimeEnergyConsumedID)
-                                        value:dataValueDictionary
-                        expectedValueInterval:expectedValueIntervalMs
-                            timedWriteTimeout:timedWriteTimeout];
+    [self.device
+        writeAttributeWithEndpointID:@(_endpoint)
+                           clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                         attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeLifetimeEnergyConsumedID)
+                               value:dataValueDictionary
+               expectedValueInterval:expectedValueIntervalMs
+                   timedWriteTimeout:timedWriteTimeout];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOperationModeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeOperationModeID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeOperationModeID)
                                              params:params];
 }
 
@@ -14027,8 +14094,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                  attributeID:@(MTRClusterPumpConfigurationAndControlAttributeOperationModeID)
+                                    clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeOperationModeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14037,8 +14104,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeControlModeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeControlModeID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeControlModeID)
                                              params:params];
 }
 
@@ -14054,8 +14121,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                  attributeID:@(MTRClusterPumpConfigurationAndControlAttributeControlModeID)
+                                    clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeControlModeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14063,42 +14130,45 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeGeneratedCommandListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeGeneratedCommandListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeAcceptedCommandListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeAcceptedCommandListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPumpConfigurationAndControlID)
-                                        attributeID:@(MTRClusterPumpConfigurationAndControlAttributeClusterRevisionID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypePumpConfigurationAndControlID)
+                                     attributeID:@(MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeClusterRevisionID)
+                                          params:params];
 }
 
 @end
@@ -14373,80 +14443,80 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLocalTemperatureWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeLocalTemperatureID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeLocalTemperatureID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOutdoorTemperatureWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeOutdoorTemperatureID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeOutdoorTemperatureID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOccupancyWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeOccupancyID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeOccupancyID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAbsMinHeatSetpointLimitWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeAbsMinHeatSetpointLimitID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeAbsMinHeatSetpointLimitID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAbsMaxHeatSetpointLimitWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeAbsMaxHeatSetpointLimitID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeAbsMaxHeatSetpointLimitID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAbsMinCoolSetpointLimitWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeAbsMinCoolSetpointLimitID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeAbsMinCoolSetpointLimitID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAbsMaxCoolSetpointLimitWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeAbsMaxCoolSetpointLimitID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeAbsMaxCoolSetpointLimitID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePICoolingDemandWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributePICoolingDemandID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributePICoolingDemandID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePIHeatingDemandWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributePIHeatingDemandID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributePIHeatingDemandID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeHVACSystemTypeConfigurationWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeHVACSystemTypeConfigurationID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeHVACSystemTypeConfigurationID)
                                              params:params];
 }
 
@@ -14464,8 +14534,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeHVACSystemTypeConfigurationID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeHVACSystemTypeConfigurationID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14474,8 +14544,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLocalTemperatureCalibrationWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeLocalTemperatureCalibrationID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeLocalTemperatureCalibrationID)
                                              params:params];
 }
 
@@ -14493,8 +14563,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeLocalTemperatureCalibrationID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeLocalTemperatureCalibrationID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14503,8 +14573,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOccupiedCoolingSetpointWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeOccupiedCoolingSetpointID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeOccupiedCoolingSetpointID)
                                              params:params];
 }
 
@@ -14522,8 +14592,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeOccupiedCoolingSetpointID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeOccupiedCoolingSetpointID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14532,8 +14602,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOccupiedHeatingSetpointWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeOccupiedHeatingSetpointID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeOccupiedHeatingSetpointID)
                                              params:params];
 }
 
@@ -14551,8 +14621,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeOccupiedHeatingSetpointID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeOccupiedHeatingSetpointID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14561,8 +14631,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeUnoccupiedCoolingSetpointWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeUnoccupiedCoolingSetpointID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedCoolingSetpointID)
                                              params:params];
 }
 
@@ -14580,8 +14650,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeUnoccupiedCoolingSetpointID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedCoolingSetpointID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14590,8 +14660,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeUnoccupiedHeatingSetpointWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeUnoccupiedHeatingSetpointID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedHeatingSetpointID)
                                              params:params];
 }
 
@@ -14609,8 +14679,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeUnoccupiedHeatingSetpointID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedHeatingSetpointID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14619,8 +14689,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMinHeatSetpointLimitWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeMinHeatSetpointLimitID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeMinHeatSetpointLimitID)
                                              params:params];
 }
 
@@ -14636,8 +14706,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeMinHeatSetpointLimitID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeMinHeatSetpointLimitID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14646,8 +14716,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMaxHeatSetpointLimitWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeMaxHeatSetpointLimitID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeMaxHeatSetpointLimitID)
                                              params:params];
 }
 
@@ -14663,8 +14733,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeMaxHeatSetpointLimitID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeMaxHeatSetpointLimitID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14673,8 +14743,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMinCoolSetpointLimitWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeMinCoolSetpointLimitID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeMinCoolSetpointLimitID)
                                              params:params];
 }
 
@@ -14690,8 +14760,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeMinCoolSetpointLimitID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeMinCoolSetpointLimitID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14700,8 +14770,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMaxCoolSetpointLimitWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeMaxCoolSetpointLimitID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeMaxCoolSetpointLimitID)
                                              params:params];
 }
 
@@ -14717,8 +14787,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeMaxCoolSetpointLimitID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeMaxCoolSetpointLimitID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14727,8 +14797,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMinSetpointDeadBandWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeMinSetpointDeadBandID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeMinSetpointDeadBandID)
                                              params:params];
 }
 
@@ -14744,8 +14814,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeMinSetpointDeadBandID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeMinSetpointDeadBandID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14754,8 +14824,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeRemoteSensingWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeRemoteSensingID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeRemoteSensingID)
                                              params:params];
 }
 
@@ -14771,8 +14841,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeRemoteSensingID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeRemoteSensingID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14781,8 +14851,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeControlSequenceOfOperationWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeControlSequenceOfOperationID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeControlSequenceOfOperationID)
                                              params:params];
 }
 
@@ -14800,8 +14870,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeControlSequenceOfOperationID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeControlSequenceOfOperationID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14810,8 +14880,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeSystemModeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeSystemModeID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeSystemModeID)
                                              params:params];
 }
 
@@ -14827,8 +14897,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeSystemModeID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeSystemModeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14837,40 +14907,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeThermostatRunningModeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeThermostatRunningModeID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeThermostatRunningModeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeStartOfWeekWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeStartOfWeekID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeStartOfWeekID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNumberOfWeeklyTransitionsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeNumberOfWeeklyTransitionsID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeNumberOfWeeklyTransitionsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNumberOfDailyTransitionsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeNumberOfDailyTransitionsID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeNumberOfDailyTransitionsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTemperatureSetpointHoldWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeTemperatureSetpointHoldID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeTemperatureSetpointHoldID)
                                              params:params];
 }
 
@@ -14888,8 +14958,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeTemperatureSetpointHoldID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeTemperatureSetpointHoldID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14898,8 +14968,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeTemperatureSetpointHoldDurationWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeTemperatureSetpointHoldDurationID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeTemperatureSetpointHoldDurationID)
                                              params:params];
 }
 
@@ -14917,8 +14987,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeTemperatureSetpointHoldDurationID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeTemperatureSetpointHoldDurationID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14926,10 +14996,11 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeThermostatProgrammingOperationModeWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeThermostatProgrammingOperationModeID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeThermostatID)
+                                     attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeThermostatProgrammingOperationModeID)
+                                          params:params];
 }
 
 - (void)writeAttributeThermostatProgrammingOperationModeWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -14946,8 +15017,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeThermostatProgrammingOperationModeID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeThermostatProgrammingOperationModeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -14956,40 +15027,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeThermostatRunningStateWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeThermostatRunningStateID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeThermostatRunningStateID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSetpointChangeSourceWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeSetpointChangeSourceID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeSetpointChangeSourceID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSetpointChangeAmountWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeSetpointChangeAmountID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeSetpointChangeAmountID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSetpointChangeSourceTimestampWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeSetpointChangeSourceTimestampID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeSetpointChangeSourceTimestampID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOccupiedSetbackWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeOccupiedSetbackID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeOccupiedSetbackID)
                                              params:params];
 }
 
@@ -15005,8 +15076,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeOccupiedSetbackID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeOccupiedSetbackID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15015,24 +15086,24 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOccupiedSetbackMinWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeOccupiedSetbackMinID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeOccupiedSetbackMinID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOccupiedSetbackMaxWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeOccupiedSetbackMaxID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeOccupiedSetbackMaxID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeUnoccupiedSetbackWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeUnoccupiedSetbackID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedSetbackID)
                                              params:params];
 }
 
@@ -15048,8 +15119,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeUnoccupiedSetbackID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedSetbackID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15058,24 +15129,24 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeUnoccupiedSetbackMinWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeUnoccupiedSetbackMinID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedSetbackMinID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeUnoccupiedSetbackMaxWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeUnoccupiedSetbackMaxID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeUnoccupiedSetbackMaxID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeEmergencyHeatDeltaWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeEmergencyHeatDeltaID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeEmergencyHeatDeltaID)
                                              params:params];
 }
 
@@ -15091,8 +15162,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeEmergencyHeatDeltaID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeEmergencyHeatDeltaID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15101,8 +15172,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeACTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeACTypeID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACTypeID)
                                              params:params];
 }
 
@@ -15118,8 +15189,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeACTypeID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACTypeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15128,8 +15199,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeACCapacityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeACCapacityID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACCapacityID)
                                              params:params];
 }
 
@@ -15145,8 +15216,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeACCapacityID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACCapacityID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15155,8 +15226,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeACRefrigerantTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeACRefrigerantTypeID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACRefrigerantTypeID)
                                              params:params];
 }
 
@@ -15172,8 +15243,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeACRefrigerantTypeID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACRefrigerantTypeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15182,8 +15253,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeACCompressorTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeACCompressorTypeID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACCompressorTypeID)
                                              params:params];
 }
 
@@ -15199,8 +15270,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeACCompressorTypeID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACCompressorTypeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15209,8 +15280,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeACErrorCodeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeACErrorCodeID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACErrorCodeID)
                                              params:params];
 }
 
@@ -15226,8 +15297,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeACErrorCodeID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACErrorCodeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15236,8 +15307,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeACLouverPositionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeACLouverPositionID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACLouverPositionID)
                                              params:params];
 }
 
@@ -15253,8 +15324,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeACLouverPositionID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACLouverPositionID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15263,16 +15334,16 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeACCoilTemperatureWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeACCoilTemperatureID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACCoilTemperatureID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeACCapacityformatWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeACCapacityformatID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACCapacityformatID)
                                              params:params];
 }
 
@@ -15288,8 +15359,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatID)
-                                  attributeID:@(MTRClusterThermostatAttributeACCapacityformatID)
+                                    clusterID:@(MTRClusterIDTypeThermostatID)
+                                  attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeACCapacityformatID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15298,40 +15369,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatID)
-                                        attributeID:@(MTRClusterThermostatAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeThermostatID)
+                                        attributeID:@(MTRAttributeIDTypeClusterThermostatAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -15418,8 +15489,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeFanModeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributeFanModeID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeFanModeID)
                                              params:params];
 }
 
@@ -15435,8 +15506,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterFanControlID)
-                                  attributeID:@(MTRClusterFanControlAttributeFanModeID)
+                                    clusterID:@(MTRClusterIDTypeFanControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeFanModeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15445,8 +15516,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeFanModeSequenceWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributeFanModeSequenceID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeFanModeSequenceID)
                                              params:params];
 }
 
@@ -15462,8 +15533,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterFanControlID)
-                                  attributeID:@(MTRClusterFanControlAttributeFanModeSequenceID)
+                                    clusterID:@(MTRClusterIDTypeFanControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeFanModeSequenceID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15472,8 +15543,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributePercentSettingWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributePercentSettingID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributePercentSettingID)
                                              params:params];
 }
 
@@ -15489,8 +15560,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterFanControlID)
-                                  attributeID:@(MTRClusterFanControlAttributePercentSettingID)
+                                    clusterID:@(MTRClusterIDTypeFanControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterFanControlAttributePercentSettingID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15499,24 +15570,24 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributePercentCurrentWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributePercentCurrentID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributePercentCurrentID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSpeedMaxWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributeSpeedMaxID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeSpeedMaxID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSpeedSettingWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributeSpeedSettingID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeSpeedSettingID)
                                              params:params];
 }
 
@@ -15532,8 +15603,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterFanControlID)
-                                  attributeID:@(MTRClusterFanControlAttributeSpeedSettingID)
+                                    clusterID:@(MTRClusterIDTypeFanControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeSpeedSettingID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15542,24 +15613,24 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeSpeedCurrentWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributeSpeedCurrentID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeSpeedCurrentID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRockSupportWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributeRockSupportID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeRockSupportID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRockSettingWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributeRockSettingID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeRockSettingID)
                                              params:params];
 }
 
@@ -15575,8 +15646,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterFanControlID)
-                                  attributeID:@(MTRClusterFanControlAttributeRockSettingID)
+                                    clusterID:@(MTRClusterIDTypeFanControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeRockSettingID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15585,16 +15656,16 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeWindSupportWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributeWindSupportID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeWindSupportID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeWindSettingWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributeWindSettingID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeWindSettingID)
                                              params:params];
 }
 
@@ -15610,8 +15681,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterFanControlID)
-                                  attributeID:@(MTRClusterFanControlAttributeWindSettingID)
+                                    clusterID:@(MTRClusterIDTypeFanControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeWindSettingID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -15620,40 +15691,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFanControlID)
-                                        attributeID:@(MTRClusterFanControlAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeFanControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFanControlAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -15685,11 +15756,12 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeTemperatureDisplayModeWithParams:(MTRReadParams * _Nullable)params
 {
-    return
-        [self.device readAttributeWithEndpointID:@(_endpoint)
-                                       clusterID:@(MTRClusterThermostatUserInterfaceConfigurationID)
-                                     attributeID:@(MTRClusterThermostatUserInterfaceConfigurationAttributeTemperatureDisplayModeID)
-                                          params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThermostatUserInterfaceConfigurationID)
+                        attributeID:
+                            @(MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeTemperatureDisplayModeID)
+                             params:params];
 }
 
 - (void)writeAttributeTemperatureDisplayModeWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -15705,20 +15777,23 @@ using chip::SessionHandle;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatUserInterfaceConfigurationID)
-                                  attributeID:@(MTRClusterThermostatUserInterfaceConfigurationAttributeTemperatureDisplayModeID)
-                                        value:dataValueDictionary
-                        expectedValueInterval:expectedValueIntervalMs
-                            timedWriteTimeout:timedWriteTimeout];
+    [self.device
+        writeAttributeWithEndpointID:@(_endpoint)
+                           clusterID:@(MTRClusterIDTypeThermostatUserInterfaceConfigurationID)
+                         attributeID:
+                             @(MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeTemperatureDisplayModeID)
+                               value:dataValueDictionary
+               expectedValueInterval:expectedValueIntervalMs
+                   timedWriteTimeout:timedWriteTimeout];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeKeypadLockoutWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatUserInterfaceConfigurationID)
-                                        attributeID:@(MTRClusterThermostatUserInterfaceConfigurationAttributeKeypadLockoutID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThermostatUserInterfaceConfigurationID)
+                        attributeID:@(MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeKeypadLockoutID)
+                             params:params];
 }
 
 - (void)writeAttributeKeypadLockoutWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -15732,20 +15807,22 @@ using chip::SessionHandle;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterThermostatUserInterfaceConfigurationID)
-                                  attributeID:@(MTRClusterThermostatUserInterfaceConfigurationAttributeKeypadLockoutID)
-                                        value:dataValueDictionary
-                        expectedValueInterval:expectedValueIntervalMs
-                            timedWriteTimeout:timedWriteTimeout];
+    [self.device
+        writeAttributeWithEndpointID:@(_endpoint)
+                           clusterID:@(MTRClusterIDTypeThermostatUserInterfaceConfigurationID)
+                         attributeID:@(MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeKeypadLockoutID)
+                               value:dataValueDictionary
+               expectedValueInterval:expectedValueIntervalMs
+                   timedWriteTimeout:timedWriteTimeout];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeScheduleProgrammingVisibilityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device
         readAttributeWithEndpointID:@(_endpoint)
-                          clusterID:@(MTRClusterThermostatUserInterfaceConfigurationID)
-                        attributeID:@(MTRClusterThermostatUserInterfaceConfigurationAttributeScheduleProgrammingVisibilityID)
+                          clusterID:@(MTRClusterIDTypeThermostatUserInterfaceConfigurationID)
+                        attributeID:
+                            @(MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeScheduleProgrammingVisibilityID)
                              params:params];
 }
 
@@ -15764,8 +15841,9 @@ using chip::SessionHandle;
 
     [self.device
         writeAttributeWithEndpointID:@(_endpoint)
-                           clusterID:@(MTRClusterThermostatUserInterfaceConfigurationID)
-                         attributeID:@(MTRClusterThermostatUserInterfaceConfigurationAttributeScheduleProgrammingVisibilityID)
+                           clusterID:@(MTRClusterIDTypeThermostatUserInterfaceConfigurationID)
+                         attributeID:
+                             @(MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeScheduleProgrammingVisibilityID)
                                value:dataValueDictionary
                expectedValueInterval:expectedValueIntervalMs
                    timedWriteTimeout:timedWriteTimeout];
@@ -15773,42 +15851,47 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatUserInterfaceConfigurationID)
-                                        attributeID:@(MTRClusterThermostatUserInterfaceConfigurationAttributeGeneratedCommandListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThermostatUserInterfaceConfigurationID)
+                        attributeID:@(MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeGeneratedCommandListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatUserInterfaceConfigurationID)
-                                        attributeID:@(MTRClusterThermostatUserInterfaceConfigurationAttributeAcceptedCommandListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThermostatUserInterfaceConfigurationID)
+                        attributeID:@(MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeAcceptedCommandListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatUserInterfaceConfigurationID)
-                                        attributeID:@(MTRClusterThermostatUserInterfaceConfigurationAttributeAttributeListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThermostatUserInterfaceConfigurationID)
+                        attributeID:@(MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeAttributeListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatUserInterfaceConfigurationID)
-                                        attributeID:@(MTRClusterThermostatUserInterfaceConfigurationAttributeFeatureMapID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThermostatUserInterfaceConfigurationID)
+                        attributeID:@(MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeFeatureMapID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterThermostatUserInterfaceConfigurationID)
-                                        attributeID:@(MTRClusterThermostatUserInterfaceConfigurationAttributeClusterRevisionID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeThermostatUserInterfaceConfigurationID)
+                        attributeID:@(MTRAttributeIDTypeClusterThermostatUserInterfaceConfigurationAttributeClusterRevisionID)
+                             params:params];
 }
 
 @end
@@ -16855,80 +16938,80 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeCurrentHueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeCurrentHueID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeCurrentHueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentSaturationWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeCurrentSaturationID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeCurrentSaturationID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRemainingTimeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeRemainingTimeID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeRemainingTimeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentXWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeCurrentXID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeCurrentXID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentYWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeCurrentYID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeCurrentYID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDriftCompensationWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeDriftCompensationID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeDriftCompensationID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCompensationTextWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeCompensationTextID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeCompensationTextID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeColorTemperatureMiredsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorTemperatureMiredsID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorTemperatureMiredsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeColorModeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorModeID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorModeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOptionsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeOptionsID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeOptionsID)
                                              params:params];
 }
 
@@ -16944,8 +17027,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterColorControlID)
-                                  attributeID:@(MTRClusterColorControlAttributeOptionsID)
+                                    clusterID:@(MTRClusterIDTypeColorControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeOptionsID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -16954,160 +17037,160 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNumberOfPrimariesWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeNumberOfPrimariesID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeNumberOfPrimariesID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary1XWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary1XID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary1XID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary1YWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary1YID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary1YID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary1IntensityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary1IntensityID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary1IntensityID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary2XWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary2XID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary2XID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary2YWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary2YID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary2YID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary2IntensityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary2IntensityID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary2IntensityID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary3XWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary3XID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary3XID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary3YWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary3YID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary3YID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary3IntensityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary3IntensityID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary3IntensityID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary4XWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary4XID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary4XID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary4YWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary4YID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary4YID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary4IntensityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary4IntensityID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary4IntensityID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary5XWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary5XID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary5XID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary5YWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary5YID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary5YID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary5IntensityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary5IntensityID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary5IntensityID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary6XWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary6XID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary6XID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary6YWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary6YID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary6YID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePrimary6IntensityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributePrimary6IntensityID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributePrimary6IntensityID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeWhitePointXWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeWhitePointXID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeWhitePointXID)
                                              params:params];
 }
 
@@ -17123,8 +17206,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterColorControlID)
-                                  attributeID:@(MTRClusterColorControlAttributeWhitePointXID)
+                                    clusterID:@(MTRClusterIDTypeColorControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeWhitePointXID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17133,8 +17216,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeWhitePointYWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeWhitePointYID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeWhitePointYID)
                                              params:params];
 }
 
@@ -17150,8 +17233,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterColorControlID)
-                                  attributeID:@(MTRClusterColorControlAttributeWhitePointYID)
+                                    clusterID:@(MTRClusterIDTypeColorControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeWhitePointYID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17160,8 +17243,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeColorPointRXWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorPointRXID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointRXID)
                                              params:params];
 }
 
@@ -17177,8 +17260,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterColorControlID)
-                                  attributeID:@(MTRClusterColorControlAttributeColorPointRXID)
+                                    clusterID:@(MTRClusterIDTypeColorControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointRXID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17187,8 +17270,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeColorPointRYWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorPointRYID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointRYID)
                                              params:params];
 }
 
@@ -17204,8 +17287,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterColorControlID)
-                                  attributeID:@(MTRClusterColorControlAttributeColorPointRYID)
+                                    clusterID:@(MTRClusterIDTypeColorControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointRYID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17214,8 +17297,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeColorPointRIntensityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorPointRIntensityID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointRIntensityID)
                                              params:params];
 }
 
@@ -17231,8 +17314,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterColorControlID)
-                                  attributeID:@(MTRClusterColorControlAttributeColorPointRIntensityID)
+                                    clusterID:@(MTRClusterIDTypeColorControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointRIntensityID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17241,8 +17324,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeColorPointGXWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorPointGXID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointGXID)
                                              params:params];
 }
 
@@ -17258,8 +17341,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterColorControlID)
-                                  attributeID:@(MTRClusterColorControlAttributeColorPointGXID)
+                                    clusterID:@(MTRClusterIDTypeColorControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointGXID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17268,8 +17351,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeColorPointGYWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorPointGYID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointGYID)
                                              params:params];
 }
 
@@ -17285,8 +17368,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterColorControlID)
-                                  attributeID:@(MTRClusterColorControlAttributeColorPointGYID)
+                                    clusterID:@(MTRClusterIDTypeColorControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointGYID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17295,8 +17378,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeColorPointGIntensityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorPointGIntensityID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointGIntensityID)
                                              params:params];
 }
 
@@ -17312,8 +17395,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterColorControlID)
-                                  attributeID:@(MTRClusterColorControlAttributeColorPointGIntensityID)
+                                    clusterID:@(MTRClusterIDTypeColorControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointGIntensityID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17322,8 +17405,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeColorPointBXWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorPointBXID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointBXID)
                                              params:params];
 }
 
@@ -17339,8 +17422,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterColorControlID)
-                                  attributeID:@(MTRClusterColorControlAttributeColorPointBXID)
+                                    clusterID:@(MTRClusterIDTypeColorControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointBXID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17349,8 +17432,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeColorPointBYWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorPointBYID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointBYID)
                                              params:params];
 }
 
@@ -17366,8 +17449,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterColorControlID)
-                                  attributeID:@(MTRClusterColorControlAttributeColorPointBYID)
+                                    clusterID:@(MTRClusterIDTypeColorControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointBYID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17376,8 +17459,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeColorPointBIntensityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorPointBIntensityID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointBIntensityID)
                                              params:params];
 }
 
@@ -17393,8 +17476,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterColorControlID)
-                                  attributeID:@(MTRClusterColorControlAttributeColorPointBIntensityID)
+                                    clusterID:@(MTRClusterIDTypeColorControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorPointBIntensityID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17403,96 +17486,97 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeEnhancedCurrentHueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeEnhancedCurrentHueID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeEnhancedCurrentHueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeEnhancedColorModeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeEnhancedColorModeID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeEnhancedColorModeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeColorLoopActiveWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorLoopActiveID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorLoopActiveID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeColorLoopDirectionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorLoopDirectionID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorLoopDirectionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeColorLoopTimeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorLoopTimeID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorLoopTimeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeColorLoopStartEnhancedHueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorLoopStartEnhancedHueID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorLoopStartEnhancedHueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeColorLoopStoredEnhancedHueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorLoopStoredEnhancedHueID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorLoopStoredEnhancedHueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeColorCapabilitiesWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorCapabilitiesID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorCapabilitiesID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeColorTempPhysicalMinMiredsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorTempPhysicalMinMiredsID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorTempPhysicalMinMiredsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeColorTempPhysicalMaxMiredsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeColorTempPhysicalMaxMiredsID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeColorTempPhysicalMaxMiredsID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCoupleColorTempToLevelMinMiredsWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeCoupleColorTempToLevelMinMiredsID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeColorControlID)
+                                     attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeCoupleColorTempToLevelMinMiredsID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeStartUpColorTemperatureMiredsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeStartUpColorTemperatureMiredsID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeStartUpColorTemperatureMiredsID)
                                              params:params];
 }
 
@@ -17510,8 +17594,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterColorControlID)
-                                  attributeID:@(MTRClusterColorControlAttributeStartUpColorTemperatureMiredsID)
+                                    clusterID:@(MTRClusterIDTypeColorControlID)
+                                  attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeStartUpColorTemperatureMiredsID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17520,40 +17604,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterColorControlID)
-                                        attributeID:@(MTRClusterColorControlAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeColorControlID)
+                                        attributeID:@(MTRAttributeIDTypeClusterColorControlAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -17776,32 +17860,32 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributePhysicalMinLevelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributePhysicalMinLevelID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributePhysicalMinLevelID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePhysicalMaxLevelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributePhysicalMaxLevelID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributePhysicalMaxLevelID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeBallastStatusWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeBallastStatusID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeBallastStatusID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinLevelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeMinLevelID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeMinLevelID)
                                              params:params];
 }
 
@@ -17817,8 +17901,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBallastConfigurationID)
-                                  attributeID:@(MTRClusterBallastConfigurationAttributeMinLevelID)
+                                    clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeMinLevelID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17827,8 +17911,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMaxLevelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeMaxLevelID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeMaxLevelID)
                                              params:params];
 }
 
@@ -17844,8 +17928,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBallastConfigurationID)
-                                  attributeID:@(MTRClusterBallastConfigurationAttributeMaxLevelID)
+                                    clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeMaxLevelID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17853,10 +17937,11 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeIntrinsicBalanceFactorWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeIntrinsicBalanceFactorID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                     attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeIntrinsicBalanceFactorID)
+                                          params:params];
 }
 
 - (void)writeAttributeIntrinsicBalanceFactorWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -17873,8 +17958,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBallastConfigurationID)
-                                  attributeID:@(MTRClusterBallastConfigurationAttributeIntrinsicBalanceFactorID)
+                                    clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeIntrinsicBalanceFactorID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17882,10 +17967,11 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeBallastFactorAdjustmentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeBallastFactorAdjustmentID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                     attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeBallastFactorAdjustmentID)
+                                          params:params];
 }
 
 - (void)writeAttributeBallastFactorAdjustmentWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -17902,8 +17988,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBallastConfigurationID)
-                                  attributeID:@(MTRClusterBallastConfigurationAttributeBallastFactorAdjustmentID)
+                                    clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeBallastFactorAdjustmentID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17912,16 +17998,16 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLampQuantityWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeLampQuantityID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeLampQuantityID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLampTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeLampTypeID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeLampTypeID)
                                              params:params];
 }
 
@@ -17937,8 +18023,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBallastConfigurationID)
-                                  attributeID:@(MTRClusterBallastConfigurationAttributeLampTypeID)
+                                    clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeLampTypeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17947,8 +18033,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLampManufacturerWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeLampManufacturerID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeLampManufacturerID)
                                              params:params];
 }
 
@@ -17964,8 +18050,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBallastConfigurationID)
-                                  attributeID:@(MTRClusterBallastConfigurationAttributeLampManufacturerID)
+                                    clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeLampManufacturerID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -17974,8 +18060,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLampRatedHoursWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeLampRatedHoursID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeLampRatedHoursID)
                                              params:params];
 }
 
@@ -17991,8 +18077,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBallastConfigurationID)
-                                  attributeID:@(MTRClusterBallastConfigurationAttributeLampRatedHoursID)
+                                    clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeLampRatedHoursID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -18001,8 +18087,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLampBurnHoursWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeLampBurnHoursID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeLampBurnHoursID)
                                              params:params];
 }
 
@@ -18018,8 +18104,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBallastConfigurationID)
-                                  attributeID:@(MTRClusterBallastConfigurationAttributeLampBurnHoursID)
+                                    clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeLampBurnHoursID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -18028,8 +18114,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLampAlarmModeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeLampAlarmModeID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeLampAlarmModeID)
                                              params:params];
 }
 
@@ -18045,8 +18131,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBallastConfigurationID)
-                                  attributeID:@(MTRClusterBallastConfigurationAttributeLampAlarmModeID)
+                                    clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeLampAlarmModeID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -18054,10 +18140,11 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeLampBurnHoursTripPointWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeLampBurnHoursTripPointID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                     attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeLampBurnHoursTripPointID)
+                                          params:params];
 }
 
 - (void)writeAttributeLampBurnHoursTripPointWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -18074,8 +18161,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterBallastConfigurationID)
-                                  attributeID:@(MTRClusterBallastConfigurationAttributeLampBurnHoursTripPointID)
+                                    clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                  attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeLampBurnHoursTripPointID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -18084,40 +18171,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterBallastConfigurationID)
-                                        attributeID:@(MTRClusterBallastConfigurationAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeBallastConfigurationID)
+                                        attributeID:@(MTRAttributeIDTypeClusterBallastConfigurationAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -18150,80 +18237,81 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIlluminanceMeasurementID)
-                                        attributeID:@(MTRClusterIlluminanceMeasurementAttributeMeasuredValueID)
+                                          clusterID:@(MTRClusterIDTypeIlluminanceMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeMeasuredValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIlluminanceMeasurementID)
-                                        attributeID:@(MTRClusterIlluminanceMeasurementAttributeMinMeasuredValueID)
+                                          clusterID:@(MTRClusterIDTypeIlluminanceMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeMinMeasuredValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIlluminanceMeasurementID)
-                                        attributeID:@(MTRClusterIlluminanceMeasurementAttributeMaxMeasuredValueID)
+                                          clusterID:@(MTRClusterIDTypeIlluminanceMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeMaxMeasuredValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeToleranceWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIlluminanceMeasurementID)
-                                        attributeID:@(MTRClusterIlluminanceMeasurementAttributeToleranceID)
+                                          clusterID:@(MTRClusterIDTypeIlluminanceMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeToleranceID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLightSensorTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIlluminanceMeasurementID)
-                                        attributeID:@(MTRClusterIlluminanceMeasurementAttributeLightSensorTypeID)
+                                          clusterID:@(MTRClusterIDTypeIlluminanceMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeLightSensorTypeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIlluminanceMeasurementID)
-                                        attributeID:@(MTRClusterIlluminanceMeasurementAttributeGeneratedCommandListID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeIlluminanceMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeGeneratedCommandListID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIlluminanceMeasurementID)
-                                        attributeID:@(MTRClusterIlluminanceMeasurementAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeIlluminanceMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIlluminanceMeasurementID)
-                                        attributeID:@(MTRClusterIlluminanceMeasurementAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeIlluminanceMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIlluminanceMeasurementID)
-                                        attributeID:@(MTRClusterIlluminanceMeasurementAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeIlluminanceMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIlluminanceMeasurementID)
-                                        attributeID:@(MTRClusterIlluminanceMeasurementAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeIlluminanceMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterIlluminanceMeasurementAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -18256,72 +18344,73 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTemperatureMeasurementID)
-                                        attributeID:@(MTRClusterTemperatureMeasurementAttributeMeasuredValueID)
+                                          clusterID:@(MTRClusterIDTypeTemperatureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTemperatureMeasurementAttributeMeasuredValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTemperatureMeasurementID)
-                                        attributeID:@(MTRClusterTemperatureMeasurementAttributeMinMeasuredValueID)
+                                          clusterID:@(MTRClusterIDTypeTemperatureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTemperatureMeasurementAttributeMinMeasuredValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTemperatureMeasurementID)
-                                        attributeID:@(MTRClusterTemperatureMeasurementAttributeMaxMeasuredValueID)
+                                          clusterID:@(MTRClusterIDTypeTemperatureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTemperatureMeasurementAttributeMaxMeasuredValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeToleranceWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTemperatureMeasurementID)
-                                        attributeID:@(MTRClusterTemperatureMeasurementAttributeToleranceID)
+                                          clusterID:@(MTRClusterIDTypeTemperatureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTemperatureMeasurementAttributeToleranceID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTemperatureMeasurementID)
-                                        attributeID:@(MTRClusterTemperatureMeasurementAttributeGeneratedCommandListID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeTemperatureMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterTemperatureMeasurementAttributeGeneratedCommandListID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTemperatureMeasurementID)
-                                        attributeID:@(MTRClusterTemperatureMeasurementAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeTemperatureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTemperatureMeasurementAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTemperatureMeasurementID)
-                                        attributeID:@(MTRClusterTemperatureMeasurementAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeTemperatureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTemperatureMeasurementAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTemperatureMeasurementID)
-                                        attributeID:@(MTRClusterTemperatureMeasurementAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeTemperatureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTemperatureMeasurementAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTemperatureMeasurementID)
-                                        attributeID:@(MTRClusterTemperatureMeasurementAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeTemperatureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTemperatureMeasurementAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -18354,112 +18443,112 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPressureMeasurementID)
-                                        attributeID:@(MTRClusterPressureMeasurementAttributeMeasuredValueID)
+                                          clusterID:@(MTRClusterIDTypePressureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPressureMeasurementAttributeMeasuredValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPressureMeasurementID)
-                                        attributeID:@(MTRClusterPressureMeasurementAttributeMinMeasuredValueID)
+                                          clusterID:@(MTRClusterIDTypePressureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPressureMeasurementAttributeMinMeasuredValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPressureMeasurementID)
-                                        attributeID:@(MTRClusterPressureMeasurementAttributeMaxMeasuredValueID)
+                                          clusterID:@(MTRClusterIDTypePressureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPressureMeasurementAttributeMaxMeasuredValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeToleranceWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPressureMeasurementID)
-                                        attributeID:@(MTRClusterPressureMeasurementAttributeToleranceID)
+                                          clusterID:@(MTRClusterIDTypePressureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPressureMeasurementAttributeToleranceID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeScaledValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPressureMeasurementID)
-                                        attributeID:@(MTRClusterPressureMeasurementAttributeScaledValueID)
+                                          clusterID:@(MTRClusterIDTypePressureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPressureMeasurementAttributeScaledValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinScaledValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPressureMeasurementID)
-                                        attributeID:@(MTRClusterPressureMeasurementAttributeMinScaledValueID)
+                                          clusterID:@(MTRClusterIDTypePressureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPressureMeasurementAttributeMinScaledValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxScaledValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPressureMeasurementID)
-                                        attributeID:@(MTRClusterPressureMeasurementAttributeMaxScaledValueID)
+                                          clusterID:@(MTRClusterIDTypePressureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPressureMeasurementAttributeMaxScaledValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeScaledToleranceWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPressureMeasurementID)
-                                        attributeID:@(MTRClusterPressureMeasurementAttributeScaledToleranceID)
+                                          clusterID:@(MTRClusterIDTypePressureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPressureMeasurementAttributeScaledToleranceID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeScaleWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPressureMeasurementID)
-                                        attributeID:@(MTRClusterPressureMeasurementAttributeScaleID)
+                                          clusterID:@(MTRClusterIDTypePressureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPressureMeasurementAttributeScaleID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPressureMeasurementID)
-                                        attributeID:@(MTRClusterPressureMeasurementAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypePressureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPressureMeasurementAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPressureMeasurementID)
-                                        attributeID:@(MTRClusterPressureMeasurementAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypePressureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPressureMeasurementAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPressureMeasurementID)
-                                        attributeID:@(MTRClusterPressureMeasurementAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypePressureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPressureMeasurementAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPressureMeasurementID)
-                                        attributeID:@(MTRClusterPressureMeasurementAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypePressureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPressureMeasurementAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterPressureMeasurementID)
-                                        attributeID:@(MTRClusterPressureMeasurementAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypePressureMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterPressureMeasurementAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -18492,72 +18581,72 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFlowMeasurementID)
-                                        attributeID:@(MTRClusterFlowMeasurementAttributeMeasuredValueID)
+                                          clusterID:@(MTRClusterIDTypeFlowMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFlowMeasurementAttributeMeasuredValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFlowMeasurementID)
-                                        attributeID:@(MTRClusterFlowMeasurementAttributeMinMeasuredValueID)
+                                          clusterID:@(MTRClusterIDTypeFlowMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFlowMeasurementAttributeMinMeasuredValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFlowMeasurementID)
-                                        attributeID:@(MTRClusterFlowMeasurementAttributeMaxMeasuredValueID)
+                                          clusterID:@(MTRClusterIDTypeFlowMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFlowMeasurementAttributeMaxMeasuredValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeToleranceWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFlowMeasurementID)
-                                        attributeID:@(MTRClusterFlowMeasurementAttributeToleranceID)
+                                          clusterID:@(MTRClusterIDTypeFlowMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFlowMeasurementAttributeToleranceID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFlowMeasurementID)
-                                        attributeID:@(MTRClusterFlowMeasurementAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeFlowMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFlowMeasurementAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFlowMeasurementID)
-                                        attributeID:@(MTRClusterFlowMeasurementAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeFlowMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFlowMeasurementAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFlowMeasurementID)
-                                        attributeID:@(MTRClusterFlowMeasurementAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeFlowMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFlowMeasurementAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFlowMeasurementID)
-                                        attributeID:@(MTRClusterFlowMeasurementAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeFlowMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFlowMeasurementAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterFlowMeasurementID)
-                                        attributeID:@(MTRClusterFlowMeasurementAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeFlowMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterFlowMeasurementAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -18590,73 +18679,78 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterRelativeHumidityMeasurementID)
-                                        attributeID:@(MTRClusterRelativeHumidityMeasurementAttributeMeasuredValueID)
+                                          clusterID:@(MTRClusterIDTypeRelativeHumidityMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeMeasuredValueID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMinMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterRelativeHumidityMeasurementID)
-                                        attributeID:@(MTRClusterRelativeHumidityMeasurementAttributeMinMeasuredValueID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeRelativeHumidityMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeMinMeasuredValueID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMaxMeasuredValueWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterRelativeHumidityMeasurementID)
-                                        attributeID:@(MTRClusterRelativeHumidityMeasurementAttributeMaxMeasuredValueID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeRelativeHumidityMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeMaxMeasuredValueID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeToleranceWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterRelativeHumidityMeasurementID)
-                                        attributeID:@(MTRClusterRelativeHumidityMeasurementAttributeToleranceID)
+                                          clusterID:@(MTRClusterIDTypeRelativeHumidityMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeToleranceID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterRelativeHumidityMeasurementID)
-                                        attributeID:@(MTRClusterRelativeHumidityMeasurementAttributeGeneratedCommandListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeRelativeHumidityMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeGeneratedCommandListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterRelativeHumidityMeasurementID)
-                                        attributeID:@(MTRClusterRelativeHumidityMeasurementAttributeAcceptedCommandListID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeRelativeHumidityMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeAcceptedCommandListID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterRelativeHumidityMeasurementID)
-                                        attributeID:@(MTRClusterRelativeHumidityMeasurementAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeRelativeHumidityMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterRelativeHumidityMeasurementID)
-                                        attributeID:@(MTRClusterRelativeHumidityMeasurementAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeRelativeHumidityMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterRelativeHumidityMeasurementID)
-                                        attributeID:@(MTRClusterRelativeHumidityMeasurementAttributeClusterRevisionID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeRelativeHumidityMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterRelativeHumidityMeasurementAttributeClusterRevisionID)
+                                          params:params];
 }
 
 @end
@@ -18688,33 +18782,34 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOccupancyWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributeOccupancyID)
+                                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributeOccupancyID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOccupancySensorTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributeOccupancySensorTypeID)
+                                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributeOccupancySensorTypeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOccupancySensorTypeBitmapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributeOccupancySensorTypeBitmapID)
+                                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributeOccupancySensorTypeBitmapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePirOccupiedToUnoccupiedDelayWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributePirOccupiedToUnoccupiedDelayID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                                     attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePirOccupiedToUnoccupiedDelayID)
+                                          params:params];
 }
 
 - (void)writeAttributePirOccupiedToUnoccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -18731,8 +18826,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterOccupancySensingID)
-                                  attributeID:@(MTRClusterOccupancySensingAttributePirOccupiedToUnoccupiedDelayID)
+                                    clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePirOccupiedToUnoccupiedDelayID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -18740,10 +18835,11 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributePirUnoccupiedToOccupiedDelayWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributePirUnoccupiedToOccupiedDelayID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                                     attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePirUnoccupiedToOccupiedDelayID)
+                                          params:params];
 }
 
 - (void)writeAttributePirUnoccupiedToOccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -18760,8 +18856,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterOccupancySensingID)
-                                  attributeID:@(MTRClusterOccupancySensingAttributePirUnoccupiedToOccupiedDelayID)
+                                    clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePirUnoccupiedToOccupiedDelayID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -18769,10 +18865,11 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributePirUnoccupiedToOccupiedThresholdWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributePirUnoccupiedToOccupiedThresholdID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePirUnoccupiedToOccupiedThresholdID)
+                             params:params];
 }
 
 - (void)writeAttributePirUnoccupiedToOccupiedThresholdWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -18788,20 +18885,22 @@ using chip::SessionHandle;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterOccupancySensingID)
-                                  attributeID:@(MTRClusterOccupancySensingAttributePirUnoccupiedToOccupiedThresholdID)
-                                        value:dataValueDictionary
-                        expectedValueInterval:expectedValueIntervalMs
-                            timedWriteTimeout:timedWriteTimeout];
+    [self.device
+        writeAttributeWithEndpointID:@(_endpoint)
+                           clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                         attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePirUnoccupiedToOccupiedThresholdID)
+                               value:dataValueDictionary
+               expectedValueInterval:expectedValueIntervalMs
+                   timedWriteTimeout:timedWriteTimeout];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeUltrasonicOccupiedToUnoccupiedDelayWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributeUltrasonicOccupiedToUnoccupiedDelayID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicOccupiedToUnoccupiedDelayID)
+                             params:params];
 }
 
 - (void)writeAttributeUltrasonicOccupiedToUnoccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -18817,20 +18916,22 @@ using chip::SessionHandle;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterOccupancySensingID)
-                                  attributeID:@(MTRClusterOccupancySensingAttributeUltrasonicOccupiedToUnoccupiedDelayID)
-                                        value:dataValueDictionary
-                        expectedValueInterval:expectedValueIntervalMs
-                            timedWriteTimeout:timedWriteTimeout];
+    [self.device
+        writeAttributeWithEndpointID:@(_endpoint)
+                           clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                         attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicOccupiedToUnoccupiedDelayID)
+                               value:dataValueDictionary
+               expectedValueInterval:expectedValueIntervalMs
+                   timedWriteTimeout:timedWriteTimeout];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeUltrasonicUnoccupiedToOccupiedDelayWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedDelayID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedDelayID)
+                             params:params];
 }
 
 - (void)writeAttributeUltrasonicUnoccupiedToOccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -18846,20 +18947,22 @@ using chip::SessionHandle;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterOccupancySensingID)
-                                  attributeID:@(MTRClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedDelayID)
-                                        value:dataValueDictionary
-                        expectedValueInterval:expectedValueIntervalMs
-                            timedWriteTimeout:timedWriteTimeout];
+    [self.device
+        writeAttributeWithEndpointID:@(_endpoint)
+                           clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                         attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedDelayID)
+                               value:dataValueDictionary
+               expectedValueInterval:expectedValueIntervalMs
+                   timedWriteTimeout:timedWriteTimeout];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeUltrasonicUnoccupiedToOccupiedThresholdWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedThresholdID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedThresholdID)
+                             params:params];
 }
 
 - (void)writeAttributeUltrasonicUnoccupiedToOccupiedThresholdWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -18875,20 +18978,22 @@ using chip::SessionHandle;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterOccupancySensingID)
-                                  attributeID:@(MTRClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedThresholdID)
-                                        value:dataValueDictionary
-                        expectedValueInterval:expectedValueIntervalMs
-                            timedWriteTimeout:timedWriteTimeout];
+    [self.device
+        writeAttributeWithEndpointID:@(_endpoint)
+                           clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                         attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedThresholdID)
+                               value:dataValueDictionary
+               expectedValueInterval:expectedValueIntervalMs
+                   timedWriteTimeout:timedWriteTimeout];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePhysicalContactOccupiedToUnoccupiedDelayWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributePhysicalContactOccupiedToUnoccupiedDelayID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePhysicalContactOccupiedToUnoccupiedDelayID)
+                             params:params];
 }
 
 - (void)writeAttributePhysicalContactOccupiedToUnoccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -18904,20 +19009,22 @@ using chip::SessionHandle;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterOccupancySensingID)
-                                  attributeID:@(MTRClusterOccupancySensingAttributePhysicalContactOccupiedToUnoccupiedDelayID)
-                                        value:dataValueDictionary
-                        expectedValueInterval:expectedValueIntervalMs
-                            timedWriteTimeout:timedWriteTimeout];
+    [self.device
+        writeAttributeWithEndpointID:@(_endpoint)
+                           clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                         attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePhysicalContactOccupiedToUnoccupiedDelayID)
+                               value:dataValueDictionary
+               expectedValueInterval:expectedValueIntervalMs
+                   timedWriteTimeout:timedWriteTimeout];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePhysicalContactUnoccupiedToOccupiedDelayWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedDelayID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedDelayID)
+                             params:params];
 }
 
 - (void)writeAttributePhysicalContactUnoccupiedToOccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -18933,12 +19040,13 @@ using chip::SessionHandle;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterOccupancySensingID)
-                                  attributeID:@(MTRClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedDelayID)
-                                        value:dataValueDictionary
-                        expectedValueInterval:expectedValueIntervalMs
-                            timedWriteTimeout:timedWriteTimeout];
+    [self.device
+        writeAttributeWithEndpointID:@(_endpoint)
+                           clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                         attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedDelayID)
+                               value:dataValueDictionary
+               expectedValueInterval:expectedValueIntervalMs
+                   timedWriteTimeout:timedWriteTimeout];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePhysicalContactUnoccupiedToOccupiedThresholdWithParams:
@@ -18946,8 +19054,9 @@ using chip::SessionHandle;
 {
     return [self.device
         readAttributeWithEndpointID:@(_endpoint)
-                          clusterID:@(MTRClusterOccupancySensingID)
-                        attributeID:@(MTRClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedThresholdID)
+                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                        attributeID:
+                            @(MTRAttributeIDTypeClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedThresholdID)
                              params:params];
 }
 
@@ -18964,51 +19073,53 @@ using chip::SessionHandle;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterOccupancySensingID)
-                                  attributeID:@(MTRClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedThresholdID)
-                                        value:dataValueDictionary
-                        expectedValueInterval:expectedValueIntervalMs
-                            timedWriteTimeout:timedWriteTimeout];
+    [self.device
+        writeAttributeWithEndpointID:@(_endpoint)
+                           clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                         attributeID:
+                             @(MTRAttributeIDTypeClusterOccupancySensingAttributePhysicalContactUnoccupiedToOccupiedThresholdID)
+                               value:dataValueDictionary
+               expectedValueInterval:expectedValueIntervalMs
+                   timedWriteTimeout:timedWriteTimeout];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterOccupancySensingID)
-                                        attributeID:@(MTRClusterOccupancySensingAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeOccupancySensingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -19041,48 +19152,48 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMACAddressWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWakeOnLanID)
-                                        attributeID:@(MTRClusterWakeOnLanAttributeMACAddressID)
+                                          clusterID:@(MTRClusterIDTypeWakeOnLanID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLanAttributeMACAddressID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWakeOnLanID)
-                                        attributeID:@(MTRClusterWakeOnLanAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeWakeOnLanID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLanAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWakeOnLanID)
-                                        attributeID:@(MTRClusterWakeOnLanAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeWakeOnLanID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLanAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWakeOnLanID)
-                                        attributeID:@(MTRClusterWakeOnLanAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeWakeOnLanID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLanAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWakeOnLanID)
-                                        attributeID:@(MTRClusterWakeOnLanAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeWakeOnLanID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLanAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterWakeOnLanID)
-                                        attributeID:@(MTRClusterWakeOnLanAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeWakeOnLanID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLanAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -19260,64 +19371,64 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeChannelListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterChannelID)
-                                        attributeID:@(MTRClusterChannelAttributeChannelListID)
+                                          clusterID:@(MTRClusterIDTypeChannelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterChannelAttributeChannelListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLineupWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterChannelID)
-                                        attributeID:@(MTRClusterChannelAttributeLineupID)
+                                          clusterID:@(MTRClusterIDTypeChannelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterChannelAttributeLineupID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentChannelWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterChannelID)
-                                        attributeID:@(MTRClusterChannelAttributeCurrentChannelID)
+                                          clusterID:@(MTRClusterIDTypeChannelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterChannelAttributeCurrentChannelID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterChannelID)
-                                        attributeID:@(MTRClusterChannelAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeChannelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterChannelAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterChannelID)
-                                        attributeID:@(MTRClusterChannelAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeChannelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterChannelAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterChannelID)
-                                        attributeID:@(MTRClusterChannelAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeChannelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterChannelAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterChannelID)
-                                        attributeID:@(MTRClusterChannelAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeChannelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterChannelAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterChannelID)
-                                        attributeID:@(MTRClusterChannelAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeChannelID)
+                                        attributeID:@(MTRAttributeIDTypeClusterChannelAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -19434,56 +19545,56 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeTargetListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTargetNavigatorID)
-                                        attributeID:@(MTRClusterTargetNavigatorAttributeTargetListID)
+                                          clusterID:@(MTRClusterIDTypeTargetNavigatorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTargetNavigatorAttributeTargetListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentTargetWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTargetNavigatorID)
-                                        attributeID:@(MTRClusterTargetNavigatorAttributeCurrentTargetID)
+                                          clusterID:@(MTRClusterIDTypeTargetNavigatorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTargetNavigatorAttributeCurrentTargetID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTargetNavigatorID)
-                                        attributeID:@(MTRClusterTargetNavigatorAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeTargetNavigatorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTargetNavigatorAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTargetNavigatorID)
-                                        attributeID:@(MTRClusterTargetNavigatorAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeTargetNavigatorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTargetNavigatorAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTargetNavigatorID)
-                                        attributeID:@(MTRClusterTargetNavigatorAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeTargetNavigatorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTargetNavigatorAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTargetNavigatorID)
-                                        attributeID:@(MTRClusterTargetNavigatorAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeTargetNavigatorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTargetNavigatorAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterTargetNavigatorID)
-                                        attributeID:@(MTRClusterTargetNavigatorAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeTargetNavigatorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterTargetNavigatorAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -20094,96 +20205,96 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeCurrentStateWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaPlaybackID)
-                                        attributeID:@(MTRClusterMediaPlaybackAttributeCurrentStateID)
+                                          clusterID:@(MTRClusterIDTypeMediaPlaybackID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaPlaybackAttributeCurrentStateID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeStartTimeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaPlaybackID)
-                                        attributeID:@(MTRClusterMediaPlaybackAttributeStartTimeID)
+                                          clusterID:@(MTRClusterIDTypeMediaPlaybackID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaPlaybackAttributeStartTimeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDurationWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaPlaybackID)
-                                        attributeID:@(MTRClusterMediaPlaybackAttributeDurationID)
+                                          clusterID:@(MTRClusterIDTypeMediaPlaybackID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaPlaybackAttributeDurationID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSampledPositionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaPlaybackID)
-                                        attributeID:@(MTRClusterMediaPlaybackAttributeSampledPositionID)
+                                          clusterID:@(MTRClusterIDTypeMediaPlaybackID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaPlaybackAttributeSampledPositionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePlaybackSpeedWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaPlaybackID)
-                                        attributeID:@(MTRClusterMediaPlaybackAttributePlaybackSpeedID)
+                                          clusterID:@(MTRClusterIDTypeMediaPlaybackID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaPlaybackAttributePlaybackSpeedID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSeekRangeEndWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaPlaybackID)
-                                        attributeID:@(MTRClusterMediaPlaybackAttributeSeekRangeEndID)
+                                          clusterID:@(MTRClusterIDTypeMediaPlaybackID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaPlaybackAttributeSeekRangeEndID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSeekRangeStartWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaPlaybackID)
-                                        attributeID:@(MTRClusterMediaPlaybackAttributeSeekRangeStartID)
+                                          clusterID:@(MTRClusterIDTypeMediaPlaybackID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaPlaybackAttributeSeekRangeStartID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaPlaybackID)
-                                        attributeID:@(MTRClusterMediaPlaybackAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeMediaPlaybackID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaPlaybackAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaPlaybackID)
-                                        attributeID:@(MTRClusterMediaPlaybackAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeMediaPlaybackID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaPlaybackAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaPlaybackID)
-                                        attributeID:@(MTRClusterMediaPlaybackAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeMediaPlaybackID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaPlaybackAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaPlaybackID)
-                                        attributeID:@(MTRClusterMediaPlaybackAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeMediaPlaybackID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaPlaybackAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaPlaybackID)
-                                        attributeID:@(MTRClusterMediaPlaybackAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeMediaPlaybackID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaPlaybackAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -20663,56 +20774,56 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInputListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaInputID)
-                                        attributeID:@(MTRClusterMediaInputAttributeInputListID)
+                                          clusterID:@(MTRClusterIDTypeMediaInputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaInputAttributeInputListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentInputWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaInputID)
-                                        attributeID:@(MTRClusterMediaInputAttributeCurrentInputID)
+                                          clusterID:@(MTRClusterIDTypeMediaInputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaInputAttributeCurrentInputID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaInputID)
-                                        attributeID:@(MTRClusterMediaInputAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeMediaInputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaInputAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaInputID)
-                                        attributeID:@(MTRClusterMediaInputAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeMediaInputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaInputAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaInputID)
-                                        attributeID:@(MTRClusterMediaInputAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeMediaInputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaInputAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaInputID)
-                                        attributeID:@(MTRClusterMediaInputAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeMediaInputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaInputAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterMediaInputID)
-                                        attributeID:@(MTRClusterMediaInputAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeMediaInputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterMediaInputAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -20857,40 +20968,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLowPowerID)
-                                        attributeID:@(MTRClusterLowPowerAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeLowPowerID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLowPowerAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLowPowerID)
-                                        attributeID:@(MTRClusterLowPowerAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeLowPowerID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLowPowerAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLowPowerID)
-                                        attributeID:@(MTRClusterLowPowerAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeLowPowerID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLowPowerAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLowPowerID)
-                                        attributeID:@(MTRClusterLowPowerAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeLowPowerID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLowPowerAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterLowPowerID)
-                                        attributeID:@(MTRClusterLowPowerAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeLowPowerID)
+                                        attributeID:@(MTRAttributeIDTypeClusterLowPowerAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -20988,40 +21099,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterKeypadInputID)
-                                        attributeID:@(MTRClusterKeypadInputAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeKeypadInputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterKeypadInputAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterKeypadInputID)
-                                        attributeID:@(MTRClusterKeypadInputAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeKeypadInputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterKeypadInputAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterKeypadInputID)
-                                        attributeID:@(MTRClusterKeypadInputAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeKeypadInputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterKeypadInputAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterKeypadInputID)
-                                        attributeID:@(MTRClusterKeypadInputAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeKeypadInputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterKeypadInputAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterKeypadInputID)
-                                        attributeID:@(MTRClusterKeypadInputAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeKeypadInputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterKeypadInputAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -21315,17 +21426,18 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeAcceptHeaderWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterContentLauncherID)
-                                        attributeID:@(MTRClusterContentLauncherAttributeAcceptHeaderID)
+                                          clusterID:@(MTRClusterIDTypeContentLauncherID)
+                                        attributeID:@(MTRAttributeIDTypeClusterContentLauncherAttributeAcceptHeaderID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeSupportedStreamingProtocolsWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterContentLauncherID)
-                                        attributeID:@(MTRClusterContentLauncherAttributeSupportedStreamingProtocolsID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeContentLauncherID)
+                                     attributeID:@(MTRAttributeIDTypeClusterContentLauncherAttributeSupportedStreamingProtocolsID)
+                                          params:params];
 }
 
 - (void)writeAttributeSupportedStreamingProtocolsWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -21342,8 +21454,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterContentLauncherID)
-                                  attributeID:@(MTRClusterContentLauncherAttributeSupportedStreamingProtocolsID)
+                                    clusterID:@(MTRClusterIDTypeContentLauncherID)
+                                  attributeID:@(MTRAttributeIDTypeClusterContentLauncherAttributeSupportedStreamingProtocolsID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -21352,40 +21464,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterContentLauncherID)
-                                        attributeID:@(MTRClusterContentLauncherAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeContentLauncherID)
+                                        attributeID:@(MTRAttributeIDTypeClusterContentLauncherAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterContentLauncherID)
-                                        attributeID:@(MTRClusterContentLauncherAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeContentLauncherID)
+                                        attributeID:@(MTRAttributeIDTypeClusterContentLauncherAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterContentLauncherID)
-                                        attributeID:@(MTRClusterContentLauncherAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeContentLauncherID)
+                                        attributeID:@(MTRAttributeIDTypeClusterContentLauncherAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterContentLauncherID)
-                                        attributeID:@(MTRClusterContentLauncherAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeContentLauncherID)
+                                        attributeID:@(MTRAttributeIDTypeClusterContentLauncherAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterContentLauncherID)
-                                        attributeID:@(MTRClusterContentLauncherAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeContentLauncherID)
+                                        attributeID:@(MTRAttributeIDTypeClusterContentLauncherAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -21545,56 +21657,56 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOutputListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAudioOutputID)
-                                        attributeID:@(MTRClusterAudioOutputAttributeOutputListID)
+                                          clusterID:@(MTRClusterIDTypeAudioOutputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAudioOutputAttributeOutputListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentOutputWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAudioOutputID)
-                                        attributeID:@(MTRClusterAudioOutputAttributeCurrentOutputID)
+                                          clusterID:@(MTRClusterIDTypeAudioOutputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAudioOutputAttributeCurrentOutputID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAudioOutputID)
-                                        attributeID:@(MTRClusterAudioOutputAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeAudioOutputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAudioOutputAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAudioOutputID)
-                                        attributeID:@(MTRClusterAudioOutputAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeAudioOutputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAudioOutputAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAudioOutputID)
-                                        attributeID:@(MTRClusterAudioOutputAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeAudioOutputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAudioOutputAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAudioOutputID)
-                                        attributeID:@(MTRClusterAudioOutputAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeAudioOutputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAudioOutputAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAudioOutputID)
-                                        attributeID:@(MTRClusterAudioOutputAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeAudioOutputID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAudioOutputAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -21792,16 +21904,16 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeCatalogListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationLauncherID)
-                                        attributeID:@(MTRClusterApplicationLauncherAttributeCatalogListID)
+                                          clusterID:@(MTRClusterIDTypeApplicationLauncherID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationLauncherAttributeCatalogListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentAppWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationLauncherID)
-                                        attributeID:@(MTRClusterApplicationLauncherAttributeCurrentAppID)
+                                          clusterID:@(MTRClusterIDTypeApplicationLauncherID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationLauncherAttributeCurrentAppID)
                                              params:params];
 }
 
@@ -21817,8 +21929,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterApplicationLauncherID)
-                                  attributeID:@(MTRClusterApplicationLauncherAttributeCurrentAppID)
+                                    clusterID:@(MTRClusterIDTypeApplicationLauncherID)
+                                  attributeID:@(MTRAttributeIDTypeClusterApplicationLauncherAttributeCurrentAppID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -21827,40 +21939,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationLauncherID)
-                                        attributeID:@(MTRClusterApplicationLauncherAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeApplicationLauncherID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationLauncherAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationLauncherID)
-                                        attributeID:@(MTRClusterApplicationLauncherAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeApplicationLauncherID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationLauncherAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationLauncherID)
-                                        attributeID:@(MTRClusterApplicationLauncherAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeApplicationLauncherID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationLauncherAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationLauncherID)
-                                        attributeID:@(MTRClusterApplicationLauncherAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeApplicationLauncherID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationLauncherAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationLauncherID)
-                                        attributeID:@(MTRClusterApplicationLauncherAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeApplicationLauncherID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationLauncherAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -21935,104 +22047,104 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeVendorNameWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationBasicID)
-                                        attributeID:@(MTRClusterApplicationBasicAttributeVendorNameID)
+                                          clusterID:@(MTRClusterIDTypeApplicationBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationBasicAttributeVendorNameID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeVendorIDWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationBasicID)
-                                        attributeID:@(MTRClusterApplicationBasicAttributeVendorIDID)
+                                          clusterID:@(MTRClusterIDTypeApplicationBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationBasicAttributeVendorIDID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeApplicationNameWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationBasicID)
-                                        attributeID:@(MTRClusterApplicationBasicAttributeApplicationNameID)
+                                          clusterID:@(MTRClusterIDTypeApplicationBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationBasicAttributeApplicationNameID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeProductIDWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationBasicID)
-                                        attributeID:@(MTRClusterApplicationBasicAttributeProductIDID)
+                                          clusterID:@(MTRClusterIDTypeApplicationBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationBasicAttributeProductIDID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeApplicationWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationBasicID)
-                                        attributeID:@(MTRClusterApplicationBasicAttributeApplicationID)
+                                          clusterID:@(MTRClusterIDTypeApplicationBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationBasicAttributeApplicationID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeStatusWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationBasicID)
-                                        attributeID:@(MTRClusterApplicationBasicAttributeStatusID)
+                                          clusterID:@(MTRClusterIDTypeApplicationBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationBasicAttributeStatusID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeApplicationVersionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationBasicID)
-                                        attributeID:@(MTRClusterApplicationBasicAttributeApplicationVersionID)
+                                          clusterID:@(MTRClusterIDTypeApplicationBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationBasicAttributeApplicationVersionID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAllowedVendorListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationBasicID)
-                                        attributeID:@(MTRClusterApplicationBasicAttributeAllowedVendorListID)
+                                          clusterID:@(MTRClusterIDTypeApplicationBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationBasicAttributeAllowedVendorListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationBasicID)
-                                        attributeID:@(MTRClusterApplicationBasicAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeApplicationBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationBasicAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationBasicID)
-                                        attributeID:@(MTRClusterApplicationBasicAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeApplicationBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationBasicAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationBasicID)
-                                        attributeID:@(MTRClusterApplicationBasicAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeApplicationBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationBasicAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationBasicID)
-                                        attributeID:@(MTRClusterApplicationBasicAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeApplicationBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationBasicAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterApplicationBasicID)
-                                        attributeID:@(MTRClusterApplicationBasicAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeApplicationBasicID)
+                                        attributeID:@(MTRAttributeIDTypeClusterApplicationBasicAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -22224,40 +22336,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccountLoginID)
-                                        attributeID:@(MTRClusterAccountLoginAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeAccountLoginID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAccountLoginAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccountLoginID)
-                                        attributeID:@(MTRClusterAccountLoginAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeAccountLoginID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAccountLoginAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccountLoginID)
-                                        attributeID:@(MTRClusterAccountLoginAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeAccountLoginID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAccountLoginAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccountLoginID)
-                                        attributeID:@(MTRClusterAccountLoginAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeAccountLoginID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAccountLoginAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterAccountLoginID)
-                                        attributeID:@(MTRClusterAccountLoginAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeAccountLoginID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAccountLoginAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -22441,473 +22553,492 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMeasurementTypeWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeMeasurementTypeID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasurementTypeID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcVoltageWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcVoltageID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcVoltageMinWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcVoltageMinID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageMinID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcVoltageMaxWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcVoltageMaxID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageMaxID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcCurrentWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcCurrentID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcCurrentMinWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcCurrentMinID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentMinID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcCurrentMaxWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcCurrentMaxID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentMaxID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcPowerWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcPowerID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcPowerMinWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcPowerMinID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerMinID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcPowerMaxWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcPowerMaxID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerMaxID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcVoltageMultiplierWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcVoltageMultiplierID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageMultiplierID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcVoltageDivisorWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcVoltageDivisorID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcVoltageDivisorID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcCurrentMultiplierWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcCurrentMultiplierID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentMultiplierID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcCurrentDivisorWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcCurrentDivisorID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcCurrentDivisorID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcPowerMultiplierWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcPowerMultiplierID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerMultiplierID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeDcPowerDivisorWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeDcPowerDivisorID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeDcPowerDivisorID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcFrequencyWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcFrequencyID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcFrequencyMinWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcFrequencyMinID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyMinID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcFrequencyMaxWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcFrequencyMaxID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyMaxID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeNeutralCurrentWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeNeutralCurrentID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeNeutralCurrentID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTotalActivePowerWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeTotalActivePowerID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeTotalActivePowerID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTotalReactivePowerWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeTotalReactivePowerID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeTotalReactivePowerID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeTotalApparentPowerWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeTotalApparentPowerID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeTotalApparentPowerID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasured1stHarmonicCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeMeasured1stHarmonicCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured1stHarmonicCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasured3rdHarmonicCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeMeasured3rdHarmonicCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured3rdHarmonicCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasured5thHarmonicCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeMeasured5thHarmonicCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured5thHarmonicCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasured7thHarmonicCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeMeasured7thHarmonicCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured7thHarmonicCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasured9thHarmonicCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeMeasured9thHarmonicCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured9thHarmonicCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasured11thHarmonicCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeMeasured11thHarmonicCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasured11thHarmonicCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredPhase1stHarmonicCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeMeasuredPhase1stHarmonicCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase1stHarmonicCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredPhase3rdHarmonicCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeMeasuredPhase3rdHarmonicCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase3rdHarmonicCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredPhase5thHarmonicCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeMeasuredPhase5thHarmonicCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase5thHarmonicCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredPhase7thHarmonicCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeMeasuredPhase7thHarmonicCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase7thHarmonicCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredPhase9thHarmonicCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeMeasuredPhase9thHarmonicCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase9thHarmonicCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeMeasuredPhase11thHarmonicCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeMeasuredPhase11thHarmonicCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeMeasuredPhase11thHarmonicCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcFrequencyMultiplierWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcFrequencyMultiplierID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyMultiplierID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcFrequencyDivisorWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcFrequencyDivisorID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcFrequencyDivisorID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePowerMultiplierWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributePowerMultiplierID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerMultiplierID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePowerDivisorWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributePowerDivisorID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerDivisorID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeHarmonicCurrentMultiplierWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeHarmonicCurrentMultiplierID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeHarmonicCurrentMultiplierID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePhaseHarmonicCurrentMultiplierWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributePhaseHarmonicCurrentMultiplierID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributePhaseHarmonicCurrentMultiplierID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeInstantaneousVoltageWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeInstantaneousVoltageID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousVoltageID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeInstantaneousLineCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeInstantaneousLineCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousLineCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeInstantaneousActiveCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeInstantaneousActiveCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousActiveCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeInstantaneousReactiveCurrentWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeInstantaneousReactiveCurrentID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousReactiveCurrentID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeInstantaneousPowerWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeInstantaneousPowerID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeInstantaneousPowerID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageMinWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageMinID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMinID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageMaxWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageMaxID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMaxID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsCurrentWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsCurrentID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsCurrentMinWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsCurrentMinID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMinID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsCurrentMaxWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsCurrentMaxID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMaxID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActivePowerWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeActivePowerID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActivePowerMinWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeActivePowerMinID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMinID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActivePowerMaxWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeActivePowerMaxID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMaxID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeReactivePowerWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeReactivePowerID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactivePowerID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeApparentPowerWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeApparentPowerID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeApparentPowerID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePowerFactorWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributePowerFactorID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerFactorID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAverageRmsVoltageMeasurementPeriodWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodID)
+                             params:params];
 }
 
 - (void)writeAttributeAverageRmsVoltageMeasurementPeriodWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -22923,20 +23054,22 @@ using chip::SessionHandle;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterElectricalMeasurementID)
-                                  attributeID:@(MTRClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodID)
-                                        value:dataValueDictionary
-                        expectedValueInterval:expectedValueIntervalMs
-                            timedWriteTimeout:timedWriteTimeout];
+    [self.device
+        writeAttributeWithEndpointID:@(_endpoint)
+                           clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                         attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodID)
+                               value:dataValueDictionary
+               expectedValueInterval:expectedValueIntervalMs
+                   timedWriteTimeout:timedWriteTimeout];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAverageRmsUnderVoltageCounterWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterID)
+                             params:params];
 }
 
 - (void)writeAttributeAverageRmsUnderVoltageCounterWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -22952,20 +23085,22 @@ using chip::SessionHandle;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterElectricalMeasurementID)
-                                  attributeID:@(MTRClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterID)
-                                        value:dataValueDictionary
-                        expectedValueInterval:expectedValueIntervalMs
-                            timedWriteTimeout:timedWriteTimeout];
+    [self.device
+        writeAttributeWithEndpointID:@(_endpoint)
+                           clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                         attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterID)
+                               value:dataValueDictionary
+               expectedValueInterval:expectedValueIntervalMs
+                   timedWriteTimeout:timedWriteTimeout];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsExtremeOverVoltagePeriodWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodID)
+                             params:params];
 }
 
 - (void)writeAttributeRmsExtremeOverVoltagePeriodWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -22981,20 +23116,22 @@ using chip::SessionHandle;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterElectricalMeasurementID)
-                                  attributeID:@(MTRClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodID)
-                                        value:dataValueDictionary
-                        expectedValueInterval:expectedValueIntervalMs
-                            timedWriteTimeout:timedWriteTimeout];
+    [self.device
+        writeAttributeWithEndpointID:@(_endpoint)
+                           clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                         attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodID)
+                               value:dataValueDictionary
+               expectedValueInterval:expectedValueIntervalMs
+                   timedWriteTimeout:timedWriteTimeout];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsExtremeUnderVoltagePeriodWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodID)
+                             params:params];
 }
 
 - (void)writeAttributeRmsExtremeUnderVoltagePeriodWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -23010,19 +23147,20 @@ using chip::SessionHandle;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterElectricalMeasurementID)
-                                  attributeID:@(MTRClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodID)
-                                        value:dataValueDictionary
-                        expectedValueInterval:expectedValueIntervalMs
-                            timedWriteTimeout:timedWriteTimeout];
+    [self.device
+        writeAttributeWithEndpointID:@(_endpoint)
+                           clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                         attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodID)
+                               value:dataValueDictionary
+               expectedValueInterval:expectedValueIntervalMs
+                   timedWriteTimeout:timedWriteTimeout];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageSagPeriodWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageSagPeriodID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSagPeriodID)
                                              params:params];
 }
 
@@ -23038,8 +23176,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterElectricalMeasurementID)
-                                  attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageSagPeriodID)
+                                    clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                  attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSagPeriodID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -23047,10 +23185,11 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageSwellPeriodWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodID)
+                                          params:params];
 }
 
 - (void)writeAttributeRmsVoltageSwellPeriodWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -23067,8 +23206,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterElectricalMeasurementID)
-                                  attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodID)
+                                    clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                  attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -23077,56 +23216,56 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeAcVoltageMultiplierWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcVoltageMultiplierID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcVoltageMultiplierID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcVoltageDivisorWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcVoltageDivisorID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcVoltageDivisorID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcCurrentMultiplierWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcCurrentMultiplierID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcCurrentMultiplierID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcCurrentDivisorWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcCurrentDivisorID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcCurrentDivisorID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcPowerMultiplierWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcPowerMultiplierID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcPowerMultiplierID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcPowerDivisorWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcPowerDivisorID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcPowerDivisorID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeOverloadAlarmsMaskWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeOverloadAlarmsMaskID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeOverloadAlarmsMaskID)
                                              params:params];
 }
 
@@ -23142,8 +23281,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterElectricalMeasurementID)
-                                  attributeID:@(MTRClusterElectricalMeasurementAttributeOverloadAlarmsMaskID)
+                                    clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                  attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeOverloadAlarmsMaskID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -23152,24 +23291,24 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeVoltageOverloadWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeVoltageOverloadID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeVoltageOverloadID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeCurrentOverloadWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeCurrentOverloadID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeCurrentOverloadID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcOverloadAlarmsMaskWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcOverloadAlarmsMaskID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcOverloadAlarmsMaskID)
                                              params:params];
 }
 
@@ -23185,8 +23324,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterElectricalMeasurementID)
-                                  attributeID:@(MTRClusterElectricalMeasurementAttributeAcOverloadAlarmsMaskID)
+                                    clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                  attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcOverloadAlarmsMaskID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -23195,200 +23334,207 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeAcVoltageOverloadWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcVoltageOverloadID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcVoltageOverloadID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcCurrentOverloadWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcCurrentOverloadID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcCurrentOverloadID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcActivePowerOverloadWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcActivePowerOverloadID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcActivePowerOverloadID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcReactivePowerOverloadWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcReactivePowerOverloadID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcReactivePowerOverloadID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAverageRmsOverVoltageWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAverageRmsOverVoltageID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsOverVoltageID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAverageRmsUnderVoltageWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAverageRmsUnderVoltageID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsUnderVoltageID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsExtremeOverVoltageWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsExtremeOverVoltageID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeOverVoltageID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsExtremeUnderVoltageWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsExtremeUnderVoltageID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeUnderVoltageID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageSagWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageSagID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSagID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageSwellWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageSwellID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSwellID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLineCurrentPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeLineCurrentPhaseBID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeLineCurrentPhaseBID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActiveCurrentPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeActiveCurrentPhaseBID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeActiveCurrentPhaseBID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeReactiveCurrentPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeReactiveCurrentPhaseBID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactiveCurrentPhaseBID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltagePhaseBWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltagePhaseBID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltagePhaseBID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageMinPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageMinPhaseBID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMinPhaseBID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageMaxPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageMaxPhaseBID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMaxPhaseBID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsCurrentPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsCurrentPhaseBID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentPhaseBID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsCurrentMinPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsCurrentMinPhaseBID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMinPhaseBID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsCurrentMaxPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsCurrentMaxPhaseBID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMaxPhaseBID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActivePowerPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeActivePowerPhaseBID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerPhaseBID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActivePowerMinPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeActivePowerMinPhaseBID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMinPhaseBID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActivePowerMaxPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeActivePowerMaxPhaseBID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMaxPhaseBID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeReactivePowerPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeReactivePowerPhaseBID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactivePowerPhaseBID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeApparentPowerPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeApparentPowerPhaseBID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeApparentPowerPhaseBID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePowerFactorPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributePowerFactorPhaseBID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerFactorPhaseBID)
                                              params:params];
 }
 
@@ -23396,176 +23542,184 @@ using chip::SessionHandle;
 {
     return [self.device
         readAttributeWithEndpointID:@(_endpoint)
-                          clusterID:@(MTRClusterElectricalMeasurementID)
-                        attributeID:@(MTRClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodPhaseBID)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:
+                            @(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodPhaseBID)
                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAverageRmsOverVoltageCounterPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAverageRmsOverVoltageCounterPhaseBID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsOverVoltageCounterPhaseBID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAverageRmsUnderVoltageCounterPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterPhaseBID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterPhaseBID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsExtremeOverVoltagePeriodPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodPhaseBID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodPhaseBID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsExtremeUnderVoltagePeriodPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodPhaseBID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodPhaseBID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageSagPeriodPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageSagPeriodPhaseBID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSagPeriodPhaseBID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageSwellPeriodPhaseBWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodPhaseBID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodPhaseBID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeLineCurrentPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeLineCurrentPhaseCID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeLineCurrentPhaseCID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActiveCurrentPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeActiveCurrentPhaseCID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeActiveCurrentPhaseCID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeReactiveCurrentPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeReactiveCurrentPhaseCID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                     attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactiveCurrentPhaseCID)
+                                          params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltagePhaseCWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltagePhaseCID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltagePhaseCID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageMinPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageMinPhaseCID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMinPhaseCID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageMaxPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageMaxPhaseCID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageMaxPhaseCID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsCurrentPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsCurrentPhaseCID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentPhaseCID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsCurrentMinPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsCurrentMinPhaseCID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMinPhaseCID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsCurrentMaxPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsCurrentMaxPhaseCID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsCurrentMaxPhaseCID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActivePowerPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeActivePowerPhaseCID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerPhaseCID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActivePowerMinPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeActivePowerMinPhaseCID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMinPhaseCID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeActivePowerMaxPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeActivePowerMaxPhaseCID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeActivePowerMaxPhaseCID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeReactivePowerPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeReactivePowerPhaseCID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeReactivePowerPhaseCID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeApparentPowerPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeApparentPowerPhaseCID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeApparentPowerPhaseCID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributePowerFactorPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributePowerFactorPhaseCID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributePowerFactorPhaseCID)
                                              params:params];
 }
 
@@ -23573,96 +23727,103 @@ using chip::SessionHandle;
 {
     return [self.device
         readAttributeWithEndpointID:@(_endpoint)
-                          clusterID:@(MTRClusterElectricalMeasurementID)
-                        attributeID:@(MTRClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodPhaseCID)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:
+                            @(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsVoltageMeasurementPeriodPhaseCID)
                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAverageRmsOverVoltageCounterPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAverageRmsOverVoltageCounterPhaseCID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsOverVoltageCounterPhaseCID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAverageRmsUnderVoltageCounterPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterPhaseCID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAverageRmsUnderVoltageCounterPhaseCID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsExtremeOverVoltagePeriodPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodPhaseCID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeOverVoltagePeriodPhaseCID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsExtremeUnderVoltagePeriodPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodPhaseCID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsExtremeUnderVoltagePeriodPhaseCID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageSagPeriodPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageSagPeriodPhaseCID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSagPeriodPhaseCID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeRmsVoltageSwellPeriodPhaseCWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodPhaseCID)
-                                             params:params];
+    return [self.device
+        readAttributeWithEndpointID:@(_endpoint)
+                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeRmsVoltageSwellPeriodPhaseCID)
+                             params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterElectricalMeasurementID)
-                                        attributeID:@(MTRClusterElectricalMeasurementAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeElectricalMeasurementID)
+                                        attributeID:@(MTRAttributeIDTypeClusterElectricalMeasurementAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -25536,8 +25697,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBooleanWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeBooleanID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeBooleanID)
                                              params:params];
 }
 
@@ -25553,8 +25714,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeBooleanID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeBooleanID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25563,8 +25724,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBitmap8WithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeBitmap8ID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeBitmap8ID)
                                              params:params];
 }
 
@@ -25580,8 +25741,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeBitmap8ID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeBitmap8ID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25590,8 +25751,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBitmap16WithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeBitmap16ID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeBitmap16ID)
                                              params:params];
 }
 
@@ -25607,8 +25768,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeBitmap16ID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeBitmap16ID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25617,8 +25778,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBitmap32WithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeBitmap32ID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeBitmap32ID)
                                              params:params];
 }
 
@@ -25634,8 +25795,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeBitmap32ID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeBitmap32ID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25644,8 +25805,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeBitmap64WithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeBitmap64ID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeBitmap64ID)
                                              params:params];
 }
 
@@ -25661,8 +25822,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeBitmap64ID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeBitmap64ID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25671,8 +25832,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt8uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt8uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt8uID)
                                              params:params];
 }
 
@@ -25688,8 +25849,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt8uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt8uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25698,8 +25859,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt16uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt16uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt16uID)
                                              params:params];
 }
 
@@ -25715,8 +25876,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt16uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt16uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25725,8 +25886,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt24uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt24uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt24uID)
                                              params:params];
 }
 
@@ -25742,8 +25903,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt24uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt24uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25752,8 +25913,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt32uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt32uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt32uID)
                                              params:params];
 }
 
@@ -25769,8 +25930,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt32uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt32uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25779,8 +25940,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt40uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt40uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt40uID)
                                              params:params];
 }
 
@@ -25796,8 +25957,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt40uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt40uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25806,8 +25967,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt48uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt48uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt48uID)
                                              params:params];
 }
 
@@ -25823,8 +25984,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt48uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt48uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25833,8 +25994,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt56uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt56uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt56uID)
                                              params:params];
 }
 
@@ -25850,8 +26011,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt56uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt56uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25860,8 +26021,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt64uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt64uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt64uID)
                                              params:params];
 }
 
@@ -25877,8 +26038,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt64uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt64uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25887,8 +26048,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt8sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt8sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt8sID)
                                              params:params];
 }
 
@@ -25904,8 +26065,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt8sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt8sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25914,8 +26075,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt16sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt16sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt16sID)
                                              params:params];
 }
 
@@ -25931,8 +26092,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt16sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt16sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25941,8 +26102,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt24sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt24sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt24sID)
                                              params:params];
 }
 
@@ -25958,8 +26119,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt24sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt24sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25968,8 +26129,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt32sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt32sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt32sID)
                                              params:params];
 }
 
@@ -25985,8 +26146,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt32sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt32sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -25995,8 +26156,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt40sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt40sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt40sID)
                                              params:params];
 }
 
@@ -26012,8 +26173,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt40sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt40sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26022,8 +26183,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt48sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt48sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt48sID)
                                              params:params];
 }
 
@@ -26039,8 +26200,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt48sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt48sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26049,8 +26210,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt56sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt56sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt56sID)
                                              params:params];
 }
 
@@ -26066,8 +26227,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt56sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt56sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26076,8 +26237,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeInt64sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeInt64sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt64sID)
                                              params:params];
 }
 
@@ -26093,8 +26254,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeInt64sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeInt64sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26103,8 +26264,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeEnum8WithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeEnum8ID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeEnum8ID)
                                              params:params];
 }
 
@@ -26120,8 +26281,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeEnum8ID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeEnum8ID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26130,8 +26291,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeEnum16WithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeEnum16ID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeEnum16ID)
                                              params:params];
 }
 
@@ -26147,8 +26308,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeEnum16ID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeEnum16ID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26157,8 +26318,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeFloatSingleWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeFloatSingleID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeFloatSingleID)
                                              params:params];
 }
 
@@ -26174,8 +26335,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeFloatSingleID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeFloatSingleID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26184,8 +26345,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeFloatDoubleWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeFloatDoubleID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeFloatDoubleID)
                                              params:params];
 }
 
@@ -26201,8 +26362,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeFloatDoubleID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeFloatDoubleID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26211,8 +26372,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeOctetStringWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeOctetStringID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeOctetStringID)
                                              params:params];
 }
 
@@ -26228,8 +26389,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeOctetStringID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeOctetStringID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26238,8 +26399,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeListInt8uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeListInt8uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeListInt8uID)
                                              params:params];
 }
 
@@ -26255,8 +26416,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeListInt8uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeListInt8uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26265,8 +26426,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeListOctetStringWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeListOctetStringID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeListOctetStringID)
                                              params:params];
 }
 
@@ -26282,8 +26443,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeListOctetStringID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeListOctetStringID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26292,8 +26453,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeListStructOctetStringWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeListStructOctetStringID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeListStructOctetStringID)
                                              params:params];
 }
 
@@ -26311,8 +26472,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeListStructOctetStringID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeListStructOctetStringID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26321,8 +26482,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLongOctetStringWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeLongOctetStringID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeLongOctetStringID)
                                              params:params];
 }
 
@@ -26338,8 +26499,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeLongOctetStringID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeLongOctetStringID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26348,8 +26509,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeCharStringWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeCharStringID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeCharStringID)
                                              params:params];
 }
 
@@ -26365,8 +26526,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeCharStringID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeCharStringID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26375,8 +26536,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeLongCharStringWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeLongCharStringID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeLongCharStringID)
                                              params:params];
 }
 
@@ -26392,8 +26553,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeLongCharStringID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeLongCharStringID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26402,8 +26563,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeEpochUsWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeEpochUsID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeEpochUsID)
                                              params:params];
 }
 
@@ -26419,8 +26580,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeEpochUsID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeEpochUsID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26429,8 +26590,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeEpochSWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeEpochSID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeEpochSID)
                                              params:params];
 }
 
@@ -26446,8 +26607,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeEpochSID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeEpochSID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26456,8 +26617,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeVendorIdWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeVendorIdID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeVendorIdID)
                                              params:params];
 }
 
@@ -26473,8 +26634,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeVendorIdID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeVendorIdID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26482,10 +26643,11 @@ using chip::SessionHandle;
 
 - (NSDictionary<NSString *, id> *)readAttributeListNullablesAndOptionalsStructWithParams:(MTRReadParams * _Nullable)params
 {
-    return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeListNullablesAndOptionalsStructID)
-                                             params:params];
+    return
+        [self.device readAttributeWithEndpointID:@(_endpoint)
+                                       clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                     attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeListNullablesAndOptionalsStructID)
+                                          params:params];
 }
 
 - (void)writeAttributeListNullablesAndOptionalsStructWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
@@ -26502,8 +26664,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeListNullablesAndOptionalsStructID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeListNullablesAndOptionalsStructID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26512,8 +26674,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeEnumAttrWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeEnumAttrID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeEnumAttrID)
                                              params:params];
 }
 
@@ -26529,8 +26691,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeEnumAttrID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeEnumAttrID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26539,8 +26701,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeStructAttrWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeStructAttrID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeStructAttrID)
                                              params:params];
 }
 
@@ -26556,8 +26718,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeStructAttrID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeStructAttrID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26566,8 +26728,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeRangeRestrictedInt8uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeRangeRestrictedInt8uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt8uID)
                                              params:params];
 }
 
@@ -26583,8 +26745,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeRangeRestrictedInt8uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt8uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26593,8 +26755,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeRangeRestrictedInt8sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeRangeRestrictedInt8sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt8sID)
                                              params:params];
 }
 
@@ -26610,8 +26772,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeRangeRestrictedInt8sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt8sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26620,8 +26782,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeRangeRestrictedInt16uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeRangeRestrictedInt16uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt16uID)
                                              params:params];
 }
 
@@ -26639,8 +26801,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeRangeRestrictedInt16uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt16uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26649,8 +26811,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeRangeRestrictedInt16sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeRangeRestrictedInt16sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt16sID)
                                              params:params];
 }
 
@@ -26668,8 +26830,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeRangeRestrictedInt16sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeRangeRestrictedInt16sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26678,8 +26840,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeListLongOctetStringWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeListLongOctetStringID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeListLongOctetStringID)
                                              params:params];
 }
 
@@ -26695,8 +26857,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeListLongOctetStringID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeListLongOctetStringID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26705,8 +26867,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeListFabricScopedWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeListFabricScopedID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeListFabricScopedID)
                                              params:params];
 }
 
@@ -26722,8 +26884,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeListFabricScopedID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeListFabricScopedID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26732,8 +26894,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeTimedWriteBooleanWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeTimedWriteBooleanID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeTimedWriteBooleanID)
                                              params:params];
 }
 
@@ -26749,8 +26911,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeTimedWriteBooleanID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeTimedWriteBooleanID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26759,8 +26921,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneralErrorBooleanWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeGeneralErrorBooleanID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeGeneralErrorBooleanID)
                                              params:params];
 }
 
@@ -26776,8 +26938,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeGeneralErrorBooleanID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeGeneralErrorBooleanID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26786,8 +26948,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeClusterErrorBooleanWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeClusterErrorBooleanID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeClusterErrorBooleanID)
                                              params:params];
 }
 
@@ -26803,8 +26965,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeClusterErrorBooleanID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeClusterErrorBooleanID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26813,8 +26975,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeUnsupportedWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeUnsupportedID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeUnsupportedID)
                                              params:params];
 }
 
@@ -26830,8 +26992,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeUnsupportedID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeUnsupportedID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26840,8 +27002,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableBooleanWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableBooleanID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableBooleanID)
                                              params:params];
 }
 
@@ -26857,8 +27019,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableBooleanID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableBooleanID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26867,8 +27029,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableBitmap8WithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableBitmap8ID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap8ID)
                                              params:params];
 }
 
@@ -26884,8 +27046,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableBitmap8ID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap8ID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26894,8 +27056,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableBitmap16WithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableBitmap16ID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap16ID)
                                              params:params];
 }
 
@@ -26911,8 +27073,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableBitmap16ID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap16ID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26921,8 +27083,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableBitmap32WithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableBitmap32ID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap32ID)
                                              params:params];
 }
 
@@ -26938,8 +27100,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableBitmap32ID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap32ID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26948,8 +27110,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableBitmap64WithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableBitmap64ID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap64ID)
                                              params:params];
 }
 
@@ -26965,8 +27127,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableBitmap64ID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableBitmap64ID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -26975,8 +27137,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt8uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt8uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt8uID)
                                              params:params];
 }
 
@@ -26992,8 +27154,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt8uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt8uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27002,8 +27164,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt16uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt16uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt16uID)
                                              params:params];
 }
 
@@ -27019,8 +27181,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt16uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt16uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27029,8 +27191,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt24uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt24uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt24uID)
                                              params:params];
 }
 
@@ -27046,8 +27208,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt24uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt24uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27056,8 +27218,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt32uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt32uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt32uID)
                                              params:params];
 }
 
@@ -27073,8 +27235,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt32uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt32uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27083,8 +27245,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt40uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt40uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt40uID)
                                              params:params];
 }
 
@@ -27100,8 +27262,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt40uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt40uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27110,8 +27272,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt48uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt48uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt48uID)
                                              params:params];
 }
 
@@ -27127,8 +27289,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt48uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt48uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27137,8 +27299,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt56uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt56uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt56uID)
                                              params:params];
 }
 
@@ -27154,8 +27316,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt56uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt56uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27164,8 +27326,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt64uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt64uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt64uID)
                                              params:params];
 }
 
@@ -27181,8 +27343,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt64uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt64uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27191,8 +27353,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt8sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt8sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt8sID)
                                              params:params];
 }
 
@@ -27208,8 +27370,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt8sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt8sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27218,8 +27380,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt16sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt16sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt16sID)
                                              params:params];
 }
 
@@ -27235,8 +27397,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt16sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt16sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27245,8 +27407,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt24sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt24sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt24sID)
                                              params:params];
 }
 
@@ -27262,8 +27424,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt24sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt24sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27272,8 +27434,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt32sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt32sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt32sID)
                                              params:params];
 }
 
@@ -27289,8 +27451,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt32sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt32sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27299,8 +27461,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt40sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt40sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt40sID)
                                              params:params];
 }
 
@@ -27316,8 +27478,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt40sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt40sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27326,8 +27488,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt48sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt48sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt48sID)
                                              params:params];
 }
 
@@ -27343,8 +27505,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt48sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt48sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27353,8 +27515,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt56sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt56sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt56sID)
                                              params:params];
 }
 
@@ -27370,8 +27532,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt56sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt56sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27380,8 +27542,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableInt64sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableInt64sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt64sID)
                                              params:params];
 }
 
@@ -27397,8 +27559,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableInt64sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableInt64sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27407,8 +27569,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableEnum8WithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableEnum8ID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableEnum8ID)
                                              params:params];
 }
 
@@ -27424,8 +27586,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableEnum8ID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableEnum8ID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27434,8 +27596,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableEnum16WithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableEnum16ID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableEnum16ID)
                                              params:params];
 }
 
@@ -27451,8 +27613,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableEnum16ID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableEnum16ID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27461,8 +27623,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableFloatSingleWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableFloatSingleID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableFloatSingleID)
                                              params:params];
 }
 
@@ -27478,8 +27640,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableFloatSingleID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableFloatSingleID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27488,8 +27650,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableFloatDoubleWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableFloatDoubleID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableFloatDoubleID)
                                              params:params];
 }
 
@@ -27505,8 +27667,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableFloatDoubleID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableFloatDoubleID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27515,8 +27677,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableOctetStringWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableOctetStringID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableOctetStringID)
                                              params:params];
 }
 
@@ -27532,8 +27694,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableOctetStringID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableOctetStringID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27542,8 +27704,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableCharStringWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableCharStringID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableCharStringID)
                                              params:params];
 }
 
@@ -27559,8 +27721,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableCharStringID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableCharStringID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27569,8 +27731,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableEnumAttrWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableEnumAttrID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableEnumAttrID)
                                              params:params];
 }
 
@@ -27586,8 +27748,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableEnumAttrID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableEnumAttrID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27596,8 +27758,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableStructWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableStructID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableStructID)
                                              params:params];
 }
 
@@ -27613,8 +27775,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableStructID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableStructID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27623,8 +27785,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableRangeRestrictedInt8uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableRangeRestrictedInt8uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt8uID)
                                              params:params];
 }
 
@@ -27642,8 +27804,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableRangeRestrictedInt8uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt8uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27652,8 +27814,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableRangeRestrictedInt8sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableRangeRestrictedInt8sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt8sID)
                                              params:params];
 }
 
@@ -27671,8 +27833,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableRangeRestrictedInt8sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt8sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27681,8 +27843,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableRangeRestrictedInt16uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableRangeRestrictedInt16uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt16uID)
                                              params:params];
 }
 
@@ -27700,8 +27862,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableRangeRestrictedInt16uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt16uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27710,8 +27872,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeNullableRangeRestrictedInt16sWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeNullableRangeRestrictedInt16sID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt16sID)
                                              params:params];
 }
 
@@ -27729,8 +27891,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeNullableRangeRestrictedInt16sID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeNullableRangeRestrictedInt16sID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27739,8 +27901,8 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeWriteOnlyInt8uWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeWriteOnlyInt8uID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeWriteOnlyInt8uID)
                                              params:params];
 }
 
@@ -27756,8 +27918,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterUnitTestingID)
-                                  attributeID:@(MTRClusterUnitTestingAttributeWriteOnlyInt8uID)
+                                    clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                  attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeWriteOnlyInt8uID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -27766,40 +27928,40 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterUnitTestingID)
-                                        attributeID:@(MTRClusterUnitTestingAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeUnitTestingID)
+                                        attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeClusterRevisionID)
                                              params:params];
 }
 


### PR DESCRIPTION
This is a re-landing of PR #22673 but with backwards-compat preserved.

* Update generated code
