### PR TITLE
Add asUpperCamelCase and asLowerCamelCase as jinja filters

### DIFF
--- a/scripts/idl/BUILD.gn
+++ b/scripts/idl/BUILD.gn
@@ -94,6 +94,7 @@ pw_python_package("idl") {
     "test_matter_idl_parser.py",
     "test_generators.py",
     "test_xml_parser.py",
+    "generators/test_filters.py",
   ]
 
   # TODO: at a future time consider enabling all (* or missing) here to get

--- a/scripts/idl/generators/filters.py
+++ b/scripts/idl/generators/filters.py
@@ -28,6 +28,7 @@ def normalize_acronyms(s: str) -> str:
 
 WORD_SPLIT_RE = re.compile('[- /_]')
 
+
 def _splitWords(s: str) -> List[str]:
     """
     Split a string into its underlying words
@@ -57,20 +58,19 @@ def asUpperCamelCase(s: str, preserve_acronyms: bool = True) -> str:
 
     Resulting camel case has all first letters of words as upper case.
     """
-    return "".join(_splitIntoWords(s, preserve_acronyms=preserve_acronyms,transform=str.title))
+    return "".join(_splitIntoWords(s, preserve_acronyms=preserve_acronyms, transform=str.title))
+
 
 def asLowerCamelCase(s: str, preserve_acronyms: bool = True) -> str:
     """
     Same as asUpperCamelCase except first word is lowercased EXCEPT if it is
     an acronym.
     """
-    words = _splitIntoWords(s, preserve_acronyms=preserve_acronyms,transform=str.title)
+    words = _splitIntoWords(s, preserve_acronyms=preserve_acronyms, transform=str.title)
     if not preserve_acronyms or words[0].upper() != words[0]:
         words[0] = words[0][0].lower() + words[0][1:]
 
     return ''.join(words)
-
-
 
 
 def RegisterCommonFilters(filtermap):
@@ -91,7 +91,6 @@ def RegisterCommonFilters(filtermap):
     filtermap['spinalcase'] = stringcase.spinalcase
 
     filtermap['normalize_acronyms'] = normalize_acronyms
-
 
     # equivalence methods from zap templates. These are expected to
     # be identical with zap

--- a/scripts/idl/generators/filters.py
+++ b/scripts/idl/generators/filters.py
@@ -95,3 +95,4 @@ def RegisterCommonFilters(filtermap):
     # equivalence methods from zap templates. These are expected to
     # be identical with zap
     filtermap['asUpperCamelCase'] = asUpperCamelCase
+    filtermap['asLowerCamelCase'] = asLowerCamelCase

--- a/scripts/idl/generators/test_filters.py
+++ b/scripts/idl/generators/test_filters.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+import yaml
+import logging
+from typing import List
+from dataclasses import dataclass, field
+
+try:
+    from idl.generators.filters import *
+except:
+    import sys
+
+    sys.path.append(os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '..', '..')))
+    from idl.generators.filters import *
+
+
+class TestFilders(unittest.TestCase):
+    def test_as_upper_camel_case(self):
+        self.assertEqual(asUpperCamelCase('foo'), 'Foo')
+
+        # basic separators and casing
+        self.assertEqual(asUpperCamelCase('foo-bar'), 'FooBar')
+        self.assertEqual(asUpperCamelCase('fOo-bAr-BaZ'), 'FooBarBaz')
+        self.assertEqual(asUpperCamelCase('fOo bAr/BaZ'), 'FooBarBaz')
+        self.assertEqual(asUpperCamelCase('fOo_bAr BaZ'), 'FooBarBaz')
+
+        # handling of acronyms
+        self.assertEqual(asUpperCamelCase('FOO_bAr BaZ'), 'FOOBarBaz')
+        self.assertEqual(asUpperCamelCase('FOO_bAr/BaZ', preserve_acronyms=False), 'FooBarBaz')
+        self.assertEqual(asUpperCamelCase('fOo-BAR/BAZ'), 'FooBARBAZ')
+        self.assertEqual(asUpperCamelCase('fOo/BAR-BAZ', preserve_acronyms=False), 'FooBarBaz')
+
+    def test_as_lower_camel_case(self):
+        self.assertEqual(asLowerCamelCase('foo'), 'foo')
+        self.assertEqual(asLowerCamelCase('fOo'), 'foo')
+
+        # basic separators and casing
+        self.assertEqual(asLowerCamelCase('foo-bar'), 'fooBar')
+        self.assertEqual(asLowerCamelCase('fOo-bAr-BaZ'), 'fooBarBaz')
+        self.assertEqual(asLowerCamelCase('fOo bAr/BaZ'), 'fooBarBaz')
+        self.assertEqual(asLowerCamelCase('fOo_bAr BaZ'), 'fooBarBaz')
+
+        # handling of acronyms
+        self.assertEqual(asLowerCamelCase('FOO_bAr BaZ'), 'FOOBarBaz')
+        self.assertEqual(asLowerCamelCase('FOO_bAr/BaZ', preserve_acronyms=False), 'fooBarBaz')
+        self.assertEqual(asLowerCamelCase('fOo-BAR/BAZ'), 'fooBARBAZ')
+        self.assertEqual(asLowerCamelCase('fOo/BAR-BAZ', preserve_acronyms=False), 'fooBarBaz')
+        self.assertEqual(asLowerCamelCase('FOO-BAR/BAZ'), 'FOOBARBAZ')
+        self.assertEqual(asLowerCamelCase('FOO/BAR-BAZ', preserve_acronyms=False), 'fooBarBaz')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is for easier zap template equivalence as these filters seem to be reasonably heavily used.
The logic of split and acronyms remains the same as zap - have some unit tests for this. If we find incompatibilities, we can update logic and tests.