### PR TITLE
[ESP32] Add the missing judgement condition of GetPartitionLabelByNamespace

### DIFF
--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -105,7 +105,7 @@ const char * ESP32Config::GetPartitionLabelByNamespace(const char * ns)
     {
         return CHIP_DEVICE_CONFIG_CHIP_CONFIG_NAMESPACE_PARTITION;
     }
-    else if (strcmp(ns, kConfigNamespace_ChipCounters))
+    else if (strcmp(ns, kConfigNamespace_ChipCounters) == 0)
     {
         return CHIP_DEVICE_CONFIG_CHIP_COUNTERS_NAMESPACE_PARTITION;
     }


### PR DESCRIPTION
In the ESP32Config::GetPartitionLabelByNamespace() function, there is a judgement condition missing when get kConfigNamespace_ChipCounters namespace partition.

In this PR I add this condition.