### PR TITLE
Enable thread safety analysis for system mutex

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -267,6 +267,7 @@ config("strict_warnings") {
       "-Wheader-hygiene",
       "-Wshorten-64-to-32",
       "-Wformat-type-confusion",
+      "-Wthread-safety",
     ]
 
     # TODO: can make this back fatal in once pigweed updates can be taken again.

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -259,6 +259,7 @@ config("strict_warnings") {
 
   cflags_cc = [ "-Wnon-virtual-dtor" ]
 
+  configs = []
   ldflags = []
 
   if (is_clang) {
@@ -267,8 +268,9 @@ config("strict_warnings") {
       "-Wheader-hygiene",
       "-Wshorten-64-to-32",
       "-Wformat-type-confusion",
-      "-Wthread-safety",
     ]
+
+    configs += [ "$dir_pw_build:clang_thread_safety_warnings" ]
 
     # TODO: can make this back fatal in once pigweed updates can be taken again.
     #       See https://github.com/project-chip/connectedhomeip/pull/22079

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -45,6 +45,7 @@
 #include <platform/Linux/dbus/wpa/DBusWpaBss.h>
 #include <platform/Linux/dbus/wpa/DBusWpaInterface.h>
 #include <platform/Linux/dbus/wpa/DBusWpaNetwork.h>
+#include <system/SystemMutex.h>
 
 #include <mutex>
 #endif
@@ -207,7 +208,7 @@ private:
 
     static bool mAssociationStarted;
     static BitFlags<ConnectivityFlags> mConnectivityFlag;
-    static GDBusWpaSupplicant mWpaSupplicant;
+    static GDBusWpaSupplicant mWpaSupplicant CHIP_GUARDED_BY(mWpaSupplicantMutex);
     // Access to mWpaSupplicant has to be protected by a mutex because it is accessed from
     // the CHIP event loop thread and dedicated D-Bus thread started by platform manager.
     static std::mutex mWpaSupplicantMutex;

--- a/src/system/SystemMutex.h
+++ b/src/system/SystemMutex.h
@@ -24,8 +24,6 @@
 
 #pragma once
 
-#include <mutex>
-
 // Include configuration headers
 #include <system/SystemConfig.h>
 
@@ -94,38 +92,6 @@ namespace System {
 #define CHIP_NO_THREAD_SAFETY_ANALYSIS CHIP_TSA_ATTRIBUTE__(no_thread_safety_analysis)
 
 /**
- *  @class LockGuard
- *
- *  @brief
- *      This class template is a wrapper for std::lock_guard that provides
- *      a way to annotate the lock guard with thread safety attributes.
- *
- */
-template <typename _Mutex>
-class CHIP_SCOPED_CAPABILITY LockGuard : public std::lock_guard<_Mutex>
-{
-public:
-    explicit LockGuard(_Mutex & __m) CHIP_ACQUIRE(__m) : std::lock_guard<_Mutex>(__m) {}
-    ~LockGuard() CHIP_RELEASE() = default;
-};
-
-/**
- *  @class UniqueLock
- *
- *  @brief
- *      This class template is a wrapper for std::unique_lock that provides
- *      a way to annotate the unique lock with thread safety attributes.
- *
- */
-template <typename _Mutex>
-class CHIP_SCOPED_CAPABILITY UniqueLock : public std::unique_lock<_Mutex>
-{
-public:
-    explicit UniqueLock(_Mutex & __m) CHIP_ACQUIRE(__m) : std::unique_lock<_Mutex>(__m) {}
-    ~UniqueLock() CHIP_RELEASE() = default;
-};
-
-/**
  *  @class Mutex
  *
  *  @brief
@@ -185,9 +151,6 @@ private:
     Mutex(const Mutex &) = delete;
     Mutex & operator=(const Mutex &) = delete;
 };
-
-using MutexLockGuard  = LockGuard<Mutex>;
-using MutexUniqueLock = UniqueLock<Mutex>;
 
 #if CHIP_SYSTEM_CONFIG_NO_LOCKING
 inline CHIP_ERROR Init(Mutex & aMutex)

--- a/src/system/SystemMutex.h
+++ b/src/system/SystemMutex.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <mutex>
+
 // Include configuration headers
 #include <system/SystemConfig.h>
 
@@ -63,6 +65,66 @@
 namespace chip {
 namespace System {
 
+// Enable thread safety attributes only with clang.
+#if defined(__clang__) && (!defined(SWIG))
+#define CHIP_TSA_ATTRIBUTE__(x) __attribute__((x))
+#else
+#define CHIP_TSA_ATTRIBUTE__(x)
+#endif
+
+#define CHIP_CAPABILITY(x) CHIP_TSA_ATTRIBUTE__(capability(x))
+#define CHIP_SCOPED_CAPABILITY CHIP_TSA_ATTRIBUTE__(scoped_lockable)
+#define CHIP_GUARDED_BY(x) CHIP_TSA_ATTRIBUTE__(guarded_by(x))
+#define CHIP_PT_GUARDED_BY(x) CHIP_TSA_ATTRIBUTE__(pt_guarded_by(x))
+#define CHIP_ACQUIRED_BEFORE(...) CHIP_TSA_ATTRIBUTE__(acquired_before(__VA_ARGS__))
+#define CHIP_ACQUIRED_AFTER(...) CHIP_TSA_ATTRIBUTE__(acquired_after(__VA_ARGS__))
+#define CHIP_REQUIRES(...) CHIP_TSA_ATTRIBUTE__(requires_capability(__VA_ARGS__))
+#define CHIP_REQUIRES_SHARED(...) CHIP_TSA_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
+#define CHIP_ACQUIRE(...) CHIP_TSA_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
+#define CHIP_ACQUIRE_SHARED(...) CHIP_TSA_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
+#define CHIP_RELEASE(...) CHIP_TSA_ATTRIBUTE__(release_capability(__VA_ARGS__))
+#define CHIP_RELEASE_SHARED(...) CHIP_TSA_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
+#define CHIP_RELEASE_GENERIC(...) CHIP_TSA_ATTRIBUTE__(release_generic_capability(__VA_ARGS__))
+#define CHIP_TRY_ACQUIRE(...) CHIP_TSA_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
+#define CHIP_TRY_ACQUIRE_SHARED(...) CHIP_TSA_ATTRIBUTE__(try_acquire_shared_capability(__VA_ARGS__))
+#define CHIP_EXCLUDES(...) CHIP_TSA_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+#define CHIP_ASSERT_CAPABILITY(x) CHIP_TSA_ATTRIBUTE__(assert_capability(x))
+#define CHIP_ASSERT_SHARED_CAPABILITY(x) CHIP_TSA_ATTRIBUTE__(assert_shared_capability(x))
+#define CHIP_RETURN_CAPABILITY(x) CHIP_TSA_ATTRIBUTE__(lock_returned(x))
+#define CHIP_NO_THREAD_SAFETY_ANALYSIS CHIP_TSA_ATTRIBUTE__(no_thread_safety_analysis)
+
+/**
+ *  @class LockGuard
+ *
+ *  @brief
+ *      This class template is a wrapper for std::lock_guard that provides
+ *      a way to annotate the lock guard with thread safety attributes.
+ *
+ */
+template <typename _Mutex>
+class CHIP_SCOPED_CAPABILITY LockGuard : public std::lock_guard<_Mutex>
+{
+public:
+    explicit LockGuard(_Mutex & __m) CHIP_ACQUIRE(__m) : std::lock_guard<_Mutex>(__m) {}
+    ~LockGuard() CHIP_RELEASE() = default;
+};
+
+/**
+ *  @class UniqueLock
+ *
+ *  @brief
+ *      This class template is a wrapper for std::unique_lock that provides
+ *      a way to annotate the unique lock with thread safety attributes.
+ *
+ */
+template <typename _Mutex>
+class CHIP_SCOPED_CAPABILITY UniqueLock : public std::unique_lock<_Mutex>
+{
+public:
+    explicit UniqueLock(_Mutex & __m) CHIP_ACQUIRE(__m) : std::unique_lock<_Mutex>(__m) {}
+    ~UniqueLock() CHIP_RELEASE() = default;
+};
+
 /**
  *  @class Mutex
  *
@@ -73,8 +135,12 @@ namespace System {
  *      objects with \c static storage duration and uninitialized memory. Use \c Init method to initialize. The copy/move
  *      operators are not provided.
  *
+ * @note
+ *      This class is compatible with \c std::lock_guard and provides
+ *      annotations for thread safety analysis.
+ *
  */
-class DLL_EXPORT Mutex
+class DLL_EXPORT CHIP_CAPABILITY("mutex") Mutex
 {
 public:
     Mutex() = default;
@@ -84,12 +150,12 @@ public:
     inline bool isInitialized() { return mInitialized; }
 #endif // CHIP_SYSTEM_CONFIG_FREERTOS_LOCKING
 
-    void Lock();   /**< Acquire the mutual exclusion lock, blocking the current thread indefinitely if necessary. */
-    void Unlock(); /**< Release the mutual exclusion lock (can block on some systems until scheduler completes). */
+    void Lock() CHIP_ACQUIRE();   /**< Acquire the mutual exclusion lock, blocking the current thread indefinitely if necessary. */
+    void Unlock() CHIP_RELEASE(); /**< Release the mutual exclusion lock (can block on some systems until scheduler completes). */
 
     // Synonyms for compatibility with std::lock_guard.
-    void lock() { Lock(); }
-    void unlock() { Unlock(); }
+    void lock() CHIP_ACQUIRE() { Lock(); }
+    void unlock() CHIP_RELEASE() { Unlock(); }
 
 private:
 #if CHIP_SYSTEM_CONFIG_POSIX_LOCKING
@@ -119,6 +185,9 @@ private:
     Mutex(const Mutex &) = delete;
     Mutex & operator=(const Mutex &) = delete;
 };
+
+using MutexLockGuard  = LockGuard<Mutex>;
+using MutexUniqueLock = UniqueLock<Mutex>;
 
 #if CHIP_SYSTEM_CONFIG_NO_LOCKING
 inline CHIP_ERROR Init(Mutex & aMutex)


### PR DESCRIPTION
### New Feature

[Thread Safety Analysis](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html) is a clang extension tool which adds static analysis for potential race conditions.

This PR adds support for such thread safety analysis to Matter system mutex class.

Simple usage:

```c++
int state CHIP_GUARDED_BY(stateMtx);
chip::System::Mutex stateMtx;

void setState_wrong(int value) {
	state = value;      // <--- this will generate clang error during compilation because mutex is not acquired
}

void setState(int value) {
	chip::System::MutexUniqueLock lock(stateMtx);
	state = value;
}
```

### Testing

CI will test build break with new feature added.