### PR TITLE
Setup ChipDeviceController for all Matter commands

### DIFF
--- a/examples/java-matter-controller/java/src/com/matter/controller/Main.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/Main.java
@@ -27,13 +27,15 @@ import java.util.ArrayList;
 
 public class Main {
   private static void registerCommandsDiscover(
-      CommandManager commandManager, CredentialsIssuer credentialsIssuer) {
+      ChipDeviceController controller,
+      CommandManager commandManager,
+      CredentialsIssuer credentialsIssuer) {
     ArrayList<Command> clusterCommands = new ArrayList<Command>();
-    DiscoverCommand discoverCommand = new DiscoverCommand(credentialsIssuer);
+    DiscoverCommand discoverCommand = new DiscoverCommand(controller, credentialsIssuer);
     DiscoverCommissionablesCommand discoverCommissionablesCommand =
-        new DiscoverCommissionablesCommand(credentialsIssuer);
+        new DiscoverCommissionablesCommand(controller, credentialsIssuer);
     DiscoverCommissionersCommand discoverCommissionersCommand =
-        new DiscoverCommissionersCommand(credentialsIssuer);
+        new DiscoverCommissionersCommand(controller, credentialsIssuer);
     clusterCommands.add(discoverCommand);
     clusterCommands.add(discoverCommissionablesCommand);
     clusterCommands.add(discoverCommissionersCommand);
@@ -42,29 +44,36 @@ public class Main {
   }
 
   private static void registerCommandsPairing(
-      CommandManager commandManager, CredentialsIssuer credentialsIssuer) {
+      ChipDeviceController controller,
+      CommandManager commandManager,
+      CredentialsIssuer credentialsIssuer) {
     ArrayList<Command> clusterCommands = new ArrayList<Command>();
-    UnpairCommand unpairCommand = new UnpairCommand(credentialsIssuer);
-    PairCodeCommand pairCodeCommand = new PairCodeCommand(credentialsIssuer);
-    PairCodePaseCommand pairCodePaseCommand = new PairCodePaseCommand(credentialsIssuer);
-    PairCodeWifiCommand pairCodeWifiCommand = new PairCodeWifiCommand(credentialsIssuer);
-    PairCodeThreadCommand pairCodeThreadCommand = new PairCodeThreadCommand(credentialsIssuer);
-    PairEthernetCommand pairEthernetCommand = new PairEthernetCommand(credentialsIssuer);
-    PairOnNetworkCommand pairOnNetworkCommand = new PairOnNetworkCommand(credentialsIssuer);
+    UnpairCommand unpairCommand = new UnpairCommand(controller, credentialsIssuer);
+    PairCodeCommand pairCodeCommand = new PairCodeCommand(controller, credentialsIssuer);
+    PairCodePaseCommand pairCodePaseCommand =
+        new PairCodePaseCommand(controller, credentialsIssuer);
+    PairCodeWifiCommand pairCodeWifiCommand =
+        new PairCodeWifiCommand(controller, credentialsIssuer);
+    PairCodeThreadCommand pairCodeThreadCommand =
+        new PairCodeThreadCommand(controller, credentialsIssuer);
+    PairEthernetCommand pairEthernetCommand =
+        new PairEthernetCommand(controller, credentialsIssuer);
+    PairOnNetworkCommand pairOnNetworkCommand =
+        new PairOnNetworkCommand(controller, credentialsIssuer);
     PairOnNetworkShortCommand pairOnNetworkShortCommand =
-        new PairOnNetworkShortCommand(credentialsIssuer);
+        new PairOnNetworkShortCommand(controller, credentialsIssuer);
     PairOnNetworkLongCommand pairOnNetworkLongCommand =
-        new PairOnNetworkLongCommand(credentialsIssuer);
+        new PairOnNetworkLongCommand(controller, credentialsIssuer);
     PairOnNetworkVendorCommand pairOnNetworkVendorCommand =
-        new PairOnNetworkVendorCommand(credentialsIssuer);
+        new PairOnNetworkVendorCommand(controller, credentialsIssuer);
     PairOnNetworkCommissioningModeCommand pairOnNetworkCommissioningModeCommand =
-        new PairOnNetworkCommissioningModeCommand(credentialsIssuer);
+        new PairOnNetworkCommissioningModeCommand(controller, credentialsIssuer);
     PairOnNetworkCommissionerCommand pairOnNetworkCommissionerCommand =
-        new PairOnNetworkCommissionerCommand(credentialsIssuer);
+        new PairOnNetworkCommissionerCommand(controller, credentialsIssuer);
     PairOnNetworkDeviceTypeCommand pairOnNetworkDeviceTypeCommand =
-        new PairOnNetworkDeviceTypeCommand(credentialsIssuer);
+        new PairOnNetworkDeviceTypeCommand(controller, credentialsIssuer);
     PairOnNetworkInstanceNameCommand pairOnNetworkInstanceNameCommand =
-        new PairOnNetworkInstanceNameCommand(credentialsIssuer);
+        new PairOnNetworkInstanceNameCommand(controller, credentialsIssuer);
     clusterCommands.add(unpairCommand);
     clusterCommands.add(pairCodeCommand);
     clusterCommands.add(pairCodePaseCommand);
@@ -94,8 +103,8 @@ public class Main {
     CredentialsIssuer credentialsIssuer = new CredentialsIssuer();
     CommandManager commandManager = new CommandManager();
 
-    registerCommandsDiscover(commandManager, credentialsIssuer);
-    registerCommandsPairing(commandManager, credentialsIssuer);
+    registerCommandsDiscover(controller, commandManager, credentialsIssuer);
+    registerCommandsPairing(controller, commandManager, credentialsIssuer);
 
     try {
       commandManager.run(args);

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/common/MatterCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/common/MatterCommand.java
@@ -18,6 +18,7 @@
 
 package com.matter.controller.commands.common;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.config.PersistentStorage;
 import com.matter.controller.config.PersistentStorageOpCertStore;
 import com.matter.controller.config.PersistentStorageOperationalKeystore;
@@ -26,6 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class MatterCommand extends Command {
+  private final ChipDeviceController mChipDeviceController;
   private final PersistentStorage mDefaultStorage = new PersistentStorage();
   private final PersistentStorage mCommissionerStorage = new PersistentStorage();
   private final PersistentStorageOperationalKeystore mOperationalKeystore =
@@ -40,13 +42,19 @@ public abstract class MatterCommand extends Command {
   private final AtomicBoolean mUseMaxSizedCerts = new AtomicBoolean();;
   private final AtomicBoolean mOnlyAllowTrustedCdKeys = new AtomicBoolean();;
 
-  public MatterCommand(String commandName, CredentialsIssuer credIssuerCmds) {
-    this(commandName, credIssuerCmds, null);
+  public MatterCommand(
+      ChipDeviceController controller, String commandName, CredentialsIssuer credIssuerCmds) {
+    this(controller, commandName, credIssuerCmds, null);
   }
 
-  public MatterCommand(String commandName, CredentialsIssuer credIssuerCmds, String helpText) {
+  public MatterCommand(
+      ChipDeviceController controller,
+      String commandName,
+      CredentialsIssuer credIssuerCmds,
+      String helpText) {
     super(commandName, helpText);
     this.mCredIssuerCmds = Optional.ofNullable(credIssuerCmds);
+    this.mChipDeviceController = controller;
 
     addArgument(
         "paa-trust-store-path",
@@ -79,6 +87,11 @@ public abstract class MatterCommand extends Command {
         mOnlyAllowTrustedCdKeys,
         "Only allow trusted CD verifying keys (disallow test keys). If not provided or 0 (\"false\"), untrusted CD "
             + "verifying keys are allowed. If 1 (\"true\"), test keys are disallowed.");
+  }
+
+  // This method returns the commissioner instance to be used for running the command.
+  public ChipDeviceController currentCommissioner() {
+    return mChipDeviceController;
   }
 
   /////////// Command Interface /////////

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/discover/DiscoverCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/discover/DiscoverCommand.java
@@ -18,6 +18,7 @@
 
 package com.matter.controller.commands.discover;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 import com.matter.controller.commands.common.MatterCommand;
 import java.util.concurrent.atomic.AtomicLong;
@@ -26,8 +27,8 @@ public final class DiscoverCommand extends MatterCommand {
   private final AtomicLong mNodeId = new AtomicLong();
   private final AtomicLong mFabricId = new AtomicLong();
 
-  public DiscoverCommand(CredentialsIssuer credsIssuer) {
-    super("resolve", credsIssuer);
+  public DiscoverCommand(ChipDeviceController controller, CredentialsIssuer credsIssuer) {
+    super(controller, "resolve", credsIssuer);
     addArgument("nodeid", 0, Long.MAX_VALUE, mNodeId, null);
     addArgument("fabricid", 0, Long.MAX_VALUE, mFabricId, null);
   }

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/discover/DiscoverCommissionablesCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/discover/DiscoverCommissionablesCommand.java
@@ -18,12 +18,14 @@
 
 package com.matter.controller.commands.discover;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 import com.matter.controller.commands.common.MatterCommand;
 
 public final class DiscoverCommissionablesCommand extends MatterCommand {
-  public DiscoverCommissionablesCommand(CredentialsIssuer credsIssuer) {
-    super("commissionables", credsIssuer);
+  public DiscoverCommissionablesCommand(
+      ChipDeviceController controller, CredentialsIssuer credsIssuer) {
+    super(controller, "commissionables", credsIssuer);
   }
 
   @Override

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/discover/DiscoverCommissionersCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/discover/DiscoverCommissionersCommand.java
@@ -18,12 +18,14 @@
 
 package com.matter.controller.commands.discover;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 import com.matter.controller.commands.common.MatterCommand;
 
 public final class DiscoverCommissionersCommand extends MatterCommand {
-  public DiscoverCommissionersCommand(CredentialsIssuer credsIssuer) {
-    super("commissioners", credsIssuer);
+  public DiscoverCommissionersCommand(
+      ChipDeviceController controller, CredentialsIssuer credsIssuer) {
+    super(controller, "commissioners", credsIssuer);
   }
 
   @Override

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/CloseSessionCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/CloseSessionCommand.java
@@ -18,6 +18,7 @@
 
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 import com.matter.controller.commands.common.MatterCommand;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -27,8 +28,8 @@ public final class CloseSessionCommand extends MatterCommand {
   private final AtomicLong mDestinationId = new AtomicLong();
   private final AtomicInteger mTimeoutSecs = new AtomicInteger();
 
-  public CloseSessionCommand(CredentialsIssuer credsIssuer) {
-    super("close-session", credsIssuer);
+  public CloseSessionCommand(ChipDeviceController controller, CredentialsIssuer credsIssuer) {
+    super(controller, "close-session", credsIssuer);
     addArgument("destination-id", 0, Long.MAX_VALUE, mDestinationId, null);
     addArgument(
         "timeout",

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodeCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodeCommand.java
@@ -1,10 +1,11 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 
 public final class PairCodeCommand extends PairingCommand {
-  public PairCodeCommand(CredentialsIssuer credsIssue) {
-    super("code", PairingModeType.CODE, PairingNetworkType.NONE, credsIssue);
+  public PairCodeCommand(ChipDeviceController controller, CredentialsIssuer credsIssue) {
+    super(controller, "code", PairingModeType.CODE, PairingNetworkType.NONE, credsIssue);
   }
 
   @Override

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodePaseCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodePaseCommand.java
@@ -1,10 +1,16 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 
 public final class PairCodePaseCommand extends PairingCommand {
-  public PairCodePaseCommand(CredentialsIssuer credsIssue) {
-    super("code-paseonly", PairingModeType.CODE_PASE_ONLY, PairingNetworkType.NONE, credsIssue);
+  public PairCodePaseCommand(ChipDeviceController controller, CredentialsIssuer credsIssue) {
+    super(
+        controller,
+        "code-paseonly",
+        PairingModeType.CODE_PASE_ONLY,
+        PairingNetworkType.NONE,
+        credsIssue);
   }
 
   @Override

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodeThreadCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodeThreadCommand.java
@@ -1,10 +1,11 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 
 public final class PairCodeThreadCommand extends PairingCommand {
-  public PairCodeThreadCommand(CredentialsIssuer credsIssue) {
-    super("code-thread", PairingModeType.CODE, PairingNetworkType.THREAD, credsIssue);
+  public PairCodeThreadCommand(ChipDeviceController controller, CredentialsIssuer credsIssue) {
+    super(controller, "code-thread", PairingModeType.CODE, PairingNetworkType.THREAD, credsIssue);
   }
 
   @Override

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodeWifiCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodeWifiCommand.java
@@ -1,10 +1,11 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 
 public final class PairCodeWifiCommand extends PairingCommand {
-  public PairCodeWifiCommand(CredentialsIssuer credsIssue) {
-    super("code-wifi", PairingModeType.CODE, PairingNetworkType.WIFI, credsIssue);
+  public PairCodeWifiCommand(ChipDeviceController controller, CredentialsIssuer credsIssue) {
+    super(controller, "code-wifi", PairingModeType.CODE, PairingNetworkType.WIFI, credsIssue);
   }
 
   @Override

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairEthernetCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairEthernetCommand.java
@@ -1,10 +1,12 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 
 public final class PairEthernetCommand extends PairingCommand {
-  public PairEthernetCommand(CredentialsIssuer credsIssue) {
-    super("ethernet", PairingModeType.ETHERNET, PairingNetworkType.ETHERNET, credsIssue);
+  public PairEthernetCommand(ChipDeviceController controller, CredentialsIssuer credsIssue) {
+    super(
+        controller, "ethernet", PairingModeType.ETHERNET, PairingNetworkType.ETHERNET, credsIssue);
   }
 
   @Override

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkCommand.java
@@ -1,10 +1,11 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 
 public final class PairOnNetworkCommand extends PairingCommand {
-  public PairOnNetworkCommand(CredentialsIssuer credsIssue) {
-    super("onnetwork", PairingModeType.ON_NETWORK, PairingNetworkType.NONE, credsIssue);
+  public PairOnNetworkCommand(ChipDeviceController controller, CredentialsIssuer credsIssue) {
+    super(controller, "onnetwork", PairingModeType.ON_NETWORK, PairingNetworkType.NONE, credsIssue);
   }
 
   @Override

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkCommissionerCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkCommissionerCommand.java
@@ -1,10 +1,13 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 
 public final class PairOnNetworkCommissionerCommand extends PairingCommand {
-  public PairOnNetworkCommissionerCommand(CredentialsIssuer credsIssue) {
+  public PairOnNetworkCommissionerCommand(
+      ChipDeviceController controller, CredentialsIssuer credsIssue) {
     super(
+        controller,
         "onnetwork-commissioner",
         PairingModeType.ON_NETWORK,
         PairingNetworkType.NONE,

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkCommissioningModeCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkCommissioningModeCommand.java
@@ -1,10 +1,13 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 
 public final class PairOnNetworkCommissioningModeCommand extends PairingCommand {
-  public PairOnNetworkCommissioningModeCommand(CredentialsIssuer credsIssue) {
+  public PairOnNetworkCommissioningModeCommand(
+      ChipDeviceController controller, CredentialsIssuer credsIssue) {
     super(
+        controller,
         "onnetwork-commissioning-mode",
         PairingModeType.ON_NETWORK,
         PairingNetworkType.NONE,

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkDeviceTypeCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkDeviceTypeCommand.java
@@ -1,10 +1,13 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 
 public final class PairOnNetworkDeviceTypeCommand extends PairingCommand {
-  public PairOnNetworkDeviceTypeCommand(CredentialsIssuer credsIssue) {
+  public PairOnNetworkDeviceTypeCommand(
+      ChipDeviceController controller, CredentialsIssuer credsIssue) {
     super(
+        controller,
         "onnetwork-device-type",
         PairingModeType.ON_NETWORK,
         PairingNetworkType.NONE,

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkFabricCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkFabricCommand.java
@@ -1,11 +1,14 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 import java.net.UnknownHostException;
 
 public final class PairOnNetworkFabricCommand extends PairingCommand {
-  public PairOnNetworkFabricCommand(CredentialsIssuer credsIssue) throws UnknownHostException {
+  public PairOnNetworkFabricCommand(ChipDeviceController controller, CredentialsIssuer credsIssue)
+      throws UnknownHostException {
     super(
+        controller,
         "onnetwork-fabric",
         PairingModeType.ON_NETWORK,
         PairingNetworkType.NONE,

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkInstanceNameCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkInstanceNameCommand.java
@@ -1,10 +1,13 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 
 public final class PairOnNetworkInstanceNameCommand extends PairingCommand {
-  public PairOnNetworkInstanceNameCommand(CredentialsIssuer credsIssue) {
+  public PairOnNetworkInstanceNameCommand(
+      ChipDeviceController controller, CredentialsIssuer credsIssue) {
     super(
+        controller,
         "onnetwork-instance-name",
         PairingModeType.ON_NETWORK,
         PairingNetworkType.NONE,

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongCommand.java
@@ -1,10 +1,12 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 
 public final class PairOnNetworkLongCommand extends PairingCommand {
-  public PairOnNetworkLongCommand(CredentialsIssuer credsIssue) {
+  public PairOnNetworkLongCommand(ChipDeviceController controller, CredentialsIssuer credsIssue) {
     super(
+        controller,
         "onnetwork-long",
         PairingModeType.ON_NETWORK,
         PairingNetworkType.NONE,

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkShortCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkShortCommand.java
@@ -1,10 +1,12 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 
 public final class PairOnNetworkShortCommand extends PairingCommand {
-  public PairOnNetworkShortCommand(CredentialsIssuer credsIssue) {
+  public PairOnNetworkShortCommand(ChipDeviceController controller, CredentialsIssuer credsIssue) {
     super(
+        controller,
         "onnetwork-short",
         PairingModeType.ON_NETWORK,
         PairingNetworkType.NONE,

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkVendorCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkVendorCommand.java
@@ -1,10 +1,12 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 
 public final class PairOnNetworkVendorCommand extends PairingCommand {
-  public PairOnNetworkVendorCommand(CredentialsIssuer credsIssue) {
+  public PairOnNetworkVendorCommand(ChipDeviceController controller, CredentialsIssuer credsIssue) {
     super(
+        controller,
         "onnetwork-vendor",
         PairingModeType.ON_NETWORK,
         PairingNetworkType.NONE,

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.java
@@ -18,6 +18,7 @@
 
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 import com.matter.controller.commands.common.IPAddress;
 import com.matter.controller.commands.common.MatterCommand;
@@ -47,20 +48,22 @@ public abstract class PairingCommand extends MatterCommand {
   private final StringBuffer mDiscoveryFilterInstanceName = new StringBuffer();
 
   public PairingCommand(
+      ChipDeviceController controller,
       String commandName,
       PairingModeType mode,
       PairingNetworkType networkType,
       CredentialsIssuer credsIssuer) {
-    this(commandName, mode, networkType, credsIssuer, DiscoveryFilterType.NONE);
+    this(controller, commandName, mode, networkType, credsIssuer, DiscoveryFilterType.NONE);
   }
 
   public PairingCommand(
+      ChipDeviceController controller,
       String commandName,
       PairingModeType mode,
       PairingNetworkType networkType,
       CredentialsIssuer credsIssuer,
       DiscoveryFilterType filterType) {
-    super(commandName, credsIssuer);
+    super(controller, commandName, credsIssuer);
     this.mPairingMode = mode;
     this.mNetworkType = networkType;
     this.mFilterType = filterType;

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/UnpairCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/UnpairCommand.java
@@ -1,10 +1,11 @@
 package com.matter.controller.commands.pairing;
 
+import chip.devicecontroller.ChipDeviceController;
 import com.matter.controller.commands.common.CredentialsIssuer;
 
 public final class UnpairCommand extends PairingCommand {
-  public UnpairCommand(CredentialsIssuer credsIssue) {
-    super("unpair", PairingModeType.NONE, PairingNetworkType.NONE, credsIssue);
+  public UnpairCommand(ChipDeviceController controller, CredentialsIssuer credsIssue) {
+    super(controller, "unpair", PairingModeType.NONE, PairingNetworkType.NONE, credsIssue);
   }
 
   @Override


### PR DESCRIPTION
Currently, Matter command does not have access to ChipDeviceController reference to trigger the operations in SDK.

Now the ChipDeviceController instance has been initiated in the java-matter-controller, we can populate the reference of ChipDeviceController instance to all Matter commands.

This is needed for both discover and pairing command implementation.

