### PR TITLE
Interleave parsing testcase step and executing step

### DIFF
--- a/src/controller/python/chip/yaml/constraints.py
+++ b/src/controller/python/chip/yaml/constraints.py
@@ -112,7 +112,7 @@ class _ConstraintMinValue(_LoadableConstraint):
         super().__init__(min_value, field_type, variable_storage, config_values)
 
     def is_met(self, response) -> bool:
-        # Codegen c++ code will automatically pass min value check is response is NullValue
+        # Codegen c++ code will automatically pass min value check if response is NullValue
         if response == NullValue:
             return True
         min_value = self.get_value()
@@ -125,7 +125,7 @@ class _ConstraintMaxValue(_LoadableConstraint):
         super().__init__(max_value, field_type, variable_storage, config_values)
 
     def is_met(self, response) -> bool:
-        # Codegen c++ code will automatically pass max value check is response is NullValue
+        # Codegen c++ code will automatically pass max value check if response is NullValue
         if response == NullValue:
             return True
         max_value = self.get_value()

--- a/src/controller/python/chip/yaml/parser.py
+++ b/src/controller/python/chip/yaml/parser.py
@@ -350,9 +350,9 @@ class WriteAttributeAction(BaseAction):
 
 
 class YamlTestParser:
-    '''Parses the test YAMLs and converts to a more natural Pythonic representation.
+    '''Parses and execute the test YAMLs
 
-    The parser also permits execution of those tests there-after.
+    Parser converts YAML to Pythonic representation for executing.
     '''
 
     def __init__(self, yaml_path: str):
@@ -429,7 +429,11 @@ class YamlTestParser:
             return None
 
     def parse_and_execute_test(self, dev_ctrl: ChipDeviceCtrl):
-        '''Parse and execute YAML tests.'''
+        '''Parse and execute YAML tests.
+
+        Parsing and execution are interleaved. Before step 2 is parsed this will have already
+        Parsed and executed test step 1.
+        '''
         self._context.variable_storage.clear()
         test_step = 0
         for item in self._raw_data['tests']:


### PR DESCRIPTION
This change is a precursor to simplify loading save values when performing SendCommand, WriteAttribute or ReadEvent where some of the arguments sent are variables.

Also fixed a couple of minor issue created from recent refactors.

Tested inside chip-repl with the following commands (with all-cluster app running on separate terminal already commissioned). Confirmed there was an improvement in overall test coverage:

```
import chip.yaml
foo = chip.yaml.Yaml.YamlTestParser("src/app/tests/suites/TestCluster.yaml")
foo.parse_and_execute_test(devCtrl)
```

```
import chip.yaml
foo = chip.yaml.Yaml.YamlTestParser("src/app/tests/suites/TestConstraints.yaml")
foo.parse_and_execute_test(devCtrl)
```