### PR TITLE
Package the java-matter-controller as an executable format

### DIFF
--- a/examples/java-matter-controller/Manifest.txt
+++ b/examples/java-matter-controller/Manifest.txt
@@ -1,2 +1,3 @@
 Main-Class: com.matter.controller.Main
+Class-Path: ../lib/third_party/connectedhomeip/src/controller/java/CHIPController.jar ../lib/third_party/connectedhomeip/src/setup_payload/java/SetupPayloadParser.jar
 

--- a/examples/java-matter-controller/README.md
+++ b/examples/java-matter-controller/README.md
@@ -18,41 +18,41 @@ cluster requests to a Matter device
 
 ## Requirements for building
 
-You need Android SDK 21 & NDK 21.4.7075529 downloaded to your machine. Set the
-`$ANDROID_HOME` environment variable to where the SDK is downloaded and the
-`$ANDROID_NDK_HOME` environment variable to point to where the NDK package is
-downloaded.
+You need to have the following two software installed on your Ubuntu system:
 
-1. Install [Android Studio](https://developer.android.com/studio)
-2. Install NDK:
-    1. Tools -> SDK Manager -> SDK Tools Tab
-    2. Click [x] Show Package Details
-    3. Select NDK (Side by Side) -> 21.4.7075529
-    4. Apply
-3. Install Command Line Tools:
-    1. Tools -> SDK Manager -> SDK Tools Tab -> Android SDK Command Line Tools
-       (latest)
-    2. Apply
-4. Install SDK 21:
-    1. Tools -> SDK Manager -> SDK Platforms Tab -> Android 5.0 (Lollipop) SDK
-       Level 21
-    2. Apply
-5. Install Emulator:
-    1. Tools -> Device Manager -> Create device -> Pixel 5 -> Android S API 31
-       -> Download
+1. Java Runtime Environment (JRE)
+2. Java Development Kit (JDK)
+
+```
+java -version
+```
+
+This will ensure either Java Runtime Environment is already installed on your
+system or not. In order to install the Java Runtime Environment on your system,
+run the following command as root:
+
+```
+sudo apt install default-jre Install Java default JRE
+```
+
+After installing the JRE, let us check if we have the Java Development Kit
+installed on our system or not.
+
+```
+javac -version
+```
+
+The above output shows that I need to install the Java compiler or the JDK on my
+system. You can install it through the following command as root:
+
+```
+sudo apt install default-jdk
+```
 
 ### Linux
 
 ```
-export ANDROID_HOME=~/Android/Sdk
-export ANDROID_NDK_HOME=~/Android/Sdk/ndk/21.4.7075529
-```
-
-### MacOS
-
-```
-export ANDROID_HOME=~/Library/Android/sdk
-export ANDROID_NDK_HOME=~/Library/Android/sdk/ndk/21.4.7075529
+export JAVA_PATH=[JDK path]
 ```
 
 <hr>
@@ -79,7 +79,7 @@ This is the simplest option. In the command line, run the following command from
 the top Matter directory:
 
 ```shell
-./scripts/build/build_examples.py --target android-x86-java-matter-controller build
+./scripts/build/build_examples.py --target linux-x64-java-matter-controller build
 ```
 
 The Java executable file `java-matter-controller` will be generated at

--- a/examples/java-matter-controller/README.md
+++ b/examples/java-matter-controller/README.md
@@ -84,3 +84,9 @@ the top Matter directory:
 
 The Java executable file `java-matter-controller` will be generated at
 `out/android-x86-java-matter-controller/bin/`
+
+Run the java-matter-controller
+
+```
+java -Djava.library.path=../lib/jni -jar java-matter-controller
+```

--- a/examples/java-matter-controller/java/src/com/matter/controller/Main.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/Main.java
@@ -23,7 +23,6 @@ import chip.devicecontroller.ControllerParams;
 import com.matter.controller.commands.common.*;
 import com.matter.controller.commands.discover.*;
 import com.matter.controller.commands.pairing.*;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 
 public class Main {
@@ -85,21 +84,6 @@ public class Main {
   }
 
   public static void main(String[] args) {
-    System.setProperty("java.library.path", "../lib/jni");
-
-    Field fieldSysPath = null;
-    try {
-      fieldSysPath = ClassLoader.class.getDeclaredField("sys_paths");
-    } catch (NoSuchFieldException e) {
-      throw new RuntimeException(e);
-    }
-    fieldSysPath.setAccessible(true);
-    try {
-      fieldSysPath.set(null, null);
-    } catch (IllegalAccessException e) {
-      throw new RuntimeException(e);
-    }
-
     ChipDeviceController controller =
         new ChipDeviceController(
             ControllerParams.newBuilder()

--- a/examples/java-matter-controller/java/src/com/matter/controller/Main.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/Main.java
@@ -18,9 +18,12 @@
 
 package com.matter.controller;
 
+import chip.devicecontroller.ChipDeviceController;
+import chip.devicecontroller.ControllerParams;
 import com.matter.controller.commands.common.*;
 import com.matter.controller.commands.discover.*;
 import com.matter.controller.commands.pairing.*;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 
 public class Main {
@@ -82,14 +85,27 @@ public class Main {
   }
 
   public static void main(String[] args) {
-    /* TODO: uncomment when SDK integration is done
+    System.setProperty("java.library.path", "../lib/jni");
+
+    Field fieldSysPath = null;
+    try {
+      fieldSysPath = ClassLoader.class.getDeclaredField("sys_paths");
+    } catch (NoSuchFieldException e) {
+      throw new RuntimeException(e);
+    }
+    fieldSysPath.setAccessible(true);
+    try {
+      fieldSysPath.set(null, null);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+
     ChipDeviceController controller =
         new ChipDeviceController(
             ControllerParams.newBuilder()
                 .setUdpListenPort(0)
                 .setControllerVendorId(0xFFF1)
                 .build());
-    */
 
     CredentialsIssuer credentialsIssuer = new CredentialsIssuer();
     CommandManager commandManager = new CommandManager();

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -432,7 +432,7 @@ class HostBuilder(GnBuilder):
             self._Execute(['genhtml', os.path.join(self.coverage_dir, 'lcov_final.info'), '--output-directory',
                            os.path.join(self.coverage_dir, 'html')], title="HTML coverage")
 
-        if self.app.ExamplePath() == "java-matter-controller" and 'JAVA_PATH' in os.environ:
+        if self.app == HostApp.JAVA_MATTER_CONTROLLER:
             self.createJavaExecutable("java-matter-controller")
 
     def build_outputs(self):

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -363,31 +363,6 @@ class HostBuilder(GnBuilder):
         else:
             raise Exception('Unknown host board type: %r' % self)
 
-    def copyToExampleApp(self, jnilibs_dir, libs_dir, libs, jars):
-        self._Execute(
-            ["mkdir", "-p", jnilibs_dir], title="Prepare Native libs " + self.identifier
-        )
-
-        for libName in libs:
-            self._Execute(
-                [
-                    "cp",
-                    os.path.join(
-                        self.output_dir, "lib", "jni", self.board.AbiName(), libName
-                    ),
-                    os.path.join(jnilibs_dir, libName),
-                ]
-            )
-
-        for jarName in jars.keys():
-            self._Execute(
-                [
-                    "cp",
-                    os.path.join(self.output_dir, "lib", jars[jarName]),
-                    os.path.join(libs_dir, jarName),
-                ]
-            )
-
     def createJavaExecutable(self, java_program):
         self._Execute(
             [
@@ -442,32 +417,6 @@ class HostBuilder(GnBuilder):
                            '--exclude', os.path.join(self.chip_dir, 'third_party/*'),
                            '--exclude', '/usr/include/*',
                            '--output-file', os.path.join(self.coverage_dir, 'lcov_base.info')], title="Initial coverage baseline")
-            if self.app.exampleName == "java-matter-controller" and 'JAVA_PATH' in os.environ:
-                jnilibs_dir = os.path.join(
-                    self.root,
-                    "examples/",
-                    self.app.ExampleName(),
-                    "app/libs/jniLibs",
-                    self.board.AbiName(),
-                )
-
-                libs_dir = os.path.join(
-                    self.root, "examples/", self.app.ExampleName(), "app/libs"
-                )
-
-                libs = [
-                    "libSetupPayloadParser.so",
-                    "libCHIPController.so",
-                    "libc++_shared.so",
-                ]
-
-                jars = {
-                    "CHIPController.jar": "third_party/connectedhomeip/src/controller/java/CHIPController.jar",
-                    "SetupPayloadParser.jar": "third_party/connectedhomeip/src/setup_payload/java/SetupPayloadParser.jar",
-                }
-
-                self.copyToExampleApp(jnilibs_dir, libs_dir, libs, jars)
-                self.createJavaExecutable("java-matter-controller")
 
     def PostBuildCommand(self):
         if self.app == HostApp.TESTS and self.use_coverage:
@@ -482,6 +431,9 @@ class HostBuilder(GnBuilder):
                            ], title="Final coverage info")
             self._Execute(['genhtml', os.path.join(self.coverage_dir, 'lcov_final.info'), '--output-directory',
                            os.path.join(self.coverage_dir, 'html')], title="HTML coverage")
+
+        if self.app.ExamplePath() == "java-matter-controller" and 'JAVA_PATH' in os.environ:
+            self.createJavaExecutable("java-matter-controller")
 
     def build_outputs(self):
         outputs = {}


### PR DESCRIPTION
Currently, we need to run the java-matter-controller with the following format 

`java -verbose:jni -Xcheck:jni -Djava.library.path=out/linux-x64-java-matter-controller/lib/jni -cp out/linux-x64-java-matter-controller/lib/third_party/connectedhomeip/src/controller/java/CHIPController.jar:out/linux-x64-java-matter-controller/bin/java-matter-controller com.matter.controller.Main `

We need to package it in an executable format to be run like
 $ java -Djava.library.path=../lib/jni -jar java-matter-controller
