### PR TITLE
[nrfconnect] Fixed factory data generation bug

### DIFF
--- a/docs/guides/nrfconnect_factory_data_configuration.md
+++ b/docs/guides/nrfconnect_factory_data_configuration.md
@@ -225,11 +225,8 @@ $ python scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py -h
     - Automatic:
 
         ```
-        --passcode <pass_code> --spake2p_path <path to spake2p executable>
+        --passcode <pass_code>
         ```
-
-    > Note: To generate new SPAKE2+ verifier you need `spake2p` executable. See
-    > the note at the end of this section to learn how to get it.
 
     - Manual:
 
@@ -320,7 +317,6 @@ $ python scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py \
 --discriminator 0xF00 \
 --generate_rd_uid \
 --passcode 20202021 \
---spake2p_path "src/tools/spake2p/out/spake2p" \
 --out "build.json" \
 --schema "scripts/tools/nrfconnect/nrfconnect_factory_data.schema"
 ```
@@ -332,16 +328,6 @@ JSON file is verified using the prepared JSON Schema.
 If the script finishes successfully, go to the location you provided with the
 `-o` argument. Use the JSON file you find there when
 [generating the factory data partition](#generating_factory_data_partition).
-
-> Note: Generating the SPAKE2+ verifier is optional and requires providing a
-> path to the `spake2p` executable. To get it, complete the following steps:
->
-> 1.  Navigate to the `connectedhomeip` root directory.
-> 2.  In a terminal, run the command:
->     `cd src/tools/spake2p && gn gen out && ninja -C out spake2p` to build the
->     executable.
-> 3.  Add the `connectedhomeip/src/tools/spake2p/out/spake2p` path as an
->     argument of `--spake2p_path` for the Python script.
 
 > Note: Generating new certificates is optional if default vendor and product
 > IDs are used and requires providing a path to the `chip-cert` executable. To

--- a/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
+++ b/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
@@ -317,7 +317,7 @@ class FactoryDataGenerator:
             if self._args.enable_key:
                 self._add_entry("enable_key", HEX_PREFIX + self._args.enable_key)
             if self._args.user:
-                self._add_entry("user", self._args.user)
+                self._add_entry("user", self._user_data)
 
             factory_data_dict = dict(self._factory_data)
 


### PR DESCRIPTION
Current factory data generation version has a bug that results in throwing expection if optional --user value is specified. Additionally the documentation guide is slightly out of date.

Summary of changes:
* Fixed a bug by passing dict argument instead of string
* Removed from guide information about spake2p_path and SPAKE2 executable generation.
