### PR TITLE
Run zap in parallel by default for zap_regen_all.py

### DIFF
--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -32,6 +32,7 @@ class CmdLineArgs:
     templateFile: str
     outputDir: str
     runBootstrap: bool
+    parallel: bool = True
 
 
 CHIP_ROOT_DIR = os.path.realpath(
@@ -103,6 +104,9 @@ def runArgumentsParser() -> CmdLineArgs:
                         help='Output directory for the generated files (default: automatically selected)')
     parser.add_argument('--run-bootstrap', default=None, action='store_true',
                         help='Automatically run ZAP bootstrap. By default the bootstrap is not triggered')
+    parser.add_argument('--parallel', action='store_true')
+    parser.add_argument('--no-parallel', action='store_false', dest='parallel')
+    parser.set_defaults(parallel=True)
     args = parser.parse_args()
 
     # By default, this script assumes that the global CHIP template is used with

--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -259,6 +259,11 @@ def main():
 
     # The maximum memory usage is over 4GB (#15620)
     os.environ["NODE_OPTIONS"] = "--max-old-space-size=8192"
+
+    if cmdLineArgs.parallel:
+        # Parallel-compatible runs will need separate state
+        os.environ["ZAP_TEMPSTATE"] = "1"
+
     runGeneration(cmdLineArgs.zapFile, cmdLineArgs.zclFile, cmdLineArgs.templateFile, cmdLineArgs.outputDir)
 
     prettifiers = [

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -119,7 +119,7 @@ def setupArgumentsParser():
     parser.add_argument('--parallel', action='store_true')
     parser.add_argument('--no-parallel', action='store_false', dest='parallel')
     parser.set_defaults(parallel=True)
-                        
+
     return parser.parse_args()
 
 
@@ -259,12 +259,14 @@ def getTargets(type, test_target):
 
     return targets
 
+
 def _ParallelGenerateOne(target):
     """
     Helper method to be passed to multiprocessing parallel generation of
     items.
     """
     target.generate()
+
 
 def main():
     logging.basicConfig(

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -21,6 +21,8 @@ from pathlib import Path
 import sys
 import subprocess
 import logging
+import multiprocessing
+
 from dataclasses import dataclass
 
 CHIP_ROOT_DIR = os.path.realpath(
@@ -113,6 +115,11 @@ def setupArgumentsParser():
                         help="Don't do any generation, just log what targets would be generated (default: False)")
     parser.add_argument('--run-bootstrap', default=None, action='store_true',
                         help='Automatically run ZAP bootstrap. By default the bootstrap is not triggered')
+
+    parser.add_argument('--parallel', action='store_true')
+    parser.add_argument('--no-parallel', action='store_false', dest='parallel')
+    parser.set_defaults(parallel=True)
+                        
     return parser.parse_args()
 
 
@@ -252,6 +259,12 @@ def getTargets(type, test_target):
 
     return targets
 
+def _ParallelGenerateOne(target):
+    """
+    Helper method to be passed to multiprocessing parallel generation of
+    items.
+    """
+    target.generate()
 
 def main():
     logging.basicConfig(
@@ -269,8 +282,15 @@ def main():
         if args.run_bootstrap:
             subprocess.check_call(os.path.join(CHIP_ROOT_DIR, "scripts/tools/zap/zap_bootstrap.sh"), shell=True)
 
-        for target in targets:
-            target.generate()
+        if args.parallel:
+            # Ensure each zap run is independent
+            os.environ['ZAP_TEMPSTATE'] = '1'
+            with multiprocessing.Pool() as pool:
+                for _ in pool.imap_unordered(_ParallelGenerateOne, targets):
+                    pass
+        else:
+            for target in targets:
+                target.generate()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It seems that `ZAP_TEMPDIR=1` allows zap to not conflict with itself. This allows significant parallelism. There seems to still be some wait state to me (I see zap has a default cleanup state of 1.5 seconds) but on my 12 core machine I still see a 2.5x speedup in regen_all.

We may want to experiment later with maybe increasing parallelism beyond number of cores to take into account that zap seems to be I/O bound at times (unsure what the issue is ... but I do not get it currently to use 100% cpu even with this multiprocessing setting).