### PR TITLE
Fix the issue of unreleased JNI references.

### DIFF
--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -95,15 +95,15 @@ CHIP_ERROR AppContentLauncherManager::HandleGetAcceptHeaderList(AttributeValueEn
         if (reader.parse(resStr, value))
         {
             std::string attrId = to_string(chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::Id);
-            ChipLogProgress(
-                Zcl, "AppContentLauncherManager::HandleGetAcceptHeaderList response parsing done. reading attr %s",
-                attrId.c_str());
+            ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetAcceptHeaderList response parsing done. reading attr %s",
+                            attrId.c_str());
             if (value[attrId].isArray())
             {
                 mAcceptHeaderList.clear();
                 for (Json::Value & entry : value[attrId])
                 {
-                    if (entry.isString()){
+                    if (entry.isString())
+                    {
                         mAcceptHeaderList.push_back(entry.asString());
                     }
                 }

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -85,10 +85,10 @@ CHIP_ERROR AppContentLauncherManager::HandleGetAcceptHeaderList(AttributeValueEn
     ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetAcceptHeaderList");
     chip::app::ConcreteReadAttributePath aPath(mEndpointId, chip::app::Clusters::ContentLauncher::Id,
                                                chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::Id);
-    const char * resStr = mAttributeDelegate->Read(aPath);
-    ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response %s", resStr);
+    std::string resStr = mAttributeDelegate->Read(aPath);
+    ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetAcceptHeaderList response %s", resStr.c_str());
 
-    if (resStr != nullptr && *resStr != 0)
+    if (resStr.length() != 0)
     {
         Json::Reader reader;
         Json::Value value;
@@ -96,14 +96,16 @@ CHIP_ERROR AppContentLauncherManager::HandleGetAcceptHeaderList(AttributeValueEn
         {
             std::string attrId = to_string(chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::Id);
             ChipLogProgress(
-                Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response parsing done. reading attr %s",
+                Zcl, "AppContentLauncherManager::HandleGetAcceptHeaderList response parsing done. reading attr %s",
                 attrId.c_str());
             if (value[attrId].isArray())
             {
                 mAcceptHeaderList.clear();
                 for (Json::Value & entry : value[attrId])
                 {
-                    mAcceptHeaderList.push_back(entry.asString());
+                    if (entry.isString()){
+                        mAcceptHeaderList.push_back(entry.asString());
+                    }
                 }
             }
         }
@@ -124,10 +126,10 @@ uint32_t AppContentLauncherManager::HandleGetSupportedStreamingProtocols()
     ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols");
     chip::app::ConcreteReadAttributePath aPath(mEndpointId, chip::app::Clusters::ContentLauncher::Id,
                                                chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::Id);
-    const char * resStr = mAttributeDelegate->Read(aPath);
-    ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response %s", resStr);
+    std::string resStr = mAttributeDelegate->Read(aPath);
+    ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response %s", resStr.c_str());
 
-    if (resStr == nullptr || *resStr == 0)
+    if (resStr.length() == 0)
     {
         return mSupportedStreamingProtocols;
     }
@@ -141,7 +143,7 @@ uint32_t AppContentLauncherManager::HandleGetSupportedStreamingProtocols()
     std::string attrId = to_string(chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::Id);
     ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response parsing done. reading attr %s",
                     attrId.c_str());
-    if (!value[attrId].empty())
+    if (!value[attrId].empty() && value[attrId].isInt())
     {
         uint32_t supportedStreamingProtocols = static_cast<uint32_t>(value[attrId].asInt());
         mSupportedStreamingProtocols         = supportedStreamingProtocols;

--- a/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
+++ b/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
@@ -195,7 +195,8 @@ CHIP_ERROR AppMediaPlaybackManager::HandleGetSampledPosition(AttributeValueEncod
                     static_cast<uint32_t>(chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::Fields::kUpdatedAt));
                 std::string position = to_string(
                     static_cast<uint32_t>(chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::Fields::kPosition));
-                if (!value[attrId][updatedAt].empty() && !value[attrId][position].empty() && value[attrId][updatedAt].isUInt() && value[attrId][position].isUInt())
+                if (!value[attrId][updatedAt].empty() && !value[attrId][position].empty() && value[attrId][updatedAt].isUInt() &&
+                    value[attrId][position].isUInt())
                 {
                     // valid response
                     response.updatedAt = value[attrId][updatedAt].asUInt();

--- a/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
+++ b/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
@@ -130,11 +130,11 @@ uint64_t AppMediaPlaybackManager::HandleMediaRequestGetAttribute(chip::Attribute
 {
     ChipLogProgress(Zcl, "Received AppMediaPlaybackManager::HandleMediaRequestGetAttribute:%d", attributeId);
     chip::app::ConcreteReadAttributePath aPath(mEndpointId, chip::app::Clusters::MediaPlayback::Id, attributeId);
-    const char * resStr = mAttributeDelegate->Read(aPath);
-    ChipLogProgress(Zcl, "AppMediaPlaybackManager::HandleMediaRequestGetAttribute response %s", resStr);
+    std::string resStr = mAttributeDelegate->Read(aPath);
+    ChipLogProgress(Zcl, "AppMediaPlaybackManager::HandleMediaRequestGetAttribute response %s", resStr.c_str());
 
     uint64_t ret = std::numeric_limits<uint64_t>::max();
-    if (resStr != nullptr && *resStr != 0)
+    if (resStr.length() != 0)
     {
         Json::Reader reader;
         Json::Value value;
@@ -143,7 +143,7 @@ uint64_t AppMediaPlaybackManager::HandleMediaRequestGetAttribute(chip::Attribute
             std::string attrId = to_string(attributeId);
             ChipLogProgress(Zcl, "AppMediaPlaybackManager::HandleMediaRequestGetAttribute response parsing done. reading attr %s",
                             attrId.c_str());
-            if (!value[attrId].empty())
+            if (!value[attrId].empty() && value[attrId].isUInt())
             {
                 ret = static_cast<uint64_t>(value[attrId].asUInt());
                 return ret;
@@ -177,9 +177,10 @@ CHIP_ERROR AppMediaPlaybackManager::HandleGetSampledPosition(AttributeValueEncod
     ChipLogProgress(Zcl, "AppMediaPlaybackManager::HandleGetSampledPosition");
     chip::app::ConcreteReadAttributePath aPath(mEndpointId, chip::app::Clusters::MediaPlayback::Id,
                                                chip::app::Clusters::MediaPlayback::Attributes::SampledPosition::Id);
-    const char * resStr = mAttributeDelegate->Read(aPath);
+    std::string resStr = mAttributeDelegate->Read(aPath);
+    ChipLogProgress(Zcl, "AppMediaPlaybackManager::HandleGetSampledPosition response %s", resStr.c_str());
 
-    if (resStr != nullptr && *resStr != 0)
+    if (resStr.length() != 0)
     {
         Json::Reader reader;
         Json::Value value;
@@ -188,13 +189,13 @@ CHIP_ERROR AppMediaPlaybackManager::HandleGetSampledPosition(AttributeValueEncod
             std::string attrId = to_string(chip::app::Clusters::MediaPlayback::Attributes::SampledPosition::Id);
             ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSampledPosition response parsing done. reading attr %s",
                             attrId.c_str());
-            if (!value[attrId].empty())
+            if (!value[attrId].empty() && value[attrId].isObject())
             {
                 std::string updatedAt = to_string(
                     static_cast<uint32_t>(chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::Fields::kUpdatedAt));
                 std::string position = to_string(
                     static_cast<uint32_t>(chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::Fields::kPosition));
-                if (!value[attrId][updatedAt].empty() && !value[attrId][position].empty())
+                if (!value[attrId][updatedAt].empty() && !value[attrId][position].empty() && value[attrId][updatedAt].isUInt() && value[attrId][position].isUInt())
                 {
                     // valid response
                     response.updatedAt = value[attrId][updatedAt].asUInt();

--- a/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
@@ -39,10 +39,10 @@ CHIP_ERROR TargetNavigatorManager::HandleGetTargetList(AttributeValueEncoder & a
     {
         chip::app::ConcreteReadAttributePath aPath(mEndpointId, chip::app::Clusters::TargetNavigator::Id,
                                                    chip::app::Clusters::TargetNavigator::Attributes::TargetList::Id);
-        const char * resStr = mAttributeDelegate->Read(aPath);
-        ChipLogProgress(Zcl, "TargetNavigatorManager::HandleNavigateTarget response %s", resStr);
+        std::string resStr = mAttributeDelegate->Read(aPath);
+        ChipLogProgress(Zcl, "TargetNavigatorManager::HandleNavigateTarget response %s", resStr.c_str());
 
-        if (resStr != nullptr && *resStr != 0)
+        if (resStr.length() != 0)
         {
             Json::Reader reader;
             Json::Value value;
@@ -104,10 +104,10 @@ uint8_t TargetNavigatorManager::HandleGetCurrentTarget()
     {
         chip::app::ConcreteReadAttributePath aPath(mEndpointId, chip::app::Clusters::TargetNavigator::Id,
                                                    chip::app::Clusters::TargetNavigator::Attributes::TargetList::Id);
-        const char * resStr = mAttributeDelegate->Read(aPath);
-        ChipLogProgress(Zcl, "TargetNavigatorManager::HandleGetCurrentTarget response %s", resStr);
+        std::string resStr = mAttributeDelegate->Read(aPath);
+        ChipLogProgress(Zcl, "TargetNavigatorManager::HandleGetCurrentTarget response %s", resStr.c_str());
 
-        if (resStr != nullptr && *resStr != 0)
+        if (resStr.length() != 0)
         {
             Json::Reader reader;
             Json::Value value;

--- a/examples/tv-app/android/java/ContentAppAttributeDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppAttributeDelegate.cpp
@@ -34,14 +34,15 @@ namespace AppPlatform {
 
 using LaunchResponseType = chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::Type;
 
-const char * ContentAppAttributeDelegate::Read(const chip::app::ConcreteReadAttributePath & aPath)
+std::string ContentAppAttributeDelegate::Read(const chip::app::ConcreteReadAttributePath & aPath)
 {
     if (aPath.mEndpointId < FIXED_ENDPOINT_COUNT)
     {
+        // returning blank string causes the caller to default to output required by the tests
         return "";
     }
-    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
 
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     ChipLogProgress(Zcl, "ContentAppAttributeDelegate::Read being called for endpoint %d cluster %d attribute %d",
                     aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId);
 
@@ -53,11 +54,15 @@ const char * ContentAppAttributeDelegate::Read(const chip::app::ConcreteReadAttr
         ChipLogError(Zcl, "Java exception in ContentAppAttributeDelegate::Read");
         env->ExceptionDescribe();
         env->ExceptionClear();
+        // returning blank string causes the caller to default to output required by the tests
         return "";
     }
     const char * respStr = env->GetStringUTFChars(resp, 0);
+    std::string retStr(respStr);
+    env->ReleaseStringUTFChars(resp, respStr);
+    env->DeleteLocalRef(resp);
     ChipLogProgress(Zcl, "ContentAppAttributeDelegate::Read got response %s", respStr);
-    return respStr;
+    return retStr;
 }
 
 } // namespace AppPlatform

--- a/examples/tv-app/android/java/ContentAppAttributeDelegate.h
+++ b/examples/tv-app/android/java/ContentAppAttributeDelegate.h
@@ -51,7 +51,7 @@ public:
         env->DeleteGlobalRef(mContentAppEndpointManager);
     }
 
-    const char * Read(const chip::app::ConcreteReadAttributePath & aPath);
+    std::string Read(const chip::app::ConcreteReadAttributePath & aPath);
 
 private:
     void InitializeJNIObjects(jobject manager)

--- a/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
@@ -60,13 +60,12 @@ void ContentAppCommandDelegate::InvokeCommand(CommandHandlerInterface::HandlerCo
             return;
         }
 
-        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-        Json::Value value = json["value"];
+        JNIEnv * env        = JniReferences::GetInstance().GetEnvForCurrentThread();
+        Json::Value value   = json["value"];
         std::string payload = JsonToString(value);
         UtfString jsonString(env, payload.c_str());
 
-        ChipLogProgress(Zcl, "ContentAppCommandDelegate::InvokeCommand send command being called with payload %s",
-                        payload.c_str());
+        ChipLogProgress(Zcl, "ContentAppCommandDelegate::InvokeCommand send command being called with payload %s", payload.c_str());
 
         jstring resp = (jstring) env->CallObjectMethod(
             mContentAppEndpointManager, mSendCommandMethod, static_cast<jint>(handlerContext.mRequestPath.mEndpointId),

--- a/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
@@ -60,12 +60,13 @@ void ContentAppCommandDelegate::InvokeCommand(CommandHandlerInterface::HandlerCo
             return;
         }
 
-        JNIEnv * env      = JniReferences::GetInstance().GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         Json::Value value = json["value"];
-        UtfString jsonString(env, JsonToString(value).c_str());
+        std::string payload = JsonToString(value);
+        UtfString jsonString(env, payload.c_str());
 
         ChipLogProgress(Zcl, "ContentAppCommandDelegate::InvokeCommand send command being called with payload %s",
-                        JsonToString(json).c_str());
+                        payload.c_str());
 
         jstring resp = (jstring) env->CallObjectMethod(
             mContentAppEndpointManager, mSendCommandMethod, static_cast<jint>(handlerContext.mRequestPath.mEndpointId),
@@ -82,6 +83,8 @@ void ContentAppCommandDelegate::InvokeCommand(CommandHandlerInterface::HandlerCo
         const char * respStr = env->GetStringUTFChars(resp, 0);
         ChipLogProgress(Zcl, "ContentAppCommandDelegate::InvokeCommand got response %s", respStr);
         FormatResponseData(handlerContext, respStr);
+        env->ReleaseStringUTFChars(resp, respStr);
+        env->DeleteLocalRef(resp);
     }
     else
     {


### PR DESCRIPTION
Fixes #23648 

There were unreleased JNI references that caused the reference table to overflow and caused the crash of the application. Fixed to release/delete references.
