### PR TITLE
Add missing endWork calls in MTRClusters.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
@@ -63,19 +63,19 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice *baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID controller:self.device.deviceController];
         auto * bridge = new MTR{{>callbackName}}CallbackBridge(self.callbackQueue,
+          ^(id _Nullable value, NSError * _Nullable error) {
           {{#if hasSpecificResponse}}
             {{! This treats completion as taking an id for the data.  This is
                 not great from a type-safety perspective, of course. }}
-            completion,
+            completion(value, error);
           {{else}}
             {{! For now, don't change the bridge API; instead just use an adapter
                 to invoke our completion handler. This is not great from a
                 type-safety perspective, of course. }}
-            ^(id _Nullable value, NSError * _Nullable error) {
-              completion(error);
-                  [workItem endWork];
-            },
+            completion(error);
           {{/if}}
+            [workItem endWork];
+          },
           ^(ExchangeManager & exchangeManager, const SessionHandle & session, {{>callbackName}}CallbackType successCb, MTRErrorCallback failureCb, MTRCallbackBridgeBase * bridge) {
             chip::Optional<uint16_t> timedInvokeTimeoutMs;
             ListFreer listFreer;

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
@@ -31,7 +31,7 @@ MTR_NEWLY_AVAILABLE
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs {{#if (isStrEqual source "server")}}MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands"){{/if}};
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
@@ -292,7 +292,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRGroupsClusterAddGroupResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRGroupsClusterAddGroupResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session, GroupsClusterAddGroupResponseCallbackType successCb,
                 MTRErrorCallback failureCb, MTRCallbackBridgeBase * bridge) {
                 chip::Optional<uint16_t> timedInvokeTimeoutMs;
@@ -338,7 +343,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRGroupsClusterViewGroupResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRGroupsClusterViewGroupResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 GroupsClusterViewGroupResponseCallbackType successCb, MTRErrorCallback failureCb, MTRCallbackBridgeBase * bridge) {
                 chip::Optional<uint16_t> timedInvokeTimeoutMs;
@@ -383,7 +393,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRGroupsClusterGetGroupMembershipResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRGroupsClusterGetGroupMembershipResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 GroupsClusterGetGroupMembershipResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -450,7 +465,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRGroupsClusterRemoveGroupResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRGroupsClusterRemoveGroupResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 GroupsClusterRemoveGroupResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -762,7 +782,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRScenesClusterAddSceneResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRScenesClusterAddSceneResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session, ScenesClusterAddSceneResponseCallbackType successCb,
                 MTRErrorCallback failureCb, MTRCallbackBridgeBase * bridge) {
                 chip::Optional<uint16_t> timedInvokeTimeoutMs;
@@ -884,7 +909,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRScenesClusterViewSceneResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRScenesClusterViewSceneResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ScenesClusterViewSceneResponseCallbackType successCb, MTRErrorCallback failureCb, MTRCallbackBridgeBase * bridge) {
                 chip::Optional<uint16_t> timedInvokeTimeoutMs;
@@ -930,7 +960,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRScenesClusterRemoveSceneResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRScenesClusterRemoveSceneResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ScenesClusterRemoveSceneResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -977,7 +1012,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRScenesClusterRemoveAllScenesResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRScenesClusterRemoveAllScenesResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ScenesClusterRemoveAllScenesResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -1023,7 +1063,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRScenesClusterStoreSceneResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRScenesClusterStoreSceneResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ScenesClusterStoreSceneResponseCallbackType successCb, MTRErrorCallback failureCb, MTRCallbackBridgeBase * bridge) {
                 chip::Optional<uint16_t> timedInvokeTimeoutMs;
@@ -1128,7 +1173,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRScenesClusterGetSceneMembershipResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRScenesClusterGetSceneMembershipResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ScenesClusterGetSceneMembershipResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -1174,7 +1224,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRScenesClusterEnhancedAddSceneResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRScenesClusterEnhancedAddSceneResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ScenesClusterEnhancedAddSceneResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -1297,7 +1352,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRScenesClusterEnhancedViewSceneResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRScenesClusterEnhancedViewSceneResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ScenesClusterEnhancedViewSceneResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -1344,7 +1404,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRScenesClusterCopySceneResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRScenesClusterCopySceneResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ScenesClusterCopySceneResponseCallbackType successCb, MTRErrorCallback failureCb, MTRCallbackBridgeBase * bridge) {
                 chip::Optional<uint16_t> timedInvokeTimeoutMs;
@@ -5023,7 +5088,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTROtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTROtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 OtaSoftwareUpdateProviderClusterQueryImageResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -5111,7 +5181,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 OtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -6210,7 +6285,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRGeneralCommissioningClusterArmFailSafeResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRGeneralCommissioningClusterArmFailSafeResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 GeneralCommissioningClusterArmFailSafeResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -6257,7 +6337,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 GeneralCommissioningClusterSetRegulatoryConfigResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -6319,21 +6404,25 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge
-            = new MTRGeneralCommissioningClusterCommissioningCompleteResponseCallbackBridge(self.callbackQueue, completion,
-                ^(ExchangeManager & exchangeManager, const SessionHandle & session,
-                    GeneralCommissioningClusterCommissioningCompleteResponseCallbackType successCb, MTRErrorCallback failureCb,
-                    MTRCallbackBridgeBase * bridge) {
-                    chip::Optional<uint16_t> timedInvokeTimeoutMs;
-                    ListFreer listFreer;
-                    GeneralCommissioning::Commands::CommissioningComplete::Type request;
-                    if (timedInvokeTimeoutMsParam != nil) {
-                        timedInvokeTimeoutMs.SetValue(timedInvokeTimeoutMsParam.unsignedShortValue);
-                    }
+        auto * bridge = new MTRGeneralCommissioningClusterCommissioningCompleteResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
+            ^(ExchangeManager & exchangeManager, const SessionHandle & session,
+                GeneralCommissioningClusterCommissioningCompleteResponseCallbackType successCb, MTRErrorCallback failureCb,
+                MTRCallbackBridgeBase * bridge) {
+                chip::Optional<uint16_t> timedInvokeTimeoutMs;
+                ListFreer listFreer;
+                GeneralCommissioning::Commands::CommissioningComplete::Type request;
+                if (timedInvokeTimeoutMsParam != nil) {
+                    timedInvokeTimeoutMs.SetValue(timedInvokeTimeoutMsParam.unsignedShortValue);
+                }
 
-                    chip::Controller::GeneralCommissioningCluster cppCluster(exchangeManager, session, self->_endpoint);
-                    return cppCluster.InvokeCommand(request, bridge, successCb, failureCb, timedInvokeTimeoutMs);
-                });
+                chip::Controller::GeneralCommissioningCluster cppCluster(exchangeManager, session, self->_endpoint);
+                return cppCluster.InvokeCommand(request, bridge, successCb, failureCb, timedInvokeTimeoutMs);
+            });
         std::move(*bridge).DispatchAction(baseDevice);
     };
     workItem.readyHandler = readyHandler;
@@ -6550,7 +6639,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRNetworkCommissioningClusterScanNetworksResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRNetworkCommissioningClusterScanNetworksResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 NetworkCommissioningClusterScanNetworksResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -6610,7 +6704,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRNetworkCommissioningClusterNetworkConfigResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRNetworkCommissioningClusterNetworkConfigResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 NetworkCommissioningClusterNetworkConfigResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -6661,7 +6760,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRNetworkCommissioningClusterNetworkConfigResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRNetworkCommissioningClusterNetworkConfigResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 NetworkCommissioningClusterNetworkConfigResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -6711,7 +6815,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRNetworkCommissioningClusterNetworkConfigResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRNetworkCommissioningClusterNetworkConfigResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 NetworkCommissioningClusterNetworkConfigResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -6761,7 +6870,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRNetworkCommissioningClusterConnectNetworkResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRNetworkCommissioningClusterConnectNetworkResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 NetworkCommissioningClusterConnectNetworkResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -6811,7 +6925,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRNetworkCommissioningClusterNetworkConfigResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRNetworkCommissioningClusterNetworkConfigResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 NetworkCommissioningClusterNetworkConfigResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -7105,7 +7224,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRDiagnosticLogsClusterRetrieveLogsResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRDiagnosticLogsClusterRetrieveLogsResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 DiagnosticLogsClusterRetrieveLogsResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -9306,7 +9430,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTROperationalCredentialsClusterAttestationResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTROperationalCredentialsClusterAttestationResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 OperationalCredentialsClusterAttestationResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -9352,7 +9481,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTROperationalCredentialsClusterCertificateChainResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTROperationalCredentialsClusterCertificateChainResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 OperationalCredentialsClusterCertificateChainResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -9398,7 +9532,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTROperationalCredentialsClusterCSRResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTROperationalCredentialsClusterCSRResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 OperationalCredentialsClusterCSRResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -9448,7 +9587,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTROperationalCredentialsClusterNOCResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTROperationalCredentialsClusterNOCResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 OperationalCredentialsClusterNOCResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -9502,7 +9646,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTROperationalCredentialsClusterNOCResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTROperationalCredentialsClusterNOCResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 OperationalCredentialsClusterNOCResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -9552,7 +9701,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTROperationalCredentialsClusterNOCResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTROperationalCredentialsClusterNOCResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 OperationalCredentialsClusterNOCResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -9598,7 +9752,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTROperationalCredentialsClusterNOCResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTROperationalCredentialsClusterNOCResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 OperationalCredentialsClusterNOCResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -10009,7 +10168,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRGroupKeyManagementClusterKeySetReadResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRGroupKeyManagementClusterKeySetReadResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 GroupKeyManagementClusterKeySetReadResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -10104,7 +10268,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRGroupKeyManagementClusterKeySetReadAllIndicesResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRGroupKeyManagementClusterKeySetReadAllIndicesResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 GroupKeyManagementClusterKeySetReadAllIndicesResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -11016,7 +11185,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRDoorLockClusterGetWeekDayScheduleResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRDoorLockClusterGetWeekDayScheduleResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 DoorLockClusterGetWeekDayScheduleResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -11165,7 +11339,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRDoorLockClusterGetYearDayScheduleResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRDoorLockClusterGetYearDayScheduleResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 DoorLockClusterGetYearDayScheduleResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -11315,7 +11494,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRDoorLockClusterGetHolidayScheduleResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRDoorLockClusterGetHolidayScheduleResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 DoorLockClusterGetHolidayScheduleResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -11496,7 +11680,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRDoorLockClusterGetUserResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRDoorLockClusterGetUserResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 DoorLockClusterGetUserResponseCallbackType successCb, MTRErrorCallback failureCb, MTRCallbackBridgeBase * bridge) {
                 chip::Optional<uint16_t> timedInvokeTimeoutMs;
@@ -11593,7 +11782,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRDoorLockClusterSetCredentialResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRDoorLockClusterSetCredentialResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 DoorLockClusterSetCredentialResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -11668,7 +11862,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRDoorLockClusterGetCredentialStatusResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRDoorLockClusterGetCredentialStatusResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 DoorLockClusterGetCredentialStatusResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -14280,7 +14479,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRThermostatClusterGetWeeklyScheduleResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRThermostatClusterGetWeeklyScheduleResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ThermostatClusterGetWeeklyScheduleResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -19128,7 +19332,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRChannelClusterChangeChannelResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRChannelClusterChangeChannelResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ChannelClusterChangeChannelResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -19397,7 +19606,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRTargetNavigatorClusterNavigateTargetResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRTargetNavigatorClusterNavigateTargetResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 TargetNavigatorClusterNavigateTargetResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -19551,7 +19765,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 MediaPlaybackClusterPlaybackResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -19603,7 +19822,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 MediaPlaybackClusterPlaybackResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -19658,7 +19882,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 MediaPlaybackClusterPlaybackResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -19713,7 +19942,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 MediaPlaybackClusterPlaybackResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -19765,7 +19999,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 MediaPlaybackClusterPlaybackResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -19817,7 +20056,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 MediaPlaybackClusterPlaybackResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -19869,7 +20113,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 MediaPlaybackClusterPlaybackResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -19924,7 +20173,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 MediaPlaybackClusterPlaybackResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -19969,7 +20223,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 MediaPlaybackClusterPlaybackResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -20015,7 +20274,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 MediaPlaybackClusterPlaybackResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -20061,7 +20325,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRMediaPlaybackClusterPlaybackResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 MediaPlaybackClusterPlaybackResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -20955,7 +21224,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRKeypadInputClusterSendKeyResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRKeypadInputClusterSendKeyResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 KeypadInputClusterSendKeyResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -21081,7 +21355,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRContentLauncherClusterLaunchResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRContentLauncherClusterLaunchResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ContentLauncherClusterLaunchResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -21184,7 +21463,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRContentLauncherClusterLaunchResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRContentLauncherClusterLaunchResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ContentLauncherClusterLaunchResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -21660,7 +21944,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRApplicationLauncherClusterLauncherResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRApplicationLauncherClusterLauncherResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ApplicationLauncherClusterLauncherResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -21711,7 +22000,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRApplicationLauncherClusterLauncherResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRApplicationLauncherClusterLauncherResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ApplicationLauncherClusterLauncherResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -21758,7 +22052,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRApplicationLauncherClusterLauncherResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRApplicationLauncherClusterLauncherResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 ApplicationLauncherClusterLauncherResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -22078,7 +22377,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRAccountLoginClusterGetSetupPINResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRAccountLoginClusterGetSetupPINResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 AccountLoginClusterGetSetupPINResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -23858,7 +24162,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterTestSpecificResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterTestSpecificResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterTestSpecificResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -23960,7 +24269,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterTestAddArgumentsResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterTestAddArgumentsResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterTestAddArgumentsResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -24007,7 +24321,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterTestSimpleArgumentResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterTestSimpleArgumentResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterTestSimpleArgumentResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -24054,7 +24373,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterTestStructArrayArgumentResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterTestStructArrayArgumentResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterTestStructArrayArgumentResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -24311,7 +24635,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterBooleanResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterBooleanResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterBooleanResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -24364,7 +24693,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterBooleanResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterBooleanResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterBooleanResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -24421,7 +24755,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterBooleanResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterBooleanResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterBooleanResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -24497,7 +24836,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterBooleanResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterBooleanResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterBooleanResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -24564,7 +24908,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterBooleanResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterBooleanResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterBooleanResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -24719,7 +25068,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterBooleanResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterBooleanResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterBooleanResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -24898,7 +25252,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterTestListInt8UReverseResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterTestListInt8UReverseResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterTestListInt8UReverseResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -24965,7 +25324,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterTestEnumsResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterTestEnumsResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterTestEnumsResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -25012,7 +25376,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterTestNullableOptionalResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterTestNullableOptionalResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterTestNullableOptionalResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -25070,7 +25439,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterTestComplexNullableOptionalResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterTestComplexNullableOptionalResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterTestComplexNullableOptionalResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -25285,7 +25659,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterSimpleStructResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterSimpleStructResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterSimpleStructResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -25452,7 +25831,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterTestEmitTestEventResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterTestEmitTestEventResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterTestEmitTestEventResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {
@@ -25503,7 +25887,12 @@ using chip::SessionHandle;
     MTRAsyncCallbackReadyHandler readyHandler = ^(MTRDevice * device, NSUInteger retryCount) {
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:self.device.nodeID
                                                                 controller:self.device.deviceController];
-        auto * bridge = new MTRUnitTestingClusterTestEmitTestFabricScopedEventResponseCallbackBridge(self.callbackQueue, completion,
+        auto * bridge = new MTRUnitTestingClusterTestEmitTestFabricScopedEventResponseCallbackBridge(
+            self.callbackQueue,
+            ^(id _Nullable value, NSError * _Nullable error) {
+                completion(value, error);
+                [workItem endWork];
+            },
             ^(ExchangeManager & exchangeManager, const SessionHandle & session,
                 UnitTestingClusterTestEmitTestFabricScopedEventResponseCallbackType successCb, MTRErrorCallback failureCb,
                 MTRCallbackBridgeBase * bridge) {

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
@@ -109,7 +109,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -157,7 +158,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -203,7 +205,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -249,7 +252,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -349,7 +353,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -405,7 +410,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -455,7 +461,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -501,7 +508,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -551,7 +559,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -627,7 +636,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -683,7 +693,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -739,7 +750,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -795,7 +807,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -1557,7 +1570,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -1605,7 +1619,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -1707,7 +1722,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -1757,7 +1773,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -1801,7 +1818,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -1853,7 +1871,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -1953,7 +1972,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -2003,7 +2023,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -2083,7 +2104,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -2331,7 +2353,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -2375,7 +2398,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -2423,7 +2447,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -2503,7 +2528,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -2635,7 +2661,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -2701,7 +2728,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -2885,7 +2913,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -2991,7 +3020,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -3095,7 +3125,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -3213,7 +3244,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -3293,7 +3325,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -3345,7 +3378,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -3609,7 +3643,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -4289,7 +4324,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -4383,7 +4419,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -4611,7 +4648,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -4783,7 +4821,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -4859,7 +4898,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -4997,7 +5037,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5041,7 +5082,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5113,7 +5155,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5165,7 +5208,8 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5240,7 +5284,8 @@ MTR_NEWLY_AVAILABLE
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5294,7 +5339,8 @@ MTR_NEWLY_AVAILABLE
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5348,7 +5394,8 @@ MTR_NEWLY_AVAILABLE
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5412,7 +5459,8 @@ MTR_NEWLY_AVAILABLE
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5470,7 +5518,8 @@ MTR_NEWLY_AVAILABLE
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5528,7 +5577,8 @@ MTR_NEWLY_AVAILABLE
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5600,7 +5650,8 @@ MTR_NEWLY_AVAILABLE
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5710,7 +5761,8 @@ MTR_NEWLY_AVAILABLE
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5767,7 +5819,8 @@ MTR_NEWLY_AVAILABLE
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5823,7 +5876,8 @@ MTR_NEWLY_AVAILABLE
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5879,7 +5933,8 @@ MTR_NEWLY_AVAILABLE
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
@@ -5936,7 +5991,8 @@ MTR_NEWLY_AVAILABLE
  * request) within the timeout window.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable)
+    NSNumber * timedInvokeTimeoutMs MTR_NEWLY_DEPRECATED("Timed invoke does not make sense for server to client commands");
 
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -770,6 +770,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // reportHandler returns TRUE if it got the things it was looking for or if there's an error.
     __block BOOL (^reportHandler)(NSArray * _Nullable value, NSError * _Nullable error);
     __auto_type * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(2) maxInterval:@(60)];
+    params.resubscribeIfLost = NO;
     [device subscribeWithQueue:queue
         params:params
         attributeCacheContainer:attributeCacheContainer
@@ -836,6 +837,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     XCTestExpectation * newSubscriptionEstablished = [self expectationWithDescription:@"New subscription established"];
     MTRSubscribeParams * newParams = [[MTRSubscribeParams alloc] initWithMinInterval:@(2) maxInterval:@(60)];
     newParams.replaceExistingSubscriptions = NO;
+    newParams.resubscribeIfLost = NO;
     [cluster subscribeAttributeOnOffWithParams:newParams
         subscriptionEstablished:^{
             NSLog(@"New subscription was established");
@@ -1023,6 +1025,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Subscribe
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
     MTRSubscribeParams * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(1) maxInterval:@(10)];
+    params.resubscribeIfLost = NO;
     [device subscribeToAttributesWithEndpointID:@1
         clusterID:@6
         attributeID:@0
@@ -1432,6 +1435,91 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     [self waitForExpectations:@[ errorExpectation ] timeout:60];
 }
 
+- (void)test019_MTRDeviceMultipleCommands
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+
+    __auto_type * device = [MTRDevice deviceWithNodeID:kDeviceId deviceController:sController];
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    __auto_type * opcredsCluster = [[MTRClusterOperationalCredentials alloc] initWithDevice:device endpointID:@(0) queue:queue];
+    __auto_type * onOffCluster = [[MTRClusterOnOff alloc] initWithDevice:device endpointID:@(1) queue:queue];
+    __auto_type * badOnOffCluster = [[MTRClusterOnOff alloc] initWithDevice:device endpointID:@(0) queue:queue];
+
+    XCTestExpectation * onExpectation = [self expectationWithDescription:@"On command executed"];
+    [onOffCluster onWithParams:nil
+                expectedValues:nil
+         expectedValueInterval:nil
+                    completion:^(NSError * _Nullable error) {
+                        XCTAssertNil(error);
+                        [onExpectation fulfill];
+                    }];
+
+    XCTestExpectation * offFailedExpectation = [self expectationWithDescription:@"Off command failed"];
+    [badOnOffCluster offWithParams:nil
+                    expectedValues:nil
+             expectedValueInterval:nil
+                        completion:^(NSError * _Nullable error) {
+                            XCTAssertNotNil(error);
+                            [offFailedExpectation fulfill];
+                        }];
+
+    XCTestExpectation * updateLabelExpectation = [self expectationWithDescription:@"Fabric label updated"];
+    __auto_type * params = [[MTROperationalCredentialsClusterUpdateFabricLabelParams alloc] init];
+    params.label = @("Test");
+    [opcredsCluster updateFabricLabelWithParams:params
+                                 expectedValues:nil
+                          expectedValueInterval:nil
+                                     completion:^(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data,
+                                         NSError * _Nullable error) {
+                                         XCTAssertNil(error);
+                                         XCTAssertNotNil(data);
+                                         XCTAssertEqualObjects(data.statusCode, @(0));
+                                         XCTAssertNotNil(data.fabricIndex);
+                                         [updateLabelExpectation fulfill];
+                                     }];
+
+    XCTestExpectation * offExpectation = [self expectationWithDescription:@"Off command executed"];
+    [onOffCluster offWithParams:nil
+                 expectedValues:nil
+          expectedValueInterval:nil
+                     completion:^(NSError * _Nullable error) {
+                         XCTAssertNil(error);
+                         [offExpectation fulfill];
+                     }];
+
+    XCTestExpectation * onFailedExpectation = [self expectationWithDescription:@"On command failed"];
+    [badOnOffCluster onWithParams:nil
+                   expectedValues:nil
+            expectedValueInterval:nil
+                       completion:^(NSError * _Nullable error) {
+                           XCTAssertNotNil(error);
+                           [onFailedExpectation fulfill];
+                       }];
+
+    XCTestExpectation * updateLabelFailedExpectation = [self expectationWithDescription:@"Fabric label update failed"];
+    params.label = @("12345678901234567890123445678901234567890"); // Too long
+    [opcredsCluster updateFabricLabelWithParams:params
+                                 expectedValues:nil
+                          expectedValueInterval:nil
+                                     completion:^(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data,
+                                         NSError * _Nullable error) {
+                                         XCTAssertNotNil(error);
+                                         XCTAssertNil(data);
+                                         [updateLabelFailedExpectation fulfill];
+                                     }];
+
+    [self waitForExpectations:@[
+        onExpectation, offFailedExpectation, updateLabelExpectation, offExpectation, onFailedExpectation,
+        updateLabelFailedExpectation
+    ]
+                      timeout:60
+                 enforceOrder:YES];
+}
+
 - (void)test900_SubscribeAllAttributes
 {
 #if MANUAL_INDIVIDUAL_TEST
@@ -1453,6 +1541,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     __block void (^reportHandler)(id _Nullable values, NSError * _Nullable error) = nil;
 
     MTRSubscribeParams * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(2) maxInterval:@(10)];
+    params.resubscribeIfLost = NO;
     [device subscribeToAttributesWithEndpointID:@1
         clusterID:@6
         attributeID:@0xffffffff


### PR DESCRIPTION
We were missing endWork bits for command invokes when the command has a data (not status) response.  This would end up permanently blocking the MTRDevice's work queue once such a command (e.g. UpdateFabricLabel) was issued.

The changes here are as follows:

1) Rearrange the logic in MTRClusters-src.zapt so that the endWork happens
   regardless of whether hasSpecificResponse is true.
2) Add a deprecation message to the timedInvokeTimeoutMs field in _response_
   command params, since that should never be used (ran into this when writing
   the tests for this PR).
3) Set resubscribeIfLost to NO on various subscriptions in MTRDeviceTests, so if
   another test takes a while we don't fail due to the canceled subscriptions
   re-subscribing and over-fullfilling the subscription expectations.
4) Add a test for a mix of passing and failing commands on MTRCluster instances,
   with some of the commands defined as getting status-only responses and some
   defined as getting data responses.  This test fails without the endWork fix.
