### PR TITLE
[darwin-framework-tool] Do not build Matter SDK twice when config_enable_yaml_tests=false

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -17,8 +17,8 @@
  */
 
 #include "Command.h"
-#include "platform/PlatformManager.h"
 
+#include <functional>
 #include <netdb.h>
 #include <sstream>
 #include <sys/socket.h>

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -21,7 +21,6 @@
 #include <app/data-model/Nullable.h>
 #include <commands/clusters/ComplexArgument.h>
 #include <commands/clusters/CustomArgument.h>
-#include <controller/CHIPDeviceController.h>
 #include <inet/InetInterface.h>
 #include <lib/core/Optional.h>
 #include <lib/support/Span.h>

--- a/examples/chip-tool/commands/common/CredentialIssuerCommands.h
+++ b/examples/chip-tool/commands/common/CredentialIssuerCommands.h
@@ -19,11 +19,17 @@
 #pragma once
 
 #include <app/util/basic-types.h>
-#include <controller/CHIPDeviceControllerFactory.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <vector>
+
+namespace chip {
+namespace Controller {
+struct SetupParams;
+class OperationalCredentialsDelegate;
+} // namespace Controller
+} // namespace chip
 
 class CredentialIssuerCommands
 {

--- a/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
@@ -18,6 +18,7 @@
 
 #include "DiscoverCommissionersCommand.h"
 #include <arpa/inet.h>
+#include <controller/CHIPDeviceController.h>
 
 using namespace ::chip;
 

--- a/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h
+++ b/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <commands/common/CredentialIssuerCommands.h>
+#include <controller/CHIPDeviceControllerFactory.h>
 #include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -143,20 +143,6 @@ executable("darwin-framework-tool") {
 
   deps = [
     ":build-darwin-framework",
-    "${chip_root}/src/app/tests/suites/commands/delay",
-
-    # IM is needed for MTRError
-    "${chip_root}/src/app/tests/suites/commands/interaction_model",
-
-    # Log is needed by tests UserPrompt and Log
-    "${chip_root}/src/app/tests/suites/commands/log",
-
-    # System is needed by tests FactoryReset etc..
-    "${chip_root}/src/app/tests/suites/commands/system",
-
-    # pics is needed by tests
-    "${chip_root}/src/app/tests/suites/pics",
-    "${chip_root}/third_party/inipp",
     "${chip_root}/third_party/jsoncpp",
   ]
 
@@ -174,6 +160,60 @@ executable("darwin-framework-tool") {
     "Matter.framework",
     "Security.framework",
   ]
+
+  # When config_enable_yaml_tests=true the Matter SDK is pulled in as a dependency because the code of the test suite
+  # uses some helpers from the Matter SDK. As a result, the SDK is built twice. Once because of this dependency and once
+  # when the Matter.framework is built.
+  # It may results in different versions of the Matter SDK between the output binary and the linked Matter.framework.
+  #
+  # When config_enable_yaml_tests=false the Matter SDK is built once when the Matter.framework is built and the resulting
+  # libCHIP.a library is linked statically to the output binary.
+  if (config_enable_yaml_tests) {
+    deps += [
+      "${chip_root}/src/app/tests/suites/commands/delay",
+
+      # IM is needed for MTRError
+      "${chip_root}/src/app/tests/suites/commands/interaction_model",
+
+      # Log is needed by tests UserPrompt and Log
+      "${chip_root}/src/app/tests/suites/commands/log",
+
+      # System is needed by tests FactoryReset etc..
+      "${chip_root}/src/app/tests/suites/commands/system",
+
+      # pics is needed by tests
+      "${chip_root}/src/app/tests/suites/pics",
+    ]
+  } else {
+    include_dirs = [
+      "${chip_root}/config/standalone/",
+      "${chip_root}/src/",
+      "${chip_root}/src/include/",
+      "${chip_root}/third_party/nlassert/repo/include/",
+      "${chip_root}/third_party/nlio/repo/include/",
+      "${chip_root}/zzz_generated/app-common/",
+      "${root_gen_dir}/include",
+      "${root_out_dir}/macos_framework_output/Build/Intermediates.noindex/Matter.build/${output_sdk_type}/Matter.build/out/gen/include",
+    ]
+
+    defines = [
+      "CHIP_HAVE_CONFIG_H=1",
+      "CHIP_SYSTEM_CONFIG_USE_SOCKETS=1",
+    ]
+
+    frameworks += [
+      "CoreFoundation.framework",
+      "Foundation.framework",
+      "CoreBluetooth.framework",
+      "Network.framework",
+    ]
+
+    # Other SDKs are linked statically to Matter.framework but the macosx SDK is linked dynamically but needs some symbols that are
+    # not exposed by the dylib.
+    if (sdk == "macosx") {
+      libs = [ "${root_out_dir}/macos_framework_output/Build/Intermediates.noindex/Matter.build/${output_sdk_type}/Matter.build/out/lib/libCHIP.a" ]
+    }
+  }
 
   public_configs = [ ":config" ]
 

--- a/examples/darwin-framework-tool/commands/clusters/ModelCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ModelCommandBridge.h
@@ -24,8 +24,6 @@
 class ModelCommand : public CHIPCommandBridge
 {
 public:
-    using ChipDevice = ::chip::OperationalDeviceProxy;
-
     ModelCommand(const char * _Nonnull commandName) : CHIPCommandBridge(commandName) {}
 
     void AddArguments()

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
@@ -21,6 +21,7 @@
 #include <commands/common/Command.h>
 #include <commands/common/CredentialIssuerCommands.h>
 #include <map>
+#include <set>
 #include <string>
 
 #include "../provider/OTAProviderDelegate.h"

--- a/examples/darwin-framework-tool/commands/pairing/OpenCommissioningWindowCommand.h
+++ b/examples/darwin-framework-tool/commands/pairing/OpenCommissioningWindowCommand.h
@@ -31,8 +31,8 @@ public:
                     "1 to use Enhanced Commissioning Method.\n  0 to use Basic Commissioning Method.");
         AddArgument("window-timeout", 0, UINT16_MAX, &mCommissioningWindowTimeoutMs,
                     "Time, in seconds, before the commissioning window closes.");
-        AddArgument("iteration", chip::kSpake2p_Min_PBKDF_Iterations, chip::kSpake2p_Max_PBKDF_Iterations, &mIteration,
-                    "Number of PBKDF iterations to use to derive the verifier.  Ignored if 'option' is 0.");
+        AddArgument("iteration", chip::Crypto::kSpake2p_Min_PBKDF_Iterations, chip::Crypto::kSpake2p_Max_PBKDF_Iterations,
+                    &mIteration, "Number of PBKDF iterations to use to derive the verifier.  Ignored if 'option' is 0.");
         AddArgument("discriminator", 0, 4096, &mDiscriminator, "Discriminator to use for advertising.  Ignored if 'option' is 0.");
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout, "Time, in seconds, before this command is considered to have timed out.");
     }

--- a/examples/darwin-framework-tool/templates/tests/commands.zapt
+++ b/examples/darwin-framework-tool/templates/tests/commands.zapt
@@ -4,6 +4,7 @@
 
 #if CONFIG_ENABLE_YAML_TESTS
 
+#include <app/util/af-enums.h>
 #include <commands/tests/TestCommandBridge.h>
 #include <lib/core/Optional.h>
 #include <system/SystemClock.h>

--- a/scripts/build/build_darwin_framework.py
+++ b/scripts/build/build_darwin_framework.py
@@ -65,6 +65,10 @@ def build_darwin_framework(args):
             # Build Matter.framework as a static library
             "SUPPORTS_TEXT_BASED_API=NO",
             "MACH_O_TYPE=staticlib",
+            # Change visibility flags such that both darwin-framework-tool and Matter.framework
+            # are built with the same flags.
+            "GCC_INLINES_ARE_PRIVATE_EXTERN=NO",
+            "GCC_SYMBOLS_PRIVATE_EXTERN=NO",
         ]
     command_result = run_command(command)
 


### PR DESCRIPTION

#### Problem

Running `./scripts/examples/gn_build_example.sh examples/darwin-framework-tool out/debug/standalone` results into building the Matter SDK twice. Once because some `darwin-framework-tool` dependencies pulls in the Matter SDK and one because of `Matter.framework`. Worst, the 2 versions of the SDK can be built with different flags which introduce strange behaviour when `Matter.framework` is statically linked.

This PR update `examples/darwin-framework-tool` such that adding `config_enable_yaml_tests=false` does results into a single copy of the SDK.

In a future patch, I'm planning to update `chip-tool` and `darwin-framework-tool` to not have to pull in dependencies from `src/app/tests/suites` in order to runs the tests which should make it fine all the time. But this is a non-negligeable amount of work and this is out of the scope of this PR which is to allow `darwin-framework-tool` to not creates an extra copy of the SDK.