### PR TITLE
Fix invalid split in documented command

### DIFF
--- a/docs/code_generation.md
+++ b/docs/code_generation.md
@@ -170,8 +170,9 @@ Additionally, individual code regeneration can be done using
 `./scripts/tools/zap/generate.py`:
 
 ```bash
-/scripts/tools/zap/generate.py examples/bridge-app/bridge-common/bridge-app.zap -o zzz_generated/bridge-app/zap-g
-enerated
+/scripts/tools/zap/generate.py                       \
+    examples/bridge-app/bridge-common/bridge-app.zap \
+    -o zzz_generated/bridge-app/zap-generated
 ```
 
 ### `*.matter` code generation


### PR DESCRIPTION
The max line rule split an example command in documentation.

Re-wrote it so that it is a usable copy&paste-able command.