### PR TITLE
Fix Matter command argument list mismatch error

### DIFF
--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/common/Argument.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/common/Argument.java
@@ -33,59 +33,78 @@ public final class Argument {
   private final long mMax;
   private final Object mValue;
   private final Optional<String> mDesc;
+  private final boolean mOptional;
 
-  public Argument(String name, IPAddress value) {
+  boolean isOptional() {
+    return mOptional;
+  }
+
+  public Argument(String name, IPAddress value, boolean optional) {
     this.mName = name;
     this.mType = ArgumentType.ADDRESS;
     this.mMin = 0;
     this.mMax = 0;
     this.mValue = value;
     this.mDesc = Optional.empty();
+    this.mOptional = optional;
   }
 
-  public Argument(String name, StringBuffer value, @Nullable String desc) {
+  public Argument(String name, StringBuffer value, @Nullable String desc, boolean optional) {
     this.mName = name;
     this.mType = ArgumentType.STRING;
     this.mMin = 0;
     this.mMax = 0;
     this.mValue = value;
     this.mDesc = Optional.ofNullable(desc);
+    this.mOptional = optional;
   }
 
-  public Argument(String name, AtomicBoolean value, @Nullable String desc) {
+  public Argument(String name, AtomicBoolean value, @Nullable String desc, boolean optional) {
     this.mName = name;
     this.mType = ArgumentType.BOOL;
     this.mMin = 0;
     this.mMax = 0;
     this.mValue = value;
     this.mDesc = Optional.ofNullable(desc);
+    this.mOptional = optional;
   }
 
-  public Argument(String name, short min, short max, AtomicInteger value, @Nullable String desc) {
+  public Argument(
+      String name,
+      short min,
+      short max,
+      AtomicInteger value,
+      @Nullable String desc,
+      boolean optional) {
     this.mName = name;
     this.mType = ArgumentType.NUMBER_INT16;
     this.mMin = min;
     this.mMax = max;
     this.mValue = value;
     this.mDesc = Optional.ofNullable(desc);
+    this.mOptional = optional;
   }
 
-  public Argument(String name, int min, int max, AtomicInteger value, @Nullable String desc) {
+  public Argument(
+      String name, int min, int max, AtomicInteger value, @Nullable String desc, boolean optional) {
     this.mName = name;
     this.mType = ArgumentType.NUMBER_INT32;
     this.mMin = min;
     this.mMax = max;
     this.mValue = value;
     this.mDesc = Optional.ofNullable(desc);
+    this.mOptional = optional;
   }
 
-  public Argument(String name, long min, long max, AtomicLong value, @Nullable String desc) {
+  public Argument(
+      String name, long min, long max, AtomicLong value, @Nullable String desc, boolean optional) {
     this.mName = name;
     this.mType = ArgumentType.NUMBER_INT64;
     this.mMin = min;
     this.mMax = max;
     this.mValue = value;
     this.mDesc = Optional.ofNullable(desc);
+    this.mOptional = optional;
   }
 
   public String getName() {

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/common/MatterCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/common/MatterCommand.java
@@ -57,40 +57,43 @@ public abstract class MatterCommand extends Command {
     this.mCredIssuerCmds = Optional.ofNullable(credIssuerCmds);
     this.mChipDeviceController = controller;
 
-    // TODO: Add support to enable the below optional arguments
-    /*
     addArgument(
-        "paa-trust-store-path",
+        "--paa-trust-store-path",
         mPaaTrustStorePath,
         "Path to directory holding PAA certificate information.  Can be absolute or relative to the current working "
-            + "directory.");
+            + "directory.",
+        true);
     addArgument(
-        "cd-trust-store-path",
+        "--cd-trust-store-path",
         mCDTrustStorePath,
         "Path to directory holding CD certificate information.  Can be absolute or relative to the current working "
-            + "directory.");
+            + "directory.",
+        true);
     addArgument(
-        "commissioner-name",
+        "--commissioner-name",
         mCommissionerName,
         "Name of fabric to use. Valid values are \"alpha\", \"beta\", \"gamma\", and integers greater than or equal to "
-            + "4.  The default if not specified is \"alpha\".");
+            + "4.  The default if not specified is \"alpha\".",
+        true);
     addArgument(
-        "commissioner-nodeid",
+        "--commissioner-nodeid",
         0,
         Long.MAX_VALUE,
         mCommissionerNodeId,
-        "The node id to use for chip-tool.  If not provided, kTestControllerNodeId (112233, 0x1B669) will be used.");
+        "The node id to use for chip-tool.  If not provided, kTestControllerNodeId (112233, 0x1B669) will be used.",
+        true);
     addArgument(
-        "use-max-sized-certs",
+        "--use-max-sized-certs",
         mUseMaxSizedCerts,
         "Maximize the size of operational certificates. If not provided or 0 (\"false\"), normally sized operational "
-            + "certificates are generated.");
+            + "certificates are generated.",
+        true);
     addArgument(
-        "only-allow-trusted-cd-keys",
+        "--only-allow-trusted-cd-keys",
         mOnlyAllowTrustedCdKeys,
         "Only allow trusted CD verifying keys (disallow test keys). If not provided or 0 (\"false\"), untrusted CD "
-            + "verifying keys are allowed. If 1 (\"true\"), test keys are disallowed.");
-    */
+            + "verifying keys are allowed. If 1 (\"true\"), test keys are disallowed.",
+        true);
   }
 
   // This method returns the commissioner instance to be used for running the command.

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/discover/DiscoverCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/discover/DiscoverCommand.java
@@ -29,8 +29,8 @@ public final class DiscoverCommand extends MatterCommand {
 
   public DiscoverCommand(ChipDeviceController controller, CredentialsIssuer credsIssuer) {
     super(controller, "resolve", credsIssuer);
-    addArgument("nodeid", 0, Long.MAX_VALUE, mNodeId, null);
-    addArgument("fabricid", 0, Long.MAX_VALUE, mFabricId, null);
+    addArgument("nodeid", 0, Long.MAX_VALUE, mNodeId, null, false);
+    addArgument("fabricid", 0, Long.MAX_VALUE, mFabricId, null, false);
   }
 
   @Override

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/CloseSessionCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/CloseSessionCommand.java
@@ -30,13 +30,14 @@ public final class CloseSessionCommand extends MatterCommand {
 
   public CloseSessionCommand(ChipDeviceController controller, CredentialsIssuer credsIssuer) {
     super(controller, "close-session", credsIssuer);
-    addArgument("destination-id", 0, Long.MAX_VALUE, mDestinationId, null);
+    addArgument("destination-id", 0, Long.MAX_VALUE, mDestinationId, null, false);
     addArgument(
         "timeout",
         (short) 0,
         Short.MAX_VALUE,
         mTimeoutSecs,
-        "Time, in seconds, before this command is considered to have timed out.");
+        "Time, in seconds, before this command is considered to have timed out.",
+        false);
   }
 
   @Override

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.java
@@ -163,18 +163,18 @@ public abstract class PairingCommand extends MatterCommand
       throw new RuntimeException(e);
     }
 
-    addArgument("node-id", 0, Long.MAX_VALUE, mNodeId, null);
+    addArgument("node-id", 0, Long.MAX_VALUE, mNodeId, null, false);
 
     switch (networkType) {
       case NONE:
       case ETHERNET:
         break;
       case WIFI:
-        addArgument("ssid", mSSID, null);
-        addArgument("password", mPassword, null);
+        addArgument("ssid", mSSID, null, false);
+        addArgument("password", mPassword, null, false);
         break;
       case THREAD:
-        addArgument("operationalDataset", mOperationalDataset, null);
+        addArgument("operationalDataset", mOperationalDataset, null, false);
         break;
     }
 
@@ -184,29 +184,29 @@ public abstract class PairingCommand extends MatterCommand
       case CODE:
       case CODE_PASE_ONLY:
         Only:
-        addArgument("payload", mOnboardingPayload, null);
-        addArgument("discover-once", mDiscoverOnce, null);
-        addArgument("use-only-onnetwork-discovery", mUseOnlyOnNetworkDiscovery, null);
+        addArgument("payload", mOnboardingPayload, null, false);
+        addArgument("discover-once", mDiscoverOnce, null, false);
+        addArgument("use-only-onnetwork-discovery", mUseOnlyOnNetworkDiscovery, null, false);
         break;
       case BLE:
-        addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null);
-        addArgument("discriminator", (short) 0, (short) 4096, mDiscriminator, null);
+        addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null, false);
+        addArgument("discriminator", (short) 0, (short) 4096, mDiscriminator, null, false);
         break;
       case ON_NETWORK:
-        addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null);
+        addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null, false);
         break;
       case SOFT_AP:
         AP:
-        addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null);
-        addArgument("discriminator", (short) 0, (short) 4096, mDiscriminator, null);
-        addArgument("device-remote-ip", mRemoteAddr);
-        addArgument("device-remote-port", (short) 0, Short.MAX_VALUE, mRemotePort, null);
+        addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null, false);
+        addArgument("discriminator", (short) 0, (short) 4096, mDiscriminator, null, false);
+        addArgument("device-remote-ip", mRemoteAddr, false);
+        addArgument("device-remote-port", (short) 0, Short.MAX_VALUE, mRemotePort, null, false);
         break;
       case ETHERNET:
-        addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null);
-        addArgument("discriminator", (short) 0, (short) 4096, mDiscriminator, null);
-        addArgument("device-remote-ip", mRemoteAddr);
-        addArgument("device-remote-port", (short) 0, Short.MAX_VALUE, mRemotePort, null);
+        addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null, false);
+        addArgument("discriminator", (short) 0, (short) 4096, mDiscriminator, null, false);
+        addArgument("device-remote-ip", mRemoteAddr, false);
+        addArgument("device-remote-port", (short) 0, Short.MAX_VALUE, mRemotePort, null, false);
         break;
     }
 
@@ -214,28 +214,28 @@ public abstract class PairingCommand extends MatterCommand
       case NONE:
         break;
       case SHORT_DISCRIMINATOR:
-        addArgument("discriminator", (short) 0, (short) 4096, mDiscriminator, null);
+        addArgument("discriminator", (short) 0, (short) 4096, mDiscriminator, null, false);
         break;
       case LONG_DISCRIMINATOR:
-        addArgument("discriminator", (short) 0, (short) 4096, mDiscriminator, null);
+        addArgument("discriminator", (short) 0, (short) 4096, mDiscriminator, null, false);
         break;
       case VENDOR_ID:
-        addArgument("vendor-id", (short) 0, Short.MAX_VALUE, mDiscoveryFilterCode, null);
+        addArgument("vendor-id", (short) 0, Short.MAX_VALUE, mDiscoveryFilterCode, null, false);
         break;
       case COMPRESSED_FABRIC_ID:
-        addArgument("fabric-id", 0, Long.MAX_VALUE, mDiscoveryFilterCode, null);
+        addArgument("fabric-id", 0, Long.MAX_VALUE, mDiscoveryFilterCode, null, false);
         break;
       case COMMISSIONING_MODE:
       case COMMISSIONER:
         break;
       case DEVICE_TYPE:
-        addArgument("device-type", (short) 0, Short.MAX_VALUE, mDiscoveryFilterCode, null);
+        addArgument("device-type", (short) 0, Short.MAX_VALUE, mDiscoveryFilterCode, null, false);
         break;
       case INSTANCE_NAME:
-        addArgument("name", mDiscoveryFilterInstanceName, null);
+        addArgument("name", mDiscoveryFilterInstanceName, null, false);
         break;
     }
 
-    addArgument("timeout", (long) 0, Long.MAX_VALUE, mTimeoutMillis, null);
+    addArgument("timeout", (long) 0, Long.MAX_VALUE, mTimeoutMillis, null, false);
   }
 }


### PR DESCRIPTION
Hit command argument list mismatch error when run pairing commands.

`"InitArgs: Wrong arguments number: 1 instead of 6"`

1.  we should only the required number of arguments against mandatory arguments
2. Optional arguments expect a name and a value, we should always initialize optional argument with its value and mandatory argument with its name

