### PR TITLE
fix paths for dynamic-bridge-app still pointing to bridge-app

### DIFF
--- a/examples/dynamic-bridge-app/linux/BUILD.gn
+++ b/examples/dynamic-bridge-app/linux/BUILD.gn
@@ -29,7 +29,7 @@ if (chip_enable_pw_rpc) {
 assert(chip_build_tools)
 
 chip_codegen("chip-bridge-codegen") {
-  input = "${chip_root}/examples/bridge-app/bridge-common/bridge-app.matter"
+  input = "${chip_root}/examples/dynamic-bridge-app/bridge-common/bridge-app.matter"
   generator = "bridge"
 
   outputs = [

--- a/examples/dynamic-bridge-app/linux/BUILD.gn
+++ b/examples/dynamic-bridge-app/linux/BUILD.gn
@@ -29,7 +29,8 @@ if (chip_enable_pw_rpc) {
 assert(chip_build_tools)
 
 chip_codegen("chip-bridge-codegen") {
-  input = "${chip_root}/examples/dynamic-bridge-app/bridge-common/bridge-app.matter"
+  input =
+      "${chip_root}/examples/dynamic-bridge-app/bridge-common/bridge-app.matter"
   generator = "bridge"
 
   outputs = [

--- a/examples/dynamic-bridge-app/linux/README.md
+++ b/examples/dynamic-bridge-app/linux/README.md
@@ -119,7 +119,7 @@ value/label pair `"room"`/`[light name]`.
 -   Build the example application:
 
           ```
-          $ cd ~/connectedhomeip/examples/bridge-app/linux
+          $ cd ~/connectedhomeip/examples/dynamic-bridge-app/linux
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ gn gen out/debug
@@ -129,7 +129,7 @@ value/label pair `"room"`/`[light name]`.
 -   To delete generated executable, libraries and object files use:
 
           ```
-          $ cd ~/connectedhomeip/examples/bridge-app/linux
+          $ cd ~/connectedhomeip/examples/dynamic-bridge-app/linux
           $ rm -rf out/
           ```
 
@@ -175,8 +175,8 @@ value/label pair `"room"`/`[light name]`.
         -   Run Linux Bridge Example App
 
                   ```
-                  $ cd ~/connectedhomeip/examples/bridge-app/linux
-                  $ sudo out/debug/chip-bridge-app --ble-device [bluetooth device number]
+                  $ cd ~/connectedhomeip/examples/dynamic-bridge-app/linux
+                  $ sudo out/debug/dynamic-chip-bridge-app --ble-device [bluetooth device number]
                   # In this example, the device we want to use is hci1
                   $ sudo out/debug/chip-bridge-app --ble-device 1
                   ```


### PR DESCRIPTION
In BUILD.gn of dynamic-bridge-app the codegen was still using the .matter file of the bridge-app example. I changed this to the dynamic-bridge-app one and also changed some paths in the README.