### PR TITLE
Rewrite webos_example script

### DIFF
--- a/scripts/examples/webos_example.sh
+++ b/scripts/examples/webos_example.sh
@@ -15,29 +15,49 @@
 #    limitations under the License.
 #
 
+SCRIPT_DIR=$(dirname "$0")
+REPO_DIR=$(realpath "$SCRIPT_DIR/../..")
+WEBOS_REPO_DIR="$REPO_DIR/third_party/webos_sdk"
+WEBOS_SDK_VER="v2.14.1"
+
+WEBOS_SDK_PATH="$WEBOS_REPO_DIR/$WEBOS_SDK_VER"
+WEBOS_SYSROOT="$WEBOS_SDK_PATH/sysroots"
+WEBOS_SDK_EXTRACT_SCRIPT_PATH="$WEBOS_SDK_PATH/webos-sdk-x86_64-cortexa7t2hf-neon-vfpv4-toolchain-2.14.1.g.sh"
+ENVIRONMENT_SETUP_SCRIPT="$WEBOS_SDK_PATH/environment-setup-cortexa7t2hf-neon-vfpv4-webos-linux-gnueabi"
+
 # Activating connectedhomeip build environment
-source scripts/activate.sh
+source "$REPO_DIR/scripts/activate.sh"
 
-# Clone webos_sdk
+echo "Clone webos_sdk"
 echo "##### Cloning webOS OSE SDK #####"
-git clone https://github.com/cabin15/webos-ose-ndk third_party/webos_sdk
 
-# Extract webOS SDK
-cat third_party/webos_sdk/v2.14.1/webos_sdk.tar* | (
-    cd third_party/webos_sdk/v2.14.1/
-    tar xvzf -
-)
+if [ ! -d "$WEBOS_REPO_DIR" ]; then
+    git clone https://github.com/cabin15/webos-ose-ndk "$WEBOS_REPO_DIR"
+else
+    echo "webOS-ose-ndk already exists in $WEBOS_REPO_DIR"
+fi
 
-# Grant execute permission for NDK install script
-chmod 555 third_party/webos_sdk/v2.14.1/webos-sdk-x86_64-cortexa7t2hf-neon-vfpv4-toolchain-2.14.1.g.sh
+echo "Extract webOS SDK"
+if [ ! -e "$WEBOS_SDK_EXTRACT_SCRIPT_PATH" ]; then
+    cat "$WEBOS_SDK_PATH/webos_sdk.tar"* | (
+        cd "$WEBOS_SDK_PATH" || (echo "Failed to cd to $WEBOS_SDK_PATH" && exit 1)
+        tar xvzf -
+    )
+else
+    echo "webOS SDK already extracted"
+fi
 
-# Install webOS OSE NDK
-echo "##### Install webOS OSE NDK #####"
-third_party/webos_sdk/v2.14.1/webos-sdk-x86_64-cortexa7t2hf-neon-vfpv4-toolchain-2.14.1.g.sh -d third_party/webos_sdk/v2.14.1 -y
+if [ ! -d "$WEBOS_SYSROOT" ]; then
+    echo "webOS SDK not extracted"
+    chmod 555 "$WEBOS_SDK_EXTRACT_SCRIPT_PATH"
+
+    echo "##### Install webOS OSE NDK #####"
+    "$WEBOS_SDK_EXTRACT_SCRIPT_PATH" -d third_party/webos_sdk/v2.14.1 -y
+fi
 
 # Activating webOS NDK build environment
 echo "##### Activating webOS NDK build environment #####"
-source third_party/webos_sdk/v2.14.1/environment-setup-cortexa7t2hf-neon-vfpv4-webos-linux-gnueabi
+source "$ENVIRONMENT_SETUP_SCRIPT"
 echo ""
 
 # Build webos example

--- a/scripts/examples/webos_example.sh
+++ b/scripts/examples/webos_example.sh
@@ -52,7 +52,7 @@ if [ ! -d "$WEBOS_SYSROOT" ]; then
     chmod 555 "$WEBOS_SDK_EXTRACT_SCRIPT_PATH"
 
     echo "##### Install webOS OSE NDK #####"
-    "$WEBOS_SDK_EXTRACT_SCRIPT_PATH" -d third_party/webos_sdk/v2.14.1 -y
+    "$WEBOS_SDK_EXTRACT_SCRIPT_PATH" -d "$WEBOS_SDK_PATH" -y
 fi
 
 # Activating webOS NDK build environment
@@ -63,7 +63,7 @@ echo ""
 # Build webos example
 echo "##### Build webos example #####"
 echo "##### Performing gn gen #####"
-gn gen out/host --args="is_debug=false target_os=\"webos\" target_cpu=\"arm\" chip_enable_python_modules=false ar_webos=\"$AR\" cc_webos=\"$CC -Wno-format-security\" cxx_webos=\"$CXX\" webos_sysroot=\"$PKG_CONFIG_SYSROOT_DIR\" chip_build_tests=false enable_syslog=true treat_warnings_as_errors=false"
+gn gen "$REPO_DIR/out/host" --args="is_debug=false target_os=\"webos\" target_cpu=\"arm\" chip_enable_python_modules=false ar_webos=\"$AR\" cc_webos=\"$CC -Wno-format-security\" cxx_webos=\"$CXX\" webos_sysroot=\"$PKG_CONFIG_SYSROOT_DIR\" chip_build_tests=false enable_syslog=true treat_warnings_as_errors=false"
 
 echo "##### Building by ninja #####"
-ninja -C out/host
+ninja -C "$REPO_DIR/out/host"

--- a/src/platform/webos/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/webos/DiagnosticDataProviderImpl.cpp
@@ -25,6 +25,7 @@
 
 #include <app-common/zap-generated/enums.h>
 #include <lib/support/CHIPMem.h>
+#include <lib/support/CHIPMemString.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/DiagnosticDataProvider.h>
 #include <platform/webos/ConnectivityUtils.h>


### PR DESCRIPTION
### Problem

When building a WebOS example using `./scripts/examples/webos_example.sh`, SDK is set up on every call of the script. Also, there was a missing header, and the example did not build at all. 

### Solution

Add conditions to the building script to set up the SDK only when corresponding files do not exist. 

### Testing 

Run `./scripts/examples/webos_example.sh` two times. 
