### PR TITLE
Increase chef cloud build timeout to 5 hours

### DIFF
--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -53,7 +53,7 @@ steps:
 logsBucket: matter-build-automation-build-logs
 
 # Global timeout for all steps
-timeout: 14400s
+timeout: 18000s
 queueTtl: 21600s
 
 artifacts:


### PR DESCRIPTION
The current global timeout of 4 hours is not enough to complete all the steps in the chef.yaml config.
