### PR TITLE
Adding conditional compilation for jlink/segger_rtt code

### DIFF
--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -182,7 +182,7 @@ declare_args() {
   build_tv_casting_common_a = false
 }
 
-assert(chip_disable_platform_kvs == false || chip_device_platform == "darwin",
+assert(!chip_disable_platform_kvs || chip_device_platform == "darwin",
        "Can only disable KVS on some platforms")
 
 if (_chip_device_layer != "none" && chip_device_platform != "external") {
@@ -200,11 +200,7 @@ if (_chip_device_layer != "none" && chip_device_platform != "external") {
 
 declare_args() {
   # Enable jlink/segger_rtt support.
-  if (chip_device_platform == "qpg") {
-    chip_enable_segger_rtt = false
-  } else {
-    chip_enable_segger_rtt = true
-  }
+  chip_enable_segger_rtt = chip_device_platform != "qpg"
 }
 
 assert(

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -198,6 +198,15 @@ if (_chip_device_layer != "none" && chip_device_platform != "external") {
       "<platform/" + _chip_device_layer + "/SystemPlatformConfig.h>"
 }
 
+declare_args() {
+  # Enable jlink/segger_rtt support.
+  if (chip_device_platform == "qpg") {
+    chip_enable_segger_rtt = false
+  } else {
+    chip_enable_segger_rtt = true
+  }
+}
+
 assert(
     (current_os != "freertos" && chip_device_platform == "none") ||
         chip_device_platform == "fake" ||

--- a/third_party/openthread/platforms/BUILD.gn
+++ b/third_party/openthread/platforms/BUILD.gn
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/chip.gni")
 import("//build_overrides/jlink.gni")
 import("//build_overrides/openthread.gni")
+import("${chip_root}/src/platform/device.gni")
 
 config("libopenthread-platform_config") {
   include_dirs = [ "${openthread_root}/examples/platforms" ]
@@ -45,8 +47,6 @@ static_library("libopenthread-platform-utils") {
     "${openthread_root}/examples/platforms/utils/code_utils.h",
     "${openthread_root}/examples/platforms/utils/debug_uart.c",
     "${openthread_root}/examples/platforms/utils/encoding.h",
-    "${openthread_root}/examples/platforms/utils/logging_rtt.c",
-    "${openthread_root}/examples/platforms/utils/logging_rtt.h",
     "${openthread_root}/examples/platforms/utils/mac_frame.cpp",
     "${openthread_root}/examples/platforms/utils/mac_frame.h",
     "${openthread_root}/examples/platforms/utils/settings.h",
@@ -54,10 +54,17 @@ static_library("libopenthread-platform-utils") {
     "${openthread_root}/examples/platforms/utils/soft_source_match_table.c",
     "${openthread_root}/examples/platforms/utils/soft_source_match_table.h",
   ]
-  public_deps = [
-    "${openthread_root}/src/core:libopenthread_core_headers",
-    "${segger_rtt_root}:segger_rtt",
-  ]
+
+  public_deps = [ "${openthread_root}/src/core:libopenthread_core_headers" ]
+
+  if (chip_enable_segger_rtt == true) {
+    sources += [
+      "${openthread_root}/examples/platforms/utils/logging_rtt.c",
+      "${openthread_root}/examples/platforms/utils/logging_rtt.h",
+    ]
+
+    public_deps += [ "${segger_rtt_root}:segger_rtt" ]
+  }
 
   public_configs = [ ":libopenthread-platform_config" ]
 }

--- a/third_party/openthread/platforms/BUILD.gn
+++ b/third_party/openthread/platforms/BUILD.gn
@@ -57,7 +57,7 @@ static_library("libopenthread-platform-utils") {
 
   public_deps = [ "${openthread_root}/src/core:libopenthread_core_headers" ]
 
-  if (chip_enable_segger_rtt == true) {
+  if (chip_enable_segger_rtt) {
     sources += [
       "${openthread_root}/examples/platforms/utils/logging_rtt.c",
       "${openthread_root}/examples/platforms/utils/logging_rtt.h",


### PR DESCRIPTION
A build argument was added to enable conditional compilation of jlink/segger_rtt code.
This was done to optimize and clean up the build, because up till now we were relying on a linker to discard jlink/segger_rtt code.