### PR TITLE
[ESP32] Rename CHIP to Matter in documentation

### DIFF
--- a/docs/guides/esp32/build_app_and_commission.md
+++ b/docs/guides/esp32/build_app_and_commission.md
@@ -20,7 +20,7 @@ the esp32 application.
 
 ## Supported target chips
 
-All the CHIP demo application is intended to work on: the
+All the Matter demo application is intended to work on: the
 [ESP32-DevKitC](https://www.espressif.com/en/products/hardware/esp32-devkitc/overview),
 the
 [ESP32-WROVER-KIT_V4.1](https://www.espressif.com/en/products/hardware/esp-wrover-kit/overview),
@@ -51,7 +51,7 @@ functionality can still work fine.
     $ source export.sh
     ```
 
--   CHIP
+-   Matter
 
     Before running any other build command, the scripts/activate.sh environment
     setup script should be sourced at the top level. This script set up a Python
@@ -79,10 +79,10 @@ functionality can still work fine.
     $ cd examples/<app-name>/esp32
     ```
 
--   Set the chip target to build
+-   Set the Matter target to build
 
     ```
-    $ idf.py set-target (CHIP)
+    $ idf.py set-target (Matter)
     ```
 
     All the example applications supports target chips: esp32, esp32s3, esp32c3

--- a/docs/guides/esp32/setup_idf_chip.md
+++ b/docs/guides/esp32/setup_idf_chip.md
@@ -1,6 +1,6 @@
-# Setup ESP-IDF and CHIP Environment
+# Setup ESP-IDF and Matter Environment
 
-Setting up IDF and CHIP environment is one time setup.
+Setting up IDF and Matter environment is one time setup.
 
 ## Setup ESP-IDF (Espressif IoT Development Framework)
 
@@ -50,7 +50,7 @@ step.
     $ ./install.sh
     ```
 
-## Setup CHIP environment
+## Setup Matter environment
 
 ### Install Prerequisites
 
@@ -77,5 +77,5 @@ source scripts/bootstrap.sh
 
 ---
 
-Once IDF and CHIP environment is set up, head over to
+Once IDF and Matter environment is set up, head over to
 [application building and commissioning guide](build_app_and_commission.md).


### PR DESCRIPTION
Fixes #23727 with this PR [ESP32] Rename CHIP to Matter in documentation
