### PR TITLE
examples/tv-casting-app: Allow setting DACCredentials on iOS and add retry mechanism for commissioner discovery

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
@@ -107,6 +107,18 @@ public class CommissionerDiscoveryFragment extends Fragment {
           }
         };
 
+    Button discoverButton = getView().findViewById(R.id.discoverButton);
+    discoverButton.setOnClickListener(
+        new View.OnClickListener() {
+          @Override
+          public void onClick(View v) {
+            Log.d(TAG, "Discovering on button click");
+            tvCastingApp.discoverVideoPlayerCommissioners(
+                DISCOVERY_DURATION_SECS, successCallback, failureCallback);
+          }
+        });
+
+    Log.d(TAG, "Auto discovering");
     tvCastingApp.discoverVideoPlayerCommissioners(
         DISCOVERY_DURATION_SECS, successCallback, failureCallback);
   }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/NsdDiscoveryListener.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/NsdDiscoveryListener.java
@@ -71,7 +71,8 @@ public class NsdDiscoveryListener implements NsdManager.DiscoveryListener {
               preCommissionedVideoPlayers,
               successCallback,
               failureCallback,
-              nsdManagerResolverAvailState));
+              nsdManagerResolverAvailState,
+              1));
     } else {
       Log.d(TAG, "Ignoring discovered service: " + service.toString());
     }

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_commissioner_discovery.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_commissioner_discovery.xml
@@ -20,6 +20,12 @@
             android:layout_height="wrap_content"
             android:text="Skip to manual commissioning >>" />
 
+        <Button
+            android:id="@+id/discoverButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Discover>" />
+
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C26AC8C2926FE0C00BA6881 /* DeviceAttestationCredentialsProviderImpl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3C26AC8B2926FE0C00BA6881 /* DeviceAttestationCredentialsProviderImpl.hpp */; };
+		3C26AC902927008900BA6881 /* DeviceAttestationCredentialsProviderImpl.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C26AC8F2927008900BA6881 /* DeviceAttestationCredentialsProviderImpl.mm */; };
+		3C26AC9329282B8100BA6881 /* DeviceAttestationCredentialsHolder.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C26AC9229282B8100BA6881 /* DeviceAttestationCredentialsHolder.m */; };
 		3C4AE650286A7D4D005B52A4 /* OnboardingPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C4AE64F286A7D4D005B52A4 /* OnboardingPayload.m */; };
 		3C4E53B028E4F28100F293E8 /* MediaPlaybackTypes.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C4E53AF28E4F28100F293E8 /* MediaPlaybackTypes.mm */; };
 		3C4E53B228E5184C00F293E8 /* TargetNavigatorTypes.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C4E53B128E5184C00F293E8 /* TargetNavigatorTypes.mm */; };
@@ -28,6 +31,10 @@
 
 /* Begin PBXFileReference section */
 		3C0D9CDF2920A30C00D3332B /* CommissionableDataProviderImpl.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CommissionableDataProviderImpl.hpp; sourceTree = "<group>"; };
+		3C26AC8B2926FE0C00BA6881 /* DeviceAttestationCredentialsProviderImpl.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = DeviceAttestationCredentialsProviderImpl.hpp; sourceTree = "<group>"; };
+		3C26AC8F2927008900BA6881 /* DeviceAttestationCredentialsProviderImpl.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DeviceAttestationCredentialsProviderImpl.mm; sourceTree = "<group>"; };
+		3C26AC91292700AD00BA6881 /* DeviceAttestationCredentialsHolder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeviceAttestationCredentialsHolder.h; sourceTree = "<group>"; };
+		3C26AC9229282B8100BA6881 /* DeviceAttestationCredentialsHolder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DeviceAttestationCredentialsHolder.m; sourceTree = "<group>"; };
 		3C4AE64E286A7D40005B52A4 /* OnboardingPayload.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OnboardingPayload.h; sourceTree = "<group>"; };
 		3C4AE64F286A7D4D005B52A4 /* OnboardingPayload.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnboardingPayload.m; sourceTree = "<group>"; };
 		3C4E53AF28E4F28100F293E8 /* MediaPlaybackTypes.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaPlaybackTypes.mm; sourceTree = "<group>"; };
@@ -113,6 +120,10 @@
 				3C4E53AF28E4F28100F293E8 /* MediaPlaybackTypes.mm */,
 				3C4E53B328E5185F00F293E8 /* TargetNavigatorTypes.h */,
 				3C4E53B128E5184C00F293E8 /* TargetNavigatorTypes.mm */,
+				3C26AC91292700AD00BA6881 /* DeviceAttestationCredentialsHolder.h */,
+				3C26AC9229282B8100BA6881 /* DeviceAttestationCredentialsHolder.m */,
+				3C26AC8B2926FE0C00BA6881 /* DeviceAttestationCredentialsProviderImpl.hpp */,
+				3C26AC8F2927008900BA6881 /* DeviceAttestationCredentialsProviderImpl.mm */,
 				3C0D9CDF2920A30C00D3332B /* CommissionableDataProviderImpl.hpp */,
 			);
 			path = MatterTvCastingBridge;
@@ -125,6 +136,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C26AC8C2926FE0C00BA6881 /* DeviceAttestationCredentialsProviderImpl.hpp in Headers */,
 				3CCB8740286A593700771BAD /* CastingServerBridge.h in Headers */,
 				3CCB8742286A593700771BAD /* ConversionUtils.hpp in Headers */,
 				3CCB8741286A593700771BAD /* DiscoveredNodeData.h in Headers */,
@@ -229,6 +241,8 @@
 				3CCB8744286A593700771BAD /* ConversionUtils.mm in Sources */,
 				3C4E53B028E4F28100F293E8 /* MediaPlaybackTypes.mm in Sources */,
 				3C66FBFC290327BB00B63FE7 /* AppParameters.mm in Sources */,
+				3C26AC9329282B8100BA6881 /* DeviceAttestationCredentialsHolder.m in Sources */,
+				3C26AC902927008900BA6881 /* DeviceAttestationCredentialsProviderImpl.mm in Sources */,
 				3CCB873F286A593700771BAD /* DiscoveredNodeData.mm in Sources */,
 				3C81C74C28F7A777001CB9D1 /* ContentApp.mm in Sources */,
 				3C4AE650286A7D4D005B52A4 /* OnboardingPayload.m in Sources */,

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/AppParameters.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/AppParameters.h
@@ -17,6 +17,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "DeviceAttestationCredentialsHolder.h"
 #import "OnboardingPayload.h"
 
 #ifndef AppParameters_h
@@ -33,6 +34,8 @@
 @property NSData * spake2pSalt;
 
 @property NSData * spake2pVerifier;
+
+@property DeviceAttestationCredentialsHolder * deviceAttestationCredentials;
 
 @end
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/DeviceAttestationCredentialsHolder.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/DeviceAttestationCredentialsHolder.h
@@ -1,0 +1,47 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#ifndef DeviceAttestationCredentialsHolder_h
+#define DeviceAttestationCredentialsHolder_h
+
+@interface DeviceAttestationCredentialsHolder : NSObject
+
+- (DeviceAttestationCredentialsHolder * _Nonnull)
+      initWithCertificationDeclaration:(NSData * _Nonnull)certificationDeclaration
+                   firmwareInformation:(NSData * _Nonnull)firmwareInformation
+                 deviceAttestationCert:(NSData * _Nonnull)deviceAttestationCert
+    productAttestationIntermediateCert:(NSData * _Nonnull)productAttestationIntermediateCert
+       deviceAttestationCertPrivateKey:(NSData * _Nonnull)deviceAttestationCertPrivateKey
+     deviceAttestationCertPublicKeyKey:(NSData * _Nonnull)deviceAttestationCertPublicKeyKey;
+
+- (NSData * _Nonnull)getCertificationDeclaration;
+
+- (NSData * _Nonnull)getFirmwareInformation;
+
+- (NSData * _Nonnull)getDeviceAttestationCert;
+
+- (NSData * _Nonnull)getProductAttestationIntermediateCert;
+
+- (NSData * _Nonnull)getDeviceAttestationCertPrivateKey;
+
+- (NSData * _Nonnull)getDeviceAttestationCertPublicKeyKey;
+
+@end
+
+#endif /* DeviceAttestationCredentialsHolder_h */

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/DeviceAttestationCredentialsHolder.m
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/DeviceAttestationCredentialsHolder.m
@@ -1,0 +1,89 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "DeviceAttestationCredentialsHolder.h"
+
+#import <Foundation/Foundation.h>
+
+@interface DeviceAttestationCredentialsHolder ()
+
+@property NSData * certificationDeclaration;
+
+@property NSData * firmwareInformation;
+
+@property NSData * deviceAttestationCert;
+
+@property NSData * productAttestationIntermediateCert;
+
+@property NSData * deviceAttestationCertPrivateKey;
+
+@property NSData * deviceAttestationCertPublicKeyKey;
+
+@end
+
+@implementation DeviceAttestationCredentialsHolder
+
+- (DeviceAttestationCredentialsHolder * _Nonnull)
+      initWithCertificationDeclaration:(NSData * _Nonnull)certificationDeclaration
+                   firmwareInformation:(NSData * _Nonnull)firmwareInformation
+                 deviceAttestationCert:(NSData * _Nonnull)deviceAttestationCert
+    productAttestationIntermediateCert:(NSData * _Nonnull)productAttestationIntermediateCert
+       deviceAttestationCertPrivateKey:(NSData * _Nonnull)deviceAttestationCertPrivateKey
+     deviceAttestationCertPublicKeyKey:(NSData * _Nonnull)deviceAttestationCertPublicKeyKey
+{
+    self = [super init];
+    if (self) {
+        _certificationDeclaration = certificationDeclaration;
+        _firmwareInformation = firmwareInformation;
+        _deviceAttestationCert = deviceAttestationCert;
+        _productAttestationIntermediateCert = productAttestationIntermediateCert;
+        _deviceAttestationCertPrivateKey = deviceAttestationCertPrivateKey;
+        _deviceAttestationCertPublicKeyKey = deviceAttestationCertPublicKeyKey;
+    }
+    return self;
+}
+
+- (NSData * _Nonnull)getCertificationDeclaration
+{
+    return _certificationDeclaration;
+}
+
+- (NSData * _Nonnull)getFirmwareInformation;
+{
+    return _firmwareInformation;
+}
+
+- (NSData * _Nonnull)getDeviceAttestationCert;
+{
+    return _deviceAttestationCert;
+}
+
+- (NSData * _Nonnull)getProductAttestationIntermediateCert;
+{
+    return _productAttestationIntermediateCert;
+}
+
+- (NSData * _Nonnull)getDeviceAttestationCertPrivateKey;
+{
+    return _deviceAttestationCertPrivateKey;
+}
+
+- (NSData * _Nonnull)getDeviceAttestationCertPublicKeyKey;
+{
+    return _deviceAttestationCertPublicKeyKey;
+}
+@end

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/DeviceAttestationCredentialsProviderImpl.hpp
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/DeviceAttestationCredentialsProviderImpl.hpp
@@ -1,0 +1,57 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <crypto/CHIPCryptoPAL.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+class DeviceAttestationCredentialsProviderImpl : public chip::Credentials::DeviceAttestationCredentialsProvider
+{
+public:
+    DeviceAttestationCredentialsProviderImpl(chip::MutableByteSpan * certificationDeclaration,
+                                             chip::MutableByteSpan * firmwareInformation,
+                                             chip::MutableByteSpan * deviceAttestationCert,
+                                             chip::MutableByteSpan * productAttestationIntermediateCert,
+                                             chip::MutableByteSpan * deviceAttestationCertPrivateKey,
+                                             chip::MutableByteSpan * deviceAttestationCertPublicKeyKey);
+
+    CHIP_ERROR GetCertificationDeclaration(chip::MutableByteSpan & outCertificationDeclaration) override;
+    CHIP_ERROR GetFirmwareInformation(chip::MutableByteSpan & outFirmwareInformation) override;
+    CHIP_ERROR GetDeviceAttestationCert(chip::MutableByteSpan & outDeviceAttestationCert) override;
+    CHIP_ERROR GetProductAttestationIntermediateCert(chip::MutableByteSpan & outProductAttestationIntermediateCert) override;
+    CHIP_ERROR SignWithDeviceAttestationKey(const chip::ByteSpan & messageToSign,
+                                            chip::MutableByteSpan & outSignatureBuffer) override;
+
+private:
+    chip::MutableByteSpan mCertificationDeclaration;
+    chip::MutableByteSpan mFirmwareInformation;
+    chip::MutableByteSpan mDeviceAttestationCert;
+    chip::MutableByteSpan mProductAttestationIntermediateCert;
+    chip::MutableByteSpan mDeviceAttestationCertPrivateKey;
+    chip::MutableByteSpan mDeviceAttestationCertPublicKeyKey;
+
+    CHIP_ERROR LoadKeypairFromRaw(chip::ByteSpan privateKey, chip::ByteSpan publicKey, chip::Crypto::P256Keypair & keypair)
+    {
+        chip::Crypto::P256SerializedKeypair serialized_keypair;
+        ReturnErrorOnFailure(serialized_keypair.SetLength(privateKey.size() + publicKey.size()));
+        memcpy(serialized_keypair.Bytes(), publicKey.data(), publicKey.size());
+        memcpy(serialized_keypair.Bytes() + publicKey.size(), privateKey.data(), privateKey.size());
+        return keypair.Deserialize(serialized_keypair);
+    }
+};

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/DeviceAttestationCredentialsProviderImpl.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/DeviceAttestationCredentialsProviderImpl.mm
@@ -1,0 +1,137 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "DeviceAttestationCredentialsProviderImpl.hpp"
+
+#import <Foundation/Foundation.h>
+
+DeviceAttestationCredentialsProviderImpl::DeviceAttestationCredentialsProviderImpl(chip::MutableByteSpan * certificationDeclaration,
+    chip::MutableByteSpan * firmwareInformation, chip::MutableByteSpan * deviceAttestationCert,
+    chip::MutableByteSpan * productAttestationIntermediateCert, chip::MutableByteSpan * deviceAttestationCertPrivateKey,
+    chip::MutableByteSpan * deviceAttestationCertPublicKeyKey)
+{
+    if (certificationDeclaration != nullptr) {
+        mCertificationDeclaration
+            = chip::MutableByteSpan(new uint8_t[certificationDeclaration->size()], certificationDeclaration->size());
+        memcpy(mCertificationDeclaration.data(), certificationDeclaration->data(), certificationDeclaration->size());
+    }
+
+    if (firmwareInformation != nullptr) {
+        mFirmwareInformation = chip::MutableByteSpan(new uint8_t[firmwareInformation->size()], firmwareInformation->size());
+        memcpy(mFirmwareInformation.data(), firmwareInformation->data(), firmwareInformation->size());
+    }
+
+    if (deviceAttestationCert != nullptr) {
+        mDeviceAttestationCert = chip::MutableByteSpan(new uint8_t[deviceAttestationCert->size()], deviceAttestationCert->size());
+        memcpy(mDeviceAttestationCert.data(), deviceAttestationCert->data(), deviceAttestationCert->size());
+    }
+
+    if (productAttestationIntermediateCert != nullptr) {
+        mProductAttestationIntermediateCert = chip::MutableByteSpan(
+            new uint8_t[productAttestationIntermediateCert->size()], productAttestationIntermediateCert->size());
+        memcpy(mProductAttestationIntermediateCert.data(), productAttestationIntermediateCert->data(),
+            productAttestationIntermediateCert->size());
+    }
+
+    if (deviceAttestationCertPrivateKey != nullptr) {
+        mDeviceAttestationCertPrivateKey
+            = chip::MutableByteSpan(new uint8_t[deviceAttestationCertPrivateKey->size()], deviceAttestationCertPrivateKey->size());
+        memcpy(mDeviceAttestationCertPrivateKey.data(), deviceAttestationCertPrivateKey->data(),
+            deviceAttestationCertPrivateKey->size());
+    }
+
+    if (deviceAttestationCertPublicKeyKey != nullptr) {
+        mDeviceAttestationCertPublicKeyKey = chip::MutableByteSpan(
+            new uint8_t[deviceAttestationCertPublicKeyKey->size()], deviceAttestationCertPublicKeyKey->size());
+        memcpy(mDeviceAttestationCertPublicKeyKey.data(), deviceAttestationCertPublicKeyKey->data(),
+            deviceAttestationCertPublicKeyKey->size());
+    }
+}
+
+CHIP_ERROR DeviceAttestationCredentialsProviderImpl::GetCertificationDeclaration(
+    chip::MutableByteSpan & outCertificationDeclaration)
+{
+    if (mCertificationDeclaration.size() > 0) {
+        if (outCertificationDeclaration.size() >= mCertificationDeclaration.size()) {
+            memcpy(outCertificationDeclaration.data(), mCertificationDeclaration.data(), mCertificationDeclaration.size());
+            outCertificationDeclaration.reduce_size(mCertificationDeclaration.size());
+        } else {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeviceAttestationCredentialsProviderImpl::GetFirmwareInformation(chip::MutableByteSpan & outFirmwareInformation)
+{
+    if (mFirmwareInformation.size() > 0) {
+        if (outFirmwareInformation.size() >= mFirmwareInformation.size()) {
+            memcpy(outFirmwareInformation.data(), mFirmwareInformation.data(), mFirmwareInformation.size());
+            outFirmwareInformation.reduce_size(mFirmwareInformation.size());
+        } else {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeviceAttestationCredentialsProviderImpl::GetDeviceAttestationCert(chip::MutableByteSpan & outDeviceAttestationCert)
+{
+    if (mDeviceAttestationCert.size() > 0) {
+        if (outDeviceAttestationCert.size() >= mDeviceAttestationCert.size()) {
+            memcpy(outDeviceAttestationCert.data(), mDeviceAttestationCert.data(), mDeviceAttestationCert.size());
+            outDeviceAttestationCert.reduce_size(mDeviceAttestationCert.size());
+        } else {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeviceAttestationCredentialsProviderImpl::GetProductAttestationIntermediateCert(
+    chip::MutableByteSpan & outProductAttestationIntermediateCert)
+{
+    if (mProductAttestationIntermediateCert.size() > 0) {
+        if (outProductAttestationIntermediateCert.size() >= mProductAttestationIntermediateCert.size()) {
+            memcpy(outProductAttestationIntermediateCert.data(), mProductAttestationIntermediateCert.data(),
+                mProductAttestationIntermediateCert.size());
+            outProductAttestationIntermediateCert.reduce_size(mProductAttestationIntermediateCert.size());
+        } else {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeviceAttestationCredentialsProviderImpl::SignWithDeviceAttestationKey(
+    const chip::ByteSpan & messageToSign, chip::MutableByteSpan & outSignatureBuffer)
+{
+    ChipLogProgress(AppServer, "DeviceAttestationCredentialsProviderImpl::SignWithDeviceAttestationKey called");
+    chip::Crypto::P256ECDSASignature signature;
+    chip::Crypto::P256Keypair keypair;
+
+    VerifyOrReturnError(IsSpanUsable(outSignatureBuffer), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(IsSpanUsable(messageToSign), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(outSignatureBuffer.size() >= signature.Capacity(), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    // In a non-exemplary implementation, the public key is not needed here. It is used here merely because
+    // Crypto::P256Keypair is only (currently) constructable from raw keys if both private/public keys are present.
+    ReturnErrorOnFailure(LoadKeypairFromRaw(mDeviceAttestationCertPrivateKey, mDeviceAttestationCertPublicKeyKey, keypair));
+    ReturnErrorOnFailure(keypair.ECDSA_sign_msg(messageToSign.data(), messageToSign.size(), signature));
+
+    return CopySpanToMutableSpan(chip::ByteSpan { signature.ConstBytes(), signature.Length() }, outSignatureBuffer);
+}


### PR DESCRIPTION
Fixes #23691 and #23514 

#### Change summary
1. Commit#1 - Allows providing a DACCredentialsHolder from the iOS app, that is converted to a DACProviderImpl and set on the Matter SDK to initialize an iOS tv-casting-app with real DAC credentials instead of the ExampleDACProvider
2. Commit#2 - Adds a retry mechanism (configured at up to 5 times, every 1 sec)  to commissioner discovery on Android tv-casting library in the case where we get a FAILURE_ALREADY_ACTIVE error intermittently.

#### Testing
Tested with the iOS and Android tv-casting-apps