### PR TITLE
Set auto_envvar_prefix for click scripts to CHIP

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,11 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
+
     build_linux_gcc_debug:
         name: Build on Linux (gcc_debug)
         timeout-minutes: 85
@@ -125,6 +129,7 @@ jobs:
             #       path: out/
             #       # objdirs are big; don't hold on to them too long.
             #       retention-days: 5
+
     build_linux:
         name: Build on Linux (fake, gcc_release, clang, simulated)
         timeout-minutes: 150
@@ -219,7 +224,6 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/run-clang-tidy-on-compile-commands.py \
-                       --no-log-timestamps \
                        --compile-database out/sanitizers/compile_commands.json \
                        --file-exclude-regex '/(repo|zzz_generated|lwip/standalone)/' \
                        check \
@@ -228,7 +232,7 @@ jobs:
               timeout-minutes: 60
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps \
+                    "./scripts/build/build_examples.py \
                        --target linux-x64-minmdns-ipv6only-clang \
                        --target linux-x64-rpc-console \
                        build \
@@ -241,7 +245,7 @@ jobs:
               timeout-minutes: 60
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps \
+                    "./scripts/build/build_examples.py \
                        --target linux-x64-all-clusters-ipv6only-clang \
                        --target linux-x64-chip-tool-ipv6only-clang \
                        --pregen-dir ./zzz_pregenerated \
@@ -255,7 +259,7 @@ jobs:
               timeout-minutes: 15
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target linux-fake-tests build"
+                    "./scripts/build/build_examples.py --target linux-fake-tests build"
             - name: Uploading core files
               uses: actions/upload-artifact@v3
               if: ${{ failure() && !env.ACT }}
@@ -295,6 +299,7 @@ jobs:
             # - name: Perform CodeQL Analysis
             #   if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/master' }}
             #   uses: github/codeql-action/analyze@v1
+
     build_linux_python_lib:
         name: Build on Linux (python_lib)
         timeout-minutes: 60
@@ -430,7 +435,6 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/run-clang-tidy-on-compile-commands.py \
-                       --no-log-timestamps \
                        --compile-database out/default/compile_commands.json \
                        check \
                     "

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -25,6 +25,9 @@ concurrency:
         'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     test_suites_chip_tool_darwin:
         name: Test Suites - Darwin

--- a/.github/workflows/examples-ameba.yaml
+++ b/.github/workflows/examples-ameba.yaml
@@ -22,6 +22,9 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     ameba:
         name: Ameba

--- a/.github/workflows/examples-bouffalolab.yaml
+++ b/.github/workflows/examples-bouffalolab.yaml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
   cancel-in-progress: true
 
+env:
+  CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
   bl602:
     name: BL602

--- a/.github/workflows/examples-cc13x2x7_26x2x7.yaml
+++ b/.github/workflows/examples-cc13x2x7_26x2x7.yaml
@@ -22,6 +22,9 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     cc26x2x7:
         name: cc26x2x7

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
   cancel-in-progress: true
 
+env:
+  CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
   efr32:
     name: EFR32

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -22,6 +22,9 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     esp32:
         name: ESP32

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -23,6 +23,9 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     infineon:
         name: Infineon examples building
@@ -69,7 +72,7 @@ jobs:
               run: |
                   scripts/run_in_build_env.sh \
                     "scripts/build/build_examples.py \
-                        --enable-flashbundle --no-log-timestamps \
+                        --enable-flashbundle \
                         --target infineon-psoc6-lock \
                         build \
                         --copy-artifacts-to out/artifacts \
@@ -83,7 +86,7 @@ jobs:
               run: |
                   scripts/run_in_build_env.sh \
                     "scripts/build/build_examples.py \
-                        --enable-flashbundle --no-log-timestamps \
+                        --enable-flashbundle \
                         --target infineon-psoc6-all-clusters \
                         build \
                         --copy-artifacts-to out/artifacts \
@@ -97,7 +100,7 @@ jobs:
               run: |
                   scripts/run_in_build_env.sh \
                     "scripts/build/build_examples.py \
-                        --enable-flashbundle --no-log-timestamps \
+                        --enable-flashbundle \
                         --target infineon-psoc6-all-clusters-minimal \
                         build \
                         --copy-artifacts-to out/artifacts \
@@ -111,7 +114,7 @@ jobs:
               run: |
                   scripts/run_in_build_env.sh \
                     "scripts/build/build_examples.py \
-                        --enable-flashbundle --no-log-timestamps \
+                        --enable-flashbundle \
                         --target infineon-psoc6-light \
                         build \
                         --copy-artifacts-to out/artifacts \

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -22,6 +22,9 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     k32w:
         name: K32W

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -22,6 +22,9 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     arm_crosscompile:
         name: Linux ARM Cross compile
@@ -64,11 +67,13 @@ jobs:
                   path: |
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
+
             - name: Build Some samples
               timeout-minutes: 45
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
+                        --target linux-arm64-chip-cert \
                         --target linux-arm64-all-clusters-clang \
                         --target linux-arm64-chip-tool-ipv6only-clang \
                         --target linux-arm64-lock-clang \

--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -22,6 +22,9 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     imx:
         name: Linux i.MX Build
@@ -45,18 +48,25 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --shallow --platform linux
 
-            - name: Build App
+            - name: Bootstrap
+              run: scripts/build/gn_bootstrap.sh
+
+            - name: Build lighting-app
               timeout-minutes: 30
               run: |
-                  ./scripts/examples/imxlinux_example.sh \
-                  examples/lighting-app/linux/ examples/lighting-app/linux/out/aarch64
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target imx-lighting-app \
+                        build"
             - name: Clean out build output
               run: rm -rf ./out
             - name: Build chip-tool
               timeout-minutes: 30
               run: |
-                  ./scripts/examples/imxlinux_example.sh \
-                  examples/chip-tool examples/chip-tool/out/aarch64
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target imx-chip-tool \
+                        build"
             - name: Clean out build output
               run: rm -rf ./out
             - name: Build thermostat
@@ -64,8 +74,8 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
-                        --target imx-thermostat build \
-                     "
+                        --target imx-thermostat \
+                        build"
             - name: Clean out build output
               run: rm -rf ./out
             - name: Build all-cluster
@@ -73,8 +83,8 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
-                         --target imx-all-clusters-app build \
-                     "
+                        --target imx-all-clusters-app \
+                        build"
             - name: Clean out build output
               run: rm -rf ./out
             - name: Build all-cluster-minimal
@@ -82,8 +92,8 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
-                         --target imx-all-clusters-minimal-app build \
-                     "
+                        --target imx-all-clusters-minimal-app \
+                        build"
             - name: Clean out build output
               run: rm -rf ./out
             - name: Build ota-provider-app
@@ -91,7 +101,7 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
-                         --target imx-ota-provider-app build
-                     "
+                        --target imx-ota-provider-app \
+                        build"
             - name: Clean out build output
               run: rm -rf ./out

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -22,13 +22,13 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     linux_standalone:
         name: Linux Standalone
         timeout-minutes: 90
-
-        env:
-            BUILD_TYPE: gn_linux
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -67,59 +67,75 @@ jobs:
                   path: |
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
+
             - name: Build Standalone cert tool
               timeout-minutes: 10
               run: |
                   ./scripts/run_in_build_env.sh \
-                  "./scripts/build/build_examples.py --no-log-timestamps \
-                      --target linux-x64-chip-cert \
-                      --target linux-arm64-chip-cert \
-                      build \
-                  "
+                     "./scripts/build/build_examples.py \
+                        --target linux-x64-chip-cert \
+                        build"
             - name: Build minmdns example with platform dns
               timeout-minutes: 10
               run: |
                   ./scripts/run_in_build_env.sh \
-                  "./scripts/build/build_examples.py --no-log-timestamps --target linux-x64-address-resolve-tool-platform-mdns-ipv6only build"
+                     "./scripts/build/build_examples.py \
+                        --target linux-x64-address-resolve-tool-platform-mdns-ipv6only \
+                        build"
             - name: Build example Standalone Echo Client
               timeout-minutes: 10
               run: |
-                  scripts/examples/gn_build_example.sh examples/chip-tool out/chip_tool_debug
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target linux-x64-chip-tool \
+                        build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     linux debug chip-tool \
-                    out/chip_tool_debug/chip-tool \
+                    out/linux-x64-chip-tool/chip-tool \
                     /tmp/bloat_reports/
             - name: Build example Standalone Shell
               timeout-minutes: 10
               run: |
-                  scripts/examples/gn_build_example.sh examples/shell/standalone out/shell_debug
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target linux-x64-shell \
+                        build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     linux debug shell \
-                    out/shell_debug/chip-shell \
+                    out/linux-x64-shell/chip-shell \
                     /tmp/bloat_reports/
             - name: Build example Standalone All Clusters Server
               timeout-minutes: 10
               run: |
-                  scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/all_clusters_debug
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target linux-x64-all-clusters \
+                        build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     linux debug all-clusters-app \
-                    out/all_clusters_debug/chip-all-clusters-app \
+                    out/linux-x64-all-clusters/chip-all-clusters-app \
                     /tmp/bloat_reports/
             - name: Build example Standalone All Clusters Mininal Server
               timeout-minutes: 10
               run: |
-                  scripts/examples/gn_build_example.sh examples/all-clusters-minimal-app/linux out/all_clusters_minimal_debug
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target linux-x64-all-clusters-minimal \
+                        build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     linux debug all-clusters-minimal-app \
-                    out/all_clusters_minimal_debug/chip-all-clusters-minimal-app \
+                    out/linux-x64-all-clusters-minimal/chip-all-clusters-app \
                     /tmp/bloat_reports/
             - name: Build example TV app
               timeout-minutes: 10
               run: |
-                  scripts/examples/gn_build_example.sh examples/tv-app/linux out/tv_app_debug
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target linux-x64-tv-app \
+                        build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     linux debug tv-app \
-                    out/tv_app_debug/chip-tv-app \
+                    out/linux-x64-tv-app/chip-tv-app \
                     /tmp/bloat_reports/
             - name: Build example Standalone TV Casting App
               timeout-minutes: 10
@@ -135,37 +151,47 @@ jobs:
             - name: Build example lighting app with RPCs
               timeout-minutes: 10
               run: |
-                  scripts/examples/gn_build_example.sh examples/lighting-app/linux out/lighting_app_debug_rpc \
-                    'import("//with_pw_rpc.gni")'
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target linux-x64-light-rpc \
+                        build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     linux debug+rpc lighting-app \
-                    out/lighting_app_debug_rpc/chip-lighting-app \
+                    out/linux-x64-light-rpc/chip-lighting-app \
                     /tmp/bloat_reports/
             - name: Build example Standalone Bridge
               timeout-minutes: 10
               run: |
-                  scripts/examples/gn_build_example.sh examples/bridge-app/linux out/bridge_debug
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target linux-x64-bridge \
+                        build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    linux debug+rpc bridge-app \
-                    out/bridge_debug/chip-bridge-app \
+                    linux debug bridge-app \
+                    out/linux-x64-bridge/chip-bridge-app \
                     /tmp/bloat_reports/
             - name: Build example OTA Provider
               timeout-minutes: 10
               run: |
-                  scripts/examples/gn_build_example.sh examples/ota-provider-app/linux out/ota_provider_debug
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target linux-x64-ota-provider \
+                        build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     linux debug ota-provider-app \
-                    out/ota_provider_debug/chip-ota-provider-app \
+                    out/linux-x64-ota-provider/chip-ota-provider-app \
                     /tmp/bloat_reports/
             - name: Build example OTA Requestor
               timeout-minutes: 10
               run: |
-                  scripts/examples/gn_build_example.sh examples/ota-requestor-app/linux out/ota_requestor_debug
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target linux-x64-ota-requestor \
+                        build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     linux debug ota-requestor-app \
-                    out/ota_requestor_debug/chip-ota-requestor-app \
+                    out/linux-x64-ota-requestor/chip-ota-requestor-app \
                     /tmp/bloat_reports/
-
             - name: Build example Standalone Lock App
               timeout-minutes: 10
               run: |
@@ -177,6 +203,7 @@ jobs:
                     linux debug lock-app \
                     out/linux-x64-lock/chip-lock-app \
                     /tmp/bloat_reports/
+
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v3
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -23,6 +23,9 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     mbedos:
         name: Mbed OS examples building
@@ -150,7 +153,7 @@ jobs:
                     mbed $APP_TARGET+$APP_PROFILE shell \
                     examples/ota-requestor-app/mbed/build-CY8CPROTO_062_4343W/release/chip-mbed-ota-requestor-app-example.elf \
                     /tmp/bloat_reports/
-            
+
             - name: Build unit tests
               # Temporarily disable build due to running out of flash space
               if: false

--- a/.github/workflows/examples-mw320.yaml
+++ b/.github/workflows/examples-mw320.yaml
@@ -22,6 +22,9 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     mw320:
         name: MW320

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -22,6 +22,9 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     nrfconnect:
         name: nRF Connect SDK
@@ -209,7 +212,7 @@ jobs:
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     nrfconnect nrf7002dk_nrf5340_cpuapp light-switch-app \
                     examples/light-switch-app/nrfconnect/build/zephyr/zephyr.elf \
-                    /tmp/bloat_reports/                    
+                    /tmp/bloat_reports/
             - name: Build example nRF Connect SDK Lighting App on nRF7002 PDK
               if: github.event_name == 'push' || steps.changed_paths.outputs.nrfconnect == 'true'
               timeout-minutes: 20
@@ -218,7 +221,7 @@ jobs:
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     nrfconnect nrf7002dk_nrf5340_cpuapp lighting-app \
                     examples/light-switch-app/nrfconnect/build/zephyr/zephyr.elf \
-                    /tmp/bloat_reports/                    
+                    /tmp/bloat_reports/
             - name: Build example nRF Connect SDK All Clusters App on nRF7002 PDK
               timeout-minutes: 20
               run: |

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -22,6 +22,9 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     qpg:
         name: QPG

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -22,6 +22,9 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     telink:
         name: Telink
@@ -57,7 +60,7 @@ jobs:
             - name: Build example Telink All Clusters App
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target 'telink-tlsr9518adk80d-all-clusters' build"
+                    "./scripts/build/build_examples.py --target 'telink-tlsr9518adk80d-all-clusters' build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     telink tlsr9518adk80d all-clusters-app \
                     out/telink-tlsr9518adk80d-all-clusters/zephyr/zephyr.elf \
@@ -66,7 +69,7 @@ jobs:
             - name: Build example Telink All Clusters Minimal App
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target 'telink-tlsr9518adk80d-all-clusters-minimal' build"
+                    "./scripts/build/build_examples.py --target 'telink-tlsr9518adk80d-all-clusters-minimal' build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     telink tlsr9518adk80d all-clusters-minimal-app \
                     out/telink-tlsr9518adk80d-all-clusters-minimal/zephyr/zephyr.elf \
@@ -75,7 +78,7 @@ jobs:
             - name: Build example Telink Lighting App
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target 'telink-tlsr9518adk80d-light' build"
+                    "./scripts/build/build_examples.py --target 'telink-tlsr9518adk80d-light' build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     telink tlsr9518adk80d lighting-app \
                     out/telink-tlsr9518adk80d-light/zephyr/zephyr.elf \
@@ -84,7 +87,7 @@ jobs:
             - name: Build example Telink Light Switch App
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target 'telink-tlsr9518adk80d-light-switch' build"
+                    "./scripts/build/build_examples.py --target 'telink-tlsr9518adk80d-light-switch' build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     telink tlsr9518adk80d light-switch-app \
                     out/telink-tlsr9518adk80d-light-switch/zephyr/zephyr.elf \
@@ -93,7 +96,7 @@ jobs:
             - name: Build example Telink OTA Requestor App
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target 'telink-tlsr9518adk80d-ota-requestor' build"
+                    "./scripts/build/build_examples.py --target 'telink-tlsr9518adk80d-ota-requestor' build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     telink tlsr9518adk80d ota-requestor-app \
                     out/telink-tlsr9518adk80d-ota-requestor/zephyr/zephyr.elf \
@@ -102,7 +105,7 @@ jobs:
             - name: Build example Telink Thermostat App
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target 'telink-tlsr9518adk80d-thermostat' build"
+                    "./scripts/build/build_examples.py --target 'telink-tlsr9518adk80d-thermostat' build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     telink tlsr9518adk80d thermostat \
                     out/telink-tlsr9518adk80d-thermostat/zephyr/zephyr.elf \

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -22,11 +22,12 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     tizen:
         name: Tizen
-        env:
-            BUILD_TYPE: tizen
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -49,6 +50,10 @@ jobs:
                   attempt_delay: 2000
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --shallow --platform tizen
+
+            - name: Bootstrap
+              run: scripts/build/gn_bootstrap.sh
+
             - name: Build Tizen examples
               run: |
                 ./scripts/run_in_build_env.sh \

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -22,6 +22,9 @@ concurrency:
     group: full-${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     full_android:
         name: Run
@@ -73,35 +76,35 @@ jobs:
             - name: Build Android arm-chip-tool
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target android-arm-chip-tool build"
+                    "./scripts/build/build_examples.py --target android-arm-chip-tool build"
             - name: Clean out build output
               run: rm -rf ./out
             - name: Build Android arm-tv-casting-app
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target android-arm-tv-casting-app build"
+                    "./scripts/build/build_examples.py --target android-arm-tv-casting-app build"
             - name: Clean out build output
               run: rm -rf ./out
             - name: Build Android arm-tv-server
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target android-arm-tv-server build"
+                    "./scripts/build/build_examples.py --target android-arm-tv-server build"
             - name: Clean out build output
               run: rm -rf ./out
             - name: Build Android arm64-tv-casting-app
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target android-arm64-tv-casting-app build"
+                    "./scripts/build/build_examples.py --target android-arm64-tv-casting-app build"
             - name: Clean out build output
               run: rm -rf ./out
             - name: Build Android arm64-tv-server
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target android-arm64-tv-server build"
+                    "./scripts/build/build_examples.py --target android-arm64-tv-server build"
             - name: Build Android arm64-chip-tool
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target android-arm64-chip-tool build"
+                    "./scripts/build/build_examples.py --target android-arm64-chip-tool build"
             - name: Run Android build rule tests
               run: |
                   ./scripts/run_in_build_env.sh \
@@ -111,4 +114,4 @@ jobs:
             # - name: Build Android Studio build (arm64 only)
             #   run: |
             #     ./scripts/run_in_build_env.sh \
-            #       "./scripts/build/build_examples.py --no-log-timestamps --target android-androidstudio-arm64-chip-tool  build"
+            #       "./scripts/build/build_examples.py --target android-androidstudio-arm64-chip-tool  build"

--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -22,6 +22,9 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     build_linux_fuzzing:
         name: Build on Linux

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -22,6 +22,9 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     qemu:
         name: ESP32

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -22,6 +22,9 @@ concurrency:
     group: smoke-${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     android:
         name: Smoke Run - Android
@@ -63,7 +66,7 @@ jobs:
             - name: Build Android CHIPTool and CHIPTest (ARM64)
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target android-arm64-chip-tool build"
+                    "./scripts/build/build_examples.py --target android-arm64-chip-tool build"
             - name: Run Android build rule tests
               run: |
                   ./scripts/run_in_build_env.sh \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,9 @@ concurrency:
         'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+
 jobs:
     test_suites_linux:
         name: Test Suites - Linux
@@ -86,7 +89,7 @@ jobs:
                   path: |
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
-            - name: Validate that xml are parseable
+            - name: Validate that xml are parsable
               timeout-minutes: 10
               # The sub-items being run here are the same as the input XMLs listed
               # at src/app/zap-templates/zcl/zcl.json
@@ -96,9 +99,9 @@ jobs:
               # unit tests)
               #
               # Also note ordering: global attributes are parsed first because other XML files may
-              # reference these. 
+              # reference these.
               #
-              # TODO: some multipass/postprocess may be more appropriate to allow any ordering of 
+              # TODO: some multipass/postprocess may be more appropriate to allow any ordering of
               #       things.
               run: |
                   ./scripts/run_in_build_env.sh \
@@ -225,6 +228,7 @@ jobs:
                   path: objdir-clone/
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5
+
     test_suites_darwin:
         name: Test Suites - Darwin
         timeout-minutes: 150
@@ -336,6 +340,7 @@ jobs:
                   path: objdir-clone/
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5
+
     repl_tests_linux:
         name: REPL Tests - Linux
         timeout-minutes: 130
@@ -408,6 +413,7 @@ jobs:
                   path: objdir-clone/
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5
+
     java_tests_linux:
         name: Java Tests - Linux
         timeout-minutes: 130

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -205,4 +205,4 @@ def cmd_build(context, copy_artifacts_to, create_archives):
 
 
 if __name__ == '__main__':
-    main()
+    main(auto_envvar_prefix='CHIP')

--- a/scripts/codegen.py
+++ b/scripts/codegen.py
@@ -147,4 +147,4 @@ def main(log_level, generator, output_dir, dry_run, name_only, expected_outputs,
 
 
 if __name__ == '__main__':
-    main()
+    main(auto_envvar_prefix='CHIP')

--- a/scripts/helpers/iwyu-check.py
+++ b/scripts/helpers/iwyu-check.py
@@ -197,4 +197,4 @@ def main(compile_commands_glob, scanning_destination, mapping_file_dir,
 
 
 if __name__ == '__main__':
-    main()
+    main(auto_envvar_prefix='CHIP')

--- a/scripts/idl/lint/lint_rules_parser.py
+++ b/scripts/idl/lint/lint_rules_parser.py
@@ -306,4 +306,4 @@ if __name__ == '__main__':
         logging.info("Data:")
         logging.info("%r" % data)
 
-    main()
+    main(auto_envvar_prefix='CHIP')

--- a/scripts/idl/matter_idl_parser.py
+++ b/scripts/idl/matter_idl_parser.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-import enum
 import functools
 import logging
+from enum import Enum
 
 from lark import Lark
 from lark.visitors import Transformer, v_args
@@ -61,7 +61,7 @@ class AddDeviceTypeToEndpointTransform:
 
 class MatterIdlTransformer(Transformer):
     """
-    A transformer capable to transform data parsed by Lark according to 
+    A transformer capable to transform data parsed by Lark according to
     matter_grammar.lark.
 
     Generally transforms a ".matter" file into an Abstract Syntax Tree (AST).
@@ -72,7 +72,7 @@ class MatterIdlTransformer(Transformer):
     purpose is to convert LARK tokens (that ar generally inputted by name)
     into underlying python types.
 
-    Some documentation to get started is available at 
+    Some documentation to get started is available at
     https://lark-parser.readthedocs.io/en/latest/visitors.html#transformer
 
     TLDR would be:
@@ -438,9 +438,10 @@ def CreateParser(skip_meta: bool = False):
 if __name__ == '__main__':
     # This Parser is generally not intended to be run as a stand-alone binary.
     # The ability to run is for debug and to print out the parsed AST.
+    import pprint
+
     import click
     import coloredlogs
-    import pprint
 
     # Supported log levels, mapping string values required for argument
     # parsing into logging constants
@@ -469,4 +470,4 @@ if __name__ == '__main__':
         logging.info("Data:")
         pprint.pp(data)
 
-    main()
+    main(auto_envvar_prefix='CHIP')

--- a/scripts/idl/xml_parser.py
+++ b/scripts/idl/xml_parser.py
@@ -76,4 +76,4 @@ if __name__ == '__main__':
             print("Data:")
             pprint.pp(data)
 
-    main()
+    main(auto_envvar_prefix='CHIP')

--- a/scripts/idl_lint.py
+++ b/scripts/idl_lint.py
@@ -86,4 +86,4 @@ def main(log_level, rules, idl_path):
 
 
 if __name__ == "__main__":
-    main()
+    main(auto_envvar_prefix='CHIP')

--- a/scripts/run-clang-tidy-on-compile-commands.py
+++ b/scripts/run-clang-tidy-on-compile-commands.py
@@ -27,9 +27,6 @@ clang-apply-replacements out/fixes.yaml
 
 """
 
-import build
-import click
-import coloredlogs
 import glob
 import json
 import logging
@@ -43,6 +40,9 @@ import sys
 import tempfile
 import threading
 import traceback
+
+import click
+import coloredlogs
 import yaml
 
 
@@ -483,4 +483,4 @@ def cmd_fix(context):
 
 
 if __name__ == "__main__":
-    main()
+    main(auto_envvar_prefix='CHIP')

--- a/scripts/run_in_build_env.sh
+++ b/scripts/run_in_build_env.sh
@@ -26,5 +26,5 @@ fi
 
 set -e
 
-echo "Executing in build environment: $@"
+echo "Executing in build environment: $*"
 bash -c -- "$@"

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -14,13 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import click
-import coloredlogs
 import datetime
 import logging
 import os
-import pathlib
-import pty
 import queue
 import re
 import shlex
@@ -31,6 +27,8 @@ import threading
 import time
 import typing
 
+import click
+import coloredlogs
 from colorama import Fore, Style
 
 DEFAULT_CHIP_ROOT = os.path.abspath(
@@ -164,4 +162,4 @@ def main(app: str, factoryreset: bool, app_args: str, script: str, script_args: 
 
 
 if __name__ == '__main__':
-    main()
+    main(auto_envvar_prefix='CHIP')

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -16,7 +16,6 @@
 
 import logging
 import os
-import shutil
 import sys
 import time
 import typing
@@ -281,4 +280,4 @@ if sys.platform == 'linux':
 
 
 if __name__ == '__main__':
-    main()
+    main(auto_envvar_prefix='CHIP')

--- a/scripts/tools/convert_ini.py
+++ b/scripts/tools/convert_ini.py
@@ -17,12 +17,13 @@
 #    limitations under the License.
 #
 import json
-from configparser import ConfigParser
-import click
-import typing
-import re
-from os.path import exists
 import logging
+import re
+import typing
+from configparser import ConfigParser
+from os.path import exists
+
+import click
 
 
 def convert_ini_to_json(ini_dir: str, json_path: str):
@@ -106,4 +107,4 @@ def main(ini_dir: str, json_path: str):
 
 
 if __name__ == '__main__':
-    main()
+    main(auto_envvar_prefix='CHIP')


### PR DESCRIPTION
### Feature

This change will allow setting default values for e.g. build_examples.py script with environment variables. Simple use case might be to enable ccache for all targets and disable timestamp logs with:

```sh
export CHIP_NO_LOG_TIMESTAMPS=true
export CHIP_PW_COMMAND_LAUNCHER=ccache
```

### Changes

- set auto_envvar_prefix to "CHIP" for click scripts
- use `CHIP_NO_LOG_TIMESTAMPS=true` in all CI workflows where build_examples.py is used
- rewrite `gn_build_example.sh` usage to `build_examples.py` where appropriate

### Testing

CI will test that