### PR TITLE
Increase EFR32 timeouts

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -72,7 +72,7 @@ jobs:
             .environment/pigweed-venv/*.log
 
       - name: Build some BRD4187C variants
-        timeout-minutes: 50
+        timeout-minutes: 90
         run: |
           ./scripts/run_in_build_env.sh \
              "./scripts/build/build_examples.py \


### PR DESCRIPTION
50 minutes seems insufficient at times. We fail like:

https://github.com/project-chip/connectedhomeip/actions/runs/3521541523/jobs/5903500033