### PR TITLE
[Tizen] Setup for using ccache with Tizen builds

### DIFF
--- a/build/toolchain/tizen/tizen_toolchain.gni
+++ b/build/toolchain/tizen/tizen_toolchain.gni
@@ -27,8 +27,15 @@ template("tizen_toolchain") {
     forward_variables_from(_invoker_toolchain_args, "*")
   }
 
-  _tizen_toolchain_prefix =
-      "${tizen_sdk_root}/tools/arm-linux-gnueabi-gcc-9.2/bin/arm-linux-gnueabi-"
+  # Try to get the toolchain from the environment. Otherwise, use the default
+  # toolchain path based on Tizen SDK location. Overwriting the toolchain env
+  # variable can for example allow ccache setup for Tizen builds.
+  _tizen_toolchain = getenv("TIZEN_SDK_TOOLCHAIN")
+  if (_tizen_toolchain == "") {
+    _tizen_toolchain = "${tizen_sdk_root}/tools/arm-linux-gnueabi-gcc-9.2"
+  }
+
+  _tizen_toolchain_prefix = "${_tizen_toolchain}/bin/arm-linux-gnueabi-"
 
   gcc_toolchain(target_name) {
     toolchain_args = _tizen_toolchain_args

--- a/examples/lighting-app/tizen/README.md
+++ b/examples/lighting-app/tizen/README.md
@@ -25,11 +25,26 @@ Building tizen-arm-light
 ninja -C $PW_PROJECT_ROOT/out/tizen-arm-light
 ```
 
-## Preparing Tizen SDK certificate
+### Using Ccache (optional)
 
-For packaging the Tizen APP, there is a need to generate an author certificate
-and security profile using the commands described below. Change password and
-author data as needed.
+In order to facilitate [ccache](https://ccache.dev) with Tizen build one should
+setup environment variables as follows (before using `gn gen ...` command):
+
+```sh
+export PATH=$TIZEN_SDK_TOOLCHAIN/bin:$PATH
+export TIZEN_SDK_TOOLCHAIN=$TIZEN_SDK_TOOLCHAIN_CCACHE
+```
+
+## Preparing Tizen SDK certificate (optional)
+
+When building Matter example application, this step is optional. If certificate
+is not found, a dummy one will be created with the following options:
+name="Matter Example" email="matter@tizen.org" password="0123456789"
+
+In order to create and use custom author certificate, one can use the commands
+described below. Change the certificate password and author data as needed. The
+security profile alias should not be changed, as the "CHIP" name is used in the
+Matter example build system.
 
 ```sh
 $TIZEN_SDK_ROOT/tools/ide/bin/tizen certificate \
@@ -59,11 +74,9 @@ rm -r \
 After that, normally call scripts to generate the author certificate and
 security profile mentioned previously.
 
-### Important
-
-Regenerating the author certificate and security profile makes it necessary to
-remove the previously installed Tizen app. You can't reinstall an application on
-the Tizen device with a different certificate.
+Please note, that regenerating the author certificate and security profile makes
+it necessary to remove the previously installed Tizen app. You can't reinstall
+an application on the Tizen device with a different certificate.
 
 ```sh
 pkgcmd -u -n org.tizen.matter.example.lighting
@@ -108,37 +121,37 @@ installed.
 
 1. Build app:
 
-```
-open the Command Palette (Ctrl+Shift+P) ->
-    Tasks: Run Task ->
-    Build LightingApp (Tizen)
-```
+    ```
+    open the Command Palette (Ctrl+Shift+P) ->
+        Tasks: Run Task ->
+        Build LightingApp (Tizen)
+    ```
 
 2. SDB connect to device: required to run Tizen commands below if device is
    debugged over network
 
-```
-open the Command Palette (Ctrl+Shift+P) ->
-    Tasks: Run Task -> Connect to device (Tizen) ->
-    insert IP address and port
-```
+    ```
+    open the Command Palette (Ctrl+Shift+P) ->
+        Tasks: Run Task -> Connect to device (Tizen) ->
+        insert IP address and port
+    ```
 
 3. Install app: it is separated from build app step.
 
-```
-open the Command Palette (Ctrl+Shift+P) ->
-    Tasks: Run Task ->
-    Install LightingApp (Tizen)
-```
+    ```
+    open the Command Palette (Ctrl+Shift+P) ->
+        Tasks: Run Task ->
+        Install LightingApp (Tizen)
+    ```
 
 4. Launch LightingApp with gdbserver attached: require to install app
    previously.
 
-```
-open the Command Palette (Ctrl+Shift+P) ->
-    Tasks: Run Task ->
-    Launch LightingApp with gdbserver attached (Tizen)
-```
+    ```
+    open the Command Palette (Ctrl+Shift+P) ->
+        Tasks: Run Task ->
+        Launch LightingApp with gdbserver attached (Tizen)
+    ```
 
 ### Debug
 

--- a/integrations/docker/images/chip-build-tizen/Dockerfile
+++ b/integrations/docker/images/chip-build-tizen/Dockerfile
@@ -47,6 +47,7 @@ RUN set -x \
 # ------------------------------------------------------------------------------
 # Set environment
 ENV TIZEN_SDK_TOOLCHAIN $TIZEN_SDK_ROOT/tools/arm-linux-gnueabi-gcc-9.2
+ENV TIZEN_SDK_TOOLCHAIN_CCACHE $TIZEN_SDK_ROOT/tools/arm-linux-gnueabi-gcc-ccache
 ENV TIZEN_SDK_SYSROOT $TIZEN_SDK_ROOT/platforms/tizen-$TIZEN_VERSION/mobile/rootstraps/mobile-$TIZEN_VERSION-device.core
 ENV PATH="$TIZEN_SDK_TOOLCHAIN/bin:$TIZEN_SDK_ROOT/tools/ide/bin:$TIZEN_SDK_ROOT/tools:$PATH"
 

--- a/integrations/docker/images/chip-build-tizen/tizen-sdk-installer/install.sh
+++ b/integrations/docker/images/chip-build-tizen/tizen-sdk-installer/install.sh
@@ -44,17 +44,17 @@ function show_help() {
     echo "Example: $SCRIPT_NAME --tizen-sdk-path ~/tizen-sdk --tizen-version 6.0 --install-dependencies"
     echo
     echo "Options:"
-    echo "  --help                     Display this information"
+    echo "  -h, --help                 Display this information"
     echo "  --tizen-sdk-path           Set directory where Tizen will be installed. Default is $TIZEN_SDK_ROOT"
     echo "  --tizen-sdk-data-path      Set directory where Tizen have data. Default is $TIZEN_SDK_DATA_PATH"
     echo "  --install-dependencies     This options install all dependencies."
     echo "  --tizen-version            Select Tizen version. Default is $TIZEN_VERSION"
-    echo "  --override-secret-tool     Without password manager circumvents the requirement of having functional D-Bus Secrets service"
+    echo "  --override-secret-tool     Circumvent the requirement of having functional D-Bus Secrets service."
     echo
     echo "Note:"
     echo "The script should run fully with ubuntu. For other distributions you may have to manually"
     echo "install all needed dependencies. Use the script specifying --tizen-sdk-path with or"
-    echo "without --tizen-version. The script will only install the tizen platform for Matter."
+    echo "without --tizen-version. The script will only install Tizen platform for Matter."
 }
 
 # ------------------------------------------------------------------------------
@@ -66,7 +66,7 @@ function error() {
 # ------------------------------------------------------------------------------
 # Info print function
 function info() {
-    echo "$COLOR_GREEN$1$COLOR_NONE"
+    echo "$COLOR_GREEN[INFO]: $1$COLOR_NONE"
 }
 
 # ------------------------------------------------------------------------------
@@ -78,7 +78,7 @@ function warning() {
 # ------------------------------------------------------------------------------
 # Show dependencies
 function show_dependencies() {
-    warning "Need dependencies for use this script installation SDK: cpio  wget unzip unrpm"
+    warning "Need dependencies for use this script installation SDK: cpio unrpm unzip wget"
     warning "Need dependencies for Tizen SDK: JAVA JRE >=8.0"
 }
 
@@ -134,10 +134,13 @@ function install_tizen_sdk() {
     info "Tizen SDK installation directory: $TIZEN_SDK_ROOT"
 
     TIZEN_SDK_SYSROOT="$TIZEN_SDK_ROOT/platforms/tizen-$TIZEN_VERSION/mobile/rootstraps/mobile-$TIZEN_VERSION-device.core"
+    TIZEN_SDK_TOOLCHAIN="$TIZEN_SDK_ROOT/tools/arm-linux-gnueabi-gcc-9.2"
+    TIZEN_SDK_TOOLCHAIN_CCACHE="$TIZEN_SDK_ROOT/tools/arm-linux-gnueabi-gcc-ccache"
 
-    # Get tizen studio CLI
-    info "Get tizen studio CLI [...]"
     cd "$TMP_DIR" || return
+
+    # Get Tizen Studio CLI
+    info "Downloading Tizen Studio CLI..."
 
     # Download
     URL="http://download.tizen.org/sdk/tizenstudio/official/binary/"
@@ -150,7 +153,7 @@ function install_tizen_sdk() {
     download "$URL" "${PKG_ARR[@]}"
 
     # Get toolchain
-    info "Get toolchain"
+    info "Downloading Tizen toolchain..."
 
     # Download
     URL="http://download.tizen.org/sdk/tizenstudio/official/binary/"
@@ -159,11 +162,11 @@ function install_tizen_sdk() {
         "sbi-toolchain-gcc-9.2.cpp.app_2.2.16_ubuntu-64.zip")
     download "$URL" "${PKG_ARR[@]}"
 
-    # Get tizen sysroot
-    info "Get tizen sysroot"
+    # Get Tizen sysroot
+    info "Downloading Tizen sysroot..."
 
     # Base sysroot
-    # Different versions of tizen have different rootstrap versions
+    # Different versions of Tizen have different rootstrap versions
     URL="http://download.tizen.org/sdk/tizenstudio/official/binary/"
     PKG_ARR=(
         "mobile-$TIZEN_VERSION-core-add-ons_*_ubuntu-64.zip"
@@ -224,7 +227,7 @@ function install_tizen_sdk() {
     download "$URL" "${PKG_ARR[@]}"
 
     # Install all
-    info "Installation Tizen SDK [...]"
+    info "Installing Tizen SDK..."
 
     unzip -o '*.zip'
     cp -rf data/* "$TIZEN_SDK_ROOT"
@@ -234,12 +237,12 @@ function install_tizen_sdk() {
 
     # Install secret tool or not
     if ("$SECRET_TOOL"); then
-        info "Override secret tool"
+        info "Overriding secret tool..."
         cp "$SCRIPT_DIR/secret-tool.py" "$TIZEN_SDK_ROOT/tools/certificate-encryptor/secret-tool"
         chmod 0755 "$TIZEN_SDK_ROOT/tools/certificate-encryptor/secret-tool"
     fi
 
-    # Configure tizen cli
+    # Configure Tizen CLI
     echo "TIZEN_SDK_INSTALLED_PATH=$TIZEN_SDK_ROOT" >"$TIZEN_SDK_ROOT/sdk.info"
     echo "TIZEN_SDK_DATA_PATH=$TIZEN_SDK_DATA_PATH" >>"$TIZEN_SDK_ROOT/sdk.info"
     ln -sf "$TIZEN_SDK_DATA_PATH/.tizen-cli-config" "$TIZEN_SDK_ROOT/tools/.tizen-cli-config"
@@ -251,12 +254,25 @@ function install_tizen_sdk() {
     ln -sf ../../lib/libcap.so.2 "$TIZEN_SDK_SYSROOT/usr/lib/libcap.so"
     ln -sf openssl1.1.pc "$TIZEN_SDK_SYSROOT/usr/lib/pkgconfig/openssl.pc"
 
+    # Setup ccache links
+    info "Setting up ccache links..."
+    CCACHE=$(command -v ccache || echo "/usr/bin/ccache")
+    mkdir -p "$TIZEN_SDK_TOOLCHAIN_CCACHE/bin"
+    ln -sf "$TIZEN_SDK_TOOLCHAIN/bin/arm-linux-gnueabi-ar" "$TIZEN_SDK_TOOLCHAIN_CCACHE/bin"
+    ln -sf "$CCACHE" "$TIZEN_SDK_TOOLCHAIN_CCACHE/bin/arm-linux-gnueabi-c++"
+    ln -sf "$CCACHE" "$TIZEN_SDK_TOOLCHAIN_CCACHE/bin/arm-linux-gnueabi-g++"
+    ln -sf "$CCACHE" "$TIZEN_SDK_TOOLCHAIN_CCACHE/bin/arm-linux-gnueabi-gcc"
+
+    info "Done."
+    echo
+
     # Information on necessary environment variables
-    warning "You must add the appropriate environment variables before proceeding with matter."
-    echo "$COLOR_YELLOW"
+    warning "Before proceeding with Matter export environment variables as follows:"
+    echo -n "$COLOR_YELLOW"
     echo "export TIZEN_VESRSION=\"$TIZEN_VERSION\""
     echo "export TIZEN_SDK_ROOT=\"$(realpath "$TIZEN_SDK_ROOT")\""
     echo "export TIZEN_SDK_TOOLCHAIN=\"\$TIZEN_SDK_ROOT/tools/arm-linux-gnueabi-gcc-9.2\""
+    echo "export TIZEN_SDK_TOOLCHAIN_CCACHE=\"\$TIZEN_SDK_ROOT/tools/arm-linux-gnueabi-gcc-ccache\""
     echo "export TIZEN_SDK_SYSROOT=\"\$TIZEN_SDK_ROOT/platforms/tizen-$TIZEN_VERSION/mobile/rootstraps/mobile-$TIZEN_VERSION-device.core\""
     echo "export PATH=\"\$TIZEN_SDK_TOOLCHAIN/bin:\$TIZEN_SDK_ROOT/tools/ide/bin:\$TIZEN_SDK_ROOT/tools:\$PATH\""
     echo -n "$COLOR_NONE"
@@ -264,7 +280,7 @@ function install_tizen_sdk() {
 
 while (($#)); do
     case $1 in
-        --help)
+        -h | --help)
             show_help
             exit 0
             ;;
@@ -308,20 +324,19 @@ if [ "$INSTALL_DEPENDENCIES" = true ]; then
         show_dependencies
         exit 1
     fi
-else
-    show_dependencies
 fi
 
 # ------------------------------------------------------------------------------
-# Checking dependencies needed to install the tizen platform
-for PKG in 'cpio' 'unzip' 'wget' 'unrpm'; do
+# Checking dependencies needed to install Tizen platform
+info "Checking required tools: cpio, java, unrpm, unzip, wget"
+for PKG in 'cpio' 'java' 'unrpm' 'unzip' 'wget'; do
     if ! command -v "$PKG" &>/dev/null; then
-        warning "Not found $PKG"
+        error "Required tool not found: $PKG"
         dep_lost=1
     fi
 done
 if [[ $dep_lost ]]; then
-    error "You need install dependencies before [HINT]: On Ubuntu-like distro run: sudo apt install ${DEPENDENCIES[@]}"
+    echo "[HINT]: sudo apt-get install ${DEPENDENCIES[*]}"
     exit 1
 fi
 

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -106,6 +106,8 @@ ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
 
 ENV TIZEN_VERSION 6.0
 ENV TIZEN_SDK_ROOT /opt/tizen-sdk
+ENV TIZEN_SDK_TOOLCHAIN $TIZEN_SDK_ROOT/tools/arm-linux-gnueabi-gcc-9.2
+ENV TIZEN_SDK_TOOLCHAIN_CCACHE $TIZEN_SDK_ROOT/tools/arm-linux-gnueabi-gcc-ccache
 ENV TIZEN_SDK_SYSROOT $TIZEN_SDK_ROOT/platforms/tizen-$TIZEN_VERSION/mobile/rootstraps/mobile-$TIZEN_VERSION-device.core
 
 ENV FVP_CORSTONE_300_PATH=/opt/FVP_Corstone_SSE-300

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.11 Version bump reason: install nodejs into chip-build image, since github js actions seem to need it.
+0.6.12 Version bump reason: Setup ccache for Tizen build


### PR DESCRIPTION
### Problem

Use ccache with Tizen builds - reduce build time when switching between branches.

### Changes

- Setup ccache links for Tizen toolchain
- Update Tizen example documentation

### Testing

Tested locally with newly installed Tizen SDK and exports shown in updated documentation.

| app | standard | rebuild with ccache |
| - | - | - |
| tizen-arm-chip-tool | 1m53s | 15s |
| tizen-arm-light | 1m24s | 17s |