### PR TITLE
[python] fix platform specific wheel to be spec compliant

### DIFF
--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -58,6 +58,8 @@ class InstalledScriptInfo:
 
 # Make sure wheel is not considered pure and avoid shared libraries in purelib
 # folder.
+
+
 class BinaryDistribution(Distribution):
     def has_ext_modules(foo):
         return True

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -23,7 +23,7 @@
 
 from __future__ import absolute_import
 from datetime import datetime
-from setuptools import setup
+from setuptools import setup, Distribution
 from wheel.bdist_wheel import bdist_wheel
 
 import argparse
@@ -55,6 +55,12 @@ class InstalledScriptInfo:
     def __init__(self, name):
         self.name = name
         self.installName = os.path.splitext(name)[0]
+
+# Make sure wheel is not considered pure and avoid shared libraries in purelib
+# folder.
+class BinaryDistribution(Distribution):
+    def has_ext_modules(foo):
+        return True
 
 
 packageName = args.package_name
@@ -102,13 +108,6 @@ try:
     for script in installScripts:
         os.rename(os.path.join(tmpDir, script.name),
                   os.path.join(tmpDir, script.installName))
-
-    # Define a custom version of the bdist_wheel command that configures the
-    # resultant wheel as platform-specific (i.e. not "pure").
-    class bdist_wheel_override(bdist_wheel):
-        def finalize_options(self):
-            bdist_wheel.finalize_options(self)
-            self.root_is_pure = False
 
     requiredPackages = manifest['package_reqs']
 
@@ -164,9 +163,7 @@ try:
                 'egg_base': tmpDir
             }
         },
-        cmdclass={
-            'bdist_wheel': bdist_wheel_override
-        } if libName else {},
+        distclass=BinaryDistribution if libName else None,
         script_args=['clean', '--all', 'bdist_wheel']
     )
 


### PR DESCRIPTION
The current build approach causes bdist_wheel to store the shared library in the purelib folder. However, a platform specific wheel should have shared libraries in the platform specific folder, not in the purelib folder.

This has been discovered using `auditwheel check`:

```
RuntimeError: Invalid binary wheel, found the following shared library/libraries in purelib folder:
        _ChipDeviceCtrl.so
The wheel has to be platlib compliant in order to be repaired by auditwheel.
```

This makes the wheel pass `auditwheel check`.



