### PR TITLE
[Telink] Allow to erase entire NVS on factory reset by default; Fix IDM-7.1 test. (Cherry-pick #23434 & #23676)

### DIFF
--- a/config/telink/chip-module/Kconfig
+++ b/config/telink/chip-module/Kconfig
@@ -266,3 +266,8 @@ config CHIP_CERTIFiCATION_DECLARATION_OTA_IMAGE_ID
 	  for sending it via OTA Software Update purposes.
 
 endif
+
+# See config/zephyr/Kconfig for full definition
+config CHIP_FACTORY_RESET_ERASE_NVS
+	bool
+	default y

--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -196,6 +196,17 @@ config CHIP_OPERATIONAL_TIME_SAVE_INTERVAL
 	  precisely operation time in case of device reboot and maximizing flash memory
 	  lifetime.
 
+config CHIP_FACTORY_RESET_ERASE_NVS
+	bool "Erase NVS flash pages on factory reset"
+	depends on SETTINGS_NVS
+	help
+	  When factory reset is requested, erase flash pages occupied by non-volatile storage
+	  instead of removing Matter-related settings only. This provides a more robust
+	  factory reset mechanism and allows to regain the original storage performance if any
+	  firmware issue has brought it to an unexpected state. For this reason, it is
+	  advisable to set this option if all configuration, including device-specific
+	  entries, is supposed to be cleared on a factory reset.
+
 config CHIP_MALLOC_SYS_HEAP
 	bool "Memory allocator based on Zephyr sys_heap"
 	imply SYS_HEAP_RUNTIME_STATS


### PR DESCRIPTION
Problem

Commissioning Failed After Opening Multiple Commissioning Windows

Cherrypick partly  https://github.com/project-chip/connectedhomeip/pull/23434
Cherrypick https://github.com/project-chip/connectedhomeip/pull/23676

Change overview

Allow to erase entire NVS on factory reset by default for Telink platform

Testing

Tested manually with chip-tool.
Steps:

Use chip-tool to perform commissioning with operational dataset in Terminal 1 and ensure our Matter device joins the network.
./chip-tool pairing ble-thread 1 hex:${DATASET} ${PIN_CODE}

In Terminal 1, use the following command to open a new ECM commissioning window:
./chip-tool pairing open-commissioning-window 1 1 400 2000 2001
This command will also generate and print out a manual pairing code (16384853021). The code will be used in the next step.

Open a new terminal 2. Perform commissioning and then open a new ECM Commissioning Window 2:
./chip-tool pairing code 2 16384853021 --commissioner-name beta
./chip-tool pairing open-commissioning-window 2 1 400 2000 2001 --commissioner-name beta
It will generate a new manual pairing code (16260155555).

Open a new terminal 3. Perform commissioning and then open a new ECM Commissioning Window 3:
./chip-tool pairing code 3 16260155555 --commissioner-name gamma
./chip-tool pairing open-commissioning-window 3 1 400 2000 2001 --commissioner-name gamma
A new manual pairing code (15433908150).

Open a new terminal 4. Perform commissioning and then open a new ECM Commissioning Window 4:
./chip-tool pairing code 4 15433908150 --commissioner-name 4
./chip-tool pairing open-commissioning-window 4 1 400 2000 2001 --commissioner-name 4
A new manual pairing code (16322914702).

Open a new terminal 5. Perform commissioning and then open a new ECM Commissioning Window 5:
./chip-tool pairing code 5 16322914702 --commissioner-name 5
./chip-tool pairing open-commissioning-window 5 1 400 2000 2001 --commissioner-name 5

After opening 5 ECM commissioning windows, just press the key 1 to perform factory reset.

Open a new terminal 6. Use chip-tool to perform commissioning with operational dataset in the new terminal.
./chip-tool pairing ble-thread 2 hex:${DATASET} ${PIN_CODE} 2001