### PR TITLE
[EFR32] Lock app lock-unlock command updated in README.md

### DIFF
--- a/examples/lock-app/efr32/README.md
+++ b/examples/lock-app/efr32/README.md
@@ -370,13 +370,13 @@ Here is some CHIPTool examples:
     Unlock door:
     ```
     ./out/chip-tool doorlock unlock-door node-id/group-id
-    ./out/chip-tool doorlock unlock-door 1 1
+    ./out/chip-tool doorlock unlock-door 1 1 --timedInteractionTimeoutMs 1000
     ```
 
     Lock door:
     ```
     ./out/chip-tool doorlock lock-door node-id/group-id
-    ./out/chip-tool doorlock lock-door 1 1
+    ./out/chip-tool doorlock lock-door 1 1 --timedInteractionTimeoutMs 1000
     ```
 
 ### Notes


### PR DESCRIPTION
If the following commands are being used, It gives an error for Timed Interaction

Unlock door:
```
./out/chip-tool doorlock unlock-door node-id/group-id
./out/chip-tool doorlock unlock-door 1 1
```
Lock door:
```
./out/chip-tool doorlock lock-door node-id/group-id
./out/chip-tool doorlock lock-door 1 1
```
To fix this issue updated these commands in README.md