### PR TITLE
[Telink] Update Telink Docker with latest Telink Zephyr (SDK 0.15.2).

### DIFF
--- a/integrations/docker/images/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/chip-build-telink/Dockerfile
@@ -11,13 +11,19 @@ RUN set -x \
 
 # Setup toolchain
 RUN set -x \
-    && wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.13.2/zephyr-toolchain-riscv64-0.13.2-linux-x86_64-setup.run -O /tmp/zephyr-toolchain-riscv64-setup.run \
-    && chmod +x /tmp/zephyr-toolchain-riscv64-setup.run \
-    && /tmp/zephyr-toolchain-riscv64-setup.run -- -d /opt/telink/zephyr-sdk-0.13.2 \
+    && mkdir /opt/telink \
+    && cd /opt/telink \
+    && wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.2/zephyr-sdk-0.15.2_linux-x86_64.tar.gz \
+    && wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.2/sha256.sum | shasum --check --ignore-missing \
+    && tar xvf zephyr-sdk-0.15.2_linux-x86_64.tar.gz \
+    && rm -rf zephyr-sdk-0.15.2_linux-x86_64.tar.gz \
+    && cd zephyr-sdk-0.15.2 \
+    && ./setup.sh -t riscv64-zephyr-elf -h -c \
+    && cd / \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=dac17979d626bb820268660b4272a56d04d8083b
+ARG ZEPHYR_REVISION=2901439a086f8202e63dc6f66a590021bb8e15d3
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \
@@ -29,16 +35,19 @@ RUN set -x \
     && west init -l \
     && cd .. \
     && west update -o=--depth=1 -n -f smart \
+    && cd modules/hal/telink \
+    && git submodule update --init \
+    && cd ../../../ \
     && west zephyr-export \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}
 
-COPY --from=build /opt/telink/zephyr-sdk-0.13.2/ /opt/telink/zephyr-sdk-0.13.2/
+COPY --from=build /opt/telink/zephyr-sdk-0.15.2/ /opt/telink/zephyr-sdk-0.15.2/
 COPY --from=build /opt/telink/zephyrproject/ /opt/telink/zephyrproject/
 
 ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-ENV ZEPHYR_SDK_INSTALL_DIR=/opt/telink/zephyr-sdk-0.13.2
+ENV ZEPHYR_SDK_INSTALL_DIR=/opt/telink/zephyr-sdk-0.15.2
 
 RUN set -x \
     && apt-get update \

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -34,7 +34,7 @@ COPY --from=mbedos /opt/openocd/ /opt/openocd/
 COPY --from=p6 /opt/ModusToolbox /opt/ModusToolbox
 
 COPY --from=telink /opt/telink/zephyrproject /opt/telink/zephyrproject
-COPY --from=telink /opt/telink/zephyr-sdk-0.13.2 /opt/telink/zephyr-sdk-0.13.2
+COPY --from=telink /opt/telink/zephyr-sdk-0.15.2 /opt/telink/zephyr-sdk-0.15.2
 
 COPY --from=tizen /opt/tizen-sdk /opt/tizen-sdk
 
@@ -102,7 +102,7 @@ ENV QEMU_ESP32=/opt/espressif/qemu/xtensa-softmmu/qemu-system-xtensa
 ENV QEMU_ESP32_DIR=/opt/espressif/qemu
 ENV SYSROOT_AARCH64=/opt/ubuntu-21.04-aarch64-sysroot
 ENV TELINK_ZEPHYR_BASE=/opt/telink/zephyrproject/zephyr
-ENV TELINK_ZEPHYR_SDK_DIR=/opt/telink/zephyr-sdk-0.13.2
+ENV TELINK_ZEPHYR_SDK_DIR=/opt/telink/zephyr-sdk-0.15.2
 ENV TI_SYSCONFIG_ROOT=/opt/ti/sysconfig_1.13.0
 ENV ZEPHYR_BASE=/opt/NordicSemiconductor/nrfconnect/zephyr
 ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.14 Version bump reason: Add checking and verification support for includes using IWYU
+0.6.15 Version bump reason: [Telink] Update Telink Docker with latest Telink Zephyr (SDK 0.15.2).


### PR DESCRIPTION
**Problem**
Need latest version of Telink Zephyr with Telink Zephyr BLE implementation and power management functionality.

**Change overview**
Updated to latest Telink Zephyr (SDK 0.15.2).

**Testing**
Tested manually.

Steps:
- Build image
- Run docker
- Check if Telink examples able to be built successfully