### PR TITLE
Hotfix: correct zap cli symlink for chip build dockerfile

### DIFF
--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -146,5 +146,5 @@ RUN set -x \
     && unzip zap-linux.zip \
     && rm zap-linux.zip \
     && rm zap \
-    && ln -s /opt/zap-${ZAP_VERSION}/zap /usr/bin/ \
+    && ln -s /opt/zap-${ZAP_VERSION}/zap-cli /usr/bin/ \
     && : # last line

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.09 Version bump reason: Install zap v2022.11.16 in docker images.
+0.6.10 Version bump reason: Fix zap link (link zap-cli into /usr/bin instead of zap)


### PR DESCRIPTION
We removed `zap` (UI utility) from the docker image because it was 140+ MB and it was not usable due to missing UI. We kept `zap-cli` however symlink from the dockerfile is wrong and was trying to link `zap`.

This PR fixes that.

