### PR TITLE
Add modernize-redundant-void-arg to clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks: >
   bugprone-*,
+  modernize-redundant-void-arg,
   modernize-use-bool-literals,
   modernize-use-nullptr,
   performance-for-range-copy,

--- a/docs/style/coding/CODING_STYLE_GUIDE.adoc
+++ b/docs/style/coding/CODING_STYLE_GUIDE.adoc
@@ -154,7 +154,7 @@ leveraged through toolchain-compatibility preprocessor macros.
 CHIP strives to use the latest C++ functionality as long as existing compilers
 support such standards.
 
-C{plusplus}14 is considered pervasive enough to be used. As compilers start 
+C{plusplus}14 is considered pervasive enough to be used. As compilers start
 supporting standards such as C{plusplus}17, C{plusplus}20 and beyond,
 CHIP may follow suit.
 
@@ -354,7 +354,7 @@ static chipDEFINE_ALIGNED_VAR(sThreadAttributes, sizeof (pthread_attr_t), uint64
 
 #endif // USE_STRUCT_STORAGE
 
-int foobar(void)
+int foobar()
 {
     int              retval;
     int              status;
@@ -427,10 +427,10 @@ destructed after deinitialization.
 class ThreadAttributes
 {
 public:
-    ThreadAttributes(void) {};
-    ~ThreadAttributes(void) {};
+    ThreadAttributes() {};
+    ~ThreadAttributes() {};
 
-    operator pthread_attr_t *(void) { return &mAttributes; }
+    operator pthread_attr_t *() { return &mAttributes; }
 
 private:
     pthread_attr_t mAttributes;
@@ -444,7 +444,7 @@ extern void * foobar_entry(void *aArgument);
 
 static chipDEFINE_ALIGNED_VAR(sThreadAttributes, sizeof (ThreadAttributes), uint64_t);
 
-int foobar(void)
+int foobar()
 {
     int                retval = -1;
     int                status;
@@ -530,9 +530,9 @@ storage of objects from a static array of storage.
 class Foo
 {
 public:
-    Foo(void);
+    Foo();
     Foo(const Foo &inFoo);
-    ~Foo(void);
+    ~Foo();
 };
 
 // Global Variables
@@ -554,7 +554,7 @@ static void CreateFooAllocator(void *inStorage,
                               inDestroy);
 }
 
-static StaticAllocatorBitmap &GetFooAllocator(void)
+static StaticAllocatorBitmap &GetFooAllocator()
 {
     return *sFooAllocator;
 }
@@ -571,7 +571,7 @@ static void FooDestroy(AllocatorBase &inAllocator, void *inObject)
     return;
 }
 
-int Init(void)
+int Init()
 {
     static const size_t sFooCount = CHIP_FOO_COUNT;
     static chipAllocatorStaticBitmapStorageDefine(sFooStorage, Foo, sFooCount, uint32_t, sizeof (void *));
@@ -586,7 +586,7 @@ int Init(void)
     return retval;
 }
 
-Foo * FooAllocate(void)
+Foo * FooAllocate()
 {
     Foo *foo;
 

--- a/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
@@ -96,7 +96,7 @@ CHIP_ERROR ActionsAttrAccess::Read(const ConcreteReadAttributePath & aPath, Attr
 }
 } // anonymous namespace
 
-void MatterActionsPluginServerInitCallback(void)
+void MatterActionsPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
 }

--- a/examples/bridge-app/linux/bridged-actions-stub.cpp
+++ b/examples/bridge-app/linux/bridged-actions-stub.cpp
@@ -131,7 +131,7 @@ CHIP_ERROR ActionsAttrAccess::Read(const ConcreteReadAttributePath & aPath, Attr
 }
 } // anonymous namespace
 
-void MatterActionsPluginServerInitCallback(void)
+void MatterActionsPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
 }

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -803,7 +803,7 @@ const char * Command::GetArgumentDescription(size_t index) const
     return nullptr;
 }
 
-const char * Command::GetAttribute(void) const
+const char * Command::GetAttribute() const
 {
     size_t argsCount = mArgs.size();
     for (size_t i = 0; i < argsCount; i++)
@@ -818,7 +818,7 @@ const char * Command::GetAttribute(void) const
     return nullptr;
 }
 
-const char * Command::GetEvent(void) const
+const char * Command::GetEvent() const
 {
     size_t argsCount = mArgs.size();
     for (size_t i = 0; i < argsCount; i++)

--- a/src/app/AttributePathExpandIterator.cpp
+++ b/src/app/AttributePathExpandIterator.cpp
@@ -36,7 +36,7 @@ using namespace chip;
 // Note: Some of the generated files that depended by af.h are gen_config.h and gen_tokens.h
 typedef uint8_t EmberAfClusterMask;
 
-extern uint16_t emberAfEndpointCount(void);
+extern uint16_t emberAfEndpointCount();
 extern uint16_t emberAfIndexFromEndpoint(EndpointId endpoint);
 extern uint8_t emberAfClusterCount(EndpointId endpoint, bool server);
 extern uint16_t emberAfGetServerAttributeCount(chip::EndpointId endpoint, chip::ClusterId cluster);

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -58,7 +58,7 @@ public:
     virtual ~CircularEventReader() = default;
 };
 
-EventManagement & EventManagement::GetInstance(void)
+EventManagement & EventManagement::GetInstance()
 {
     return sInstance;
 }

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -471,7 +471,7 @@ exit:
 // -----------------------------------------------------------------------------
 // Plugin initialization
 
-void MatterApplicationLauncherPluginServerInitCallback(void)
+void MatterApplicationLauncherPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gApplicationLauncherAttrAccess);
 }

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -265,7 +265,7 @@ exit:
 // -----------------------------------------------------------------------------
 // Plugin initialization
 
-void MatterContentLauncherPluginServerInitCallback(void)
+void MatterContentLauncherPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gContentLauncherAttrAccess);
 }

--- a/src/app/clusters/descriptor/descriptor.cpp
+++ b/src/app/clusters/descriptor/descriptor.cpp
@@ -184,7 +184,7 @@ CHIP_ERROR DescriptorAttrAccess::Read(const ConcreteReadAttributePath & aPath, A
 }
 } // anonymous namespace
 
-void MatterDescriptorPluginServerInitCallback(void)
+void MatterDescriptorPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
 }

--- a/src/app/clusters/fixed-label-server/fixed-label-server.cpp
+++ b/src/app/clusters/fixed-label-server/fixed-label-server.cpp
@@ -108,7 +108,7 @@ CHIP_ERROR FixedLabelAttrAccess::Read(const ConcreteReadAttributePath & aPath, A
 }
 } // anonymous namespace
 
-void MatterFixedLabelPluginServerInitCallback(void)
+void MatterFixedLabelPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
 }

--- a/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
+++ b/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
@@ -215,7 +215,7 @@ void emberAfLocalizationConfigurationClusterServerInitCallback(EndpointId endpoi
     }
 }
 
-void MatterLocalizationConfigurationPluginServerInitCallback(void)
+void MatterLocalizationConfigurationPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
 }

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -215,7 +215,7 @@ inline bool areStartUpModeAndCurrentModeNonVolatile(EndpointId endpointId)
 
 } // namespace
 
-void MatterModeSelectPluginServerInitCallback(void)
+void MatterModeSelectPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gModeSelectAttrAccess);
 }

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -433,7 +433,7 @@ bool OnOffServer::OnWithRecallGlobalSceneCommand(app::CommandHandler * commandOb
     return true;
 }
 
-uint32_t OnOffServer::calculateNextWaitTimeMS(void)
+uint32_t OnOffServer::calculateNextWaitTimeMS()
 {
     const chip::System::Clock::Timestamp currentTime = chip::System::SystemClock().GetMonotonicTimestamp();
     chip::System::Clock::Timestamp waitTime          = UPDATE_TIME_MS;

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -395,7 +395,7 @@ private:
 
 OpCredsFabricTableDelegate gFabricDelegate;
 
-void MatterOperationalCredentialsPluginServerInitCallback(void)
+void MatterOperationalCredentialsPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
 

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -388,7 +388,7 @@ void DefaultOTARequestorDriver::StopPeriodicQueryTimer()
     CancelDelayedAction(PeriodicQueryTimerHandler, this);
 }
 
-void DefaultOTARequestorDriver::RekickPeriodicQueryTimer(void)
+void DefaultOTARequestorDriver::RekickPeriodicQueryTimer()
 {
     ChipLogProgress(SoftwareUpdate, "Rekicking the Periodic Query timer");
     StopPeriodicQueryTimer();

--- a/src/app/clusters/ota-requestor/ota-requestor-server.cpp
+++ b/src/app/clusters/ota-requestor/ota-requestor-server.cpp
@@ -287,7 +287,7 @@ bool emberAfOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderCallback(
 // -----------------------------------------------------------------------------
 // Plugin initialization
 
-void MatterOtaSoftwareUpdateRequestorPluginServerInitCallback(void)
+void MatterOtaSoftwareUpdateRequestorPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
 }

--- a/src/app/clusters/power-source-configuration-server/power-source-configuration-server.cpp
+++ b/src/app/clusters/power-source-configuration-server/power-source-configuration-server.cpp
@@ -98,7 +98,7 @@ CHIP_ERROR PowerSourceConfigurationAttrAccess::Read(const ConcreteReadAttributeP
 
 } // anonymous namespace
 
-void MatterPowerSourceConfigurationPluginServerInitCallback(void)
+void MatterPowerSourceConfigurationPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
 }

--- a/src/app/clusters/power-source-server/power-source-server.cpp
+++ b/src/app/clusters/power-source-server/power-source-server.cpp
@@ -64,7 +64,7 @@ CHIP_ERROR PowerSourceAttrAccess::Read(const ConcreteReadAttributePath & aPath, 
 
 } // anonymous namespace
 
-void MatterPowerSourcePluginServerInitCallback(void)
+void MatterPowerSourcePluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
 }

--- a/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
+++ b/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
@@ -60,7 +60,7 @@ enum class RemoteSensorType : uint8_t
     kTemperatureSensor = 0x03,
 };
 
-static RemoteSensorType detectRemoteSensorConnected(void)
+static RemoteSensorType detectRemoteSensorConnected()
 {
     // TODO: Detect the sensor types attached to the pump control cluster
     // this could be pressure, flow or temperature sensors.
@@ -462,7 +462,7 @@ void MatterPumpConfigurationAndControlClusterServerAttributeChangedCallback(cons
     }
 }
 
-void MatterPumpConfigurationAndControlPluginServerInitCallback(void)
+void MatterPumpConfigurationAndControlPluginServerInitCallback()
 {
     emberAfDebugPrintln("Initialize PCC Plugin Server Cluster.");
 

--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -147,7 +147,7 @@ EmberAfStatus emberAfScenesClusterMakeInvalidCallback(EndpointId endpoint)
                                 ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
-void emAfPluginScenesServerPrintInfo(void)
+void emAfPluginScenesServerPrintInfo()
 {
     uint8_t i;
     EmberAfSceneTableEntry entry;

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -995,7 +995,7 @@ bool emberAfUnitTestingClusterTestSimpleOptionalArgumentRequestCallback(
 // -----------------------------------------------------------------------------
 // Plugin initialization
 
-void MatterUnitTestingPluginServerInitCallback(void)
+void MatterUnitTestingPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
 }

--- a/src/app/clusters/thermostat-client/thermostat-client.cpp
+++ b/src/app/clusters/thermostat-client/thermostat-client.cpp
@@ -23,7 +23,7 @@
 
 using namespace chip;
 
-void emberAfThermostatClusterClientInitCallback(void)
+void emberAfThermostatClusterClientInitCallback()
 {
     // TODO
 }

--- a/src/app/clusters/time-format-localization-server/time-format-localization-server.cpp
+++ b/src/app/clusters/time-format-localization-server/time-format-localization-server.cpp
@@ -220,7 +220,7 @@ void emberAfTimeFormatLocalizationClusterServerInitCallback(EndpointId endpoint)
     }
 }
 
-void MatterTimeFormatLocalizationPluginServerInitCallback(void)
+void MatterTimeFormatLocalizationPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
 }

--- a/src/app/clusters/user-label-server/user-label-server.cpp
+++ b/src/app/clusters/user-label-server/user-label-server.cpp
@@ -217,7 +217,7 @@ public:
 
 UserLabelFabricTableDelegate gUserLabelFabricDelegate;
 
-void MatterUserLabelPluginServerInitCallback(void)
+void MatterUserLabelPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
     Server::GetInstance().GetFabricTable().AddFabricDelegate(&gUserLabelFabricDelegate);

--- a/src/app/tests/integration/MockEvents.cpp
+++ b/src/app/tests/integration/MockEvents.cpp
@@ -44,9 +44,9 @@ size_t EventGenerator::GetNumStates()
     return mNumStates;
 }
 
-LivenessEventGenerator::LivenessEventGenerator(void) : EventGenerator(10, 0) {}
+LivenessEventGenerator::LivenessEventGenerator() : EventGenerator(10, 0) {}
 
-void LivenessEventGenerator::Generate(void)
+void LivenessEventGenerator::Generate()
 {
     // Scenario: monitoring liveness for two devices -- self and remote.  Remote device goes offline and returns.
     switch (mState)
@@ -131,13 +131,13 @@ chip::EventNumber LivenessEventGenerator::LogLiveness(chip::NodeId aNodeId, chip
     return number;
 }
 
-MockEventGenerator * MockEventGenerator::GetInstance(void)
+MockEventGenerator * MockEventGenerator::GetInstance()
 {
     static MockEventGeneratorImpl gMockEventGenerator;
     return &gMockEventGenerator;
 }
 
-MockEventGeneratorImpl::MockEventGeneratorImpl(void) :
+MockEventGeneratorImpl::MockEventGeneratorImpl() :
     mpExchangeMgr(nullptr), mTimeBetweenEvents(0), mEventWraparound(false), mpEventGenerator(nullptr), mEventsLeft(0)
 {}
 

--- a/src/app/tests/integration/common.cpp
+++ b/src/app/tests/integration/common.cpp
@@ -44,7 +44,7 @@ chip::TestPersistentStorageDelegate gStorage;
 chip::PersistentStorageOperationalKeystore gOperationalKeystore;
 chip::Credentials::PersistentStorageOpCertStore gOpCertStore;
 
-void InitializeChip(void)
+void InitializeChip()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::FabricTable::InitParams fabricTableInitParams;
@@ -84,7 +84,7 @@ exit:
     }
 }
 
-void ShutdownChip(void)
+void ShutdownChip()
 {
     gMessageCounterManager.Shutdown();
     gExchangeManager.Shutdown();

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -37,7 +37,7 @@ struct EmberEventData
     /** The control structure for the event. */
     EmberEventControl * control;
     /** The procedure to call when the event fires. */
-    void (*handler)(void);
+    void (*handler)();
 };
 
 // *****************************************************************************

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -110,7 +110,7 @@ static uint16_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterI
 //------------------------------------------------------------------------------
 
 // Initial configuration
-void emberAfEndpointConfigure(void)
+void emberAfEndpointConfigure()
 {
     uint16_t ep;
 
@@ -265,12 +265,12 @@ EndpointId emberAfClearDynamicEndpoint(uint16_t index)
     return ep;
 }
 
-uint16_t emberAfFixedEndpointCount(void)
+uint16_t emberAfFixedEndpointCount()
 {
     return FIXED_ENDPOINT_COUNT;
 }
 
-uint16_t emberAfEndpointCount(void)
+uint16_t emberAfEndpointCount()
 {
     return emberEndpointCount;
 }
@@ -357,7 +357,7 @@ static void initializeEndpoint(EmberAfDefinedEndpoint * definedEndpoint)
 }
 
 // Calls the init functions.
-void emAfCallInits(void)
+void emAfCallInits()
 {
     uint16_t index;
     for (index = 0; index < emberAfEndpointCount(); index++)

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -85,7 +85,7 @@ static void emberAfAttributeDecodeAndPrintCluster(ClusterId cluster)
 #endif // defined(EMBER_AF_PRINT_ENABLE) && defined(EMBER_AF_PRINT_ATTRIBUTES)
 }
 
-void emberAfPrintAttributeTable(void)
+void emberAfPrintAttributeTable()
 {
     uint8_t data[ATTRIBUTE_LARGEST];
     decltype(emberAfEndpointCount()) endpointIndex;

--- a/src/app/util/message.cpp
+++ b/src/app/util/message.cpp
@@ -44,7 +44,7 @@ static uint8_t * zeroLenBytePtr = (uint8_t *) &zeroLenByte;
 // Utilities for adding bytes to the response buffer: appResponseData. These
 // functions take care of incrementing appResponseLength.
 
-void emberAfClearResponseData(void)
+void emberAfClearResponseData()
 {
     emberAfResponseType = ZCL_UTIL_RESP_NORMAL;
     // To prevent accidentally sending to someone else,

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -96,7 +96,7 @@ uint8_t mockAttribute4[256]  = {
 
 } // namespace
 
-uint16_t emberAfEndpointCount(void)
+uint16_t emberAfEndpointCount()
 {
     return ArraySize(endpoints);
 }

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -174,7 +174,7 @@ void emberAfInit(chip::Messaging::ExchangeManager * exchangeMgr)
     emAfCallInits();
 }
 
-void emberAfTick(void)
+void emberAfTick()
 {
     // Call the AFV2-specific per-endpoint callbacks
     // Anything that defines callbacks as void *TickCallback(void) is called in
@@ -217,7 +217,7 @@ void MatterFanControlPluginServerInitCallback() {}
 // such as after a leave network. This allows zcl utils to clear state
 // that should not be kept when changing networks
 // ****************************************
-void emberAfStackDown(void)
+void emberAfStackDown()
 {
     emberAfRegistrationAbortCallback();
 }
@@ -264,7 +264,7 @@ void emberAfDecodeAndPrintCluster(ClusterId cluster)
 // If it is invalid, we just return the
 // EMBER_AF_NULL_MANUFACTURER_CODE, which we tend to use
 // for references to the standard library.
-uint16_t emberAfGetMfgCodeFromCurrentCommand(void)
+uint16_t emberAfGetMfgCodeFromCurrentCommand()
 {
     if (emberAfCurrentCommand() != nullptr)
     {
@@ -296,7 +296,7 @@ void emberAfSetRetryOverride(EmberAfRetryOverride value)
     emberAfApsRetryOverride = value;
 }
 
-EmberAfRetryOverride emberAfGetRetryOverride(void)
+EmberAfRetryOverride emberAfGetRetryOverride()
 {
     return (EmberAfRetryOverride) emberAfApsRetryOverride;
 }
@@ -330,7 +330,7 @@ void emberAfSetDisableDefaultResponse(EmberAfDisableDefaultResponse value)
     }
 }
 
-EmberAfDisableDefaultResponse emberAfGetDisableDefaultResponse(void)
+EmberAfDisableDefaultResponse emberAfGetDisableDefaultResponse()
 {
     return (EmberAfDisableDefaultResponse) emAfDisableDefaultResponse;
 }

--- a/src/ble/tests/TestBleErrorStr.cpp
+++ b/src/ble/tests/TestBleErrorStr.cpp
@@ -113,7 +113,7 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
-int TestBleErrorStr(void)
+int TestBleErrorStr()
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/credentials/tests/TestCertificationDeclaration.cpp
+++ b/src/credentials/tests/TestCertificationDeclaration.cpp
@@ -622,7 +622,7 @@ static const nlTest sTests[] = { NL_TEST_DEF_FN(TestCD_EncodeDecode),
                                  NL_TEST_DEF_FN(TestCD_DefaultCdTrustStore),
                                  NL_TEST_SENTINEL() };
 
-int TestCertificationDeclaration(void)
+int TestCertificationDeclaration()
 {
     nlTestSuite theSuite = { "CHIP Certification Declaration tests", &sTests[0], nullptr, nullptr };
 

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -2064,7 +2064,7 @@ static const nlTest sTests[] = {
 };
 // clang-format on
 
-int TestChipCert(void)
+int TestChipCert()
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -241,20 +241,20 @@ static inline mbedtls_sha256_context * to_inner_hash_sha256_context(HashSHA256Op
     return SafePointerCast<mbedtls_sha256_context *>(context);
 }
 
-Hash_SHA256_stream::Hash_SHA256_stream(void)
+Hash_SHA256_stream::Hash_SHA256_stream()
 {
     mbedtls_sha256_context * context = to_inner_hash_sha256_context(&mContext);
     mbedtls_sha256_init(context);
 }
 
-Hash_SHA256_stream::~Hash_SHA256_stream(void)
+Hash_SHA256_stream::~Hash_SHA256_stream()
 {
     mbedtls_sha256_context * context = to_inner_hash_sha256_context(&mContext);
     mbedtls_sha256_free(context);
     Clear();
 }
 
-CHIP_ERROR Hash_SHA256_stream::Begin(void)
+CHIP_ERROR Hash_SHA256_stream::Begin()
 {
     mbedtls_sha256_context * const context = to_inner_hash_sha256_context(&mContext);
 
@@ -320,7 +320,7 @@ CHIP_ERROR Hash_SHA256_stream::Finish(MutableByteSpan & out_buffer)
     return CHIP_NO_ERROR;
 }
 
-void Hash_SHA256_stream::Clear(void)
+void Hash_SHA256_stream::Clear()
 {
     mbedtls_platform_zeroize(this, sizeof(*this));
 }
@@ -969,7 +969,7 @@ static inline Spake2p_Context * to_inner_spake2p_context(Spake2pOpaqueContext * 
     return SafePointerCast<Spake2p_Context *>(context);
 }
 
-CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
+CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal()
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;

--- a/src/inet/tests/TestInetAddress.cpp
+++ b/src/inet/tests/TestInetAddress.cpp
@@ -1880,7 +1880,7 @@ int TestTeardown(void * inContext)
 
 } // namespace
 
-int TestInetAddress(void)
+int TestInetAddress()
 {
     // clang-format off
     nlTestSuite theSuite = {

--- a/src/inet/tests/TestInetErrorStr.cpp
+++ b/src/inet/tests/TestInetErrorStr.cpp
@@ -105,7 +105,7 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
-int TestInetErrorStr(void)
+int TestInetErrorStr()
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/lib/asn1/ASN1Writer.cpp
+++ b/src/lib/asn1/ASN1Writer.cpp
@@ -60,7 +60,7 @@ void ASN1Writer::Init(uint8_t * buf, size_t maxLen)
     mDeferredLengthCount = 0;
 }
 
-void ASN1Writer::InitNullWriter(void)
+void ASN1Writer::InitNullWriter()
 {
     mBuf                 = nullptr;
     mWritePoint          = nullptr;

--- a/src/lib/asn1/tests/TestASN1.cpp
+++ b/src/lib/asn1/tests/TestASN1.cpp
@@ -571,7 +571,7 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
-int TestASN1(void)
+int TestASN1()
 {
     nlTestSuite theSuite = { "Support-ASN1", &sTests[0], nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/core/tests/TestCATValues.cpp
+++ b/src/lib/core/tests/TestCATValues.cpp
@@ -226,7 +226,7 @@ int TestCATValues_Teardown(void * inContext)
     return SUCCESS;
 }
 
-int TestCATValues(void)
+int TestCATValues()
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/lib/core/tests/TestCHIPCallback.cpp
+++ b/src/lib/core/tests/TestCHIPCallback.cpp
@@ -252,7 +252,7 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
-int TestCHIPCallback(void)
+int TestCHIPCallback()
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/lib/core/tests/TestCHIPErrorStr.cpp
+++ b/src/lib/core/tests/TestCHIPErrorStr.cpp
@@ -306,7 +306,7 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
-int TestCHIPErrorStr(void)
+int TestCHIPErrorStr()
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -4497,7 +4497,7 @@ int TestCHIPTLV_Teardown(void * inContext)
     return SUCCESS;
 }
 
-int TestCHIPTLV(void)
+int TestCHIPTLV()
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/lib/core/tests/TestOTAImageHeader.cpp
+++ b/src/lib/core/tests/TestOTAImageHeader.cpp
@@ -207,7 +207,7 @@ int TearDownSuite(void * inContext)
 
 } // namespace
 
-int TestOTAImageHeader(void)
+int TestOTAImageHeader()
 {
     nlTestSuite theSuite = { "OTA Image header test", &sTests[0], SetupSuite, TearDownSuite };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/core/tests/TestOptional.cpp
+++ b/src/lib/core/tests/TestOptional.cpp
@@ -191,7 +191,7 @@ int TestOptional_Teardown(void * inContext)
     return SUCCESS;
 }
 
-int TestOptional(void)
+int TestOptional()
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/lib/core/tests/TestReferenceCounted.cpp
+++ b/src/lib/core/tests/TestReferenceCounted.cpp
@@ -112,7 +112,7 @@ int TestReferenceCounted_Teardown(void * inContext)
     return SUCCESS;
 }
 
-int TestReferenceCounted(void)
+int TestReferenceCounted()
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestFlatAllocatedQName.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestFlatAllocatedQName.cpp
@@ -133,7 +133,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestFlatAllocatedQName(void)
+int TestFlatAllocatedQName()
 {
     nlTestSuite theSuite = { "FlatAllocatedQName", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestHeapQName.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestHeapQName.cpp
@@ -93,7 +93,7 @@ int Teardown(void * inContext)
 
 } // namespace
 
-int TestHeapQName(void)
+int TestHeapQName()
 {
     nlTestSuite theSuite = {
         "HeapQName",

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestQName.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestQName.cpp
@@ -318,7 +318,7 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
-int TestQName(void)
+int TestQName()
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestRecordWriter.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestRecordWriter.cpp
@@ -177,7 +177,7 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
-int TestRecordWriter(void)
+int TestRecordWriter()
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecord.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecord.cpp
@@ -281,7 +281,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestResourceRecord(void)
+int TestResourceRecord()
 {
     nlTestSuite theSuite = { "ResourceRecord", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordIP.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordIP.cpp
@@ -185,7 +185,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestIPResourceRecord(void)
+int TestIPResourceRecord()
 {
 
     nlTestSuite theSuite = { "IPResourceRecord", sTests, nullptr, nullptr };

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordPtr.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordPtr.cpp
@@ -74,7 +74,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestPtrResourceRecord(void)
+int TestPtrResourceRecord()
 {
     nlTestSuite theSuite = { "PtrResourceRecord", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordSrv.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordSrv.cpp
@@ -79,7 +79,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestSrv(void)
+int TestSrv()
 {
     nlTestSuite theSuite = { "Srv", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordTxt.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordTxt.cpp
@@ -75,7 +75,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestTxt(void)
+int TestTxt()
 {
     nlTestSuite theSuite = { "Txt", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
@@ -135,7 +135,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestIP(void)
+int TestIP()
 {
     nlTestSuite theSuite = { "IP", sTests, &Setup, &Teardown };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
@@ -138,7 +138,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestPtr(void)
+int TestPtr()
 {
     nlTestSuite theSuite = { "IP", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestQueryResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestQueryResponder.cpp
@@ -179,7 +179,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestQueryResponder(void)
+int TestQueryResponder()
 {
     nlTestSuite theSuite = { "QueryResponder", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
@@ -546,7 +546,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestAdvertiser(void)
+int TestAdvertiser()
 {
     chip::Platform::MemoryInit();
     chip::Test::IOContext context;

--- a/src/lib/dnssd/minimal_mdns/tests/TestMinimalMdnsAllocator.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestMinimalMdnsAllocator.cpp
@@ -319,7 +319,7 @@ int TestTeardown(void * inContext)
 
 } // namespace
 
-int TestMinimalMdnsAllocator(void)
+int TestMinimalMdnsAllocator()
 {
     nlTestSuite theSuite = { "MinimalMdnsAllocator", &sTests[0], &TestSetup, &TestTeardown };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/minimal_mdns/tests/TestQueryReplyFilter.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestQueryReplyFilter.cpp
@@ -112,7 +112,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestQueryReplyFilter(void)
+int TestQueryReplyFilter()
 {
     nlTestSuite theSuite = { "QueryReplyFilter", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/minimal_mdns/tests/TestRecordData.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestRecordData.cpp
@@ -255,7 +255,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestRecordData(void)
+int TestRecordData()
 {
     nlTestSuite theSuite = { "RecordData", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
@@ -372,7 +372,7 @@ int TestTeardown(void * inContext)
 
 } // namespace
 
-int TestResponseSender(void)
+int TestResponseSender()
 {
     nlTestSuite theSuite = { "RecordData", sTests, &TestSetup, &TestTeardown };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/platform/tests/TestPlatform.cpp
+++ b/src/lib/dnssd/platform/tests/TestPlatform.cpp
@@ -241,7 +241,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestDnssdPlatform(void)
+int TestDnssdPlatform()
 {
     nlTestSuite theSuite = { "DnssdPlatform", &sTests[0], &TestSetup, &TestTeardown };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/tests/TestActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/tests/TestActiveResolveAttempts.cpp
@@ -395,7 +395,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestActiveResolveAttempts(void)
+int TestActiveResolveAttempts()
 {
     nlTestSuite theSuite = { "ActiveResolveAttempts", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/tests/TestIncrementalResolve.cpp
+++ b/src/lib/dnssd/tests/TestIncrementalResolve.cpp
@@ -437,7 +437,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestChipDnsSdIncrementalResolve(void)
+int TestChipDnsSdIncrementalResolve()
 {
     nlTestSuite theSuite = { "IncrementalResolve", &sTests[0], nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/tests/TestServiceNaming.cpp
+++ b/src/lib/dnssd/tests/TestServiceNaming.cpp
@@ -279,7 +279,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestCHIPServiceNaming(void)
+int TestCHIPServiceNaming()
 {
     nlTestSuite theSuite = { "ServiceNaming", &sTests[0], nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -642,7 +642,7 @@ const nlTest sTests[] = { NL_TEST_DEF("TxtFieldKey", TestGetTxtFieldKey),       
 
 } // namespace
 
-int TestCHIPTxtFields(void)
+int TestCHIPTxtFields()
 {
     nlTestSuite theSuite = { "TxtFields", &sTests[0], nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/shell/tests/TestShellStreamerStdio.cpp
+++ b/src/lib/shell/tests/TestShellStreamerStdio.cpp
@@ -80,7 +80,7 @@ static const nlTest sTests[] = {
     NL_TEST_SENTINEL()
 };
 
-int TestStreamerStdio(void)
+int TestStreamerStdio()
 {
     nlTestSuite theSuite = { "Test Shell: Streamer", &sTests[0], nullptr, nullptr };
 

--- a/src/lib/shell/tests/TestShellTokenizeLine.cpp
+++ b/src/lib/shell/tests/TestShellTokenizeLine.cpp
@@ -136,7 +136,7 @@ static const nlTest sTests[] = {
     NL_TEST_SENTINEL()
 };
 
-int TestShellTokenizeLine(void)
+int TestShellTokenizeLine()
 {
     nlTestSuite theSuite = { "Test Shell: MainLoop", &sTests[0], nullptr, nullptr };
 

--- a/src/lib/support/ThreadOperationalDataset.cpp
+++ b/src/lib/support/ThreadOperationalDataset.cpp
@@ -52,13 +52,13 @@ public:
         kActiveTimestamp = 14,
     };
 
-    uint8_t GetSize(void) const { return static_cast<uint8_t>(sizeof(*this) + GetLength()); }
+    uint8_t GetSize() const { return static_cast<uint8_t>(sizeof(*this) + GetLength()); }
 
-    uint8_t GetType(void) const { return mType; }
+    uint8_t GetType() const { return mType; }
 
     void SetType(uint8_t aType) { mType = aType; }
 
-    uint8_t GetLength(void) const
+    uint8_t GetLength() const
     {
         assert(mLength != kLengthEscape);
         return mLength;
@@ -70,7 +70,7 @@ public:
         mLength = aLength;
     }
 
-    const void * GetValue(void) const
+    const void * GetValue() const
     {
         assert(mLength != kLengthEscape);
 
@@ -79,7 +79,7 @@ public:
         return reinterpret_cast<const uint8_t *>(this) + sizeof(*this);
     }
 
-    void * GetValue(void) { return const_cast<void *>(const_cast<const ThreadTLV *>(this)->GetValue()); }
+    void * GetValue() { return const_cast<void *>(const_cast<const ThreadTLV *>(this)->GetValue()); }
 
     void Get64(uint64_t & aValue) const
     {
@@ -156,13 +156,13 @@ public:
         memcpy(GetValue(), aValue, aLength);
     }
 
-    const ThreadTLV * GetNext(void) const
+    const ThreadTLV * GetNext() const
     {
         static_assert(alignof(ThreadTLV) == 1, "Wrong alignment for ThreadTLV header");
         return reinterpret_cast<const ThreadTLV *>(static_cast<const uint8_t *>(GetValue()) + GetLength());
     }
 
-    ThreadTLV * GetNext(void) { return reinterpret_cast<ThreadTLV *>(static_cast<uint8_t *>(GetValue()) + GetLength()); }
+    ThreadTLV * GetNext() { return reinterpret_cast<ThreadTLV *>(static_cast<uint8_t *>(GetValue()) + GetLength()); }
 
     static bool IsValid(ByteSpan aData)
     {
@@ -480,17 +480,17 @@ CHIP_ERROR OperationalDataset::SetPSKc(const uint8_t (&aPSKc)[kSizePSKc])
     return CHIP_NO_ERROR;
 }
 
-void OperationalDataset::UnsetMasterKey(void)
+void OperationalDataset::UnsetMasterKey()
 {
     Remove(ThreadTLV::kMasterKey);
 }
 
-void OperationalDataset::UnsetPSKc(void)
+void OperationalDataset::UnsetPSKc()
 {
     Remove(ThreadTLV::kPSKc);
 }
 
-bool OperationalDataset::IsCommissioned(void) const
+bool OperationalDataset::IsCommissioned() const
 {
     return Has(ThreadTLV::kPanId) && Has(ThreadTLV::kMasterKey) && Has(ThreadTLV::kExtendedPanId) && Has(ThreadTLV::kChannel);
 }

--- a/src/lib/support/tests/TestBufferReader.cpp
+++ b/src/lib/support/tests/TestBufferReader.cpp
@@ -141,7 +141,7 @@ static const nlTest sTests[] = { NL_TEST_DEF_FN(TestBufferReader_Basic), NL_TEST
                                  NL_TEST_DEF_FN(TestBufferReader_Saturation), NL_TEST_DEF_FN(TestBufferReader_Skip),
                                  NL_TEST_SENTINEL() };
 
-int TestBufferReader(void)
+int TestBufferReader()
 {
     nlTestSuite theSuite = { "CHIP BufferReader tests", &sTests[0], nullptr, nullptr };
 

--- a/src/lib/support/tests/TestBufferWriter.cpp
+++ b/src/lib/support/tests/TestBufferWriter.cpp
@@ -236,7 +236,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestBufferWriter(void)
+int TestBufferWriter()
 {
     nlTestSuite theSuite = { "BufferWriter", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/support/tests/TestBytesToHex.cpp
+++ b/src/lib/support/tests/TestBytesToHex.cpp
@@ -445,7 +445,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestBytesToHex(void)
+int TestBytesToHex()
 {
     nlTestSuite theSuite = { "BytesToHex", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/support/tests/TestCHIPArgParser.cpp
+++ b/src/lib/support/tests/TestCHIPArgParser.cpp
@@ -759,7 +759,7 @@ static void ENFORCE_FORMAT(1, 2) HandleArgError(const char * msg, ...)
     sCallbackRecordCount++;
 }
 
-int TestCHIPArgParser(void)
+int TestCHIPArgParser()
 {
     if (chip::Platform::MemoryInit() != CHIP_NO_ERROR)
     {

--- a/src/lib/support/tests/TestCHIPCounter.cpp
+++ b/src/lib/support/tests/TestCHIPCounter.cpp
@@ -77,7 +77,7 @@ static int TestTeardown(void * inContext)
     return (SUCCESS);
 }
 
-int TestCHIPCounter(void)
+int TestCHIPCounter()
 {
     // clang-format off
     nlTestSuite theSuite = {

--- a/src/lib/support/tests/TestDefer.cpp
+++ b/src/lib/support/tests/TestDefer.cpp
@@ -52,7 +52,7 @@ static void TestDeferUsage(nlTestSuite * inSuite, void * inContext)
  */
 static const nlTest sTests[] = { NL_TEST_DEF_FN(TestDeferUsage), NL_TEST_SENTINEL() };
 
-int TestDefer(void)
+int TestDefer()
 {
     nlTestSuite theSuite = { "CHIP Defer tests", &sTests[0], nullptr, nullptr };
 

--- a/src/lib/support/tests/TestErrorStr.cpp
+++ b/src/lib/support/tests/TestErrorStr.cpp
@@ -178,7 +178,7 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
-int TestErrorStr(void)
+int TestErrorStr()
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/lib/support/tests/TestIniEscaping.cpp
+++ b/src/lib/support/tests/TestIniEscaping.cpp
@@ -100,7 +100,7 @@ const nlTest sTests[] = { NL_TEST_DEF("Test escaping API", TestEscaping), NL_TES
 
 } // namespace
 
-int TestIniEscaping(void)
+int TestIniEscaping()
 {
     nlTestSuite theSuite = { "IniEscaping tests", &sTests[0], nullptr, nullptr };
 

--- a/src/lib/support/tests/TestOwnerOf.cpp
+++ b/src/lib/support/tests/TestOwnerOf.cpp
@@ -49,7 +49,7 @@ static void TestMemberOwner(nlTestSuite * inSuite, void * inContext)
  */
 static const nlTest sTests[] = { NL_TEST_DEF_FN(TestMemberOwner), NL_TEST_SENTINEL() };
 
-int TestOwnerOf(void)
+int TestOwnerOf()
 {
     nlTestSuite theSuite = { "CHIP OwnerOf tests", &sTests[0], nullptr, nullptr };
 

--- a/src/lib/support/tests/TestPrivateHeap.cpp
+++ b/src/lib/support/tests/TestPrivateHeap.cpp
@@ -353,7 +353,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestPrivateHeap(void)
+int TestPrivateHeap()
 {
     nlTestSuite theSuite = { "PrivateHeap", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/support/tests/TestSafeInt.cpp
+++ b/src/lib/support/tests/TestSafeInt.cpp
@@ -355,7 +355,7 @@ static const nlTest sTests[] = { NL_TEST_DEF_FN(TestCanCastTo_Int8),  NL_TEST_DE
                                  NL_TEST_DEF_FN(TestCanCastTo_Int32), NL_TEST_DEF_FN(TestCanCastTo_Int64),
                                  NL_TEST_DEF_FN(TestCastToSigned),    NL_TEST_SENTINEL() };
 
-int TestSafeInt(void)
+int TestSafeInt()
 {
     nlTestSuite theSuite = { "CHIP SafeInt tests", &sTests[0], nullptr, nullptr };
 

--- a/src/lib/support/tests/TestSafeString.cpp
+++ b/src/lib/support/tests/TestSafeString.cpp
@@ -54,7 +54,7 @@ static void TestTotalStringLength(nlTestSuite * inSuite, void * inContext)
  */
 static const nlTest sTests[] = { NL_TEST_DEF_FN(TestMaxStringLength), NL_TEST_DEF_FN(TestTotalStringLength), NL_TEST_SENTINEL() };
 
-int TestSafeString(void)
+int TestSafeString()
 {
     nlTestSuite theSuite = { "CHIP SafeString tests", &sTests[0], nullptr, nullptr };
 

--- a/src/lib/support/tests/TestScopedBuffer.cpp
+++ b/src/lib/support/tests/TestScopedBuffer.cpp
@@ -141,7 +141,7 @@ static const nlTest sTests[] = {
     NL_TEST_SENTINEL()                    //
 };
 
-int TestScopedBuffer(void)
+int TestScopedBuffer()
 {
     nlTestSuite theSuite = { "CHIP ScopedBuffer tests", &sTests[0], Setup, Teardown };
 

--- a/src/lib/support/tests/TestSerializableIntegerSet.cpp
+++ b/src/lib/support/tests/TestSerializableIntegerSet.cpp
@@ -172,7 +172,7 @@ static const nlTest sTests[] = {
     NL_TEST_SENTINEL()                                   //
 };
 
-int TestSerializableIntegerSet(void)
+int TestSerializableIntegerSet()
 {
     nlTestSuite theSuite = { "CHIP SerializableIntegerSet tests", &sTests[0], Setup, Teardown };
 

--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -301,7 +301,7 @@ static const nlTest sTests[] = { NL_TEST_DEF_FN(TestByteSpan),       NL_TEST_DEF
                                  NL_TEST_DEF_FN(TestSubSpan),        NL_TEST_DEF_FN(TestFromZclString),
                                  NL_TEST_DEF_FN(TestFromCharString), NL_TEST_SENTINEL() };
 
-int TestSpan(void)
+int TestSpan()
 {
     nlTestSuite theSuite = { "CHIP Span tests", &sTests[0], nullptr, nullptr };
 

--- a/src/lib/support/tests/TestStringBuilder.cpp
+++ b/src/lib/support/tests/TestStringBuilder.cpp
@@ -87,7 +87,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestStringBuilder(void)
+int TestStringBuilder()
 {
     nlTestSuite theSuite = { "StringBuilder", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
+++ b/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
@@ -347,7 +347,7 @@ const nlTest sTests[] = { NL_TEST_DEF("Test basic API", TestBasicApi),
 
 } // namespace
 
-int TestTestPersistentStorageDelegate(void)
+int TestTestPersistentStorageDelegate()
 {
     nlTestSuite theSuite = { "TestPersistentStorageDelegate tests", &sTests[0], nullptr, nullptr };
 

--- a/src/lib/support/tests/TestThreadOperationalDataset.cpp
+++ b/src/lib/support/tests/TestThreadOperationalDataset.cpp
@@ -288,7 +288,7 @@ const nlTest sTests[] = {
 
 } // namespace
 
-int TestThreadOperationalDatasetBuilder(void)
+int TestThreadOperationalDatasetBuilder()
 {
     nlTestSuite theSuite = { "ThreadOperationalDataset", sTests, nullptr, nullptr };
 

--- a/src/lib/support/tests/TestTimeUtils.cpp
+++ b/src/lib/support/tests/TestTimeUtils.cpp
@@ -1021,7 +1021,7 @@ void TestChipEpochTimeConversion()
     }
 }
 
-int TestTimeUtils(void)
+int TestTimeUtils()
 {
     TestOrdinalDateConversion();
     TestDaysSinceEpochConversion();

--- a/src/lib/support/tests/TestTlvToJson.cpp
+++ b/src/lib/support/tests/TestTlvToJson.cpp
@@ -237,7 +237,7 @@ const nlTest sTests[] = { NL_TEST_DEF("TestConverter", TestConverter), NL_TEST_S
 
 } // namespace
 
-int TestTlvJson(void)
+int TestTlvJson()
 {
     nlTestSuite theSuite = { "TlvJson", sTests, Initialize, Finalize };
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/support/tests/TestZclString.cpp
+++ b/src/lib/support/tests/TestZclString.cpp
@@ -167,7 +167,7 @@ static const nlTest sTests[] = { NL_TEST_DEF_FN(TestZclStringWhenBufferIsZero),
                                  NL_TEST_DEF_FN(TestZclStringBiggerThanMaximumSize_Length_257),
                                  NL_TEST_SENTINEL() };
 
-int TestZclString(void)
+int TestZclString()
 {
     nlTestSuite theSuite = { "CHIP Memory Allocation tests", &sTests[0], TestZclString_Setup, TestZclString_Teardown };
 

--- a/src/messaging/tests/echo/common.cpp
+++ b/src/messaging/tests/echo/common.cpp
@@ -36,7 +36,7 @@ chip::Messaging::ExchangeManager gExchangeManager;
 chip::secure_channel::MessageCounterManager gMessageCounterManager;
 chip::TestPersistentStorageDelegate gStorage;
 
-void InitializeChip(void)
+void InitializeChip()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -62,7 +62,7 @@ exit:
     }
 }
 
-void ShutdownChip(void)
+void ShutdownChip()
 {
     gMessageCounterManager.Shutdown();
     gExchangeManager.Shutdown();

--- a/src/platform/Darwin/BLEManagerImpl.cpp
+++ b/src/platform/Darwin/BLEManagerImpl.cpp
@@ -88,7 +88,7 @@ void BLEManagerImpl::_Shutdown()
     }
 }
 
-bool BLEManagerImpl::_IsAdvertisingEnabled(void)
+bool BLEManagerImpl::_IsAdvertisingEnabled()
 {
     ChipLogDetail(DeviceLayer, "%s", __FUNCTION__);
     return false;
@@ -106,7 +106,7 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingMode(BLEAdvertisingMode mode)
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-bool BLEManagerImpl::_IsAdvertising(void)
+bool BLEManagerImpl::_IsAdvertising()
 {
     ChipLogDetail(DeviceLayer, "%s", __FUNCTION__);
     return false;
@@ -129,7 +129,7 @@ BleLayer * BLEManagerImpl::_GetBleLayer()
     return this;
 }
 
-uint16_t BLEManagerImpl::_NumConnections(void)
+uint16_t BLEManagerImpl::_NumConnections()
 {
     ChipLogDetail(DeviceLayer, "%s", __FUNCTION__);
     return 0;

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -487,7 +487,7 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
 #endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
+void ConfigurationManagerImpl::RunConfigUnitTest()
 {
 #if CHIP_DISABLE_PLATFORM_KVS
     return;

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -184,7 +184,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR PosixConfig::FactoryResetConfig(void)
+CHIP_ERROR PosixConfig::FactoryResetConfig()
 {
     CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
     SuccessOrExit(err);

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -292,7 +292,7 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return PosixConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
+void ConfigurationManagerImpl::RunConfigUnitTest()
 {
     PosixConfig::RunConfigUnitTest();
 }

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -167,7 +167,7 @@ exit:
     return false;
 }
 
-static bool __IsScanFilterSupported(void)
+static bool __IsScanFilterSupported()
 {
     // Tizen API: bt_adapter_le_is_scan_filter_supported() is currently internal
     // Defaulting to true
@@ -221,7 +221,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipDeviceScanner::StopChipScan(void)
+CHIP_ERROR ChipDeviceScanner::StopChipScan()
 {
     int ret = BT_ERROR_NONE;
     ReturnErrorCodeIf(!mIsScanning, CHIP_ERROR_INCORRECT_STATE);
@@ -245,7 +245,7 @@ CHIP_ERROR ChipDeviceScanner::StopChipScan(void)
     return CHIP_NO_ERROR;
 }
 
-void ChipDeviceScanner::UnRegisterScanFilter(void)
+void ChipDeviceScanner::UnRegisterScanFilter()
 {
     if (mScanFilter)
     {

--- a/src/platform/Tizen/ConfigurationManagerImpl.cpp
+++ b/src/platform/Tizen/ConfigurationManagerImpl.cpp
@@ -43,7 +43,7 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
     return sInstance;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::Init(void)
+CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR error;
 
@@ -88,12 +88,12 @@ CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 #endif
 }
 
-bool ConfigurationManagerImpl::CanFactoryReset(void)
+bool ConfigurationManagerImpl::CanFactoryReset()
 {
     return true;
 }
 
-void ConfigurationManagerImpl::InitiateFactoryReset(void) {}
+void ConfigurationManagerImpl::InitiateFactoryReset() {}
 
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(Platform::PersistedStorage::Key key, uint32_t & value)
 {
@@ -170,7 +170,7 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return Internal::PosixConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
+void ConfigurationManagerImpl::RunConfigUnitTest()
 {
     Internal::PosixConfig::RunConfigUnitTest();
 }

--- a/src/platform/Tizen/ConnectivityManagerImpl.cpp
+++ b/src/platform/Tizen/ConnectivityManagerImpl.cpp
@@ -50,7 +50,7 @@ namespace DeviceLayer {
 
 ConnectivityManagerImpl ConnectivityManagerImpl::sInstance;
 
-CHIP_ERROR ConnectivityManagerImpl::_Init(void)
+CHIP_ERROR ConnectivityManagerImpl::_Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -72,7 +72,7 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event) {}
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
-ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMode(void)
+ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMode()
 {
     CHIP_ERROR err                          = CHIP_NO_ERROR;
     wifi_manager_device_state_e deviceState = WIFI_MANAGER_DEVICE_STATE_DEACTIVATED;
@@ -113,7 +113,7 @@ CHIP_ERROR ConnectivityManagerImpl::_SetWiFiStationMode(ConnectivityManager::WiF
     return err;
 }
 
-System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiStationReconnectInterval(void)
+System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiStationReconnectInterval()
 {
     return mWiFiStationReconnectInterval;
 }
@@ -125,7 +125,7 @@ CHIP_ERROR ConnectivityManagerImpl::_SetWiFiStationReconnectInterval(System::Clo
     return CHIP_NO_ERROR;
 }
 
-bool ConnectivityManagerImpl::_IsWiFiStationEnabled(void)
+bool ConnectivityManagerImpl::_IsWiFiStationEnabled()
 {
     bool isWiFiStationEnabled = false;
 
@@ -134,7 +134,7 @@ bool ConnectivityManagerImpl::_IsWiFiStationEnabled(void)
     return isWiFiStationEnabled;
 }
 
-bool ConnectivityManagerImpl::_IsWiFiStationConnected(void)
+bool ConnectivityManagerImpl::_IsWiFiStationConnected()
 {
     CHIP_ERROR err                                  = CHIP_NO_ERROR;
     wifi_manager_connection_state_e connectionState = WIFI_MANAGER_CONNECTION_STATE_DISCONNECTED;
@@ -149,7 +149,7 @@ bool ConnectivityManagerImpl::_IsWiFiStationConnected(void)
     return isWiFiStationConnected;
 }
 
-bool ConnectivityManagerImpl::_IsWiFiStationProvisioned(void)
+bool ConnectivityManagerImpl::_IsWiFiStationProvisioned()
 {
     CHIP_ERROR err                                  = CHIP_NO_ERROR;
     wifi_manager_connection_state_e connectionState = WIFI_MANAGER_CONNECTION_STATE_DISCONNECTED;
@@ -164,12 +164,12 @@ bool ConnectivityManagerImpl::_IsWiFiStationProvisioned(void)
     return isWiFiStationProvisioned;
 }
 
-void ConnectivityManagerImpl::_ClearWiFiStationProvision(void)
+void ConnectivityManagerImpl::_ClearWiFiStationProvision()
 {
     Internal::WiFiMgr().RemoveAllConfigs();
 }
 
-bool ConnectivityManagerImpl::_CanStartWiFiScan(void)
+bool ConnectivityManagerImpl::_CanStartWiFiScan()
 {
     return false;
 }
@@ -189,20 +189,20 @@ bool ConnectivityManagerImpl::_IsWiFiAPActive()
     return mWiFiAPState == kWiFiAPState_Active;
 }
 
-void ConnectivityManagerImpl::_DemandStartWiFiAP(void) {}
+void ConnectivityManagerImpl::_DemandStartWiFiAP() {}
 
-void ConnectivityManagerImpl::_StopOnDemandWiFiAP(void) {}
+void ConnectivityManagerImpl::_StopOnDemandWiFiAP() {}
 
-void ConnectivityManagerImpl::_MaintainOnDemandWiFiAP(void) {}
+void ConnectivityManagerImpl::_MaintainOnDemandWiFiAP() {}
 
 void ConnectivityManagerImpl::_SetWiFiAPIdleTimeout(System::Clock::Timeout val) {}
 
-void ConnectivityManagerImpl::StartWiFiManagement(void)
+void ConnectivityManagerImpl::StartWiFiManagement()
 {
     SystemLayer().ScheduleWork(ActivateWiFiManager, nullptr);
 }
 
-void ConnectivityManagerImpl::StopWiFiManagement(void)
+void ConnectivityManagerImpl::StopWiFiManagement()
 {
     SystemLayer().ScheduleWork(DeactivateWiFiManager, nullptr);
 }

--- a/src/platform/Tizen/MainLoop.cpp
+++ b/src/platform/Tizen/MainLoop.cpp
@@ -100,7 +100,7 @@ bool MainLoop::Init(initFn_t initFn, gpointer userData)
     return true;
 }
 
-void MainLoop::Deinit(void)
+void MainLoop::Deinit()
 {
     for (auto & loopData : mLoopData)
     {
@@ -144,7 +144,7 @@ bool MainLoop::AsyncRequest(asyncFn_t asyncFn, gpointer asyncUserData, guint tim
     return true;
 }
 
-MainLoop & MainLoop::Instance(void)
+MainLoop & MainLoop::Instance()
 {
     static MainLoop sMainLoop;
     return sMainLoop;

--- a/src/platform/Tizen/PlatformManagerImpl.cpp
+++ b/src/platform/Tizen/PlatformManagerImpl.cpp
@@ -36,7 +36,7 @@ namespace DeviceLayer {
 
 PlatformManagerImpl PlatformManagerImpl::sInstance;
 
-CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
+CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 {
     ReturnErrorOnFailure(Internal::PosixConfig::Init());
 

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -329,7 +329,7 @@ gboolean WiFiManager::_WiFiInitialize(gpointer userData)
     return true;
 }
 
-void WiFiManager::_WiFiDeinitialize(void)
+void WiFiManager::_WiFiDeinitialize()
 {
     int wifiErr = WIFI_MANAGER_ERROR_NONE;
 
@@ -421,7 +421,7 @@ gboolean WiFiManager::_WiFiConnect(GMainLoop * mainLoop, gpointer userData)
     return true;
 }
 
-void WiFiManager::_WiFiSetStates(void)
+void WiFiManager::_WiFiSetStates()
 {
     int wifiErr          = WIFI_MANAGER_ERROR_NONE;
     bool isWiFiActivated = false;
@@ -446,7 +446,7 @@ void WiFiManager::_WiFiSetStates(void)
     }
 }
 
-void WiFiManager::_WiFiSetCallbacks(void)
+void WiFiManager::_WiFiSetCallbacks()
 {
     int wifiErr = WIFI_MANAGER_ERROR_NONE;
 
@@ -493,7 +493,7 @@ void WiFiManager::_WiFiSetCallbacks(void)
     }
 }
 
-void WiFiManager::_WiFiUnsetCallbacks(void)
+void WiFiManager::_WiFiUnsetCallbacks()
 {
     int wifiErr = WIFI_MANAGER_ERROR_NONE;
 
@@ -558,7 +558,7 @@ void WiFiManager::_WiFiSetConnectionState(wifi_manager_connection_state_e connec
     ChipLogProgress(DeviceLayer, "Set WiFi connection state [%s]", __WiFiConnectionStateToStr(mConnectionState));
 }
 
-wifi_manager_ap_h WiFiManager::_WiFiGetFoundAP(void)
+wifi_manager_ap_h WiFiManager::_WiFiGetFoundAP()
 {
     int wifiErr               = WIFI_MANAGER_ERROR_NONE;
     wifi_manager_ap_h foundAp = nullptr;
@@ -576,7 +576,7 @@ wifi_manager_ap_h WiFiManager::_WiFiGetFoundAP(void)
     return foundAp;
 }
 
-void WiFiManager::Init(void)
+void WiFiManager::Init()
 {
     sInstance.mDeviceState     = WIFI_MANAGER_DEVICE_STATE_DEACTIVATED;
     sInstance.mModuleState     = WIFI_MANAGER_MODULE_STATE_DETACHED;
@@ -585,7 +585,7 @@ void WiFiManager::Init(void)
     MainLoop::Instance().Init(_WiFiInitialize);
 }
 
-void WiFiManager::Deinit(void)
+void WiFiManager::Deinit()
 {
     sInstance._WiFiDeinitialize();
     MainLoop::Instance().Deinit();
@@ -610,7 +610,7 @@ CHIP_ERROR WiFiManager::IsActivated(bool * isWiFiActivated)
     return err;
 }
 
-CHIP_ERROR WiFiManager::Activate(void)
+CHIP_ERROR WiFiManager::Activate()
 {
     CHIP_ERROR err       = CHIP_NO_ERROR;
     int wifiErr          = WIFI_MANAGER_ERROR_NONE;
@@ -633,7 +633,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR WiFiManager::Deactivate(void)
+CHIP_ERROR WiFiManager::Deactivate()
 {
     CHIP_ERROR err       = CHIP_NO_ERROR;
     int wifiErr          = WIFI_MANAGER_ERROR_NONE;
@@ -733,7 +733,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR WiFiManager::RemoveAllConfigs(void)
+CHIP_ERROR WiFiManager::RemoveAllConfigs()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     int wifiErr    = WIFI_MANAGER_ERROR_NONE;

--- a/src/platform/webos/BLEManagerImpl.cpp
+++ b/src/platform/webos/BLEManagerImpl.cpp
@@ -72,7 +72,7 @@ void HandleIncomingBleConnection(BLEEndPoint * bleEP)
     ChipLogProgress(DeviceLayer, "con rcvd");
 }
 
-void BLEManagerImpl::InitConnectionData(void)
+void BLEManagerImpl::InitConnectionData()
 {
     /* Initialize Hashmap */
     if (!mConnectionMap)
@@ -917,7 +917,7 @@ void BLEManagerImpl::NotifyBLEPeripheralAdvStopComplete(bool aIsSuccess, void * 
     PlatformMgr().PostEventOrDie(&event);
 }
 
-void BLEManagerImpl::OnChipScanComplete(void)
+void BLEManagerImpl::OnChipScanComplete()
 {
     if (mBLEScanConfig.mBleScanState != BleScanState::kScanForDiscriminator &&
         mBLEScanConfig.mBleScanState != BleScanState::kScanForAddress)

--- a/src/platform/webos/ChipDeviceScanner.cpp
+++ b/src/platform/webos/ChipDeviceScanner.cpp
@@ -322,7 +322,7 @@ bool ChipDeviceScanner::cancelDiscoveryCb(LSHandle * sh, LSMessage * message, vo
     return true;
 }
 
-CHIP_ERROR ChipDeviceScanner::StopChipScan(void)
+CHIP_ERROR ChipDeviceScanner::StopChipScan()
 {
     int ret = 0;
     ReturnErrorCodeIf(!mIsScanning, CHIP_ERROR_INCORRECT_STATE);

--- a/src/platform/webos/ConfigurationManagerImpl.cpp
+++ b/src/platform/webos/ConfigurationManagerImpl.cpp
@@ -285,7 +285,7 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return PosixConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
+void ConfigurationManagerImpl::RunConfigUnitTest()
 {
     PosixConfig::RunConfigUnitTest();
 }

--- a/src/platform/webos/MainLoop.cpp
+++ b/src/platform/webos/MainLoop.cpp
@@ -140,7 +140,7 @@ void MainLoop::DeleteData(LoopData * loopData)
     chip::Platform::Delete(loopData);
 }
 
-void MainLoop::Deinit(void)
+void MainLoop::Deinit()
 {
     std::vector<LoopData *>::const_iterator iter = mLoopData.cbegin();
     while (iter != mLoopData.cend())
@@ -203,7 +203,7 @@ gpointer MainLoop::ThreadStartLSMainLoopHandler(gpointer data)
     return NULL;
 }
 
-bool MainLoop::StartLSMainLoop(void)
+bool MainLoop::StartLSMainLoop()
 {
     bool result = true;
     LSError lserror;
@@ -238,7 +238,7 @@ bool MainLoop::StartLSMainLoop(void)
     return result;
 }
 
-MainLoop & MainLoop::Instance(void)
+MainLoop & MainLoop::Instance()
 {
     static MainLoop sMainLoop;
     return sMainLoop;

--- a/src/system/tests/TestSystemClock.cpp
+++ b/src/system/tests/TestSystemClock.cpp
@@ -115,7 +115,7 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
-int TestSystemClock(void)
+int TestSystemClock()
 {
     nlTestSuite theSuite = {
         "chip-systemclock", &sTests[0], nullptr /* setup */, nullptr /* teardown */

--- a/src/system/tests/TestSystemErrorStr.cpp
+++ b/src/system/tests/TestSystemErrorStr.cpp
@@ -97,7 +97,7 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
-int TestSystemErrorStr(void)
+int TestSystemErrorStr()
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -2008,7 +2008,7 @@ const nlTest sTests[] =
 };
 // clang-format on
 
-int TestSystemPacketBuffer(void)
+int TestSystemPacketBuffer()
 {
     // clang-format off
     nlTestSuite theSuite = {

--- a/src/system/tests/TestSystemScheduleLambda.cpp
+++ b/src/system/tests/TestSystemScheduleLambda.cpp
@@ -83,7 +83,7 @@ static int TestTeardown(void * aContext)
     return (SUCCESS);
 }
 
-int TestSystemScheduleLambda(void)
+int TestSystemScheduleLambda()
 {
     // Run test suit againt one lContext.
     nlTestRunner(&kTheSuite, nullptr);

--- a/src/system/tests/TestSystemScheduleWork.cpp
+++ b/src/system/tests/TestSystemScheduleWork.cpp
@@ -96,7 +96,7 @@ static int TestTeardown(void * aContext)
     return (SUCCESS);
 }
 
-int TestSystemScheduleWork(void)
+int TestSystemScheduleWork()
 {
     // Run test suit againt one lContext.
     nlTestRunner(&kTheSuite, nullptr);

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -658,7 +658,7 @@ static int TestTeardown(void * aContext)
     return (SUCCESS);
 }
 
-int TestSystemTimer(void)
+int TestSystemTimer()
 {
     return chip::ExecuteTestsWithContext<TestContext>(&kTheSuite);
 }

--- a/src/system/tests/TestSystemWakeEvent.cpp
+++ b/src/system/tests/TestSystemWakeEvent.cpp
@@ -182,7 +182,7 @@ static const nlTest sTests[] =
 
 static nlTestSuite kTheSuite = { "chip-system-wake-event", sTests };
 
-int TestSystemWakeEvent(void)
+int TestSystemWakeEvent()
 {
     return chip::ExecuteTestsWithContext<TestContext>(&kTheSuite);
 }

--- a/src/system/tests/TestTimeSource.cpp
+++ b/src/system/tests/TestTimeSource.cpp
@@ -78,7 +78,7 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
-int TestTimeSource(void)
+int TestTimeSource()
 {
     nlTestSuite theSuite = {
         "chip-timesource", &sTests[0], nullptr /* setup */, nullptr /* teardown */

--- a/src/tools/chip-cert/chip-cert.cpp
+++ b/src/tools/chip-cert/chip-cert.cpp
@@ -76,7 +76,7 @@ const char * const sHelp =
  * @return Unconditionally returns true.
  *
  */
-bool PrintVersion(void)
+bool PrintVersion()
 {
     printf("chip " CHIP_VERSION_STRING "\n" COPYRIGHT_STRING);
 

--- a/src/tools/spake2p/spake2p.cpp
+++ b/src/tools/spake2p/spake2p.cpp
@@ -53,7 +53,7 @@ const char * const sHelp =
  * @return Unconditionally returns true.
  *
  */
-bool PrintVersion(void)
+bool PrintVersion()
 {
     printf("chip " CHIP_VERSION_STRING "\n" COPYRIGHT_STRING);
 

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -548,7 +548,7 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
-int TestMessageHeader(void)
+int TestMessageHeader()
 {
     nlTestSuite theSuite = { "Transport-MessageHeader", &sTests[0], nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);

--- a/src/transport/raw/tests/TestPeerAddress.cpp
+++ b/src/transport/raw/tests/TestPeerAddress.cpp
@@ -124,7 +124,7 @@ const nlTest sTests[] =
 
 } // namespace
 
-int TestPeerAddress(void)
+int TestPeerAddress()
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -162,7 +162,7 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
-int TestPeerConnectionsFn(void)
+int TestPeerConnectionsFn()
 {
     nlTestSuite theSuite = { "Transport-SecureSessionTable", &sTests[0], Initialize, Finalize };
     nlTestRunner(&theSuite, nullptr);


### PR DESCRIPTION
### Problem

For C++ code in functions without arguments void arg is not necessary. Since Matter SDK is C++ project it seems reasonable to enforce such style with clang-format.

### Changes

* add modernize-redundant-void-arg to clang-format checks
* remove redundant `void` from functions

### Testing

CI will test that