### PR TITLE
[java-matter-controller] Support to print help info for command

### DIFF
--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/common/Command.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/common/Command.java
@@ -76,6 +76,10 @@ public abstract class Command {
     return mArgs.size();
   }
 
+  public final boolean getArgumentIsOptional(int index) {
+    return mArgs.get(index).isOptional();
+  }
+
   /**
    * @brief Get argument description if it exists
    * @return A pointer to an Optional where the argument description will be stored

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/common/CommandManager.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/common/CommandManager.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public final class CommandManager {
   private final ArrayList<Command> mCommandMgr = new ArrayList<Command>();
@@ -96,7 +97,7 @@ public final class CommandManager {
       command.initArguments(temp.length, temp);
       command.run();
     } catch (IllegalArgumentException e) {
-      System.out.println("Arguments init failed with exception: " + e.getMessage());
+      showCommand(args[0], command);
     } catch (Exception e) {
       System.out.println("Run command failed with exception: " + e.getMessage());
     }
@@ -243,5 +244,46 @@ public final class CommandManager {
     }
     System.out.println(
         "  +-------------------------------------------------------------------------------------+");
+  }
+
+  private void showCommand(String clusterName, Command command) {
+    System.out.println("Usage:");
+
+    String arguments = command.getName();
+    String description = "";
+
+    int argumentsCount = command.getArgumentsCount();
+    for (int i = 0; i < argumentsCount; i++) {
+      String arg = "";
+      boolean isOptional = command.getArgumentIsOptional(i);
+      if (isOptional) {
+        arg += "[--";
+      }
+      arg += command.getArgumentName(i);
+      if (isOptional) {
+        arg += "]";
+      }
+      arguments += " ";
+      arguments += arg;
+
+      Optional<String> argDescription = command.getArgumentDescription(i);
+      if (argDescription.isPresent()) {
+        description += "\n";
+        description += arg;
+        description += ":\n  ";
+        description += argDescription.get();
+        description += "\n";
+      }
+    }
+    System.out.format("  java-matter-controller %s %s\n", clusterName, arguments);
+
+    Optional<String> helpText = command.getHelpText();
+    if (helpText.isPresent()) {
+      System.out.format("\n%s\n", helpText.get());
+    }
+
+    if (!description.isEmpty()) {
+      System.out.println(description);
+    }
   }
 }

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/common/MatterCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/common/MatterCommand.java
@@ -58,38 +58,38 @@ public abstract class MatterCommand extends Command {
     this.mChipDeviceController = controller;
 
     addArgument(
-        "--paa-trust-store-path",
+        "paa-trust-store-path",
         mPaaTrustStorePath,
         "Path to directory holding PAA certificate information.  Can be absolute or relative to the current working "
             + "directory.",
         true);
     addArgument(
-        "--cd-trust-store-path",
+        "cd-trust-store-path",
         mCDTrustStorePath,
         "Path to directory holding CD certificate information.  Can be absolute or relative to the current working "
             + "directory.",
         true);
     addArgument(
-        "--commissioner-name",
+        "commissioner-name",
         mCommissionerName,
         "Name of fabric to use. Valid values are \"alpha\", \"beta\", \"gamma\", and integers greater than or equal to "
             + "4.  The default if not specified is \"alpha\".",
         true);
     addArgument(
-        "--commissioner-nodeid",
+        "commissioner-nodeid",
         0,
         Long.MAX_VALUE,
         mCommissionerNodeId,
-        "The node id to use for chip-tool.  If not provided, kTestControllerNodeId (112233, 0x1B669) will be used.",
+        "The node id to use for java-matter-controller.  If not provided, kTestControllerNodeId (112233, 0x1B669) will be used.",
         true);
     addArgument(
-        "--use-max-sized-certs",
+        "use-max-sized-certs",
         mUseMaxSizedCerts,
         "Maximize the size of operational certificates. If not provided or 0 (\"false\"), normally sized operational "
             + "certificates are generated.",
         true);
     addArgument(
-        "--only-allow-trusted-cd-keys",
+        "only-allow-trusted-cd-keys",
         mOnlyAllowTrustedCdKeys,
         "Only allow trusted CD verifying keys (disallow test keys). If not provided or 0 (\"false\"), untrusted CD "
             + "verifying keys are allowed. If 1 (\"true\"), test keys are disallowed.",


### PR DESCRIPTION
Support to print help info for each command.

```
yufengw@yufengw:~/connectedhomeip$   java -Djava.library.path=out/linux-x64-java-matter-controller/lib/jni -jar out/linux-x64-java-matter-controller/bin/java-matter-controller pairing onnetwork-long ?

Usage:
  java-matter-controller pairing onnetwork-long node-id setup-pin-code discriminator timeout [--paa-trust-store-path] [--cd-trust-store-path] [--commissioner-name] [--commissioner-nodeid] [--use-max-sized-certs] [--only-allow-trusted-cd-keys]

[--paa-trust-store-path]:
  Path to directory holding PAA certificate information.  Can be absolute or relative to the current working directory.

[--cd-trust-store-path]:
  Path to directory holding CD certificate information.  Can be absolute or relative to the current working directory.

[--commissioner-name]:
  Name of fabric to use. Valid values are "alpha", "beta", "gamma", and integers greater than or equal to 4.  The default if not specified is "alpha".

[--commissioner-nodeid]:
  The node id to use for java-matter-controller.  If not provided, kTestControllerNodeId (112233, 0x1B669) will be used.

[--use-max-sized-certs]:
  Maximize the size of operational certificates. If not provided or 0 ("false"), normally sized operational certificates are generated.

[--only-allow-trusted-cd-keys]:
  Only allow trusted CD verifying keys (disallow test keys). If not provided or 0 ("false"), untrusted CD verifying keys are allowed. If 1 ("true"), test keys are disallowed.


```