### PR TITLE
Have CI use python YAML parser to run tests

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -101,7 +101,6 @@ jobs:
             - name: Run Tests
               timeout-minutes: 65
               run: |
-                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_wheel build-env'
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
                      --chip-tool ./out/darwin-x64-darwin-framework-tool-${BUILD_VARIANT}/darwin-framework-tool \

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -101,6 +101,7 @@ jobs:
             - name: Run Tests
               timeout-minutes: 65
               run: |
+                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_wheel build-env'
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
                      --chip-tool ./out/darwin-x64-darwin-framework-tool-${BUILD_VARIANT}/darwin-framework-tool \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -181,6 +181,7 @@ jobs:
             - name: Build Apps
               timeout-minutes: 45
               run: |
+                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_wheel build-env'
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT} \
@@ -196,6 +197,7 @@ jobs:
             - name: Run Tests
               timeout-minutes: 65
               run: |
+                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_wheel build-env'
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
                      --chip-tool ./out/linux-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
@@ -300,6 +302,7 @@ jobs:
             - name: Run Tests
               timeout-minutes: 80
               run: |
+                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_wheel build-env'
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
                      --chip-tool ./out/darwin-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -197,10 +197,10 @@ jobs:
             - name: Run Tests
               timeout-minutes: 65
               run: |
-                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_wheel build-env'
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
                      --chip-tool ./out/linux-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
+                     --run-yaml-python-parser \
                      run \
                      --iterations 1 \
                      --test-timeout-seconds 120 \
@@ -302,7 +302,6 @@ jobs:
             - name: Run Tests
               timeout-minutes: 80
               run: |
-                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_wheel build-env'
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
                      --chip-tool ./out/darwin-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \

--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -23,13 +23,16 @@ from .test_definition import ApplicationPaths, TestDefinition, TestTarget
 
 
 _DEFAULT_CHIP_ROOT = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+    os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 _YAML_TEST_SUITE_PATH = os.path.abspath(
-    os.path.join(_DEFAULT_CHIP_ROOT, 'src/app/tests/suites'))
+    os.path.join(_DEFAULT_CHIP_ROOT, "src/app/tests/suites"))
 
 
 def _FindYamlTestPath(name: str):
-    for path in Path(_YAML_TEST_SUITE_PATH).rglob(name):
+    yaml_test_suite_path = Path(_YAML_TEST_SUITE_PATH)
+    if not yaml_test_suite_path.exists():
+        raise FileNotFoundError(f"Expected directory {_YAML_TEST_SUITE_PATH} to exist")
+    for path in yaml_test_suite_path.rglob(name):
         if not path.is_file():
             continue
         if path.name != name:
@@ -74,7 +77,7 @@ def tests_with_command(chip_tool: str, is_manual: bool):
 # TODO We will move away from hardcoded list of yaml tests to run in python once python
 # yaml parser reaches functionality parity with the code gen version.
 def _hardcoded_python_yaml_tests():
-    currently_supported_yaml_tests = ['TestConstraints.yaml']
+    currently_supported_yaml_tests = ["TestConstraints.yaml"]
 
     for name in currently_supported_yaml_tests:
         yaml_test_path = _FindYamlTestPath(name)
@@ -88,15 +91,16 @@ def _hardcoded_python_yaml_tests():
         )
 
 
-def AllTests(chip_tool: str):
+def AllTests(chip_tool: str, run_yaml_python_parser: bool):
     for test in tests_with_command(chip_tool, is_manual=False):
         yield test
 
     for test in tests_with_command(chip_tool, is_manual=True):
         yield test
 
-    for test in _hardcoded_python_yaml_tests():
-        yield test
+    if run_yaml_python_parser:
+        for test in _hardcoded_python_yaml_tests():
+            yield test
 
 
 __all__ = [

--- a/scripts/tests/chiptest/linux.py
+++ b/scripts/tests/chiptest/linux.py
@@ -149,4 +149,5 @@ def PathsWithNetworkNamespaces(paths: ApplicationPaths) -> ApplicationPaths:
         ota_requestor_app='ip netns exec app'.split() + paths.ota_requestor_app,
         tv_app='ip netns exec app'.split() + paths.tv_app,
         bridge_app='ip netns exec app'.split() + paths.bridge_app,
+        python_yaml_tester_cmd='ip netns exec tool'.split() + paths.python_yaml_tester_cmd,
     )

--- a/scripts/tests/chiptest/python_yaml_tester.py
+++ b/scripts/tests/chiptest/python_yaml_tester.py
@@ -1,0 +1,59 @@
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import click
+
+from chip import ChipDeviceCtrl
+from chip.ChipStack import *
+import chip.FabricAdmin
+import chip.CertificateAuthority
+import chip.native
+import chip.yaml
+
+
+@click.command()
+@click.option(
+    '--setup-code',
+    default=None,
+    help='setup-code')
+@click.option(
+    '--yaml-path',
+    default=None,
+    help='yaml-path')
+def main(setup_code, yaml_path):
+    chip.native.Init()
+    chipStack = ChipStack("/tmp/repl-storage.json")
+    certificateAuthorityManager = chip.CertificateAuthority.CertificateAuthorityManager(chipStack, chipStack.GetStorageManager())
+    certificateAuthorityManager.LoadAuthoritiesFromStorage()
+
+    if (len(certificateAuthorityManager.activeCaList) == 0):
+        ca = certificateAuthorityManager.NewCertificateAuthority()
+        ca.NewFabricAdmin(vendorId=0xFFF1, fabricId=1)
+    elif (len(certificateAuthorityManager.activeCaList[0].adminList) == 0):
+        certificateAuthorityManager.activeCaList[0].NewFabricAdmin(vendorId=0xFFF1, fabricId=1)
+
+    caList = certificateAuthorityManager.activeCaList
+
+    devCtrl = caList[0].adminList[0].NewController()
+    devCtrl.CommissionWithCode(setup_code, 0x12344321)
+
+    parsed_test = chip.yaml.parser.YamlTestParser(yaml_path)
+    parsed_test.execute_tests(devCtrl)
+    certificateAuthorityManager.Shutdown()
+    chipStack.Shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tests/chiptest/python_yaml_tester.py
+++ b/scripts/tests/chiptest/python_yaml_tester.py
@@ -38,7 +38,7 @@ import chip.yaml
     default=0x12344321,
     help='Node ID to use when commissioning device')
 def main(setup_code, yaml_path, node_id):
-    exit(-1)
+    # Setting up python enviroment for running YAML CI tests using python parser.
     chip_stack_storage = tempfile.NamedTemporaryFile()
     chip.native.Init()
     chip_stack = ChipStack(chip_stack_storage.name)
@@ -53,11 +53,16 @@ def main(setup_code, yaml_path, node_id):
 
     ca_list = certificate_authority_manager.activeCaList
 
+    # Creating and commissioning to a single controller to match what is currently done when
+    # running.
     devCtrl = ca_list[0].adminList[0].NewController()
     devCtrl.CommissionWithCode(setup_code, node_id)
 
+    # Parsing and executing test.
     parsed_test = chip.yaml.parser.YamlTestParser(yaml_path)
     parsed_test.execute_tests(devCtrl)
+
+    # Tearing down chip stack. If not done in the correct order test will fail.
     certificate_authority_manager.Shutdown()
     chip_stack.Shutdown()
 

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -168,7 +168,7 @@ class ApplicationPaths:
     python_yaml_tester_cmd: typing.List[str]
 
     def items(self):
-        return [self.chip_tool, self.all_clusters_app, self.lock_app, self.ota_provider_app, self.ota_requestor_app, self.tv_app, self.bridge_app]
+        return [self.chip_tool, self.all_clusters_app, self.lock_app, self.ota_provider_app, self.ota_requestor_app, self.tv_app, self.bridge_app, self.python_yaml_tester_cmd]
 
 
 @dataclass
@@ -240,8 +240,8 @@ class TestDefinition:
                                 "don't know which application to run")
 
             for path in paths.items():
-                # Do not add chip-tool to the register
-                if path == paths.chip_tool:
+                # Do not add chip-tool or python-yaml-tester-cmd to the register
+                if path == paths.chip_tool or path == paths.python_yaml_tester_cmd:
                     continue
 
                 # For the app indicated by self.target, give it the 'default' key to add to the register

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -165,6 +165,7 @@ class ApplicationPaths:
     ota_requestor_app: typing.List[str]
     tv_app: typing.List[str]
     bridge_app: typing.List[str]
+    python_yaml_tester_cmd: typing.List[str]
 
     def items(self):
         return [self.chip_tool, self.all_clusters_app, self.lock_app, self.ota_provider_app, self.ota_requestor_app, self.tv_app, self.bridge_app]
@@ -215,6 +216,7 @@ class TestDefinition:
     run_name: str
     target: TestTarget
     is_manual: bool
+    use_python_parser: bool = False
 
     def Run(self, runner, apps_register, paths: ApplicationPaths, pics_file: str, timeout_seconds: typing.Optional[int], dry_run=False):
         """
@@ -278,7 +280,11 @@ class TestDefinition:
             if dry_run:
                 logging.info(" ".join(pairing_cmd))
                 logging.info(" ".join(test_cmd))
-
+            elif self.use_python_parser:
+                python_yaml_tester_cmd = paths.python_yaml_tester_cmd
+                python_cmd = python_yaml_tester_cmd + \
+                    ['--setup-code', app.setupCode] + ['--yaml-path', self.run_name]
+                runner.RunSubprocess(python_cmd, name='PYTHON_YAML', dependencies=[apps_register], timeout_seconds=timeout_seconds)
             else:
                 runner.RunSubprocess(pairing_cmd,
                                      name='PAIR', dependencies=[apps_register])

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -193,6 +193,9 @@ def cmd_list(context):
     '--bridge-app',
     help='what bridge app to use')
 @click.option(
+    '--python-yaml-tester',
+    help='what python script to use to run yaml tests')
+@click.option(
     '--pics-file',
     type=click.Path(exists=True),
     default="src/app/tests/suites/certification/ci-pics-values",
@@ -203,7 +206,7 @@ def cmd_list(context):
     type=int,
     help='If provided, fail if a test runs for longer than this time')
 @click.pass_context
-def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, ota_requestor_app, tv_app, bridge_app, pics_file, test_timeout_seconds):
+def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, ota_requestor_app, tv_app, bridge_app, python_yaml_tester, pics_file, test_timeout_seconds):
     runner = chiptest.runner.Runner()
 
     if all_clusters_app is None:
@@ -224,6 +227,9 @@ def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, o
     if bridge_app is None:
         bridge_app = FindBinaryPath('chip-bridge-app')
 
+    if python_yaml_tester is None:
+        python_yaml_tester = FindBinaryPath('python_yaml_tester.py')
+
     # Command execution requires an array
     paths = chiptest.ApplicationPaths(
         chip_tool=[context.obj.chip_tool],
@@ -232,7 +238,8 @@ def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, o
         ota_provider_app=[ota_provider_app],
         ota_requestor_app=[ota_requestor_app],
         tv_app=[tv_app],
-        bridge_app=[bridge_app]
+        bridge_app=[bridge_app],
+        python_yaml_tester_cmd=['python3'] + [python_yaml_tester]
     )
 
     if sys.platform == 'linux':

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -109,11 +109,16 @@ class RunContext:
     help='Internal flag for running inside a unshared environment'
 )
 @click.option(
+    '--run-yaml-python-parser',
+    default=False,
+    is_flag=True,
+    help='Run YAML tests using python parser in addition to any other tests')
+@click.option(
     '--chip-tool',
     help='Binary path of chip tool app to use to run the test')
 @click.pass_context
 def main(context, dry_run, log_level, target, target_glob, target_skip_glob,
-         no_log_timestamps, root, internal_inside_unshare, chip_tool):
+         no_log_timestamps, root, internal_inside_unshare, run_yaml_python_parser, chip_tool):
     # Ensures somewhat pretty logging of what is going on
     log_fmt = '%(asctime)s.%(msecs)03d %(levelname)-7s %(message)s'
     if no_log_timestamps:
@@ -124,7 +129,7 @@ def main(context, dry_run, log_level, target, target_glob, target_skip_glob,
         chip_tool = FindBinaryPath('chip-tool')
 
     # Figures out selected test that match the given name(s)
-    all_tests = [test for test in chiptest.AllTests(chip_tool)]
+    all_tests = [test for test in chiptest.AllTests(chip_tool, run_yaml_python_parser)]
 
     # Default to only non-manual tests unless explicit targets are specified.
     tests = list(filter(lambda test: not test.is_manual, all_tests))


### PR DESCRIPTION
Start to include running python YAML test parser in tests that currently pass. This is not a removal of old tests simply an addition of running same tests using runtime parse instead of from codegen files

Testing: Confirm CI passes
