### PR TITLE
[crypto] Added target type to the P256KeyPair initialize method

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -421,7 +421,7 @@ CHIP_ERROR CHIPCommand::InitializeCommissioner(const CommissionerIdentity & iden
         chip::MutableByteSpan icacSpan(icac.Get(), chip::Controller::kMaxCHIPDERCertLength);
         chip::MutableByteSpan rcacSpan(rcac.Get(), chip::Controller::kMaxCHIPDERCertLength);
 
-        ReturnLogErrorOnFailure(ephemeralKey.Initialize());
+        ReturnLogErrorOnFailure(ephemeralKey.Initialize(chip::Crypto::ECPKeyTarget::ECDSA));
 
         ReturnLogErrorOnFailure(mCredIssuerCmds->GenerateControllerNOCChain(identity.mLocalNodeId, fabricId,
                                                                             mCommissionerStorage.GetCommissionerCATs(),

--- a/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
@@ -31,7 +31,7 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
 
 - (BOOL)initialize
 {
-    return _mKeyPair.Initialize() == CHIP_NO_ERROR;
+    return _mKeyPair.Initialize(chip::Crypto::ECPKeyTarget::ECDSA) == CHIP_NO_ERROR;
 }
 
 - (NSData *)signMessageECDSA_RAW:(NSData *)message

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -171,7 +171,7 @@ CHIP_ERROR InitCommissioner(uint16_t commissionerPort, uint16_t udcListenPort, F
     MutableByteSpan rcacSpan(rcac.Get(), Controller::kMaxCHIPDERCertLength);
 
     Crypto::P256Keypair ephemeralKey;
-    ReturnErrorOnFailure(ephemeralKey.Initialize());
+    ReturnErrorOnFailure(ephemeralKey.Initialize(Crypto::ECPKeyTarget::ECDSA));
 
     ReturnErrorOnFailure(gOpCredsIssuer.GenerateNOCChainAfterValidation(gLocalId, /* fabricId = */ 1, chip::kUndefinedCATs,
                                                                         ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan));

--- a/examples/platform/nxp/se05x/DeviceAttestationSe05xCredsExample.cpp
+++ b/examples/platform/nxp/se05x/DeviceAttestationSe05xCredsExample.cpp
@@ -145,7 +145,7 @@ CHIP_ERROR ExampleSe05xDACProvider::SignWithDeviceAttestationKey(const ByteSpan 
 
     keypair.SetKeyId(DEV_ATTESTATION_KEY_SE05X_ID);
     keypair.provisioned_key = true;
-    keypair.Initialize();
+    keypair.Initialize(Crypto::ECPKeyTarget::ECDSA);
 
     ReturnErrorOnFailure(keypair.ECDSA_sign_msg(message_to_sign.data(), message_to_sign.size(), signature));
 

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -182,7 +182,7 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
     {
         ChipLogProgress(Controller, "Couldn't get %s from storage: %s", kOperationalCredentialsIssuerKeypairStorage, ErrorStr(err));
         // Storage doesn't have an existing keypair. Let's create one and add it to the storage.
-        ReturnErrorOnFailure(mIssuer.Initialize());
+        ReturnErrorOnFailure(mIssuer.Initialize(Crypto::ECPKeyTarget::ECDSA));
         ReturnErrorOnFailure(mIssuer.Serialize(serializedKey));
 
         PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIssuerKeypairStorage, key,
@@ -209,7 +209,7 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
         ChipLogProgress(Controller, "Couldn't get %s from storage: %s", kOperationalCredentialsIntermediateIssuerKeypairStorage,
                         ErrorStr(err));
         // Storage doesn't have an existing keypair. Let's create one and add it to the storage.
-        ReturnErrorOnFailure(mIntermediateIssuer.Initialize());
+        ReturnErrorOnFailure(mIntermediateIssuer.Initialize(Crypto::ECPKeyTarget::ECDSA));
         ReturnErrorOnFailure(mIntermediateIssuer.Serialize(serializedKey));
 
         PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIntermediateIssuerKeypairStorage, key,

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -235,7 +235,7 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     {
         CHIPP256KeypairBridge * nativeKeypairBridge = wrapper->GetP256KeypairBridge();
         nativeKeypairBridge->SetDelegate(keypairDelegate);
-        *errInfoOnFailure = nativeKeypairBridge->Initialize();
+        *errInfoOnFailure = nativeKeypairBridge->Initialize(Crypto::ECPKeyTarget::ECDSA);
         if (*errInfoOnFailure != CHIP_NO_ERROR)
         {
             return nullptr;
@@ -272,7 +272,7 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
         ChipLogProgress(Controller,
                         "No existing credentials provided: generating ephemeral local NOC chain with OperationalCredentialsIssuer");
 
-        *errInfoOnFailure = ephemeralKey.Initialize();
+        *errInfoOnFailure = ephemeralKey.Initialize(Crypto::ECPKeyTarget::ECDSA);
         if (*errInfoOnFailure != CHIP_NO_ERROR)
         {
             return nullptr;

--- a/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
@@ -68,7 +68,7 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::Initialize(PersistentStorageDele
     if (storage.SyncGetKeyValue(kOperationalCredentialsIssuerKeypairStorage, &serializedKey, keySize) != CHIP_NO_ERROR)
     {
         // Storage doesn't have an existing keypair. Let's create one and add it to the storage.
-        ReturnErrorOnFailure(mIssuer.Initialize());
+        ReturnErrorOnFailure(mIssuer.Initialize(Crypto::ECPKeyTarget::ECDSA));
         ReturnErrorOnFailure(mIssuer.Serialize(serializedKey));
 
         keySize = static_cast<uint16_t>(sizeof(serializedKey));

--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -343,7 +343,7 @@ PyChipError pychip_OpCreds_AllocateController(OpCredsContext * context, chip::Co
     SetDeviceAttestationVerifier(GetDefaultDACVerifier(testingRootStore));
 
     chip::Crypto::P256Keypair ephemeralKey;
-    CHIP_ERROR err = ephemeralKey.Initialize();
+    CHIP_ERROR err = ephemeralKey.Initialize(chip::Crypto::ECPKeyTarget::ECDSA);
     VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> noc;

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -145,7 +145,7 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
 
         commissionerParams.pairingDelegate = &gPairingDelegate;
 
-        err = ephemeralKey.Initialize();
+        err = ephemeralKey.Initialize(chip::Crypto::ECPKeyTarget::ECDSA);
         SuccessOrExit(err);
 
         err = gOperationalCredentialsIssuer.Initialize(gServerStorage);

--- a/src/credentials/TestOnlyLocalCertificateAuthority.h
+++ b/src/credentials/TestOnlyLocalCertificateAuthority.h
@@ -74,7 +74,7 @@ public:
         }
         else
         {
-            mRootKeypair->Initialize();
+            mRootKeypair->Initialize(Crypto::ECPKeyTarget::ECDSA);
         }
         mCurrentStatus = GenerateRootCert(*mRootKeypair.get());
         SuccessOrExit(mCurrentStatus);
@@ -155,7 +155,7 @@ protected:
         ReturnErrorOnFailure(ExtractSubjectDNFromChipCert(ByteSpan{ mLastRcac.Get(), mLastRcac.AllocatedSize() }, rcac_dn));
 
         Crypto::P256Keypair icacKeypair;
-        ReturnErrorOnFailure(icacKeypair.Initialize()); // Maybe we won't use it, but it's OK
+        ReturnErrorOnFailure(icacKeypair.Initialize(Crypto::ECPKeyTarget::ECDSA)); // Maybe we won't use it, but it's OK
 
         Crypto::P256Keypair * nocIssuerKeypair = mRootKeypair.get();
         ChipDN * issuer_dn                     = &rcac_dn;

--- a/src/credentials/tests/TestCertificationDeclaration.cpp
+++ b/src/credentials/tests/TestCertificationDeclaration.cpp
@@ -355,7 +355,7 @@ static void TestCD_CMSSignAndVerify(nlTestSuite * inSuite, void * inContext)
 
     // Test with random key
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, CMS_Sign(cdContentIn, signerKeyId, keypair, signedMessage) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, CMS_Verify(signedMessage, keypair.Pubkey(), cdContentOut) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, cdContentIn.data_equal(cdContentOut));

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -1234,7 +1234,7 @@ static void TestChipCert_GenerateRootCert(nlTestSuite * inSuite, void * inContex
 {
     // Generate a new keypair for cert signing
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
 
@@ -1289,7 +1289,7 @@ static void TestChipCert_GenerateRootFabCert(nlTestSuite * inSuite, void * inCon
 {
     // Generate a new keypair for cert signing
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
 
@@ -1316,7 +1316,7 @@ static void TestChipCert_GenerateICACert(nlTestSuite * inSuite, void * inContext
 {
     // Generate a new keypair for cert signing
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
 
@@ -1332,7 +1332,7 @@ static void TestChipCert_GenerateICACert(nlTestSuite * inSuite, void * inContext
 
     X509CertRequestParams ica_params = { 1234, 631161876, 729942000, ica_dn, issuer_dn };
     P256Keypair ica_keypair;
-    NL_TEST_ASSERT(inSuite, ica_keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, ica_keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     MutableByteSpan signed_cert_span(signed_cert);
     NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params, ica_keypair.Pubkey(), keypair, signed_cert_span) == CHIP_NO_ERROR);
@@ -1370,7 +1370,7 @@ static void TestChipCert_GenerateNOCRoot(nlTestSuite * inSuite, void * inContext
 {
     // Generate a new keypair for cert signing
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
 
@@ -1387,7 +1387,7 @@ static void TestChipCert_GenerateNOCRoot(nlTestSuite * inSuite, void * inContext
 
     X509CertRequestParams noc_params = { 123456, 631161876, 729942000, noc_dn, issuer_dn };
     P256Keypair noc_keypair;
-    NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, noc_keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     MutableByteSpan signed_cert_span(signed_cert, sizeof(signed_cert));
     NL_TEST_ASSERT(inSuite,
@@ -1441,7 +1441,7 @@ static void TestChipCert_GenerateNOCICA(nlTestSuite * inSuite, void * inContext)
 {
     // Generate a new keypair for cert signing
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
 
@@ -1471,7 +1471,7 @@ static void TestChipCert_GenerateNOCICA(nlTestSuite * inSuite, void * inContext)
 
     X509CertRequestParams noc_params = { 12348765, 631161876, 729942000, noc_dn, ica_dn };
     P256Keypair noc_keypair;
-    NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, noc_keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     MutableByteSpan signed_cert_span(signed_cert);
     NL_TEST_ASSERT(inSuite,
@@ -1489,7 +1489,7 @@ static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inCo
 {
     // Generate a new keypair for cert signing
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     static uint8_t root_cert[kMaxDERCertLength];
 
@@ -1509,7 +1509,7 @@ static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inCo
 
     X509CertRequestParams ica_params = { 12345, 631161876, 729942000, ica_dn, root_dn };
     P256Keypair ica_keypair;
-    NL_TEST_ASSERT(inSuite, ica_keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, ica_keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     MutableByteSpan ica_cert_span(ica_cert);
     NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params, ica_keypair.Pubkey(), keypair, ica_cert_span) == CHIP_NO_ERROR);
@@ -1522,7 +1522,7 @@ static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inCo
 
     X509CertRequestParams noc_params = { 123456, 631161876, 729942000, noc_dn, ica_dn };
     P256Keypair noc_keypair;
-    NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, noc_keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     MutableByteSpan noc_cert_span(noc_cert, sizeof(noc_cert));
     NL_TEST_ASSERT(inSuite,
@@ -1567,7 +1567,7 @@ static void TestChipCert_VerifyGeneratedCertsNoICA(nlTestSuite * inSuite, void *
 {
     // Generate a new keypair for cert signing
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     static uint8_t root_cert[kMaxDERCertLength];
 
@@ -1594,7 +1594,7 @@ static void TestChipCert_VerifyGeneratedCertsNoICA(nlTestSuite * inSuite, void *
 
     X509CertRequestParams noc_params = { 1234, 631161876, 729942000, noc_dn, root_dn };
     P256Keypair noc_keypair;
-    NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, noc_keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     MutableByteSpan noc_cert_span(noc_cert);
     NL_TEST_ASSERT(inSuite, NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, noc_cert_span) == CHIP_NO_ERROR);

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -514,7 +514,7 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
     constexpr uint16_t kVendorId = 0xFFF1u;
 
     chip::Crypto::P256Keypair fabric11Node55Keypair; // Fabric ID 11,
-    NL_TEST_ASSERT(inSuite, fabric11Node55Keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, fabric11Node55Keypair.Initialize(Crypto::ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     // Initialize a fabric table.
     ScopedFabricTable fabricTableHolder;
@@ -2523,7 +2523,7 @@ void TestEphemeralKeys(nlTestSuite * inSuite, void * inContext)
 
         Crypto::P256Keypair * ephemeralKeypair = fabricTable.AllocateEphemeralKeypairForCASE();
         NL_TEST_ASSERT(inSuite, ephemeralKeypair != nullptr);
-        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Initialize());
+        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Initialize(Crypto::ECPKeyTarget::ECDSA));
 
         NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->ECDSA_sign_msg(message, sizeof(message), sig));
         NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Pubkey().ECDSA_validate_msg_signature(message, sizeof(message), sig));
@@ -2550,7 +2550,7 @@ void TestEphemeralKeys(nlTestSuite * inSuite, void * inContext)
 
         Crypto::P256Keypair * ephemeralKeypair = fabricTable.AllocateEphemeralKeypairForCASE();
         NL_TEST_ASSERT(inSuite, ephemeralKeypair != nullptr);
-        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Initialize());
+        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Initialize(Crypto::ECPKeyTarget::ECDSA));
 
         NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->ECDSA_sign_msg(message, sizeof(message), sig));
         NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Pubkey().ECDSA_validate_msg_signature(message, sizeof(message), sig));

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -170,6 +170,12 @@ enum class SupportedECPKeyTypes : uint8_t
     ECP256R1 = 0,
 };
 
+enum class ECPKeyTarget : uint8_t
+{
+    ECDH  = 0,
+    ECDSA = 1,
+};
+
 /** @brief Safely clears the first `len` bytes of memory area `buf`.
  * @param buf Pointer to a memory buffer holding secret data that must be cleared.
  * @param len Specifies secret data size in bytes.
@@ -385,7 +391,7 @@ public:
      * @brief Initialize the keypair.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    virtual CHIP_ERROR Initialize() = 0;
+    virtual CHIP_ERROR Initialize(ECPKeyTarget key_target) = 0;
 
     /**
      * @brief Serialize the keypair.
@@ -410,7 +416,7 @@ public:
      * @brief Initialize the keypair.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR Initialize() override;
+    CHIP_ERROR Initialize(ECPKeyTarget key_target) override;
 
     /**
      * @brief Serialize the keypair.

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -1020,7 +1020,7 @@ exit:
     return error;
 }
 
-CHIP_ERROR P256Keypair::Initialize()
+CHIP_ERROR P256Keypair::Initialize(ECPKeyTarget key_target)
 {
     ERR_clear_error();
 

--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -515,30 +515,6 @@ static inline const PsaP256KeypairContext & to_const_keypair_ctx(const P256Keypa
     return *SafePointerCast<const PsaP256KeypairContext *>(&context);
 }
 
-static psa_status_t ConvertEcdsaKeyToEcdh(psa_key_id_t * destination, psa_key_id_t source)
-{
-    psa_status_t status             = PSA_SUCCESS;
-    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    uint8_t privateKey[kP256_PrivateKey_Length];
-    size_t privateKeyLength;
-
-    status = psa_export_key(source, privateKey, sizeof(privateKey), &privateKeyLength);
-
-    if (status == PSA_SUCCESS)
-    {
-        // Type based on ECC with the elliptic curve SECP256r1 -> PSA_ECC_FAMILY_SECP_R1
-        // Algorithm Elliptic Curve Diffie-Hellman (ECDH)
-        psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
-        psa_set_key_bits(&attributes, kP256_PrivateKey_Length * 8);
-        psa_set_key_algorithm(&attributes, PSA_ALG_ECDH);
-        psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DERIVE);
-        status = psa_import_key(&attributes, privateKey, privateKeyLength, destination);
-    }
-
-    psa_reset_key_attributes(&attributes);
-    return status;
-}
-
 CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, P256ECDSASignature & out_signature) const
 {
     VerifyOrReturnError(mInitialized, CHIP_ERROR_WELL_UNINITIALIZED);
@@ -624,22 +600,17 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
 
     CHIP_ERROR error                      = CHIP_NO_ERROR;
     psa_status_t status                   = PSA_SUCCESS;
-    psa_key_id_t keyId                    = 0;
     const PsaP256KeypairContext & context = to_const_keypair_ctx(mKeypair);
     const size_t outputSize               = (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length();
     size_t outputLength;
 
-    status = ConvertEcdsaKeyToEcdh(&keyId, context.key_id);
-    VerifyOrExit(status == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
-
-    status = psa_raw_key_agreement(PSA_ALG_ECDH, keyId, remote_public_key.ConstBytes(), remote_public_key.Length(),
+    status = psa_raw_key_agreement(PSA_ALG_ECDH, context.key_id, remote_public_key.ConstBytes(), remote_public_key.Length(),
                                    out_secret.Bytes(), outputSize, &outputLength);
     VerifyOrExit(status == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
     SuccessOrExit(out_secret.SetLength(outputLength));
 
 exit:
     logPsaError(status);
-    psa_destroy_key(keyId);
 
     return error;
 }
@@ -675,7 +646,7 @@ bool IsBufferContentEqualConstantTime(const void * a, const void * b, size_t n)
     return mbedtls_ct_memcmp_copy(a, b, n) == 0;
 }
 
-CHIP_ERROR P256Keypair::Initialize()
+CHIP_ERROR P256Keypair::Initialize(ECPKeyTarget key_target)
 {
     VerifyOrReturnError(!mInitialized, CHIP_ERROR_INCORRECT_STATE);
 
@@ -686,11 +657,23 @@ CHIP_ERROR P256Keypair::Initialize()
     size_t publicKeyLength          = 0;
 
     // Type based on ECC with the elliptic curve SECP256r1 -> PSA_ECC_FAMILY_SECP_R1
-    // Algorithm Elliptic Curve Digital Signature Algorithm (ECDSA)
     psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
     psa_set_key_bits(&attributes, kP256_PrivateKey_Length * 8);
-    psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
-    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_SIGN_MESSAGE);
+
+    if (key_target == ECPKeyTarget::ECDH)
+    {
+        psa_set_key_algorithm(&attributes, PSA_ALG_ECDH);
+        psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DERIVE);
+    }
+    else if (key_target == ECPKeyTarget::ECDSA)
+    {
+        psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
+        psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_SIGN_MESSAGE);
+    }
+    else
+    {
+        ExitNow(error = CHIP_ERROR_UNKNOWN_KEY_TYPE);
+    }
 
     status = psa_generate_key(&attributes, &context.key_id);
     VerifyOrExit(status == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);

--- a/src/crypto/CHIPCryptoPALTinyCrypt.cpp
+++ b/src/crypto/CHIPCryptoPALTinyCrypt.cpp
@@ -629,7 +629,7 @@ bool IsBufferContentEqualConstantTime(const void * a, const void * b, size_t n)
     return mbedtls_ct_memcmp_copy(a, b, n) == 0;
 }
 
-CHIP_ERROR P256Keypair::Initialize()
+CHIP_ERROR P256Keypair::Initialize(ECPKeyTarget key_target)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = UECC_FAILURE;

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -712,7 +712,7 @@ bool IsBufferContentEqualConstantTime(const void * a, const void * b, size_t n)
     return mbedtls_ct_memcmp_copy(a, b, n) == 0;
 }
 
-CHIP_ERROR P256Keypair::Initialize()
+CHIP_ERROR P256Keypair::Initialize(ECPKeyTarget key_target)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;

--- a/src/crypto/PersistentStorageOperationalKeystore.cpp
+++ b/src/crypto/PersistentStorageOperationalKeystore.cpp
@@ -205,7 +205,7 @@ CHIP_ERROR PersistentStorageOperationalKeystore::NewOpKeypairForFabric(FabricInd
     mPendingKeypair = Platform::New<Crypto::P256Keypair>();
     VerifyOrReturnError(mPendingKeypair != nullptr, CHIP_ERROR_NO_MEMORY);
 
-    mPendingKeypair->Initialize();
+    mPendingKeypair->Initialize(Crypto::ECPKeyTarget::ECDSA);
     size_t csrLength = outCertificateSigningRequest.size();
     CHIP_ERROR err   = mPendingKeypair->NewCertificateSigningRequest(outCertificateSigningRequest.data(), csrLength);
     if (err != CHIP_NO_ERROR)

--- a/src/crypto/hsm/CHIPCryptoPALHsm.h
+++ b/src/crypto/hsm/CHIPCryptoPALHsm.h
@@ -124,7 +124,7 @@ public:
 
     ~P256KeypairHSM();
 
-    virtual CHIP_ERROR Initialize() override;
+    virtual CHIP_ERROR Initialize(ECPKeyTarget key_target) override;
 
     virtual CHIP_ERROR Serialize(P256SerializedKeypair & output) const override;
 

--- a/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_P256.cpp
+++ b/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_P256.cpp
@@ -63,7 +63,7 @@ P256KeypairHSM::~P256KeypairHSM()
     }
 }
 
-CHIP_ERROR P256KeypairHSM::Initialize()
+CHIP_ERROR P256KeypairHSM::Initialize(ECPKeyTarget key_target)
 {
     sss_object_t keyObject = { 0 };
     uint8_t pubkey[128]    = {

--- a/src/crypto/hsm/nxp/PersistentStorageOperationalKeystoreHSM.cpp
+++ b/src/crypto/hsm/nxp/PersistentStorageOperationalKeystoreHSM.cpp
@@ -114,7 +114,7 @@ CHIP_ERROR PersistentStorageOperationalKeystoreHSM::NewOpKeypairForFabric(Fabric
     // Key id is created as slotid + start offset of ops key id
     mPendingKeypair->SetKeyId(FABRIC_SE05X_KEYID_START + slotId);
 
-    err = mPendingKeypair->Initialize();
+    err = mPendingKeypair->Initialize(Crypto::ECPKeyTarget::ECDSA);
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_ERROR_NO_MEMORY);
 
     mPendingFabricIndex = fabricIndex;

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -839,7 +839,7 @@ static void TestECDSA_Signing_SHA256_Msg(nlTestSuite * inSuite, void * inContext
 
     Test_P256Keypair keypair;
 
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     P256ECDSASignature signature;
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(reinterpret_cast<const uint8_t *>(msg), msg_length, signature);
@@ -858,7 +858,7 @@ static void TestECDSA_Signing_SHA256_Hash(nlTestSuite * inSuite, void * inContex
     size_t msg_length   = sizeof(msg);
 
     Test_P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     // TODO: Need to make this large number (1k+) to catch some signature serialization corner cases
     //       but this is too slow on QEMU/embedded, so we need to parametrize. Signing with ECDSA
@@ -894,7 +894,7 @@ static void TestECDSA_ValidationFailsDifferentMessage(nlTestSuite * inSuite, voi
     size_t msg_length = strlen(msg);
 
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     P256ECDSASignature signature;
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(reinterpret_cast<const uint8_t *>(msg), msg_length, signature);
@@ -914,7 +914,7 @@ static void TestECDSA_ValidationFailIncorrectMsgSignature(nlTestSuite * inSuite,
     size_t msg_length = strlen(msg);
 
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     P256ECDSASignature signature;
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(reinterpret_cast<const uint8_t *>(msg), msg_length, signature);
@@ -937,7 +937,7 @@ static void TestECDSA_ValidationFailIncorrectHashSignature(nlTestSuite * inSuite
     NL_TEST_ASSERT(inSuite, Hash_SHA256(&msg[0], msg_length, &hash[0]) == CHIP_NO_ERROR);
 
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     P256ECDSASignature signature;
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(msg, msg_length, signature);
@@ -955,7 +955,7 @@ static void TestECDSA_SigningMsgInvalidParams(nlTestSuite * inSuite, void * inCo
     size_t msg_length   = strlen(reinterpret_cast<const char *>(msg));
 
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     P256ECDSASignature signature;
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(nullptr, msg_length, signature);
@@ -974,7 +974,7 @@ static void TestECDSA_ValidationMsgInvalidParam(nlTestSuite * inSuite, void * in
     size_t msg_length = strlen(msg);
 
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     P256ECDSASignature signature;
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(reinterpret_cast<const uint8_t *>(msg), msg_length, signature);
@@ -1000,7 +1000,7 @@ static void TestECDSA_ValidationHashInvalidParam(nlTestSuite * inSuite, void * i
     NL_TEST_ASSERT(inSuite, Hash_SHA256(&msg[0], msg_length, &hash[0]) == CHIP_NO_ERROR);
 
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     P256ECDSASignature signature;
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(msg, msg_length, signature);
@@ -1019,14 +1019,14 @@ static void TestECDH_EstablishSecret(nlTestSuite * inSuite, void * inContext)
 {
     HeapChecker heapChecker(inSuite);
     Test_P256Keypair keypair1;
-    NL_TEST_ASSERT(inSuite, keypair1.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair1.Initialize(ECPKeyTarget::ECDH) == CHIP_NO_ERROR);
 
 #ifdef ENABLE_HSM_EC_KEY
     Test_P256Keypair keypair2(HSM_ECC_KEYID + 1);
 #else
     Test_P256Keypair keypair2;
 #endif
-    NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair2.Initialize(ECPKeyTarget::ECDH) == CHIP_NO_ERROR);
 
     P256ECDHDerivedSecret out_secret1;
     out_secret1[0] = 0;
@@ -1125,7 +1125,7 @@ static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
 {
     HeapChecker heapChecker(inSuite);
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     const char * msg         = "Test Message for Keygen";
     const uint8_t * test_msg = Uint8::from_const_char(msg);
@@ -1308,7 +1308,7 @@ void TestCSR_GenDirect(nlTestSuite * inSuite, void * inContext)
 
     Test_P256Keypair keypair;
 
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     // Validate case of buffer too small
     uint8_t csrBufTooSmall[kMAX_CSR_Length - 1];
@@ -1351,7 +1351,7 @@ static void TestCSR_GenByKeypair(nlTestSuite * inSuite, void * inContext)
     size_t length = sizeof(csr);
 
     Test_P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, keypair.NewCertificateSigningRequest(csr, length) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, length > 0);
 
@@ -1380,7 +1380,7 @@ static void TestKeypair_Serialize(nlTestSuite * inSuite, void * inContext)
     HeapChecker heapChecker(inSuite);
     Test_P256Keypair keypair;
 
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     P256SerializedKeypair serialized;
     NL_TEST_ASSERT(inSuite, keypair.Serialize(serialized) == CHIP_NO_ERROR);

--- a/src/crypto/tests/TestPersistentStorageOpKeyStore.cpp
+++ b/src/crypto/tests/TestPersistentStorageOpKeyStore.cpp
@@ -206,7 +206,7 @@ void TestEphemeralKeys(nlTestSuite * inSuite, void * inContext)
 
     Crypto::P256Keypair * ephemeralKeypair = opKeyStore.AllocateEphemeralKeypairForCASE();
     NL_TEST_ASSERT(inSuite, ephemeralKeypair != nullptr);
-    NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Initialize());
+    NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Initialize(Crypto::ECPKeyTarget::ECDSA));
 
     NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->ECDSA_sign_msg(message, sizeof(message), sig));
     NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Pubkey().ECDSA_validate_msg_signature(message, sizeof(message), sig));

--- a/src/darwin/Framework/CHIP/MTRP256KeypairBridge.h
+++ b/src/darwin/Framework/CHIP/MTRP256KeypairBridge.h
@@ -31,7 +31,7 @@ public:
 
     bool HasKeypair() const { return mKeypair != nil; };
 
-    CHIP_ERROR Initialize() override;
+    CHIP_ERROR Initialize(chip::Crypto::ECPKeyTarget key_target) override;
 
     CHIP_ERROR Serialize(chip::Crypto::P256SerializedKeypair & output) const override;
 

--- a/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
@@ -39,7 +39,7 @@ CHIP_ERROR MTRP256KeypairBridge::Init(id<MTRKeypair> keypair)
     return setPubkey();
 }
 
-CHIP_ERROR MTRP256KeypairBridge::Initialize()
+CHIP_ERROR MTRP256KeypairBridge::Initialize(ECPKeyTarget key_target)
 {
     if (!HasKeypair()) {
         return CHIP_ERROR_INCORRECT_STATE;

--- a/src/platform/android/CHIPP256KeypairBridge.cpp
+++ b/src/platform/android/CHIPP256KeypairBridge.cpp
@@ -68,7 +68,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR CHIPP256KeypairBridge::Initialize()
+CHIP_ERROR CHIPP256KeypairBridge::Initialize(ECPKeyTarget key_target)
 {
     if (HasKeypair())
     {

--- a/src/platform/android/CHIPP256KeypairBridge.h
+++ b/src/platform/android/CHIPP256KeypairBridge.h
@@ -44,7 +44,7 @@ public:
 
     bool HasKeypair() const { return mDelegate != nullptr; }
 
-    CHIP_ERROR Initialize() override;
+    CHIP_ERROR Initialize(chip::Crypto::ECPKeyTarget key_target) override;
 
     CHIP_ERROR Serialize(chip::Crypto::P256SerializedKeypair & output) const override;
 

--- a/src/platform/silabs/EFR32/CHIPCryptoPALPsaEfr32.cpp
+++ b/src/platform/silabs/EFR32/CHIPCryptoPALPsaEfr32.cpp
@@ -822,7 +822,7 @@ bool IsBufferContentEqualConstantTime(const void * a, const void * b, size_t n)
     return mbedtls_ct_memcmp_copy(a, b, n) == 0;
 }
 
-CHIP_ERROR P256Keypair::Initialize()
+CHIP_ERROR P256Keypair::Initialize(ECPKeyTarget key_target)
 {
     CHIP_ERROR error                    = CHIP_NO_ERROR;
     psa_status_t status                 = PSA_ERROR_BAD_STATE;

--- a/src/platform/silabs/EFR32/Efr32OpaqueKeypair.h
+++ b/src/platform/silabs/EFR32/Efr32OpaqueKeypair.h
@@ -161,7 +161,7 @@ public:
      * @brief Initialize the keypair.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR Initialize() override;
+    CHIP_ERROR Initialize(chip::Crypto::ECPKeyTarget key_target) override;
 
     /**
      * @brief Serialize the keypair (unsupported on opaque keys)

--- a/src/platform/silabs/EFR32/Efr32PsaOpaqueKeypair.cpp
+++ b/src/platform/silabs/EFR32/Efr32PsaOpaqueKeypair.cpp
@@ -380,7 +380,7 @@ EFR32OpaqueP256Keypair::EFR32OpaqueP256Keypair()
 
 EFR32OpaqueP256Keypair::~EFR32OpaqueP256Keypair() {}
 
-CHIP_ERROR EFR32OpaqueP256Keypair::Initialize()
+CHIP_ERROR EFR32OpaqueP256Keypair::Initialize(chip::Crypto::ECPKeyTarget key_target)
 {
     if (mPubkeyLength > 0)
     {

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -404,7 +404,7 @@ CHIP_ERROR CASESession::SendSigma1()
     // Generate an ephemeral keypair
     mEphemeralKey = mFabricsTable->AllocateEphemeralKeypairForCASE();
     VerifyOrReturnError(mEphemeralKey != nullptr, CHIP_ERROR_NO_MEMORY);
-    ReturnErrorOnFailure(mEphemeralKey->Initialize());
+    ReturnErrorOnFailure(mEphemeralKey->Initialize(ECPKeyTarget::ECDH));
 
     // Fill in the random value
     ReturnErrorOnFailure(DRBG_get_bytes(mInitiatorRandom, sizeof(mInitiatorRandom)));
@@ -732,7 +732,7 @@ CHIP_ERROR CASESession::SendSigma2()
     // Generate an ephemeral keypair
     mEphemeralKey = mFabricsTable->AllocateEphemeralKeypairForCASE();
     VerifyOrReturnError(mEphemeralKey != nullptr, CHIP_ERROR_NO_MEMORY);
-    ReturnErrorOnFailure(mEphemeralKey->Initialize());
+    ReturnErrorOnFailure(mEphemeralKey->Initialize(ECPKeyTarget::ECDH));
 
     // Generate a Shared Secret
     ReturnErrorOnFailure(mEphemeralKey->ECDH_derive_secret(mRemotePubKey, mSharedSecret));

--- a/src/transport/tests/TestSecureSession.cpp
+++ b/src/transport/tests/TestSecureSession.cpp
@@ -39,10 +39,10 @@ void SecureChannelInitTest(nlTestSuite * inSuite, void * inContext)
     CryptoContext channel;
 
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDH) == CHIP_NO_ERROR);
 
     P256Keypair keypair2;
-    NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair2.Initialize(ECPKeyTarget::ECDH) == CHIP_NO_ERROR);
 
     // Test all combinations of invalid parameters
     NL_TEST_ASSERT(inSuite,
@@ -87,10 +87,10 @@ void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
     CryptoContext::BuildNonce(nonce, packetHeader.GetSecurityFlags(), packetHeader.GetMessageCounter(), 0);
 
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDH) == CHIP_NO_ERROR);
 
     P256Keypair keypair2;
-    NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair2.Initialize(ECPKeyTarget::ECDH) == CHIP_NO_ERROR);
 
     // Test uninitialized channel
     NL_TEST_ASSERT(inSuite,
@@ -131,10 +131,10 @@ void SecureChannelDecryptTest(nlTestSuite * inSuite, void * inContext)
     const char * salt = "Test Salt";
 
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDH) == CHIP_NO_ERROR);
 
     P256Keypair keypair2;
-    NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair2.Initialize(ECPKeyTarget::ECDH) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
                    channel.InitFromKeyPair(keypair, keypair2.Pubkey(), ByteSpan((const uint8_t *) salt, strlen(salt)),


### PR DESCRIPTION
Some of the crypto PAL implementations, like PSA require information about the target usage algoritm for the key at the moment of its generation. Current `P256KeyPair` API doesn't allow to pass such information

Summary of changes:
* Added target enum type to P256KeyPair `Initialize()` method
* Aligned all places that `Initialize()` is invoked to pass ECDSA or ECDH (basically only for the CASE) type.
* In `CryptoPALPSA` implementation removed method converting ECDSA to ECDH key and added generating ECDH or ECDSA key in the `Initialize()` method based on passed target.

Tests: Verified manually that PASE and CASE works between nrfconnect platform (using CryptoPALPSA implementation) and chiptool, and also that CHIPCryptoPAL unit tests pass.