### PR TITLE
[Silabs] Fix build when matter shell is enabled

### DIFF
--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -18,6 +18,8 @@ import("${chip_root}/src/lib/lib.gni")
 import("${chip_root}/src/platform/device.gni")
 import("${efr32_sdk_build_root}/efr32_sdk.gni")
 
+silabs_common_plat_dir = "${chip_root}/examples/platform/silabs"
+
 config("chip_examples_project_config") {
   include_dirs = [ "project_include" ]
 
@@ -60,8 +62,11 @@ source_set("efr-matter-shell") {
   if (chip_build_libshell) {
     defines = [ "ENABLE_CHIP_SHELL" ]
 
-    sources = [ "matter_shell.cpp" ]
-    include_dirs = [ "." ]
+    sources = [ "${silabs_common_plat_dir}/matter_shell.cpp" ]
+    include_dirs = [
+      ".",
+      "${silabs_common_plat_dir}",
+    ]
 
     public_deps = [
       "${chip_root}/examples/shell/shell_common:shell_common",
@@ -82,8 +87,8 @@ config("attestation-credentials-config") {
 
 source_set("efr32-attestation-credentials") {
   sources = [
-    "../SilabsDeviceAttestationCreds.cpp",
-    "../SilabsDeviceAttestationCreds.h",
+    "${silabs_common_plat_dir}/SilabsDeviceAttestationCreds.cpp",
+    "${silabs_common_plat_dir}/SilabsDeviceAttestationCreds.h",
   ]
 
   public_deps = [


### PR DESCRIPTION
Fix the path for `examples/platform/silabs/matter_shell.cpp` in the `source-set.` It was wrong since last week's Silabs folder restructure.


I validated/tested the matter shell on lighting-app and lock-app