### PR TITLE
Use build flag instead of checking env variable directly

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -14,7 +14,7 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/pigweed.gni")
-
+import("${build_root}/chip/java/config.gni")
 import("${build_root}/config/compiler/compiler.gni")
 import("${build_root}/config/sysroot.gni")
 import("${build_root}/config/target.gni")
@@ -248,7 +248,7 @@ config("strict_warnings") {
     ]
   }
 
-  if (getenv("JAVA_PATH") != "") {
+  if (build_java_matter_controller) {
     cflags -= [ "-Wshadow" ]
   }
 


### PR DESCRIPTION
It looks we missed one review comment in https://github.com/project-chip/connectedhomeip/pull/23630

