### PR TITLE
Add a warning that chip-device-ctrl is unmaintained.

### DIFF
--- a/docs/guides/python_chip_controller_building.md
+++ b/docs/guides/python_chip_controller_building.md
@@ -1,3 +1,9 @@
+# Deprecation notice
+
+chip-device-ctrl is no longer maintained and should not be used.
+
+Matter-repl is the current python controller implementation.
+
 # Working with Python CHIP Controller
 
 The Python CHIP Controller is a tool that allows to commission a Matter device


### PR DESCRIPTION
This came up from a comment in issue #9550, but isn't related to the original issue. Our documentation still talks about chip-device-ctrl, but this has been untested for some time. Adding a warning here that it's not maintained.

