### PR TITLE
[darwin-framework-tool] Propagate chip_inet_config_enable_ipv4 to chi…

### DIFF
--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -27,6 +27,11 @@ assert(chip_build_tools)
 
 declare_args() {
   chip_codesign = current_os == "ios"
+
+  # When config_enable_yaml_tests is false, the Matter SDK options are not available.
+  if (!config_enable_yaml_tests) {
+    chip_inet_config_enable_ipv4 = true
+  }
 }
 
 sdk = "macosx"
@@ -66,6 +71,10 @@ action("build-darwin-framework") {
       "--target_arch",
       mac_target_arch,
     ]
+  }
+
+  if (defined(chip_inet_config_enable_ipv4) && !chip_inet_config_enable_ipv4) {
+    args += [ "--no-ipv4" ]
   }
 
   output_name = "Matter.framework"

--- a/scripts/build/build_darwin_framework.py
+++ b/scripts/build/build_darwin_framework.py
@@ -70,6 +70,11 @@ def build_darwin_framework(args):
             "GCC_INLINES_ARE_PRIVATE_EXTERN=NO",
             "GCC_SYMBOLS_PRIVATE_EXTERN=NO",
         ]
+
+    if not args.ipv4:
+        command += [
+            "CHIP_INET_CONFIG_ENABLE_IPV4=NO",
+        ]
     command_result = run_command(command)
 
     print("Build Framework Result: {}".format(command_result))
@@ -108,6 +113,7 @@ if __name__ == "__main__":
     parser.add_argument("--log_path",
                         help="Output log file destination",
                         required=True)
+    parser.add_argument('--ipv4', action=argparse.BooleanOptionalAction)
 
     args = parser.parse_args()
     build_darwin_framework(args)

--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -113,6 +113,12 @@ declare -a args=(
     )
 }
 
+[[ $CHIP_INET_CONFIG_ENABLE_IPV4 == NO ]] && {
+    args+=(
+        'chip_inet_config_enable_ipv4=false'
+    )
+}
+
 # search current (or $2) and its parent directories until
 #  a name match is found, which is output on stdout
 find_in_ancestors() {


### PR DESCRIPTION
…p_xcode_build_connector.sh

Running `./scripts/examples/gn_build_example.sh examples/darwin-framework-tool out/debug/standalone chip_inet_config_enable_ipv4=false` does not produce the expected results since the options is passed to the Matter SDK copy that is built for `darwin-framework-tool` not for the `Matter.framework`.

This PR propagates the flag to `chip_xcode_build_connector.sh` and is meant to be on top of #23682 (this is why there are some checks related to `config_enable_yaml_tests`).