### PR TITLE
Update build script for docker to not need to guess in advance a corr…

### DIFF
--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -65,7 +65,9 @@ set -ex
 
 [[ -n $VERSION ]] || die "version cannot be empty"
 
-mb_space_before=$(df -m "$DOCKER_VOLUME_PATH" | awk 'FNR==2{print $3}')
+if [ -f "$DOCKER_VOLUME_PATH" ]; then
+    mb_space_before=$(df -m "$DOCKER_VOLUME_PATH" | awk 'FNR==2{print $3}')
+fi
 
 # go find and build any CHIP images this image is "FROM"
 awk -F/ '/^FROM connectedhomeip/ {print $2}' Dockerfile | while read -r dep; do
@@ -98,9 +100,10 @@ docker image prune --force
 }
 
 docker images --filter=reference="$ORG/*"
-df -h "$DOCKER_VOLUME_PATH"
-mb_space_after=$(df -m "$DOCKER_VOLUME_PATH" | awk 'FNR==2{print $3}')
-
-printf "%'.f MB total used\n" "$((mb_space_before - mb_space_after))"
+if [ -f "$DOCKER_VOLUME_PATH" ]; then
+    df -h "$DOCKER_VOLUME_PATH"
+    mb_space_after=$(df -m "$DOCKER_VOLUME_PATH" | awk 'FNR==2{print $3}')
+    printf "%'.f MB total used\n" "$((mb_space_before - mb_space_after))"
+fi
 
 exit 0


### PR DESCRIPTION
…ect docker path

Without this, trying to automate docker image pushes failed: a VM may not have direct access to the underlying docker storage directory.