### PR TITLE
Automatically add tizen label to Tizen related PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -216,3 +216,7 @@ zephyr:
 telink:
     - src/platform/telink/*
     - src/platform/telink/**/*
+
+tizen:
+    - src/platform/Tizen/*
+    - src/platform/Tizen/**/*


### PR DESCRIPTION
### Problem

Currently it's hard to track Tizen platform related PRs - there is no dedicated label

### Changes

Add "tizen" label to github-action bot