### PR TITLE
Nordic factory data did not validate rd_uid field properly

### DIFF
--- a/scripts/tools/nrfconnect/nrfconnect_factory_data.schema
+++ b/scripts/tools/nrfconnect/nrfconnect_factory_data.schema
@@ -94,8 +94,8 @@
             "description": "A randomly-generated 128-bit or longer octet string. Length has been expanded with 'hex:' prefix",
             "type": "string",
             "pattern": "^hex:([0-9A-Fa-f]{2}){16,}$",
-            "minLength": 20,
-            "minLength": 36
+            "minLength": 36,
+            "maxLength": 68
         },
         "dac_cert": {
             "description": "DAC certificate in hex-string format",


### PR DESCRIPTION
Nordic factory data did not validate rd_uid field.

* minLength was duplicated, was clearly maxLength.
* the length in pattern was wrong. minimum 128 bit = 16 byte = 32 hex chars (+ 4 chars for "hex:"). maximum double of the minimum.

FYI: @Damian-Nordic 
