### PR TITLE
RPC: Fix device proto FabricId to be 64 bit not 32

### DIFF
--- a/examples/common/pigweed/protos/device_service.proto
+++ b/examples/common/pigweed/protos/device_service.proto
@@ -28,7 +28,7 @@ message DeviceInfo {
 }
 
 message FabricInfo {
-  uint32 fabric_id = 1;
+  uint64 fabric_id = 1;
   uint64 node_id = 2;
 }
 


### PR DESCRIPTION
FabricInfo incorrectly defines the fabric_id as uint32 instead of uint64 causing it to get truncated.

Update the type so that it is correct. 