### PR TITLE
Stop using :latest tag for docker images in bouffalolab

### DIFF
--- a/.github/workflows/examples-bouffalolab.yaml
+++ b/.github/workflows/examples-bouffalolab.yaml
@@ -31,7 +31,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: connectedhomeip/chip-build:latest
+      image: connectedhomeip/chip-build:0.6.06
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
     steps:
@@ -87,7 +87,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: connectedhomeip/chip-build:latest
+      image: connectedhomeip/chip-build:0.6.06
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
     steps:


### PR DESCRIPTION
We need to ensure that image updates do not result in unexpected breakages in CI.