### PR TITLE
Implement command to discover commission-able devices

### DIFF
--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/discover/DiscoverCommissionablesCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/discover/DiscoverCommissionablesCommand.java
@@ -19,15 +19,46 @@
 package com.matter.controller.commands.discover;
 
 import chip.devicecontroller.ChipDeviceController;
+import chip.devicecontroller.DiscoveredDevice;
 import com.matter.controller.commands.common.CredentialsIssuer;
 import com.matter.controller.commands.common.MatterCommand;
 
 public final class DiscoverCommissionablesCommand extends MatterCommand {
+  private static final int MAX_DISCOVERED_DEVICES = 10;
+
   public DiscoverCommissionablesCommand(
       ChipDeviceController controller, CredentialsIssuer credsIssuer) {
     super(controller, "commissionables", credsIssuer);
   }
 
   @Override
-  protected final void runCommand() {}
+  protected final void runCommand() {
+    currentCommissioner().discoverCommissionableNodes();
+
+    // Pause for 7 seconds
+    try {
+      Thread.sleep(7000);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
+    getDiscoveredDevice();
+  }
+
+  private final void getDiscoveredDevice() {
+    // Log at most MAX_DISCOVERED_DEVICES discovered devices
+    for (int i = 0; i < MAX_DISCOVERED_DEVICES; i++) {
+      DiscoveredDevice device = currentCommissioner().getDiscoveredDevice(i);
+      if (device == null) {
+        break;
+      }
+
+      logDevice(device);
+    }
+  }
+
+  private final void logDevice(DiscoveredDevice device) {
+    System.out.format("\tDiscriminator: %ld", device.discriminator);
+    System.out.format("\tIP Address : %s", device.ipAddress);
+  }
 }


### PR DESCRIPTION
**Summary of Changes:**
https://github.com/project-chip/connectedhomeip/issues/23806

Implement command to discover commission-able Matter devices.

Use the following command to discover commission-able Matter devices
`java -Djava.library.path=out/linux-x64-java-matter-controller/lib/jni -jar out/linux-x64-java-matter-controller/bin/java-matter-controller discover commissionables`

Currently, we are able to call discoverCommissionableNodes() to SDK and getDiscoveredDevice() from SDK successfully,  but the found device does not have valid content in it, anyway, this is the problem in SDK and will be looked at seperately.
