### PR TITLE
Set pw_command_launcher from build_example.py CLI

### DIFF
--- a/scripts/build/build/__init__.py
+++ b/scripts/build/build/__init__.py
@@ -5,6 +5,7 @@ from enum import Enum, auto
 from typing import Sequence
 
 from .targets import BUILD_TARGETS
+from builders.builder import BuilderOptions
 
 
 class BuildSteps(Enum):
@@ -24,9 +25,7 @@ class Context:
         self.output_prefix = output_prefix
         self.completed_steps = set()
 
-    def SetupBuilders(self, targets: Sequence[str],
-                      enable_flashbundle: bool,
-                      pw_command_launcher: str):
+    def SetupBuilders(self, targets: Sequence[str], options: BuilderOptions):
         """
         Configures internal builders for the given platform/board/app
         combination.
@@ -36,9 +35,8 @@ class Context:
         for target in targets:
             found = False
             for choice in BUILD_TARGETS:
-                builder = choice.Create(
-                    target, self.runner, self.repository_path, self.output_prefix,
-                    enable_flashbundle, pw_command_launcher)
+                builder = choice.Create(target, self.runner, self.repository_path,
+                                        self.output_prefix, options)
                 if builder:
                     self.builders.append(builder)
                     found = True

--- a/scripts/build/build/__init__.py
+++ b/scripts/build/build/__init__.py
@@ -25,7 +25,8 @@ class Context:
         self.completed_steps = set()
 
     def SetupBuilders(self, targets: Sequence[str],
-                      enable_flashbundle: bool):
+                      enable_flashbundle: bool,
+                      pw_command_launcher: str):
         """
         Configures internal builders for the given platform/board/app
         combination.
@@ -35,7 +36,9 @@ class Context:
         for target in targets:
             found = False
             for choice in BUILD_TARGETS:
-                builder = choice.Create(target, self.runner, self.repository_path, self.output_prefix, enable_flashbundle)
+                builder = choice.Create(
+                    target, self.runner, self.repository_path, self.output_prefix,
+                    enable_flashbundle, pw_command_launcher)
                 if builder:
                     self.builders.append(builder)
                     found = True

--- a/scripts/build/build/target.py
+++ b/scripts/build/build/target.py
@@ -330,7 +330,7 @@ class BuildTarget:
         return _StringIntoParts(value, suffix, self.fixed_targets, self.modifiers)
 
     def Create(self, name: str, runner, repository_path: str, output_prefix: str,
-               enable_flashbundle: bool):
+               enable_flashbundle: bool, pw_command_launcher: str):
 
         parts = self.StringIntoTargetParts(name)
 
@@ -349,5 +349,6 @@ class BuildTarget:
         builder.output_dir = os.path.join(output_prefix, name)
         builder.chip_dir = repository_path
         builder.enable_flashbundle(enable_flashbundle)
+        builder.pw_command_launcher = pw_command_launcher
 
         return builder

--- a/scripts/build/build/target.py
+++ b/scripts/build/build/target.py
@@ -46,6 +46,8 @@ import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Iterable, Optional
 
+from builders.builder import BuilderOptions
+
 
 report_rejected_parts = True
 
@@ -330,7 +332,7 @@ class BuildTarget:
         return _StringIntoParts(value, suffix, self.fixed_targets, self.modifiers)
 
     def Create(self, name: str, runner, repository_path: str, output_prefix: str,
-               enable_flashbundle: bool, pw_command_launcher: str):
+               builder_options: BuilderOptions):
 
         parts = self.StringIntoTargetParts(name)
 
@@ -348,7 +350,6 @@ class BuildTarget:
         builder.identifier = name
         builder.output_dir = os.path.join(output_prefix, name)
         builder.chip_dir = repository_path
-        builder.enable_flashbundle = enable_flashbundle
-        builder.pw_command_launcher = pw_command_launcher
+        builder.options = builder_options
 
         return builder

--- a/scripts/build/build/target.py
+++ b/scripts/build/build/target.py
@@ -348,7 +348,7 @@ class BuildTarget:
         builder.identifier = name
         builder.output_dir = os.path.join(output_prefix, name)
         builder.chip_dir = repository_path
-        builder.enable_flashbundle(enable_flashbundle)
+        builder.enable_flashbundle = enable_flashbundle
         builder.pw_command_launcher = pw_command_launcher
 
         return builder

--- a/scripts/build/build/test_target.py
+++ b/scripts/build/build/test_target.py
@@ -14,15 +14,11 @@
 # limitations under the License.
 
 import unittest
+import sys
+import os
 
-try:
-    from build.target import *
-except:
-    import sys
-    import os
-
-    sys.path.append(os.path.abspath(os.path.dirname(__file__)))
-    from target import *
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from build.target import BuildTarget, TargetPart  # noqa: E402
 
 
 class FakeBuilder:

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -107,10 +107,15 @@ def ValidateRepoPath(context, parameter, value):
     default=False,
     is_flag=True,
     help='Skip timestaps in log output')
+@click.option(
+    '--pw-command-launcher',
+    help=(
+        'Set pigweed command launcher. E.g.: "--pw-command-launcher=ccache" '
+        'for using ccache when building examples.'))
 @click.pass_context
 def main(context, log_level, target, repo,
          out_prefix, clean, dry_run, dry_run_output, enable_flashbundle,
-         no_log_timestamps):
+         no_log_timestamps, pw_command_launcher):
     # Ensures somewhat pretty logging of what is going on
     log_fmt = '%(asctime)s %(levelname)-7s %(message)s'
     if no_log_timestamps:
@@ -136,7 +141,8 @@ before running this script.
     context.obj = build.Context(
         repository_path=repo, output_prefix=out_prefix, runner=runner)
     context.obj.SetupBuilders(
-        targets=requested_targets, enable_flashbundle=enable_flashbundle)
+        targets=requested_targets, enable_flashbundle=enable_flashbundle,
+        pw_command_launcher=pw_command_launcher)
 
     if clean:
         context.obj.CleanOutputDirectories()

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -22,7 +22,7 @@ import click
 import coloredlogs
 
 import build
-from glob_matcher import GlobMatcher
+from builders.builder import BuilderOptions
 from runner import PrintOnlyRunner, ShellRunner
 
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
@@ -140,9 +140,10 @@ before running this script.
 
     context.obj = build.Context(
         repository_path=repo, output_prefix=out_prefix, runner=runner)
-    context.obj.SetupBuilders(
-        targets=requested_targets, enable_flashbundle=enable_flashbundle,
-        pw_command_launcher=pw_command_launcher)
+    context.obj.SetupBuilders(targets=requested_targets, options=BuilderOptions(
+        enable_flashbundle=enable_flashbundle,
+        pw_command_launcher=pw_command_launcher,
+    ))
 
     if clean:
         context.obj.CleanOutputDirectories()

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -17,6 +17,15 @@ import os
 import shutil
 import tarfile
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class BuilderOptions:
+    # Enable flashbundle generation stage
+    enable_flashbundle: bool = False
+    # Allow to wrap default build command
+    pw_command_launcher: str = None
 
 
 class Builder(ABC):
@@ -34,11 +43,7 @@ class Builder(ABC):
         # Set post-init once actual build target is known
         self.identifier = None
         self.output_dir = None
-
-        # Enable flashbundle generation stage
-        self.enable_flashbundle = False
-        # Allow to override the default build command
-        self.pw_command_launcher = None
+        self.options = BuilderOptions()
 
     @abstractmethod
     def generate(self):
@@ -82,13 +87,13 @@ class Builder(ABC):
 
     def outputs(self):
         artifacts = self.build_outputs()
-        if self.enable_flashbundle:
+        if self.options.enable_flashbundle:
             artifacts.update(self.flashbundle())
         return artifacts
 
     def build(self):
         self._build()
-        if self.enable_flashbundle:
+        if self.options.enable_flashbundle:
             self._generate_flashbundle()
 
     def _Execute(self, cmdarray, title=None):

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -30,17 +30,15 @@ class Builder(ABC):
     def __init__(self, root, runner):
         self.root = os.path.abspath(root)
         self._runner = runner
-        self._enable_flashbundle = False
 
         # Set post-init once actual build target is known
         self.identifier = None
         self.output_dir = None
 
+        # Enable flashbundle generation stage
+        self.enable_flashbundle = False
         # Allow to override the default build command
         self.pw_command_launcher = None
-
-    def enable_flashbundle(self, enable_flashbundle: bool):
-        self._enable_flashbundle = enable_flashbundle
 
     @abstractmethod
     def generate(self):
@@ -84,13 +82,13 @@ class Builder(ABC):
 
     def outputs(self):
         artifacts = self.build_outputs()
-        if self._enable_flashbundle:
+        if self.enable_flashbundle:
             artifacts.update(self.flashbundle())
         return artifacts
 
     def build(self):
         self._build()
-        if self._enable_flashbundle:
+        if self.enable_flashbundle:
             self._generate_flashbundle()
 
     def _Execute(self, cmdarray, title=None):

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -22,8 +22,8 @@ from abc import ABC, abstractmethod
 class Builder(ABC):
     """Generic builder base class for CHIP.
 
-    Provides ability to boostrap and copy output artifacts and subclasses can use
-    a generic shell runner.
+    Provides ability to bootstrap and copy output artifacts and subclasses can
+    use a generic shell runner.
 
     """
 
@@ -35,6 +35,9 @@ class Builder(ABC):
         # Set post-init once actual build target is known
         self.identifier = None
         self.output_dir = None
+
+        # Allow to override the default build command
+        self.pw_command_launcher = None
 
     def enable_flashbundle(self, enable_flashbundle: bool):
         self._enable_flashbundle = enable_flashbundle

--- a/scripts/build/builders/gn.py
+++ b/scripts/build/builders/gn.py
@@ -60,7 +60,10 @@ class GnBuilder(Builder):
             '--root=%s' % self.root
         ]
 
-        extra_args = self.GnBuildArgs()
+        extra_args = []
+        if self.pw_command_launcher:
+            extra_args.append('pw_command_launcher="%s"' % self.pw_command_launcher)
+        extra_args.extend(self.GnBuildArgs() or [])
         if extra_args:
             cmd += ['--args=%s' % ' '.join(extra_args)]
 

--- a/scripts/build/builders/gn.py
+++ b/scripts/build/builders/gn.py
@@ -61,8 +61,8 @@ class GnBuilder(Builder):
         ]
 
         extra_args = []
-        if self.pw_command_launcher:
-            extra_args.append('pw_command_launcher="%s"' % self.pw_command_launcher)
+        if self.options.pw_command_launcher:
+            extra_args.append('pw_command_launcher="%s"' % self.options.pw_command_launcher)
         extra_args.extend(self.GnBuildArgs() or [])
         if extra_args:
             cmd += ['--args=%s' % ' '.join(extra_args)]


### PR DESCRIPTION
### Problem

There is a `pw_command_launcher` option in Pigweed which can be used to setup ccache (or something else). However, it's hard to learn about such option - it's not mentioned in matter repo anywhere.

### Changes

Add `--pw-command-launcher` option to `build_examples.py` script (it will be visible in help text)

### Testing

Tested manually with `ccache` (build time reduced significantly):
```
./scripts/build/build_examples.py --target tizen-arm-light --pw-command-launcher=ccache build
rm -rf out/tizen-arm-light
./scripts/build/build_examples.py --target tizen-arm-light --pw-command-launcher=ccache build
```