### PR TITLE
Fix tv-casting-app implementation of commissioner discovery/resolution

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/NsdDiscoveryListener.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/NsdDiscoveryListener.java
@@ -22,6 +22,7 @@ import android.net.nsd.NsdServiceInfo;
 import android.util.Log;
 import chip.platform.NsdManagerServiceResolver;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class NsdDiscoveryListener implements NsdManager.DiscoveryListener {
@@ -34,6 +35,7 @@ public class NsdDiscoveryListener implements NsdManager.DiscoveryListener {
   private final SuccessCallback<DiscoveredNodeData> successCallback;
   private final FailureCallback failureCallback;
   private final NsdManagerServiceResolver.NsdManagerResolverAvailState nsdManagerResolverAvailState;
+  private final ExecutorService resolutionExecutor;
 
   public NsdDiscoveryListener(
       NsdManager nsdManager,
@@ -50,6 +52,7 @@ public class NsdDiscoveryListener implements NsdManager.DiscoveryListener {
     this.successCallback = successCallback;
     this.failureCallback = failureCallback;
     this.nsdManagerResolverAvailState = nsdManagerResolverAvailState;
+    this.resolutionExecutor = Executors.newSingleThreadExecutor();
   }
 
   @Override
@@ -59,33 +62,32 @@ public class NsdDiscoveryListener implements NsdManager.DiscoveryListener {
 
   @Override
   public void onServiceFound(NsdServiceInfo service) {
-    Executors.newSingleThreadExecutor()
-        .execute(
-            new Runnable() {
-              @Override
-              public void run() {
-                Log.d(TAG, "Service discovery success. " + service);
-                if (service.getServiceType().equals(targetServiceType)) {
-                  if (nsdManagerResolverAvailState != null) {
-                    nsdManagerResolverAvailState.acquireResolver();
-                  }
-
-                  Log.d(TAG, "Calling NsdManager.resolveService for " + service);
-                  nsdManager.resolveService(
-                      service,
-                      new NsdResolveListener(
-                          nsdManager,
-                          deviceTypeFilter,
-                          preCommissionedVideoPlayers,
-                          successCallback,
-                          failureCallback,
-                          nsdManagerResolverAvailState,
-                          1));
-                } else {
-                  Log.d(TAG, "Ignoring discovered service: " + service.toString());
-                }
+    this.resolutionExecutor.execute(
+        new Runnable() {
+          @Override
+          public void run() {
+            Log.d(TAG, "Service discovery success. " + service);
+            if (service.getServiceType().equals(targetServiceType)) {
+              if (nsdManagerResolverAvailState != null) {
+                nsdManagerResolverAvailState.acquireResolver();
               }
-            });
+
+              Log.d(TAG, "Calling NsdManager.resolveService for " + service);
+              nsdManager.resolveService(
+                  service,
+                  new NsdResolveListener(
+                      nsdManager,
+                      deviceTypeFilter,
+                      preCommissionedVideoPlayers,
+                      successCallback,
+                      failureCallback,
+                      nsdManagerResolverAvailState,
+                      1));
+            } else {
+              Log.d(TAG, "Ignoring discovered service: " + service.toString());
+            }
+          }
+        });
   }
 
   @Override

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/NsdDiscoveryListener.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/NsdDiscoveryListener.java
@@ -22,6 +22,7 @@ import android.net.nsd.NsdServiceInfo;
 import android.util.Log;
 import chip.platform.NsdManagerServiceResolver;
 import java.util.List;
+import java.util.concurrent.Executors;
 
 public class NsdDiscoveryListener implements NsdManager.DiscoveryListener {
   private static final String TAG = NsdDiscoveryListener.class.getSimpleName();
@@ -58,24 +59,33 @@ public class NsdDiscoveryListener implements NsdManager.DiscoveryListener {
 
   @Override
   public void onServiceFound(NsdServiceInfo service) {
-    Log.d(TAG, "Service discovery success. " + service);
-    if (service.getServiceType().equals(targetServiceType)) {
-      if (nsdManagerResolverAvailState != null) {
-        nsdManagerResolverAvailState.acquireResolver();
-      }
-      nsdManager.resolveService(
-          service,
-          new NsdResolveListener(
-              nsdManager,
-              deviceTypeFilter,
-              preCommissionedVideoPlayers,
-              successCallback,
-              failureCallback,
-              nsdManagerResolverAvailState,
-              1));
-    } else {
-      Log.d(TAG, "Ignoring discovered service: " + service.toString());
-    }
+    Executors.newSingleThreadExecutor()
+        .execute(
+            new Runnable() {
+              @Override
+              public void run() {
+                Log.d(TAG, "Service discovery success. " + service);
+                if (service.getServiceType().equals(targetServiceType)) {
+                  if (nsdManagerResolverAvailState != null) {
+                    nsdManagerResolverAvailState.acquireResolver();
+                  }
+
+                  Log.d(TAG, "Calling NsdManager.resolveService for " + service);
+                  nsdManager.resolveService(
+                      service,
+                      new NsdResolveListener(
+                          nsdManager,
+                          deviceTypeFilter,
+                          preCommissionedVideoPlayers,
+                          successCallback,
+                          failureCallback,
+                          nsdManagerResolverAvailState,
+                          1));
+                } else {
+                  Log.d(TAG, "Ignoring discovered service: " + service.toString());
+                }
+              }
+            });
   }
 
   @Override

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CommissionableDataProviderImpl.hpp
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CommissionableDataProviderImpl.hpp
@@ -74,7 +74,7 @@ public:
 
     CHIP_ERROR GetSpake2pIterationCount(uint32_t & iterationCount) override
     {
-        if (mSetupDiscriminator > 0)
+        if (mSpake2pIterationCount > 0)
         {
             iterationCount = mSpake2pIterationCount;
         }

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
@@ -420,7 +420,7 @@
 					CoreData,
 					"-Wl,-unexported_symbol,\"__Z*\"",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.matter.TvCasting-sharadb";
+				PRODUCT_BUNDLE_IDENTIFIER = com.matter.TvCasting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -467,7 +467,7 @@
 					"-Wformat-nonliteral",
 					"-Wformat-security",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.matter.TvCasting-sharadb";
+				PRODUCT_BUNDLE_IDENTIFIER = com.matter.TvCasting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/TvCastingApp.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/TvCastingApp.swift
@@ -38,6 +38,12 @@ struct TvCastingApp: App {
                         }
                         appParameters.rotatingDeviceIdUniqueId = Data(rotatingDeviceIdUniqueId)
                         
+                        let onboardingParameters: OnboardingPayload = OnboardingPayload()
+                        onboardingParameters.setupPasscode = 20202021
+                        onboardingParameters.setupDiscriminator = 3840
+                        
+                        appParameters.onboardingPayload = onboardingParameters
+                        
                         castingServerBridge.initApp(appParameters, clientQueue: DispatchQueue.main, initAppStatusHandler: { (result: Bool) -> () in
                             self.Log.info("initApp result \(result)")
                         })


### PR DESCRIPTION
Fixes #23786

#### Problem
The tv-casting-app's implementation of the commissioner discovery / resolution gets deadlocked when more than 1 commissioner video players are on the network.

#### Change summary
In this change, we run the resolution (and do the preceeding locking) in a separate thread rather than the one the NsdManager is calling back on, onServiceFound.

Also, in this PR, a small bug fix (typo) where the darwin MatterTvCastingBridge.Framework was checking for mSetupDiscriminator instead of mSpake2pIterationCount in the implementation of GetSpake2pIterationCount

#### Testing
Verified the fix using the sample tv-casting-app running discovery against 2 commissioners being advertised on network.