### PR TITLE
Replace == false if conditions with `!`

### DIFF
--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -81,7 +81,7 @@ static_library("Darwin") {
     ]
   }
 
-  if (chip_disable_platform_kvs == false) {
+  if (!chip_disable_platform_kvs) {
     sources += [
       "DeviceInstanceInfoProviderImpl.cpp",
       "DeviceInstanceInfoProviderImpl.h",

--- a/src/system/system.gni
+++ b/src/system/system.gni
@@ -57,7 +57,7 @@ if (chip_system_config_locking == "") {
     chip_system_config_locking = "freertos"
   } else if (current_os == "mbed") {
     chip_system_config_locking = "mbed"
-  } else if (chip_system_config_use_dispatch == false) {
+  } else if (!chip_system_config_use_dispatch) {
     chip_system_config_locking = "posix"
   } else {
     chip_system_config_locking = "none"


### PR DESCRIPTION
Code is more consistent if using booleans as such (gn is type safe). Use `if (!...)` instead of if `(... == false)`.

This is based on patterns noticed in #23777 