### PR TITLE
[chip-tool] Add --skip-commissioning-complete optional parameter for …

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -70,17 +70,23 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
 
 CommissioningParameters PairingCommand::GetCommissioningParameters()
 {
+    auto params = CommissioningParameters();
+    params.SetSkipCommissioningComplete(mSkipCommissioningComplete.ValueOr(false));
+
     switch (mNetworkType)
     {
     case PairingNetworkType::WiFi:
-        return CommissioningParameters().SetWiFiCredentials(Controller::WiFiCredentials(mSSID, mPassword));
+        params.SetWiFiCredentials(Controller::WiFiCredentials(mSSID, mPassword));
+        break;
     case PairingNetworkType::Thread:
-        return CommissioningParameters().SetThreadOperationalDataset(mOperationalDataset);
+        params.SetThreadOperationalDataset(mOperationalDataset);
+        break;
     case PairingNetworkType::Ethernet:
     case PairingNetworkType::None:
-        return CommissioningParameters();
+        break;
     }
-    return CommissioningParameters();
+
+    return params;
 }
 
 CHIP_ERROR PairingCommand::PaseWithCode(NodeId remoteId)

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -78,20 +78,24 @@ public:
         case PairingMode::None:
             break;
         case PairingMode::Code:
+            AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
         case PairingMode::CodePaseOnly:
             AddArgument("payload", &mOnboardingPayload);
             AddArgument("discover-once", 0, 1, &mDiscoverOnce);
             AddArgument("use-only-onnetwork-discovery", 0, 1, &mUseOnlyOnNetworkDiscovery);
             break;
         case PairingMode::Ble:
+            AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
             break;
         case PairingMode::OnNetwork:
+            AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
             AddArgument("pase-only", 0, 1, &mPaseOnly);
             break;
         case PairingMode::SoftAP:
+            AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
             AddArgument("device-remote-ip", &mRemoteAddr);
@@ -99,6 +103,7 @@ public:
             AddArgument("pase-only", 0, 1, &mPaseOnly);
             break;
         case PairingMode::Ethernet:
+            AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
             AddArgument("device-remote-ip", &mRemoteAddr);
@@ -169,6 +174,7 @@ private:
     chip::Optional<bool> mDiscoverOnce;
     chip::Optional<bool> mUseOnlyOnNetworkDiscovery;
     chip::Optional<bool> mPaseOnly;
+    chip::Optional<bool> mSkipCommissioningComplete;
     uint16_t mRemotePort;
     uint16_t mDiscriminator;
     uint32_t mSetupPINCode;


### PR DESCRIPTION
…non-concurrent connection use case

In non-concurrent commissioning flow, the `commissioning-complete` command is done over a different connection. There is not way to exercise this scenario using `chip-tool` at the moment (unless manually doing all the PASE session steps...).

This PR set the right boolean flag in `CommissioningParameters` so it can be done.