### PR TITLE
[nrfconnect] Update external url to nRF Command Line Tools

### DIFF
--- a/integrations/docker/images/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrf-platform/Dockerfile
@@ -19,7 +19,7 @@ RUN set -x \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
     && mkdir -p /opt/NordicSemiconductor/nRF5_tools/ \
-    && curl --location https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-12-1/nRFCommandLineTools10121Linuxamd64.tar.gz \
+    && curl --location https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-command-line-tools/sw/versions-10-x-x/10-12-1/nrfcommandlinetools10121linuxamd64.tar.gz \
     | tar zxvf - \
     && tar xvf JLink_Linux_V688a_x86_64.tgz -C /opt/NordicSemiconductor/nRF5_tools/ \
     && tar xvf nRF-Command-Line-Tools_10_12_1.tar -C /opt/NordicSemiconductor/nRF5_tools/ \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.16 Version bump reason: [Telink] Update Telink Docker with latest Telink Zephyr (SDK 0.15.2).
+0.6.17 Version bump reason: [nrfconnect] Update external url to nRF Command Line Tools.


### PR DESCRIPTION
This PR modifies the external URL to the nRF Command Line Tools due to a hosting change.

New URL is taken from: https://www.nordicsemi.com/Products/Development-tools/nrf-command-line-tools/download