### PR TITLE
Add nrfconnect switch app in build targets script 

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -238,6 +238,7 @@ def BuildNrfTarget():
         TargetPart('all-clusters-minimal', app=NrfApp.ALL_CLUSTERS_MINIMAL),
         TargetPart('lock', app=NrfApp.LOCK),
         TargetPart('light', app=NrfApp.LIGHT),
+        TargetPart('light-switch', app=NrfApp.SWITCH),     
         TargetPart('shell', app=NrfApp.SHELL),
         TargetPart('pump', app=NrfApp.PUMP),
         TargetPart('pump-controller', app=NrfApp.PUMP_CONTROLLER),

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -238,7 +238,7 @@ def BuildNrfTarget():
         TargetPart('all-clusters-minimal', app=NrfApp.ALL_CLUSTERS_MINIMAL),
         TargetPart('lock', app=NrfApp.LOCK),
         TargetPart('light', app=NrfApp.LIGHT),
-        TargetPart('light-switch', app=NrfApp.SWITCH),     
+        TargetPart('light-switch', app=NrfApp.SWITCH),
         TargetPart('shell', app=NrfApp.SHELL),
         TargetPart('pump', app=NrfApp.PUMP),
         TargetPart('pump-controller', app=NrfApp.PUMP_CONTROLLER),

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -38,6 +38,8 @@ class NrfApp(Enum):
             return 'examples/all-clusters-minimal-app'
         elif self == NrfApp.LIGHT:
             return 'examples/lighting-app'
+        elif self == NrfApp.SWITCH:
+            return 'light-switch-app'
         elif self == NrfApp.LOCK:
             return 'examples/lock-app'
         elif self == NrfApp.SHELL:
@@ -60,6 +62,8 @@ class NrfApp(Enum):
             return 'chip-nrf-all-clusters-minimal-example'
         elif self == NrfApp.LIGHT:
             return 'chip-nrf-lighting-example'
+        elif self == NrfApp.SWITCH:
+            return 'chip-nrf-light-switch-example'
         elif self == NrfApp.LOCK:
             return 'chip-nrf-lock-example'
         elif self == NrfApp.SHELL:
@@ -82,6 +86,8 @@ class NrfApp(Enum):
             return 'chip-nrfconnect-all-clusters-minimal-app-example'
         elif self == NrfApp.LIGHT:
             return 'chip-nrfconnect-lighting-example'
+        elif self == NrfApp.SWITCH:
+            return 'chip-nrfconnect-switch-example'
         elif self == NrfApp.LOCK:
             return 'chip-nrfconnect-lock-example'
         elif self == NrfApp.SHELL:

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -28,6 +28,7 @@ class NrfApp(Enum):
     SHELL = auto()
     PUMP = auto()
     PUMP_CONTROLLER = auto()
+    SWITCH = auto()
     WINDOW_COVERING = auto()
     UNIT_TESTS = auto()
 

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -14,7 +14,7 @@ infineon-psoc6-{lock,light,all-clusters,all-clusters-minimal}[-ota][-updateimage
 k32w-{light,shell,lock,contact}[-se05x][-no-ble][-no-ota][-low-power][-nologs]
 mbed-cy8cproto_062_4343w-{lock,light,all-clusters,all-clusters-minimal,pigweed,shell}[-release][-develop][-debug]
 mw320-all-clusters-app
-nrf-{nrf5340dk,nrf52840dk,nrf52840dongle}-{all-clusters,all-clusters-minimal,lock,light,shell,pump,pump-controller}[-rpc]
+nrf-{nrf5340dk,nrf52840dk,nrf52840dongle}-{all-clusters,all-clusters-minimal,lock,light,light-switch,shell,pump,pump-controller}[-rpc]
 nrf-native-posix-64-tests
 qpg-qpg6105-{lock,light,shell,persistent-storage}
 tizen-arm-{all-clusters,all-clusters-minimal,chip-tool,light}[-no-ble][-no-wifi][-asan]


### PR DESCRIPTION
Fixes #23450 Missing nrfconnect light-switch app in NRF builder 

I would add nrfconnect light-switch app in NRF builder to be able to build it with the global script.