### PR TITLE
[Telink] Allow to erase entire NVS on factory reset by default; Fix IDM-7.1 test.

### DIFF
--- a/config/telink/chip-module/Kconfig
+++ b/config/telink/chip-module/Kconfig
@@ -266,3 +266,8 @@ config CHIP_CERTIFiCATION_DECLARATION_OTA_IMAGE_ID
 	  for sending it via OTA Software Update purposes.
 
 endif
+
+# See config/zephyr/Kconfig for full definition
+config CHIP_FACTORY_RESET_ERASE_NVS
+	bool
+	default y


### PR DESCRIPTION
**Problem**

Commissioning Failed After Opening Multiple Commissioning Windows

**Change overview**

Allow to erase entire NVS on factory reset by default

**Testing**

Tested manually with chip-tool.
Steps:

1.  Use chip-tool to perform commissioning with operational dataset in Terminal 1 and ensure our Matter device joins the network. 
./chip-tool pairing ble-thread 1 hex:${DATASET} ${PIN_CODE}

2. In Terminal 1, use the following command to open a new ECM commissioning window: 
./chip-tool pairing open-commissioning-window 1 1 400 2000 2001
This command will also generate and print out a manual pairing code (16384853021). The code will be used in the next step.

3. Open a new terminal 2. Perform commissioning and then open a new ECM Commissioning Window 2:
./chip-tool pairing code 2 16384853021 --commissioner-name beta
./chip-tool pairing open-commissioning-window 2 1 400 2000 2001 --commissioner-name beta
It will generate a new manual pairing code (16260155555).

4. Open a new terminal 3. Perform commissioning and then open a new ECM Commissioning Window 3:
./chip-tool pairing code 3 16260155555 --commissioner-name gamma
./chip-tool pairing open-commissioning-window 3 1 400 2000 2001 --commissioner-name gamma
A new manual pairing code (15433908150).
 
5. Open a new terminal 4. Perform commissioning and then open a new ECM Commissioning Window 4:
./chip-tool pairing code 4 15433908150 --commissioner-name 4
./chip-tool pairing open-commissioning-window 4 1 400 2000 2001 --commissioner-name 4
A new manual pairing code (16322914702).
 
6. Open a new terminal 5. Perform commissioning and then open a new ECM Commissioning Window 5:
./chip-tool pairing code 5 16322914702 --commissioner-name 5
./chip-tool pairing open-commissioning-window 5 1 400 2000 2001 --commissioner-name 5
 
7. After opening 5 ECM commissioning windows, just press the key 1 to perform factory reset.
 
8. Open a new terminal 6. Use chip-tool to perform commissioning with operational dataset in the new terminal. 
./chip-tool pairing ble-thread 2 hex:${DATASET} ${PIN_CODE} 2001