### PR TITLE
Minor unit test cleanups

### DIFF
--- a/src/lib/support/tests/TestBytesToHex.cpp
+++ b/src/lib/support/tests/TestBytesToHex.cpp
@@ -338,6 +338,8 @@ void TestHexToBytesAndUint(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, test16Out == test16OutExpected);
 }
 
+#if CHIP_PROGRESS_LOGGING
+
 ENFORCE_FORMAT(3, 0) void AccumulateLogLineCallback(const char * module, uint8_t category, const char * msg, va_list args)
 {
     (void) module;
@@ -427,13 +429,15 @@ void TestLogBufferAsHex(nlTestSuite * inSuite, void * inContext)
     }
 }
 
+#endif
+
 const nlTest sTests[] = {
     NL_TEST_DEF("TestBytesToHexNotNullTerminated", TestBytesToHexNotNullTerminated), //
     NL_TEST_DEF("TestBytesToHexNullTerminated", TestBytesToHexNullTerminated),       //
     NL_TEST_DEF("TestBytesToHexErrors", TestBytesToHexErrors),                       //
     NL_TEST_DEF("TestBytesToHexUint64", TestBytesToHexUint64),                       //
     NL_TEST_DEF("TestHexToBytesAndUint", TestHexToBytesAndUint),                     //
-#ifdef CHIP_PROGRESS_LOGGING
+#if CHIP_PROGRESS_LOGGING
     NL_TEST_DEF("TestLogBufferAsHex", TestLogBufferAsHex), //
 #endif
     NL_TEST_SENTINEL() //

--- a/src/transport/raw/tests/NetworkTestHelpers.h
+++ b/src/transport/raw/tests/NetworkTestHelpers.h
@@ -124,15 +124,13 @@ public:
             {
                 mDelegate->OnMessageDropped();
             }
-        }
-        else
-        {
-            System::PacketBufferHandle receivedMessage = msgBuf.CloneData();
-            mPendingMessageQueue.push(PendingMessageItem(address, std::move(receivedMessage)));
-            mSystemLayer->ScheduleWork(OnMessageReceived, this);
+
+            return CHIP_NO_ERROR;
         }
 
-        return CHIP_NO_ERROR;
+        System::PacketBufferHandle receivedMessage = msgBuf.CloneData();
+        mPendingMessageQueue.push(PendingMessageItem(address, std::move(receivedMessage)));
+        return mSystemLayer->ScheduleWork(OnMessageReceived, this);
     }
 
     bool CanSendToPeer(const Transport::PeerAddress & address) override { return true; }
@@ -158,7 +156,6 @@ public:
 
     System::Layer * mSystemLayer = nullptr;
     std::queue<PendingMessageItem> mPendingMessageQueue;
-    Transport::PeerAddress mTxAddress;
     uint32_t mNumMessagesToDrop                = 0;
     uint32_t mDroppedMessageCount              = 0;
     uint32_t mSentMessageCount                 = 0;


### PR DESCRIPTION
Unused member in loopback transport.
`ifdef` for CHIP_LOG_PROGRESS was invalid: the define is always there, but it may be 0 or 1.