### PR TITLE
Fix some loose ends from the acronym casing Darwin changes.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -88,9 +88,6 @@ MTR_NEWLY_DEPRECATED("Please use {{objCEnumName (asUpperCamelCase ../name preser
 {{/unless}}
 ;
 
-{{#if (isStrEqual (asUpperCamelCase ../name) "UnitTesting")}}
-
-{{/if}}
 {{/zcl_enums}}
 {{#zcl_bitmaps}}
 {{#*inline "bitmapDef"}}
@@ -100,29 +97,26 @@ typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName labe
    {{/zcl_bitmap_items}}
 }
 {{! TODO: We need a better setup for the API_AVALABLE annotations here; this does not scale at all sanely. }}
-{{#if (isStrEqual (asUpperCamelCase ../name) "Switch")}}
+{{#if (isStrEqual (asUpperCamelCase clusterName) "Switch")}}
 {{#if (isStrEqual (asUpperCamelCase label) "SwitchFeature")}}
 API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 {{/if}}
 {{/if}}
-{{#if (isStrEqual (asUpperCamelCase ../name) "MediaPlayback")}}
+{{#if (isStrEqual (asUpperCamelCase clusterName) "MediaPlayback")}}
 {{#if (isStrEqual (asUpperCamelCase label) "MediaPlaybackFeature")}}
 API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 {{/if}}
 {{/if}}
-{{#if (isStrEqual (asUpperCamelCase clusterName) "UnitTesting")}}
-MTR_NEWLY_AVAILABLE
-{{else if (isStrEqual (asUpperCamelCase clusterName) "TestCluster")}}
-MTR_NEWLY_DEPRECATED("Please use {{objCEnumName "UnitTesting" label}}")
-{{/if}}
-;
 {{/inline}}
-{{> bitmapDef name=name clusterName=../name label=label}}
+{{> bitmapDef name=name clusterName=(asUpperCamelCase ../name preserveAcronyms=true) label=label}}
+{{#unless (isStrEqual (asUpperCamelCase ../name preserveAcronyms=true) (compatClusterNameRemapping ../name))}}
+MTR_NEWLY_AVAILABLE;
 
-{{#if (isStrEqual (asUpperCamelCase ../name) "UnitTesting")}}
-{{> bitmapDef name=name clusterName="TestCluster" label=label}}
+{{> bitmapDef name=name clusterName=(compatClusterNameRemapping ../name) label=label}}
+MTR_NEWLY_DEPRECATED("Please use {{objCEnumName (asUpperCamelCase ../name preserveAcronyms=true) label}}")
+{{/unless}}
+;
 
-{{/if}}
 {{/zcl_bitmaps}}
 {{/zcl_clusters}}
 
@@ -153,21 +147,21 @@ MTR_NEWLY_DEPRECATED("Please use {{objCEnumName "UnitTesting" label}}")
   CompletionHandler:
 {{~/if_is_fabric_scoped_struct~}}
 (void (^)({{asObjectiveCClass type parent.name compatRemapClusterName=true}} * _Nullable value, NSError * _Nullable error))completionHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
-  MTR_NEWLY_DEPRECATED("Please use read{{>attribute}}With{{#if_is_fabric_scoped_struct type}}Params:completion:{{else}}Completion:{{/if_is_fabric_scoped_struct}}");
+  MTR_NEWLY_DEPRECATED("Please use readAttribute{{asUpperCamelCase name preserveAcronyms=true}}With{{#if_is_fabric_scoped_struct type}}Params:completion:{{else}}Completion:{{/if_is_fabric_scoped_struct}}");
 {{#if isWritableAttribute}}
 - (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name compatRemapClusterName=true}})value completionHandler:(MTRStatusCompletion)completionHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
-  MTR_NEWLY_DEPRECATED("Please use write{{>attribute}}WithValue:completion:");
+  MTR_NEWLY_DEPRECATED("Please use writeAttribute{{asUpperCamelCase name preserveAcronyms=true}}WithValue:completion:");
 - (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name compatRemapClusterName=true}})value params:(MTRWriteParams * _Nullable)params completionHandler:(MTRStatusCompletion)completionHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
-  MTR_NEWLY_DEPRECATED("Please use write{{>attribute}}WithValue:params:completion:");
+  MTR_NEWLY_DEPRECATED("Please use writeAttribute{{asUpperCamelCase name preserveAcronyms=true}}WithValue:params:completion:");
 {{/if}}
 {{#if isReportableAttribute}}
 {{! TODO: We need a better setup for the API_AVALABLE annotations here; this does not scale at all sanely. }}
 - (void) subscribe{{>attribute}}WithMinInterval:(NSNumber * _Nonnull)minInterval  maxInterval:(NSNumber * _Nonnull)maxInterval
        params:(MTRSubscribeParams * _Nullable)params
 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler reportHandler:(void (^)({{asObjectiveCClass type parent.name compatRemapClusterName=true}} * _Nullable value, NSError * _Nullable error))reportHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
-  MTR_NEWLY_DEPRECATED("Please use subscribe{{>attribute}}WithParams:subscriptionEstablished:");
+  MTR_NEWLY_DEPRECATED("Please use subscribeAttribute{{asUpperCamelCase name preserveAcronyms=true}}WithParams:subscriptionEstablished:");
 + (void) read{{>attribute}}WithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue completionHandler:(void (^)({{asObjectiveCClass type parent.name compatRemapClusterName=true}} * _Nullable value, NSError * _Nullable error))completionHandler {{#if (isStrEqual (asUpperCamelCase parent.name) "UnitTesting")}}{{#if (isStrEqual (asUpperCamelCase name) "WriteOnlyInt8u")}}API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2)){{/if}}{{/if}}
-  MTR_NEWLY_DEPRECATED("Please use read{{>attribute}}WithAttributeCache:endpoint:queue:completion:");
+  MTR_NEWLY_DEPRECATED("Please use readAttribute{{asUpperCamelCase name preserveAcronyms=true}}WithAttributeCache:endpoint:queue:completion:");
 {{/if}}
 {{/chip_server_cluster_attributes}}
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -18977,18 +18977,18 @@ typedef NS_ENUM(uint8_t, MTRFaultInjectionFaultType) {
 
 - (void)readAttributeDeviceListWithCompletionHandler:
     (void (^)(NSArray * _Nullable value, NSError * _Nullable error))completionHandler
-    MTR_NEWLY_DEPRECATED("Please use readAttributeDeviceListWithCompletion:");
+    MTR_NEWLY_DEPRECATED("Please use readAttributeDeviceTypeListWithCompletion:");
 - (void)subscribeAttributeDeviceListWithMinInterval:(NSNumber * _Nonnull)minInterval
                                         maxInterval:(NSNumber * _Nonnull)maxInterval
                                              params:(MTRSubscribeParams * _Nullable)params
                             subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
                                       reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
-    MTR_NEWLY_DEPRECATED("Please use subscribeAttributeDeviceListWithParams:subscriptionEstablished:");
+    MTR_NEWLY_DEPRECATED("Please use subscribeAttributeDeviceTypeListWithParams:subscriptionEstablished:");
 + (void)readAttributeDeviceListWithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer
                                          endpoint:(NSNumber *)endpoint
                                             queue:(dispatch_queue_t)queue
                                 completionHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completionHandler
-    MTR_NEWLY_DEPRECATED("Please use readAttributeDeviceListWithAttributeCache:endpoint:queue:completion:");
+    MTR_NEWLY_DEPRECATED("Please use readAttributeDeviceTypeListWithAttributeCache:endpoint:queue:completion:");
 
 - (void)readAttributeServerListWithCompletionHandler:
     (void (^)(NSArray * _Nullable value, NSError * _Nullable error))completionHandler
@@ -19243,25 +19243,25 @@ typedef NS_ENUM(uint8_t, MTRFaultInjectionFaultType) {
 
 - (void)readAttributeAclWithParams:(MTRReadParams * _Nullable)params
                  completionHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completionHandler
-    MTR_NEWLY_DEPRECATED("Please use readAttributeAclWithParams:completion:");
+    MTR_NEWLY_DEPRECATED("Please use readAttributeACLWithParams:completion:");
 - (void)writeAttributeAclWithValue:(NSArray * _Nonnull)value
                  completionHandler:(MTRStatusCompletion)completionHandler
-    MTR_NEWLY_DEPRECATED("Please use writeAttributeAclWithValue:completion:");
+    MTR_NEWLY_DEPRECATED("Please use writeAttributeACLWithValue:completion:");
 - (void)writeAttributeAclWithValue:(NSArray * _Nonnull)value
                             params:(MTRWriteParams * _Nullable)params
                  completionHandler:(MTRStatusCompletion)completionHandler
-    MTR_NEWLY_DEPRECATED("Please use writeAttributeAclWithValue:params:completion:");
+    MTR_NEWLY_DEPRECATED("Please use writeAttributeACLWithValue:params:completion:");
 - (void)subscribeAttributeAclWithMinInterval:(NSNumber * _Nonnull)minInterval
                                  maxInterval:(NSNumber * _Nonnull)maxInterval
                                       params:(MTRSubscribeParams * _Nullable)params
                      subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
                                reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
-    MTR_NEWLY_DEPRECATED("Please use subscribeAttributeAclWithParams:subscriptionEstablished:");
+    MTR_NEWLY_DEPRECATED("Please use subscribeAttributeACLWithParams:subscriptionEstablished:");
 + (void)readAttributeAclWithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer
                                   endpoint:(NSNumber *)endpoint
                                      queue:(dispatch_queue_t)queue
                          completionHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completionHandler
-    MTR_NEWLY_DEPRECATED("Please use readAttributeAclWithAttributeCache:endpoint:queue:completion:");
+    MTR_NEWLY_DEPRECATED("Please use readAttributeACLWithAttributeCache:endpoint:queue:completion:");
 
 - (void)readAttributeExtensionWithParams:(MTRReadParams * _Nullable)params
                        completionHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completionHandler
@@ -32044,14 +32044,14 @@ typedef NS_ENUM(uint8_t, MTRFaultInjectionFaultType) {
 
 - (void)readAttributePirOccupiedToUnoccupiedDelayWithCompletionHandler:
     (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completionHandler
-    MTR_NEWLY_DEPRECATED("Please use readAttributePirOccupiedToUnoccupiedDelayWithCompletion:");
+    MTR_NEWLY_DEPRECATED("Please use readAttributePIROccupiedToUnoccupiedDelayWithCompletion:");
 - (void)writeAttributePirOccupiedToUnoccupiedDelayWithValue:(NSNumber * _Nonnull)value
                                           completionHandler:(MTRStatusCompletion)completionHandler
-    MTR_NEWLY_DEPRECATED("Please use writeAttributePirOccupiedToUnoccupiedDelayWithValue:completion:");
+    MTR_NEWLY_DEPRECATED("Please use writeAttributePIROccupiedToUnoccupiedDelayWithValue:completion:");
 - (void)writeAttributePirOccupiedToUnoccupiedDelayWithValue:(NSNumber * _Nonnull)value
                                                      params:(MTRWriteParams * _Nullable)params
                                           completionHandler:(MTRStatusCompletion)completionHandler
-    MTR_NEWLY_DEPRECATED("Please use writeAttributePirOccupiedToUnoccupiedDelayWithValue:params:completion:");
+    MTR_NEWLY_DEPRECATED("Please use writeAttributePIROccupiedToUnoccupiedDelayWithValue:params:completion:");
 - (void)subscribeAttributePirOccupiedToUnoccupiedDelayWithMinInterval:(NSNumber * _Nonnull)minInterval
                                                           maxInterval:(NSNumber * _Nonnull)maxInterval
                                                                params:(MTRSubscribeParams * _Nullable)params
@@ -32059,24 +32059,24 @@ typedef NS_ENUM(uint8_t, MTRFaultInjectionFaultType) {
                                                   (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
                                                         reportHandler:(void (^)(NSNumber * _Nullable value,
                                                                           NSError * _Nullable error))reportHandler
-    MTR_NEWLY_DEPRECATED("Please use subscribeAttributePirOccupiedToUnoccupiedDelayWithParams:subscriptionEstablished:");
+    MTR_NEWLY_DEPRECATED("Please use subscribeAttributePIROccupiedToUnoccupiedDelayWithParams:subscriptionEstablished:");
 + (void)readAttributePirOccupiedToUnoccupiedDelayWithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer
                                                            endpoint:(NSNumber *)endpoint
                                                               queue:(dispatch_queue_t)queue
                                                   completionHandler:(void (^)(NSNumber * _Nullable value,
                                                                         NSError * _Nullable error))completionHandler
-    MTR_NEWLY_DEPRECATED("Please use readAttributePirOccupiedToUnoccupiedDelayWithAttributeCache:endpoint:queue:completion:");
+    MTR_NEWLY_DEPRECATED("Please use readAttributePIROccupiedToUnoccupiedDelayWithAttributeCache:endpoint:queue:completion:");
 
 - (void)readAttributePirUnoccupiedToOccupiedDelayWithCompletionHandler:
     (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completionHandler
-    MTR_NEWLY_DEPRECATED("Please use readAttributePirUnoccupiedToOccupiedDelayWithCompletion:");
+    MTR_NEWLY_DEPRECATED("Please use readAttributePIRUnoccupiedToOccupiedDelayWithCompletion:");
 - (void)writeAttributePirUnoccupiedToOccupiedDelayWithValue:(NSNumber * _Nonnull)value
                                           completionHandler:(MTRStatusCompletion)completionHandler
-    MTR_NEWLY_DEPRECATED("Please use writeAttributePirUnoccupiedToOccupiedDelayWithValue:completion:");
+    MTR_NEWLY_DEPRECATED("Please use writeAttributePIRUnoccupiedToOccupiedDelayWithValue:completion:");
 - (void)writeAttributePirUnoccupiedToOccupiedDelayWithValue:(NSNumber * _Nonnull)value
                                                      params:(MTRWriteParams * _Nullable)params
                                           completionHandler:(MTRStatusCompletion)completionHandler
-    MTR_NEWLY_DEPRECATED("Please use writeAttributePirUnoccupiedToOccupiedDelayWithValue:params:completion:");
+    MTR_NEWLY_DEPRECATED("Please use writeAttributePIRUnoccupiedToOccupiedDelayWithValue:params:completion:");
 - (void)subscribeAttributePirUnoccupiedToOccupiedDelayWithMinInterval:(NSNumber * _Nonnull)minInterval
                                                           maxInterval:(NSNumber * _Nonnull)maxInterval
                                                                params:(MTRSubscribeParams * _Nullable)params
@@ -32084,24 +32084,24 @@ typedef NS_ENUM(uint8_t, MTRFaultInjectionFaultType) {
                                                   (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
                                                         reportHandler:(void (^)(NSNumber * _Nullable value,
                                                                           NSError * _Nullable error))reportHandler
-    MTR_NEWLY_DEPRECATED("Please use subscribeAttributePirUnoccupiedToOccupiedDelayWithParams:subscriptionEstablished:");
+    MTR_NEWLY_DEPRECATED("Please use subscribeAttributePIRUnoccupiedToOccupiedDelayWithParams:subscriptionEstablished:");
 + (void)readAttributePirUnoccupiedToOccupiedDelayWithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer
                                                            endpoint:(NSNumber *)endpoint
                                                               queue:(dispatch_queue_t)queue
                                                   completionHandler:(void (^)(NSNumber * _Nullable value,
                                                                         NSError * _Nullable error))completionHandler
-    MTR_NEWLY_DEPRECATED("Please use readAttributePirUnoccupiedToOccupiedDelayWithAttributeCache:endpoint:queue:completion:");
+    MTR_NEWLY_DEPRECATED("Please use readAttributePIRUnoccupiedToOccupiedDelayWithAttributeCache:endpoint:queue:completion:");
 
 - (void)readAttributePirUnoccupiedToOccupiedThresholdWithCompletionHandler:
     (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completionHandler
-    MTR_NEWLY_DEPRECATED("Please use readAttributePirUnoccupiedToOccupiedThresholdWithCompletion:");
+    MTR_NEWLY_DEPRECATED("Please use readAttributePIRUnoccupiedToOccupiedThresholdWithCompletion:");
 - (void)writeAttributePirUnoccupiedToOccupiedThresholdWithValue:(NSNumber * _Nonnull)value
                                               completionHandler:(MTRStatusCompletion)completionHandler
-    MTR_NEWLY_DEPRECATED("Please use writeAttributePirUnoccupiedToOccupiedThresholdWithValue:completion:");
+    MTR_NEWLY_DEPRECATED("Please use writeAttributePIRUnoccupiedToOccupiedThresholdWithValue:completion:");
 - (void)writeAttributePirUnoccupiedToOccupiedThresholdWithValue:(NSNumber * _Nonnull)value
                                                          params:(MTRWriteParams * _Nullable)params
                                               completionHandler:(MTRStatusCompletion)completionHandler
-    MTR_NEWLY_DEPRECATED("Please use writeAttributePirUnoccupiedToOccupiedThresholdWithValue:params:completion:");
+    MTR_NEWLY_DEPRECATED("Please use writeAttributePIRUnoccupiedToOccupiedThresholdWithValue:params:completion:");
 - (void)subscribeAttributePirUnoccupiedToOccupiedThresholdWithMinInterval:(NSNumber * _Nonnull)minInterval
                                                               maxInterval:(NSNumber * _Nonnull)maxInterval
                                                                    params:(MTRSubscribeParams * _Nullable)params
@@ -32109,13 +32109,13 @@ typedef NS_ENUM(uint8_t, MTRFaultInjectionFaultType) {
                                                       (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
                                                             reportHandler:(void (^)(NSNumber * _Nullable value,
                                                                               NSError * _Nullable error))reportHandler
-    MTR_NEWLY_DEPRECATED("Please use subscribeAttributePirUnoccupiedToOccupiedThresholdWithParams:subscriptionEstablished:");
+    MTR_NEWLY_DEPRECATED("Please use subscribeAttributePIRUnoccupiedToOccupiedThresholdWithParams:subscriptionEstablished:");
 + (void)readAttributePirUnoccupiedToOccupiedThresholdWithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer
                                                                endpoint:(NSNumber *)endpoint
                                                                   queue:(dispatch_queue_t)queue
                                                       completionHandler:(void (^)(NSNumber * _Nullable value,
                                                                             NSError * _Nullable error))completionHandler
-    MTR_NEWLY_DEPRECATED("Please use readAttributePirUnoccupiedToOccupiedThresholdWithAttributeCache:endpoint:queue:completion:");
+    MTR_NEWLY_DEPRECATED("Please use readAttributePIRUnoccupiedToOccupiedThresholdWithAttributeCache:endpoint:queue:completion:");
 
 - (void)readAttributeUltrasonicOccupiedToUnoccupiedDelayWithCompletionHandler:
     (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completionHandler


### PR DESCRIPTION
* Fix deprecation messages to reference the right selectors.
* Fix bitmaps to handle cluster renames the same way enums do, instead of hardcoding UnitTesting/TestCluster.

