### PR TITLE
Put back auto-generated comments for MTRBaseClusters.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -14,7 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster {{name}}
- *    {{description}}
+ *
+ * {{description}}
  */
 {{#unless (isStrEqual (asUpperCamelCase name preserveAcronyms=true) (compatClusterNameRemapping name))}}
 MTR_NEWLY_AVAILABLE
@@ -26,6 +27,11 @@ MTR_NEWLY_AVAILABLE
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
 {{#chip_cluster_commands}}
+/**
+ * Command {{name}}
+ *
+ * {{description}}
+ */
 {{#*inline "cluster"}}{{asUpperCamelCase parent.name preserveAcronyms=true}}{{/inline~}}
 {{~#*inline "command"}}{{asUpperCamelCase name preserveAcronyms=true}}{{/inline~}}
 - (void){{asLowerCamelCase name}}WithParams:(MTR{{>cluster}}Cluster{{>command}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completion:({{>command_completion_type command=.}})completion MTR_NEWLY_AVAILABLE;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -26,7 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Identify
- *    Attributes and commands for putting a device into Identification mode (e.g. flashing a light).
+ *
+ * Attributes and commands for putting a device into Identification mode (e.g. flashing a light).
  */
 @interface MTRBaseClusterIdentify : MTRCluster
 
@@ -34,8 +35,18 @@ NS_ASSUME_NONNULL_BEGIN
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command Identify
+ *
+ * Command description for Identify
+ */
 - (void)identifyWithParams:(MTRIdentifyClusterIdentifyParams *)params
                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TriggerEffect
+ *
+ * Command description for TriggerEffect
+ */
 - (void)triggerEffectWithParams:(MTRIdentifyClusterTriggerEffectParams *)params
                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -135,7 +146,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Groups
- *    Attributes and commands for group configuration and manipulation.
+ *
+ * Attributes and commands for group configuration and manipulation.
  */
 @interface MTRBaseClusterGroups : MTRCluster
 
@@ -143,21 +155,51 @@ NS_ASSUME_NONNULL_BEGIN
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command AddGroup
+ *
+ * Command description for AddGroup
+ */
 - (void)addGroupWithParams:(MTRGroupsClusterAddGroupParams *)params
                 completion:(void (^)(MTRGroupsClusterAddGroupResponseParams * _Nullable data, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
+/**
+ * Command ViewGroup
+ *
+ * Command description for ViewGroup
+ */
 - (void)viewGroupWithParams:(MTRGroupsClusterViewGroupParams *)params
                  completion:(void (^)(MTRGroupsClusterViewGroupResponseParams * _Nullable data,
                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command GetGroupMembership
+ *
+ * Command description for GetGroupMembership
+ */
 - (void)getGroupMembershipWithParams:(MTRGroupsClusterGetGroupMembershipParams *)params
                           completion:(void (^)(MTRGroupsClusterGetGroupMembershipResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command RemoveGroup
+ *
+ * Command description for RemoveGroup
+ */
 - (void)removeGroupWithParams:(MTRGroupsClusterRemoveGroupParams *)params
                    completion:(void (^)(MTRGroupsClusterRemoveGroupResponseParams * _Nullable data,
                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command RemoveAllGroups
+ *
+ * Command description for RemoveAllGroups
+ */
 - (void)removeAllGroupsWithParams:(MTRGroupsClusterRemoveAllGroupsParams * _Nullable)params
                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)removeAllGroupsWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command AddGroupIfIdentifying
+ *
+ * Command description for AddGroupIfIdentifying
+ */
 - (void)addGroupIfIdentifyingWithParams:(MTRGroupsClusterAddGroupIfIdentifyingParams *)params
                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -240,7 +282,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Scenes
- *    Attributes and commands for scene configuration and manipulation.
+ *
+ * Attributes and commands for scene configuration and manipulation.
  */
 @interface MTRBaseClusterScenes : MTRCluster
 
@@ -248,32 +291,86 @@ NS_ASSUME_NONNULL_BEGIN
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command AddScene
+ *
+ * Add a scene to the scene table. Extension field sets are supported, and are inputed as '{"ClusterID": VALUE,
+ * "AttributeValueList":[{"AttributeId": VALUE, "AttributeValue": VALUE}]}'
+ */
 - (void)addSceneWithParams:(MTRScenesClusterAddSceneParams *)params
                 completion:(void (^)(MTRScenesClusterAddSceneResponseParams * _Nullable data, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
+/**
+ * Command ViewScene
+ *
+ * Retrieves the requested scene entry from its Scene table.
+ */
 - (void)viewSceneWithParams:(MTRScenesClusterViewSceneParams *)params
                  completion:(void (^)(MTRScenesClusterViewSceneResponseParams * _Nullable data,
                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command RemoveScene
+ *
+ * Removes the requested scene entry, corresponding to the value of the GroupID field, from its Scene Table
+ */
 - (void)removeSceneWithParams:(MTRScenesClusterRemoveSceneParams *)params
                    completion:(void (^)(MTRScenesClusterRemoveSceneResponseParams * _Nullable data,
                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command RemoveAllScenes
+ *
+ * Remove all scenes, corresponding to the value of the GroupID field, from its Scene Table
+ */
 - (void)removeAllScenesWithParams:(MTRScenesClusterRemoveAllScenesParams *)params
                        completion:(void (^)(MTRScenesClusterRemoveAllScenesResponseParams * _Nullable data,
                                       NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StoreScene
+ *
+ * Adds the scene entry into its Scene Table along with all extension field sets corresponding to the current state of other
+ * clusters on the same endpoint
+ */
 - (void)storeSceneWithParams:(MTRScenesClusterStoreSceneParams *)params
                   completion:(void (^)(MTRScenesClusterStoreSceneResponseParams * _Nullable data,
                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command RecallScene
+ *
+ * Set the attributes and corresponding state for each other cluster implemented on the endpoint accordingly to the resquested scene
+ * entry in the Scene Table
+ */
 - (void)recallSceneWithParams:(MTRScenesClusterRecallSceneParams *)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command GetSceneMembership
+ *
+ * Get an unused scene identifier when no commissioning tool is in the network, or for a commissioning tool to get the used scene
+ * identifiers within a certain group
+ */
 - (void)getSceneMembershipWithParams:(MTRScenesClusterGetSceneMembershipParams *)params
                           completion:(void (^)(MTRScenesClusterGetSceneMembershipResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command EnhancedAddScene
+ *
+ * Allows a scene to be added using a finer scene transition time than the AddScene command.
+ */
 - (void)enhancedAddSceneWithParams:(MTRScenesClusterEnhancedAddSceneParams *)params
                         completion:(void (^)(MTRScenesClusterEnhancedAddSceneResponseParams * _Nullable data,
                                        NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command EnhancedViewScene
+ *
+ * Allows a scene to be retrieved using a finer scene transition time than the ViewScene command
+ */
 - (void)enhancedViewSceneWithParams:(MTRScenesClusterEnhancedViewSceneParams *)params
                          completion:(void (^)(MTRScenesClusterEnhancedViewSceneResponseParams * _Nullable data,
                                         NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command CopyScene
+ *
+ * Allows a client to efficiently copy scenes from one group/scene identifier pair to another group/scene identifier pair.
+ */
 - (void)copySceneWithParams:(MTRScenesClusterCopySceneParams *)params
                  completion:(void (^)(MTRScenesClusterCopySceneResponseParams * _Nullable data,
                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
@@ -417,7 +514,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster On/Off
- *    Attributes and commands for switching devices between 'On' and 'Off' states.
+ *
+ * Attributes and commands for switching devices between 'On' and 'Off' states.
  */
 @interface MTRBaseClusterOnOff : MTRCluster
 
@@ -425,18 +523,56 @@ NS_ASSUME_NONNULL_BEGIN
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command Off
+ *
+ * On receipt of this command, a device SHALL enter its ‘Off’ state. This state is device dependent, but it is recommended that it
+ * is used for power off or similar functions. On receipt of the Off command, the OnTime attribute SHALL be set to 0.
+ */
 - (void)offWithParams:(MTROnOffClusterOffParams * _Nullable)params completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)offWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command On
+ *
+ * On receipt of this command, a device SHALL enter its ‘On’ state. This state is device dependent, but it is recommended that it is
+ * used for power on or similar functions. On receipt of the On command, if the value of the OnTime attribute is equal to 0, the
+ * device SHALL set the OffWaitTime attribute to 0.
+ */
 - (void)onWithParams:(MTROnOffClusterOnParams * _Nullable)params completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)onWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command Toggle
+ *
+ * On receipt of this command, if a device is in its ‘Off’ state it SHALL enter its ‘On’ state. Otherwise, if it is in its ‘On’
+ * state it SHALL enter its ‘Off’ state. On receipt of the Toggle command, if the value of the OnOff attribute is equal to FALSE and
+ * if the value of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0. If the value of the
+ * OnOff attribute is equal to TRUE, the OnTime attribute SHALL be set to 0.
+ */
 - (void)toggleWithParams:(MTROnOffClusterToggleParams * _Nullable)params
               completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)toggleWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command OffWithEffect
+ *
+ * The OffWithEffect command allows devices to be turned off using enhanced ways of fading.
+ */
 - (void)offWithEffectWithParams:(MTROnOffClusterOffWithEffectParams *)params
                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command OnWithRecallGlobalScene
+ *
+ * The OnWithRecallGlobalScene command allows the recall of the settings when the device was turned off.
+ */
 - (void)onWithRecallGlobalSceneWithParams:(MTROnOffClusterOnWithRecallGlobalSceneParams * _Nullable)params
                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)onWithRecallGlobalSceneWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command OnWithTimedOff
+ *
+ * The OnWithTimedOff command allows devices to be turned on for a specific duration with a guarded off duration so that SHOULD the
+ * device be subsequently switched off, further OnWithTimedOff commands, received during this time, are prevented from turning the
+ * devices back on.
+ */
 - (void)onWithTimedOffWithParams:(MTROnOffClusterOnWithTimedOffParams *)params
                       completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -581,7 +717,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster On/off Switch Configuration
- *    Attributes and commands for configuring On/Off switching devices.
+ *
+ * Attributes and commands for configuring On/Off switching devices.
  */
 @interface MTRBaseClusterOnOffSwitchConfiguration : MTRCluster
 
@@ -685,7 +822,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Level Control
- *    Attributes and commands for controlling devices that can be set to a level between fully 'On' and fully 'Off.'
+ *
+ * Attributes and commands for controlling devices that can be set to a level between fully 'On' and fully 'Off.'
  */
 @interface MTRBaseClusterLevelControl : MTRCluster
 
@@ -693,19 +831,65 @@ NS_ASSUME_NONNULL_BEGIN
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command MoveToLevel
+ *
+ * Command description for MoveToLevel
+ */
 - (void)moveToLevelWithParams:(MTRLevelControlClusterMoveToLevelParams *)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command Move
+ *
+ * Command description for Move
+ */
 - (void)moveWithParams:(MTRLevelControlClusterMoveParams *)params completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command Step
+ *
+ * Command description for Step
+ */
 - (void)stepWithParams:(MTRLevelControlClusterStepParams *)params completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command Stop
+ *
+ * Command description for Stop
+ */
 - (void)stopWithParams:(MTRLevelControlClusterStopParams *)params completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command MoveToLevelWithOnOff
+ *
+ * Command description for MoveToLevelWithOnOff
+ */
 - (void)moveToLevelWithOnOffWithParams:(MTRLevelControlClusterMoveToLevelWithOnOffParams *)params
                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command MoveWithOnOff
+ *
+ * Command description for MoveWithOnOff
+ */
 - (void)moveWithOnOffWithParams:(MTRLevelControlClusterMoveWithOnOffParams *)params
                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StepWithOnOff
+ *
+ * Command description for StepWithOnOff
+ */
 - (void)stepWithOnOffWithParams:(MTRLevelControlClusterStepWithOnOffParams *)params
                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StopWithOnOff
+ *
+ * Command description for StopWithOnOff
+ */
 - (void)stopWithOnOffWithParams:(MTRLevelControlClusterStopWithOnOffParams *)params
                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command MoveToClosestFrequency
+ *
+ * Change the currrent frequency to the provided one, or a close
+        approximation if the exact provided one is not possible.
+ */
 - (void)moveToClosestFrequencyWithParams:(MTRLevelControlClusterMoveToClosestFrequencyParams *)params
                               completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -977,7 +1161,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Binary Input (Basic)
- *    An interface for reading the value of a binary measurement and accessing various characteristics of that measurement.
+ *
+ * An interface for reading the value of a binary measurement and accessing various characteristics of that measurement.
  */
 @interface MTRBaseClusterBinaryInputBasic : MTRCluster
 
@@ -1189,8 +1374,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Descriptor
- *    The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its
- * endpoints and clusters.
+ *
+ * The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its endpoints
+ * and clusters.
  */
 @interface MTRBaseClusterDescriptor : MTRCluster
 
@@ -1313,7 +1499,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Binding
- *    The Binding Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for supporting the binding table.
+ *
+ * The Binding Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for supporting the binding table.
  */
 @interface MTRBaseClusterBinding : MTRCluster
 
@@ -1405,7 +1592,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Access Control
- *    The Access Control Cluster exposes a data model view of a
+ *
+ * The Access Control Cluster exposes a data model view of a
       Node's Access Control List (ACL), which codifies the rules used to manage
       and enforce Access Control for the Node's endpoints and their associated
       cluster instances.
@@ -1558,7 +1746,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Actions
- *    This cluster provides a standardized way for a Node (typically a Bridge, but could be any Node) to expose action information.
+ *
+ * This cluster provides a standardized way for a Node (typically a Bridge, but could be any Node) to expose action information.
  */
 @interface MTRBaseClusterActions : MTRCluster
 
@@ -1566,28 +1755,89 @@ NS_ASSUME_NONNULL_BEGIN
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command InstantAction
+ *
+ * This command triggers an action (state change) on the involved endpoints.
+ */
 - (void)instantActionWithParams:(MTRActionsClusterInstantActionParams *)params
                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command InstantActionWithTransition
+ *
+ * This command triggers an action (state change) on the involved endpoints, with a specified time to transition from the current
+ * state to the new state.
+ */
 - (void)instantActionWithTransitionWithParams:(MTRActionsClusterInstantActionWithTransitionParams *)params
                                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StartAction
+ *
+ * This command triggers the commencement of an action on the involved endpoints.
+ */
 - (void)startActionWithParams:(MTRActionsClusterStartActionParams *)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StartActionWithDuration
+ *
+ * This command triggers the commencement of an action (with a duration) on the involved endpoints.
+ */
 - (void)startActionWithDurationWithParams:(MTRActionsClusterStartActionWithDurationParams *)params
                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StopAction
+ *
+ * This command stops the ongoing action on the involved endpoints.
+ */
 - (void)stopActionWithParams:(MTRActionsClusterStopActionParams *)params
                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command PauseAction
+ *
+ * This command pauses an ongoing action.
+ */
 - (void)pauseActionWithParams:(MTRActionsClusterPauseActionParams *)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command PauseActionWithDuration
+ *
+ * This command pauses an ongoing action with a duration.
+ */
 - (void)pauseActionWithDurationWithParams:(MTRActionsClusterPauseActionWithDurationParams *)params
                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command ResumeAction
+ *
+ * This command resumes a previously paused action.
+ */
 - (void)resumeActionWithParams:(MTRActionsClusterResumeActionParams *)params
                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command EnableAction
+ *
+ * This command enables a certain action or automation.
+ */
 - (void)enableActionWithParams:(MTRActionsClusterEnableActionParams *)params
                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command EnableActionWithDuration
+ *
+ * This command enables a certain action or automation with a duration.
+ */
 - (void)enableActionWithDurationWithParams:(MTRActionsClusterEnableActionWithDurationParams *)params
                                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command DisableAction
+ *
+ * This command disables a certain action or automation.
+ */
 - (void)disableActionWithParams:(MTRActionsClusterDisableActionParams *)params
                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command DisableActionWithDuration
+ *
+ * This command disables a certain action or automation with a duration.
+ */
 - (void)disableActionWithDurationWithParams:(MTRActionsClusterDisableActionWithDurationParams *)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -1694,7 +1944,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Basic
- *    This cluster provides attributes and events for determining basic information about Nodes, which supports both
+ *
+ * This cluster provides attributes and events for determining basic information about Nodes, which supports both
       Commissioning and operational determination of Node characteristics, such as Vendor ID, Product ID and serial number,
       which apply to the whole Node. Also allows setting user device information such as location.
  */
@@ -1704,6 +1955,11 @@ NS_ASSUME_NONNULL_BEGIN
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command MfgSpecificPing
+ *
+ *
+ */
 - (void)mfgSpecificPingWithParams:(MTRBasicClusterMfgSpecificPingParams * _Nullable)params
                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)mfgSpecificPingWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -2028,7 +2284,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster OTA Software Update Provider
- *    Provides an interface for providing OTA software updates
+ *
+ * Provides an interface for providing OTA software updates
  */
 MTR_NEWLY_AVAILABLE
 @interface MTRBaseClusterOTASoftwareUpdateProvider : MTRCluster
@@ -2037,12 +2294,27 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command QueryImage
+ *
+ * Determine availability of a new Software Image
+ */
 - (void)queryImageWithParams:(MTROTASoftwareUpdateProviderClusterQueryImageParams *)params
                   completion:(void (^)(MTROTASoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command ApplyUpdateRequest
+ *
+ * Determine next action to take for a downloaded Software Image
+ */
 - (void)applyUpdateRequestWithParams:(MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
                           completion:(void (^)(MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command NotifyUpdateApplied
+ *
+ * Notify OTA Provider that an update was applied
+ */
 - (void)notifyUpdateAppliedWithParams:(MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -2113,7 +2385,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster OTA Software Update Requestor
- *    Provides an interface for downloading and applying OTA software updates
+ *
+ * Provides an interface for downloading and applying OTA software updates
  */
 MTR_NEWLY_AVAILABLE
 @interface MTRBaseClusterOTASoftwareUpdateRequestor : MTRCluster
@@ -2122,6 +2395,11 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command AnnounceOtaProvider
+ *
+ * Announce the presence of an OTA Provider
+ */
 - (void)announceOtaProviderWithParams:(MTROTASoftwareUpdateRequestorClusterAnnounceOtaProviderParams *)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -2246,7 +2524,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Localization Configuration
- *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
+ *
+ * Nodes should be expected to be deployed to any and all regions of the world. These global regions
       may have differing common languages, units of measurements, and numerical formatting
       standards. As such, Nodes that visually or audibly convey information need a mechanism by which
       they can be configured to use a user’s preferred language, units, etc
@@ -2353,7 +2632,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Time Format Localization
- *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
+ *
+ * Nodes should be expected to be deployed to any and all regions of the world. These global regions
       may have differing preferences for how dates and times are conveyed. As such, Nodes that visually
       or audibly convey time information need a mechanism by which they can be configured to use a
       user’s preferred format.
@@ -2476,7 +2756,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Unit Localization
- *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
+ *
+ * Nodes should be expected to be deployed to any and all regions of the world. These global regions
       may have differing preferences for the units in which values are conveyed in communication to a
       user. As such, Nodes that visually or audibly convey measurable values to the user need a
       mechanism by which they can be configured to use a user’s preferred unit.
@@ -2571,7 +2852,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Power Source Configuration
- *    This cluster is used to describe the configuration and capabilities of a Device's power system.
+ *
+ * This cluster is used to describe the configuration and capabilities of a Device's power system.
  */
 @interface MTRBaseClusterPowerSourceConfiguration : MTRCluster
 
@@ -2658,8 +2940,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Power Source
- *    This cluster is used to describe the configuration and capabilities of a physical power source that provides power to the
- * Node.
+ *
+ * This cluster is used to describe the configuration and capabilities of a physical power source that provides power to the Node.
  */
 @interface MTRBaseClusterPowerSource : MTRCluster
 
@@ -3106,7 +3388,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster General Commissioning
- *    This cluster is used to manage global aspects of the Commissioning flow.
+ *
+ * This cluster is used to manage global aspects of the Commissioning flow.
  */
 @interface MTRBaseClusterGeneralCommissioning : MTRCluster
 
@@ -3114,12 +3397,28 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command ArmFailSafe
+ *
+ * Arm the persistent fail-safe timer with an expiry time of now + ExpiryLengthSeconds using device clock
+ */
 - (void)armFailSafeWithParams:(MTRGeneralCommissioningClusterArmFailSafeParams *)params
                    completion:(void (^)(MTRGeneralCommissioningClusterArmFailSafeResponseParams * _Nullable data,
                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command SetRegulatoryConfig
+ *
+ * Set the regulatory configuration to be used during commissioning
+ */
 - (void)setRegulatoryConfigWithParams:(MTRGeneralCommissioningClusterSetRegulatoryConfigParams *)params
                            completion:(void (^)(MTRGeneralCommissioningClusterSetRegulatoryConfigResponseParams * _Nullable data,
                                           NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command CommissioningComplete
+ *
+ * Signals the Server that the Client has successfully completed all steps of Commissioning/Recofiguration needed during fail-safe
+ * period.
+ */
 - (void)commissioningCompleteWithParams:(MTRGeneralCommissioningClusterCommissioningCompleteParams * _Nullable)params
                              completion:
                                  (void (^)(MTRGeneralCommissioningClusterCommissioningCompleteResponseParams * _Nullable data,
@@ -3266,7 +3565,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Network Commissioning
- *    Functionality to configure, enable, disable network credentials and access on a Matter device.
+ *
+ * Functionality to configure, enable, disable network credentials and access on a Matter device.
  */
 @interface MTRBaseClusterNetworkCommissioning : MTRCluster
 
@@ -3274,21 +3574,51 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command ScanNetworks
+ *
+ * Detemine the set of networks the device sees as available.
+ */
 - (void)scanNetworksWithParams:(MTRNetworkCommissioningClusterScanNetworksParams * _Nullable)params
                     completion:(void (^)(MTRNetworkCommissioningClusterScanNetworksResponseParams * _Nullable data,
                                    NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command AddOrUpdateWiFiNetwork
+ *
+ * Add or update the credentials for a given Wi-Fi network.
+ */
 - (void)addOrUpdateWiFiNetworkWithParams:(MTRNetworkCommissioningClusterAddOrUpdateWiFiNetworkParams *)params
                               completion:(void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
                                              NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command AddOrUpdateThreadNetwork
+ *
+ * Add or update the credentials for a given Thread network.
+ */
 - (void)addOrUpdateThreadNetworkWithParams:(MTRNetworkCommissioningClusterAddOrUpdateThreadNetworkParams *)params
                                 completion:(void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
                                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command RemoveNetwork
+ *
+ * Remove the definition of a given network (including its credentials).
+ */
 - (void)removeNetworkWithParams:(MTRNetworkCommissioningClusterRemoveNetworkParams *)params
                      completion:(void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
                                     NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command ConnectNetwork
+ *
+ * Connect to the specified network, using previously-defined credentials.
+ */
 - (void)connectNetworkWithParams:(MTRNetworkCommissioningClusterConnectNetworkParams *)params
                       completion:(void (^)(MTRNetworkCommissioningClusterConnectNetworkResponseParams * _Nullable data,
                                      NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command ReorderNetwork
+ *
+ * Modify the order in which networks will be presented in the Networks attribute.
+ */
 - (void)reorderNetworkWithParams:(MTRNetworkCommissioningClusterReorderNetworkParams *)params
                       completion:(void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
                                      NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
@@ -3461,7 +3791,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Diagnostic Logs
- *    The cluster provides commands for retrieving unstructured diagnostic logs from a Node that may be used to aid in diagnostics.
+ *
+ * The cluster provides commands for retrieving unstructured diagnostic logs from a Node that may be used to aid in diagnostics.
  */
 @interface MTRBaseClusterDiagnosticLogs : MTRCluster
 
@@ -3469,6 +3800,11 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command RetrieveLogsRequest
+ *
+ * Retrieving diagnostic logs from a Node
+ */
 - (void)retrieveLogsRequestWithParams:(MTRDiagnosticLogsClusterRetrieveLogsRequestParams *)params
                            completion:(void (^)(MTRDiagnosticLogsClusterRetrieveLogsResponseParams * _Nullable data,
                                           NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
@@ -3540,7 +3876,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster General Diagnostics
- *    The General Diagnostics Cluster, along with other diagnostics clusters, provide a means to acquire standardized diagnostics
+ *
+ * The General Diagnostics Cluster, along with other diagnostics clusters, provide a means to acquire standardized diagnostics
  * metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRBaseClusterGeneralDiagnostics : MTRCluster
@@ -3549,6 +3886,11 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command TestEventTrigger
+ *
+ * Provide a means for certification tests to trigger some test-plan-specific events
+ */
 - (void)testEventTriggerWithParams:(MTRGeneralDiagnosticsClusterTestEventTriggerParams *)params
                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -3727,7 +4069,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Software Diagnostics
- *    The Software Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
+ *
+ * The Software Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
  * assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRBaseClusterSoftwareDiagnostics : MTRCluster
@@ -3736,6 +4079,12 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command ResetWatermarks
+ *
+ * Reception of this command SHALL reset the values: The StackFreeMinimum field of the ThreadMetrics attribute,
+ * CurrentHeapHighWaterMark attribute.
+ */
 - (void)resetWatermarksWithParams:(MTRSoftwareDiagnosticsClusterResetWatermarksParams * _Nullable)params
                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)resetWatermarksWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -3855,8 +4204,9 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Thread Network Diagnostics
- *    The Thread Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node
- * to assist a user or Administrative Node in diagnosing potential problems
+ *
+ * The Thread Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
+ * assist a user or Administrative Node in diagnosing potential problems
  */
 @interface MTRBaseClusterThreadNetworkDiagnostics : MTRCluster
 
@@ -3864,6 +4214,11 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command ResetCounts
+ *
+ * Reception of this command SHALL reset the OverrunCount attributes to 0
+ */
 - (void)resetCountsWithParams:(MTRThreadNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)resetCountsWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -4705,8 +5060,9 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster WiFi Network Diagnostics
- *    The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node
- * to assist a user or Administrative Node in diagnosing potential problems.
+ *
+ * The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
+ * assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRBaseClusterWiFiNetworkDiagnostics : MTRCluster
 
@@ -4714,6 +5070,11 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command ResetCounts
+ *
+ * Reception of this command SHALL reset the Breacon and Packet related count attributes to 0
+ */
 - (void)resetCountsWithParams:(MTRWiFiNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)resetCountsWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -4941,8 +5302,9 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Ethernet Network Diagnostics
- *    The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a
- * Node to assist a user or Administrative Node in diagnosing potential problems.
+ *
+ * The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node
+ * to assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRBaseClusterEthernetNetworkDiagnostics : MTRCluster
 
@@ -4950,6 +5312,11 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command ResetCounts
+ *
+ * Reception of this command SHALL reset the attributes: PacketRxCount, PacketTxCount, TxErrCount, CollisionCount, OverrunCount to 0
+ */
 - (void)resetCountsWithParams:(MTREthernetNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)resetCountsWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -5129,7 +5496,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Bridged Device Basic
- *    This Cluster serves two purposes towards a Node communicating with a Bridge: indicate that the functionality on
+ *
+ * This Cluster serves two purposes towards a Node communicating with a Bridge: indicate that the functionality on
           the Endpoint where it is placed (and its Parts) is bridged from a non-CHIP technology; and provide a centralized
           collection of attributes that the Node MAY collect to aid in conveying information regarding the Bridged Device to a user,
           such as the vendor name, the model name, or user-assigned name.
@@ -5391,7 +5759,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Switch
- *    This cluster exposes interactions with a switch device, for the purpose of using those interactions by other devices.
+ *
+ * This cluster exposes interactions with a switch device, for the purpose of using those interactions by other devices.
 Two types of switch devices are supported: latching switch (e.g. rocker switch) and momentary switch (e.g. push button),
 distinguished with their feature flags. Interactions with the switch device are exposed as attributes (for the latching switch) and
 as events (for both types of switches). An interested party MAY subscribe to these attributes/events and thus be informed of the
@@ -5507,7 +5876,8 @@ light or a window shade.
 
 /**
  * Cluster AdministratorCommissioning
- *    Commands to trigger a Node to allow a new Administrator to commission it.
+ *
+ * Commands to trigger a Node to allow a new Administrator to commission it.
  */
 @interface MTRBaseClusterAdministratorCommissioning : MTRCluster
 
@@ -5515,10 +5885,28 @@ light or a window shade.
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command OpenCommissioningWindow
+ *
+ * This command is used by a current Administrator to instruct a Node to go into commissioning mode using enhanced commissioning
+ * method.
+ */
 - (void)openCommissioningWindowWithParams:(MTRAdministratorCommissioningClusterOpenCommissioningWindowParams *)params
                                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command OpenBasicCommissioningWindow
+ *
+ * This command is used by a current Administrator to instruct a Node to go into commissioning mode using basic commissioning
+ * method, if the node supports it.
+ */
 - (void)openBasicCommissioningWindowWithParams:(MTRAdministratorCommissioningClusterOpenBasicCommissioningWindowParams *)params
                                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command RevokeCommissioning
+ *
+ * This command is used by a current Administrator to instruct a Node to revoke any active Open Commissioning Window or Open Basic
+ * Commissioning Window command.
+ */
 - (void)revokeCommissioningWithParams:(MTRAdministratorCommissioningClusterRevokeCommissioningParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)revokeCommissioningWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -5626,7 +6014,8 @@ light or a window shade.
 
 /**
  * Cluster Operational Credentials
- *    This cluster is used to add or remove Operational Credentials on a Commissionee or Node, as well as manage the associated
+ *
+ * This cluster is used to add or remove Operational Credentials on a Commissionee or Node, as well as manage the associated
  * Fabrics.
  */
 @interface MTRBaseClusterOperationalCredentials : MTRCluster
@@ -5635,27 +6024,68 @@ light or a window shade.
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command AttestationRequest
+ *
+ * Sender is requesting attestation information from the receiver.
+ */
 - (void)attestationRequestWithParams:(MTROperationalCredentialsClusterAttestationRequestParams *)params
                           completion:(void (^)(MTROperationalCredentialsClusterAttestationResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command CertificateChainRequest
+ *
+ * Sender is requesting a device attestation certificate from the receiver.
+ */
 - (void)certificateChainRequestWithParams:(MTROperationalCredentialsClusterCertificateChainRequestParams *)params
                                completion:(void (^)(MTROperationalCredentialsClusterCertificateChainResponseParams * _Nullable data,
                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command CSRRequest
+ *
+ * Sender is requesting a certificate signing request (CSR) from the receiver.
+ */
 - (void)CSRRequestWithParams:(MTROperationalCredentialsClusterCSRRequestParams *)params
                   completion:(void (^)(MTROperationalCredentialsClusterCSRResponseParams * _Nullable data,
                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command AddNOC
+ *
+ * Sender is requesting to add the new node operational certificates.
+ */
 - (void)addNOCWithParams:(MTROperationalCredentialsClusterAddNOCParams *)params
               completion:(void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data,
                              NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command UpdateNOC
+ *
+ * Sender is requesting to update the node operational certificates.
+ */
 - (void)updateNOCWithParams:(MTROperationalCredentialsClusterUpdateNOCParams *)params
                  completion:(void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data,
                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command UpdateFabricLabel
+ *
+ * This command SHALL be used by an Administrative Node to set the user-visible Label field for a given Fabric, as reflected by
+ * entries in the Fabrics attribute.
+ */
 - (void)updateFabricLabelWithParams:(MTROperationalCredentialsClusterUpdateFabricLabelParams *)params
                          completion:(void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data,
                                         NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command RemoveFabric
+ *
+ * This command is used by Administrative Nodes to remove a given fabric index and delete all associated fabric-scoped data.
+ */
 - (void)removeFabricWithParams:(MTROperationalCredentialsClusterRemoveFabricParams *)params
                     completion:(void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data,
                                    NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command AddTrustedRootCertificate
+ *
+ * This command SHALL add a Trusted Root CA Certificate, provided as its CHIP Certificate representation.
+ */
 - (void)addTrustedRootCertificateWithParams:(MTROperationalCredentialsClusterAddTrustedRootCertificateParams *)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -5799,7 +6229,8 @@ light or a window shade.
 
 /**
  * Cluster Group Key Management
- *    The Group Key Management Cluster is the mechanism by which group keys are managed.
+ *
+ * The Group Key Management Cluster is the mechanism by which group keys are managed.
  */
 @interface MTRBaseClusterGroupKeyManagement : MTRCluster
 
@@ -5807,13 +6238,33 @@ light or a window shade.
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command KeySetWrite
+ *
+ * Revoke a Root Key from a Group
+ */
 - (void)keySetWriteWithParams:(MTRGroupKeyManagementClusterKeySetWriteParams *)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command KeySetRead
+ *
+ * Revoke a Root Key from a Group
+ */
 - (void)keySetReadWithParams:(MTRGroupKeyManagementClusterKeySetReadParams *)params
                   completion:(void (^)(MTRGroupKeyManagementClusterKeySetReadResponseParams * _Nullable data,
                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command KeySetRemove
+ *
+ * Revoke a Root Key from a Group
+ */
 - (void)keySetRemoveWithParams:(MTRGroupKeyManagementClusterKeySetRemoveParams *)params
                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command KeySetReadAllIndices
+ *
+ * Return the list of Group Key Sets associated with the accessing fabric
+ */
 - (void)keySetReadAllIndicesWithParams:(MTRGroupKeyManagementClusterKeySetReadAllIndicesParams *)params
                             completion:(void (^)(MTRGroupKeyManagementClusterKeySetReadAllIndicesResponseParams * _Nullable data,
                                            NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
@@ -5939,7 +6390,8 @@ light or a window shade.
 
 /**
  * Cluster Fixed Label
- *    The Fixed Label Cluster provides a feature for the device to tag an endpoint with zero or more read only
+ *
+ * The Fixed Label Cluster provides a feature for the device to tag an endpoint with zero or more read only
 labels.
  */
 @interface MTRBaseClusterFixedLabel : MTRCluster
@@ -6027,7 +6479,8 @@ labels.
 
 /**
  * Cluster User Label
- *    The User Label Cluster provides a feature to tag an endpoint with zero or more labels.
+ *
+ * The User Label Cluster provides a feature to tag an endpoint with zero or more labels.
  */
 @interface MTRBaseClusterUserLabel : MTRCluster
 
@@ -6118,7 +6571,8 @@ labels.
 
 /**
  * Cluster Boolean State
- *    This cluster provides an interface to a boolean state called StateValue.
+ *
+ * This cluster provides an interface to a boolean state called StateValue.
  */
 @interface MTRBaseClusterBooleanState : MTRCluster
 
@@ -6205,7 +6659,8 @@ labels.
 
 /**
  * Cluster Mode Select
- *    Attributes and commands for selecting a mode from a list of supported options.
+ *
+ * Attributes and commands for selecting a mode from a list of supported options.
  */
 @interface MTRBaseClusterModeSelect : MTRCluster
 
@@ -6213,6 +6668,12 @@ labels.
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command ChangeToMode
+ *
+ * On receipt of this command, if the NewMode field matches the Mode field in an entry of the SupportedModes list, the server SHALL
+ * set the CurrentMode attribute to the NewMode value, otherwise, the server SHALL respond with an INVALID_COMMAND status response.
+ */
 - (void)changeToModeWithParams:(MTRModeSelectClusterChangeToModeParams *)params
                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -6364,7 +6825,8 @@ labels.
 
 /**
  * Cluster Door Lock
- *    An interface to a generic way to secure a door
+ *
+ * An interface to a generic way to secure a door
  */
 @interface MTRBaseClusterDoorLock : MTRCluster
 
@@ -6372,45 +6834,135 @@ labels.
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command LockDoor
+ *
+ * This command causes the lock device to lock the door.
+ */
 - (void)lockDoorWithParams:(MTRDoorLockClusterLockDoorParams * _Nullable)params
                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command UnlockDoor
+ *
+ * This command causes the lock device to unlock the door.
+ */
 - (void)unlockDoorWithParams:(MTRDoorLockClusterUnlockDoorParams * _Nullable)params
                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command UnlockWithTimeout
+ *
+ * This command causes the lock device to unlock the door with a timeout parameter.
+ */
 - (void)unlockWithTimeoutWithParams:(MTRDoorLockClusterUnlockWithTimeoutParams *)params
                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command SetWeekDaySchedule
+ *
+ * Set a weekly repeating schedule for a specified user.
+ */
 - (void)setWeekDayScheduleWithParams:(MTRDoorLockClusterSetWeekDayScheduleParams *)params
                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command GetWeekDaySchedule
+ *
+ * Retrieve the specific weekly schedule for the specific user.
+ */
 - (void)getWeekDayScheduleWithParams:(MTRDoorLockClusterGetWeekDayScheduleParams *)params
                           completion:(void (^)(MTRDoorLockClusterGetWeekDayScheduleResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command ClearWeekDaySchedule
+ *
+ * Clear the specific weekly schedule or all weekly schedules for the specific user.
+ */
 - (void)clearWeekDayScheduleWithParams:(MTRDoorLockClusterClearWeekDayScheduleParams *)params
                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command SetYearDaySchedule
+ *
+ * Set a time-specific schedule ID for a specified user.
+ */
 - (void)setYearDayScheduleWithParams:(MTRDoorLockClusterSetYearDayScheduleParams *)params
                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command GetYearDaySchedule
+ *
+ * Returns the year day schedule data for the specified schedule and user indexes.
+ */
 - (void)getYearDayScheduleWithParams:(MTRDoorLockClusterGetYearDayScheduleParams *)params
                           completion:(void (^)(MTRDoorLockClusterGetYearDayScheduleResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command ClearYearDaySchedule
+ *
+ * Clears the specific year day schedule or all year day schedules for the specific user.
+ */
 - (void)clearYearDayScheduleWithParams:(MTRDoorLockClusterClearYearDayScheduleParams *)params
                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command SetHolidaySchedule
+ *
+ * Set the holiday Schedule by specifying local start time and local end time with respect to any Lock Operating Mode.
+ */
 - (void)setHolidayScheduleWithParams:(MTRDoorLockClusterSetHolidayScheduleParams *)params
                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command GetHolidaySchedule
+ *
+ * Get the holiday schedule for the specified index.
+ */
 - (void)getHolidayScheduleWithParams:(MTRDoorLockClusterGetHolidayScheduleParams *)params
                           completion:(void (^)(MTRDoorLockClusterGetHolidayScheduleResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command ClearHolidaySchedule
+ *
+ * Clears the holiday schedule or all holiday schedules.
+ */
 - (void)clearHolidayScheduleWithParams:(MTRDoorLockClusterClearHolidayScheduleParams *)params
                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command SetUser
+ *
+ * Set User into the lock.
+ */
 - (void)setUserWithParams:(MTRDoorLockClusterSetUserParams *)params completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command GetUser
+ *
+ * Retrieve User.
+ */
 - (void)getUserWithParams:(MTRDoorLockClusterGetUserParams *)params
                completion:(void (^)(MTRDoorLockClusterGetUserResponseParams * _Nullable data, NSError * _Nullable error))completion
     MTR_NEWLY_AVAILABLE;
+/**
+ * Command ClearUser
+ *
+ * Clears a User or all Users.
+ */
 - (void)clearUserWithParams:(MTRDoorLockClusterClearUserParams *)params
                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command SetCredential
+ *
+ * Set a credential (e.g. PIN, RFID, Fingerprint, etc.) into the lock for a new user, existing user, or ProgrammingUser.
+ */
 - (void)setCredentialWithParams:(MTRDoorLockClusterSetCredentialParams *)params
                      completion:(void (^)(MTRDoorLockClusterSetCredentialResponseParams * _Nullable data,
                                     NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command GetCredentialStatus
+ *
+ * Retrieve the status of a particular credential (e.g. PIN, RFID, Fingerprint, etc.) by index.
+ */
 - (void)getCredentialStatusWithParams:(MTRDoorLockClusterGetCredentialStatusParams *)params
                            completion:(void (^)(MTRDoorLockClusterGetCredentialStatusResponseParams * _Nullable data,
                                           NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command ClearCredential
+ *
+ * Clear one, one type, or all credentials except ProgrammingPIN credential.
+ */
 - (void)clearCredentialWithParams:(MTRDoorLockClusterClearCredentialParams *)params
                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -7023,7 +7575,8 @@ labels.
 
 /**
  * Cluster Window Covering
- *    Provides an interface for controlling and adjusting automatic window coverings.
+ *
+ * Provides an interface for controlling and adjusting automatic window coverings.
  */
 @interface MTRBaseClusterWindowCovering : MTRCluster
 
@@ -7031,21 +7584,56 @@ labels.
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command UpOrOpen
+ *
+ * Moves window covering to InstalledOpenLimitLift and InstalledOpenLimitTilt
+ */
 - (void)upOrOpenWithParams:(MTRWindowCoveringClusterUpOrOpenParams * _Nullable)params
                 completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)upOrOpenWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command DownOrClose
+ *
+ * Moves window covering to InstalledClosedLimitLift and InstalledCloseLimitTilt
+ */
 - (void)downOrCloseWithParams:(MTRWindowCoveringClusterDownOrCloseParams * _Nullable)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)downOrCloseWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StopMotion
+ *
+ * Stop any adjusting of window covering
+ */
 - (void)stopMotionWithParams:(MTRWindowCoveringClusterStopMotionParams * _Nullable)params
                   completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)stopMotionWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command GoToLiftValue
+ *
+ * Go to lift value specified
+ */
 - (void)goToLiftValueWithParams:(MTRWindowCoveringClusterGoToLiftValueParams *)params
                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command GoToLiftPercentage
+ *
+ * Go to lift percentage specified
+ */
 - (void)goToLiftPercentageWithParams:(MTRWindowCoveringClusterGoToLiftPercentageParams *)params
                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command GoToTiltValue
+ *
+ * Go to tilt value specified
+ */
 - (void)goToTiltValueWithParams:(MTRWindowCoveringClusterGoToTiltValueParams *)params
                      completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command GoToTiltPercentage
+ *
+ * Go to tilt percentage specified
+ */
 - (void)goToTiltPercentageWithParams:(MTRWindowCoveringClusterGoToTiltPercentageParams *)params
                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -7404,7 +7992,8 @@ labels.
 
 /**
  * Cluster Barrier Control
- *    This cluster provides control of a barrier (garage door).
+ *
+ * This cluster provides control of a barrier (garage door).
  */
 @interface MTRBaseClusterBarrierControl : MTRCluster
 
@@ -7412,8 +8001,18 @@ labels.
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command BarrierControlGoToPercent
+ *
+ * Command to instruct a barrier to go to a percent open state.
+ */
 - (void)barrierControlGoToPercentWithParams:(MTRBarrierControlClusterBarrierControlGoToPercentParams *)params
                                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command BarrierControlStop
+ *
+ * Command that instructs the barrier to stop moving.
+ */
 - (void)barrierControlStopWithParams:(MTRBarrierControlClusterBarrierControlStopParams * _Nullable)params
                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)barrierControlStopWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -7635,7 +8234,8 @@ labels.
 
 /**
  * Cluster Pump Configuration and Control
- *    An interface for configuring and controlling pumps.
+ *
+ * An interface for configuring and controlling pumps.
  */
 @interface MTRBaseClusterPumpConfigurationAndControl : MTRCluster
 
@@ -8006,7 +8606,8 @@ labels.
 
 /**
  * Cluster Thermostat
- *    An interface for configuring and controlling the functionality of a thermostat.
+ *
+ * An interface for configuring and controlling the functionality of a thermostat.
  */
 @interface MTRBaseClusterThermostat : MTRCluster
 
@@ -8014,13 +8615,33 @@ labels.
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command SetpointRaiseLower
+ *
+ * Command description for SetpointRaiseLower
+ */
 - (void)setpointRaiseLowerWithParams:(MTRThermostatClusterSetpointRaiseLowerParams *)params
                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command SetWeeklySchedule
+ *
+ * Command description for SetWeeklySchedule
+ */
 - (void)setWeeklyScheduleWithParams:(MTRThermostatClusterSetWeeklyScheduleParams *)params
                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command GetWeeklySchedule
+ *
+ * Command description for GetWeeklySchedule
+ */
 - (void)getWeeklyScheduleWithParams:(MTRThermostatClusterGetWeeklyScheduleParams *)params
                          completion:(void (^)(MTRThermostatClusterGetWeeklyScheduleResponseParams * _Nullable data,
                                         NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command ClearWeeklySchedule
+ *
+ * The Clear Weekly Schedule command is used to clear the weekly schedule.
+ */
 - (void)clearWeeklyScheduleWithParams:(MTRThermostatClusterClearWeeklyScheduleParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)clearWeeklyScheduleWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -8822,7 +9443,8 @@ labels.
 
 /**
  * Cluster Fan Control
- *    An interface for controlling a fan in a heating/cooling system.
+ *
+ * An interface for controlling a fan in a heating/cooling system.
  */
 @interface MTRBaseClusterFanControl : MTRCluster
 
@@ -9058,7 +9680,8 @@ labels.
 
 /**
  * Cluster Thermostat User Interface Configuration
- *    An interface for configuring the user interface of a thermostat (which may be remote from the thermostat).
+ *
+ * An interface for configuring the user interface of a thermostat (which may be remote from the thermostat).
  */
 @interface MTRBaseClusterThermostatUserInterfaceConfiguration : MTRCluster
 
@@ -9186,7 +9809,8 @@ labels.
 
 /**
  * Cluster Color Control
- *    Attributes and commands for controlling the color properties of a color-capable light.
+ *
+ * Attributes and commands for controlling the color properties of a color-capable light.
  */
 @interface MTRBaseClusterColorControl : MTRCluster
 
@@ -9194,42 +9818,137 @@ labels.
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command MoveToHue
+ *
+ * Move to specified hue.
+ */
 - (void)moveToHueWithParams:(MTRColorControlClusterMoveToHueParams *)params
                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command MoveHue
+ *
+ * Move hue up or down at specified rate.
+ */
 - (void)moveHueWithParams:(MTRColorControlClusterMoveHueParams *)params
                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StepHue
+ *
+ * Step hue up or down by specified size at specified rate.
+ */
 - (void)stepHueWithParams:(MTRColorControlClusterStepHueParams *)params
                completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command MoveToSaturation
+ *
+ * Move to specified saturation.
+ */
 - (void)moveToSaturationWithParams:(MTRColorControlClusterMoveToSaturationParams *)params
                         completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command MoveSaturation
+ *
+ * Move saturation up or down at specified rate.
+ */
 - (void)moveSaturationWithParams:(MTRColorControlClusterMoveSaturationParams *)params
                       completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StepSaturation
+ *
+ * Step saturation up or down by specified size at specified rate.
+ */
 - (void)stepSaturationWithParams:(MTRColorControlClusterStepSaturationParams *)params
                       completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command MoveToHueAndSaturation
+ *
+ * Move to hue and saturation.
+ */
 - (void)moveToHueAndSaturationWithParams:(MTRColorControlClusterMoveToHueAndSaturationParams *)params
                               completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command MoveToColor
+ *
+ * Move to specified color.
+ */
 - (void)moveToColorWithParams:(MTRColorControlClusterMoveToColorParams *)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command MoveColor
+ *
+ * Moves the color.
+ */
 - (void)moveColorWithParams:(MTRColorControlClusterMoveColorParams *)params
                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StepColor
+ *
+ * Steps the lighting to a specific color.
+ */
 - (void)stepColorWithParams:(MTRColorControlClusterStepColorParams *)params
                  completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command MoveToColorTemperature
+ *
+ * Move to a specific color temperature.
+ */
 - (void)moveToColorTemperatureWithParams:(MTRColorControlClusterMoveToColorTemperatureParams *)params
                               completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command EnhancedMoveToHue
+ *
+ * Command description for EnhancedMoveToHue
+ */
 - (void)enhancedMoveToHueWithParams:(MTRColorControlClusterEnhancedMoveToHueParams *)params
                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command EnhancedMoveHue
+ *
+ * Command description for EnhancedMoveHue
+ */
 - (void)enhancedMoveHueWithParams:(MTRColorControlClusterEnhancedMoveHueParams *)params
                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command EnhancedStepHue
+ *
+ * Command description for EnhancedStepHue
+ */
 - (void)enhancedStepHueWithParams:(MTRColorControlClusterEnhancedStepHueParams *)params
                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command EnhancedMoveToHueAndSaturation
+ *
+ * Command description for EnhancedMoveToHueAndSaturation
+ */
 - (void)enhancedMoveToHueAndSaturationWithParams:(MTRColorControlClusterEnhancedMoveToHueAndSaturationParams *)params
                                       completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command ColorLoopSet
+ *
+ * Command description for ColorLoopSet
+ */
 - (void)colorLoopSetWithParams:(MTRColorControlClusterColorLoopSetParams *)params
                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StopMoveStep
+ *
+ * Command description for StopMoveStep
+ */
 - (void)stopMoveStepWithParams:(MTRColorControlClusterStopMoveStepParams *)params
                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command MoveColorTemperature
+ *
+ * Command description for MoveColorTemperature
+ */
 - (void)moveColorTemperatureWithParams:(MTRColorControlClusterMoveColorTemperatureParams *)params
                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StepColorTemperature
+ *
+ * Command description for StepColorTemperature
+ */
 - (void)stepColorTemperatureWithParams:(MTRColorControlClusterStepColorTemperatureParams *)params
                             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -9994,7 +10713,8 @@ labels.
 
 /**
  * Cluster Ballast Configuration
- *    Attributes and commands for configuring a lighting ballast.
+ *
+ * Attributes and commands for configuring a lighting ballast.
  */
 @interface MTRBaseClusterBallastConfiguration : MTRCluster
 
@@ -10284,7 +11004,8 @@ labels.
 
 /**
  * Cluster Illuminance Measurement
- *    Attributes and commands for configuring the measurement of illuminance, and reporting illuminance measurements.
+ *
+ * Attributes and commands for configuring the measurement of illuminance, and reporting illuminance measurements.
  */
 @interface MTRBaseClusterIlluminanceMeasurement : MTRCluster
 
@@ -10419,7 +11140,8 @@ labels.
 
 /**
  * Cluster Temperature Measurement
- *    Attributes and commands for configuring the measurement of temperature, and reporting temperature measurements.
+ *
+ * Attributes and commands for configuring the measurement of temperature, and reporting temperature measurements.
  */
 @interface MTRBaseClusterTemperatureMeasurement : MTRCluster
 
@@ -10542,7 +11264,8 @@ labels.
 
 /**
  * Cluster Pressure Measurement
- *    Attributes and commands for configuring the measurement of pressure, and reporting pressure measurements.
+ *
+ * Attributes and commands for configuring the measurement of pressure, and reporting pressure measurements.
  */
 @interface MTRBaseClusterPressureMeasurement : MTRCluster
 
@@ -10725,7 +11448,8 @@ labels.
 
 /**
  * Cluster Flow Measurement
- *    Attributes and commands for configuring the measurement of flow, and reporting flow measurements.
+ *
+ * Attributes and commands for configuring the measurement of flow, and reporting flow measurements.
  */
 @interface MTRBaseClusterFlowMeasurement : MTRCluster
 
@@ -10848,7 +11572,8 @@ labels.
 
 /**
  * Cluster Relative Humidity Measurement
- *    Attributes and commands for configuring the measurement of relative humidity, and reporting relative humidity measurements.
+ *
+ * Attributes and commands for configuring the measurement of relative humidity, and reporting relative humidity measurements.
  */
 @interface MTRBaseClusterRelativeHumidityMeasurement : MTRCluster
 
@@ -10971,7 +11696,8 @@ labels.
 
 /**
  * Cluster Occupancy Sensing
- *    Attributes and commands for configuring occupancy sensing, and reporting occupancy status.
+ *
+ * Attributes and commands for configuring occupancy sensing, and reporting occupancy status.
  */
 @interface MTRBaseClusterOccupancySensing : MTRCluster
 
@@ -11267,7 +11993,8 @@ labels.
 
 /**
  * Cluster Wake on LAN
- *    This cluster provides an interface for managing low power mode on a device that supports the Wake On LAN protocol.
+ *
+ * This cluster provides an interface for managing low power mode on a device that supports the Wake On LAN protocol.
  */
 MTR_NEWLY_AVAILABLE
 @interface MTRBaseClusterWakeOnLAN : MTRCluster
@@ -11355,7 +12082,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Channel
- *    This cluster provides an interface for controlling the current Channel on a device.
+ *
+ * This cluster provides an interface for controlling the current Channel on a device.
  */
 @interface MTRBaseClusterChannel : MTRCluster
 
@@ -11363,11 +12091,29 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command ChangeChannel
+ *
+ * Change the channel on the media player to the channel case-insensitive exact matching the value passed as an argument.
+ */
 - (void)changeChannelWithParams:(MTRChannelClusterChangeChannelParams *)params
                      completion:(void (^)(MTRChannelClusterChangeChannelResponseParams * _Nullable data,
                                     NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command ChangeChannelByNumber
+ *
+ * Change the channel on the media plaeyer to the channel with the given Number in the ChannelList attribute.
+ */
 - (void)changeChannelByNumberWithParams:(MTRChannelClusterChangeChannelByNumberParams *)params
                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command SkipChannel
+ *
+ * This command provides channel up and channel down functionality, but allows channel index jumps of size Count. When the value of
+ * the increase or decrease is larger than the number of channels remaining in the given direction, then the behavior SHALL be to
+ * return to the beginning (or end) of the channel list and continue. For example, if the current channel is at index 0 and count
+ * value of -1 is given, then the current channel should change to the last channel.
+ */
 - (void)skipChannelWithParams:(MTRChannelClusterSkipChannelParams *)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -11474,7 +12220,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Target Navigator
- *    This cluster provides an interface for UX navigation within a set of targets on a device or endpoint.
+ *
+ * This cluster provides an interface for UX navigation within a set of targets on a device or endpoint.
  */
 @interface MTRBaseClusterTargetNavigator : MTRCluster
 
@@ -11482,6 +12229,11 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command NavigateTarget
+ *
+ * Upon receipt, this SHALL navigation the UX to the target identified.
+ */
 - (void)navigateTargetWithParams:(MTRTargetNavigatorClusterNavigateTargetParams *)params
                       completion:(void (^)(MTRTargetNavigatorClusterNavigateTargetResponseParams * _Nullable data,
                                      NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
@@ -11577,8 +12329,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Media Playback
- *    This cluster provides an interface for controlling Media Playback (PLAY, PAUSE, etc) on a media device such as a TV or
- * Speaker.
+ *
+ * This cluster provides an interface for controlling Media Playback (PLAY, PAUSE, etc) on a media device such as a TV or Speaker.
  */
 @interface MTRBaseClusterMediaPlayback : MTRCluster
 
@@ -11586,52 +12338,112 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command Play
+ *
+ * Upon receipt, this SHALL play media.
+ */
 - (void)playWithParams:(MTRMediaPlaybackClusterPlayParams * _Nullable)params
             completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                            NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
 - (void)playWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command Pause
+ *
+ * Upon receipt, this SHALL pause media.
+ */
 - (void)pauseWithParams:(MTRMediaPlaybackClusterPauseParams * _Nullable)params
              completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                             NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
 - (void)pauseWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StopPlayback
+ *
+ * Upon receipt, this SHALL stop media. User experience is context-specific. This will often navigate the user back to the location
+ * where media was originally launched.
+ */
 - (void)stopPlaybackWithParams:(MTRMediaPlaybackClusterStopPlaybackParams * _Nullable)params
                     completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                    NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
 - (void)stopPlaybackWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                        NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StartOver
+ *
+ * Upon receipt, this SHALL Start Over with the current media playback item.
+ */
 - (void)startOverWithParams:(MTRMediaPlaybackClusterStartOverParams * _Nullable)params
                  completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
 - (void)startOverWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                     NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command Previous
+ *
+ * Upon receipt, this SHALL cause the handler to be invoked for "Previous". User experience is context-specific. This will often Go
+ * back to the previous media playback item.
+ */
 - (void)previousWithParams:(MTRMediaPlaybackClusterPreviousParams * _Nullable)params
                 completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
 - (void)previousWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                    NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command Next
+ *
+ * Upon receipt, this SHALL cause the handler to be invoked for "Next". User experience is context-specific. This will often Go
+ * forward to the next media playback item.
+ */
 - (void)nextWithParams:(MTRMediaPlaybackClusterNextParams * _Nullable)params
             completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                            NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
 - (void)nextWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command Rewind
+ *
+ * Upon receipt, this SHALL Rewind through media. Different Rewind speeds can be used on the TV based upon the number of sequential
+ * calls to this function. This is to avoid needing to define every speed now (multiple fast, slow motion, etc).
+ */
 - (void)rewindWithParams:(MTRMediaPlaybackClusterRewindParams * _Nullable)params
               completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                              NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
 - (void)rewindWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                  NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command FastForward
+ *
+ * Upon receipt, this SHALL Advance through media. Different FF speeds can be used on the TV based upon the number of sequential
+ * calls to this function. This is to avoid needing to define every speed now (multiple fast, slow motion, etc).
+ */
 - (void)fastForwardWithParams:(MTRMediaPlaybackClusterFastForwardParams * _Nullable)params
                    completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
 - (void)fastForwardWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                       NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command SkipForward
+ *
+ * Upon receipt, this SHALL Skip forward in the media by the given number of seconds, using the data as follows:
+ */
 - (void)skipForwardWithParams:(MTRMediaPlaybackClusterSkipForwardParams *)params
                    completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command SkipBackward
+ *
+ * Upon receipt, this SHALL Skip backward in the media by the given number of seconds, using the data as follows:
+ */
 - (void)skipBackwardWithParams:(MTRMediaPlaybackClusterSkipBackwardParams *)params
                     completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                    NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command Seek
+ *
+ * Upon receipt, this SHALL Skip backward in the media by the given number of seconds, using the data as follows:
+ */
 - (void)seekWithParams:(MTRMediaPlaybackClusterSeekParams *)params
             completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                            NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
@@ -11787,7 +12599,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Media Input
- *    This cluster provides an interface for controlling the Input Selector on a media device such as a TV.
+ *
+ * This cluster provides an interface for controlling the Input Selector on a media device such as a TV.
  */
 @interface MTRBaseClusterMediaInput : MTRCluster
 
@@ -11795,14 +12608,35 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command SelectInput
+ *
+ * Upon receipt, this SHALL change the input on the media device to the input at a specific index in the Input List.
+ */
 - (void)selectInputWithParams:(MTRMediaInputClusterSelectInputParams *)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command ShowInputStatus
+ *
+ * Upon receipt, this SHALL display the active status of the input list on screen.
+ */
 - (void)showInputStatusWithParams:(MTRMediaInputClusterShowInputStatusParams * _Nullable)params
                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)showInputStatusWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command HideInputStatus
+ *
+ * Upon receipt, this SHALL hide the input list from the screen.
+ */
 - (void)hideInputStatusWithParams:(MTRMediaInputClusterHideInputStatusParams * _Nullable)params
                        completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)hideInputStatusWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command RenameInput
+ *
+ * Upon receipt, this SHALL rename the input at a specific index in the Input List. Updates to the input name SHALL appear in the TV
+ * settings menus.
+ */
 - (void)renameInputWithParams:(MTRMediaInputClusterRenameInputParams *)params
                    completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -11897,7 +12731,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Low Power
- *    This cluster provides an interface for managing low power mode on a device.
+ *
+ * This cluster provides an interface for managing low power mode on a device.
  */
 @interface MTRBaseClusterLowPower : MTRCluster
 
@@ -11905,6 +12740,11 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command Sleep
+ *
+ * This command shall put the device into low power mode.
+ */
 - (void)sleepWithParams:(MTRLowPowerClusterSleepParams * _Nullable)params
              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)sleepWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -11976,7 +12816,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Keypad Input
- *    This cluster provides an interface for controlling a device like a TV using action commands such as UP, DOWN, and SELECT.
+ *
+ * This cluster provides an interface for controlling a device like a TV using action commands such as UP, DOWN, and SELECT.
  */
 @interface MTRBaseClusterKeypadInput : MTRCluster
 
@@ -11984,6 +12825,11 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command SendKey
+ *
+ * Upon receipt, this SHALL process a keycode as input to the media device.
+ */
 - (void)sendKeyWithParams:(MTRKeypadInputClusterSendKeyParams *)params
                completion:(void (^)(MTRKeypadInputClusterSendKeyResponseParams * _Nullable data,
                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
@@ -12055,7 +12901,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Content Launcher
- *    This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
+ *
+ * This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
  */
 @interface MTRBaseClusterContentLauncher : MTRCluster
 
@@ -12063,9 +12910,19 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command LaunchContent
+ *
+ * Upon receipt, this SHALL launch the specified content with optional search criteria.
+ */
 - (void)launchContentWithParams:(MTRContentLauncherClusterLaunchContentParams *)params
                      completion:(void (^)(MTRContentLauncherClusterLaunchResponseParams * _Nullable data,
                                     NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command LaunchURL
+ *
+ * Upon receipt, this SHALL launch content from the specified URL.
+ */
 - (void)launchURLWithParams:(MTRContentLauncherClusterLaunchURLParams *)params
                  completion:(void (^)(MTRContentLauncherClusterLaunchResponseParams * _Nullable data,
                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
@@ -12166,7 +13023,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Audio Output
- *    This cluster provides an interface for controlling the Output on a media device such as a TV.
+ *
+ * This cluster provides an interface for controlling the Output on a media device such as a TV.
  */
 @interface MTRBaseClusterAudioOutput : MTRCluster
 
@@ -12174,8 +13032,19 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command SelectOutput
+ *
+ * Upon receipt, this SHALL change the output on the media device to the output at a specific index in the Output List.
+ */
 - (void)selectOutputWithParams:(MTRAudioOutputClusterSelectOutputParams *)params
                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command RenameOutput
+ *
+ * Upon receipt, this SHALL rename the output at a specific index in the Output List. Updates to the output name SHALL appear in the
+ * TV settings menus.
+ */
 - (void)renameOutputWithParams:(MTRAudioOutputClusterRenameOutputParams *)params
                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -12270,7 +13139,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Application Launcher
- *    This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
+ *
+ * This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
  */
 @interface MTRBaseClusterApplicationLauncher : MTRCluster
 
@@ -12278,12 +13148,30 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command LaunchApp
+ *
+ * Upon receipt, this SHALL launch the specified app with optional data. The TV Device SHALL launch and bring to foreground the
+ * identified application in the command if the application is not already launched and in foreground. The TV Device SHALL update
+ * state attribute on the Application Basic cluster of the Endpoint corresponding to the launched application. This command returns
+ * a Launch Response.
+ */
 - (void)launchAppWithParams:(MTRApplicationLauncherClusterLaunchAppParams *)params
                  completion:(void (^)(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data,
                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command StopApp
+ *
+ * Upon receipt on a Video Player endpoint this SHALL stop the specified application if it is running.
+ */
 - (void)stopAppWithParams:(MTRApplicationLauncherClusterStopAppParams *)params
                completion:(void (^)(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data,
                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command HideApp
+ *
+ * Upon receipt on a Video Player endpoint this SHALL hide the specified application if it is running and visible.
+ */
 - (void)hideAppWithParams:(MTRApplicationLauncherClusterHideAppParams *)params
                completion:(void (^)(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data,
                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
@@ -12384,7 +13272,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Application Basic
- *    This cluster provides information about an application running on a TV or media player device which is represented as an
+ *
+ * This cluster provides information about an application running on a TV or media player device which is represented as an
  * endpoint.
  */
 @interface MTRBaseClusterApplicationBasic : MTRCluster
@@ -12557,9 +13446,10 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Account Login
- *    This cluster provides commands that facilitate user account login on a Content App or a node. For example, a Content App
- * running on a Video Player device, which is represented as an endpoint (see [TV Architecture]), can use this cluster to help make
- * the user account on the Content App match the user account on the Client.
+ *
+ * This cluster provides commands that facilitate user account login on a Content App or a node. For example, a Content App running
+ * on a Video Player device, which is represented as an endpoint (see [TV Architecture]), can use this cluster to help make the user
+ * account on the Content App match the user account on the Client.
  */
 @interface MTRBaseClusterAccountLogin : MTRCluster
 
@@ -12567,10 +13457,30 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command GetSetupPIN
+ *
+ * Upon receipt, the Content App checks if the account associated with the client Temp Account Identifier Rotating ID is the same
+ * acount that is active on the given Content App. If the accounts are the same, then the Content App includes the Setup PIN in the
+ * GetSetupPIN Response.
+ */
 - (void)getSetupPINWithParams:(MTRAccountLoginClusterGetSetupPINParams *)params
                    completion:(void (^)(MTRAccountLoginClusterGetSetupPINResponseParams * _Nullable data,
                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command Login
+ *
+ * Upon receipt, the Content App checks if the account associated with the client’s Temp Account Identifier (Rotating ID) has a
+ * current active Setup PIN with the given value. If the Setup PIN is valid for the user account associated with the Temp Account
+ * Identifier, then the Content App MAY make that user account active.
+ */
 - (void)loginWithParams:(MTRAccountLoginClusterLoginParams *)params completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command Logout
+ *
+ * The purpose of this command is to instruct the Content App to clear the current user account. This command SHOULD be used by
+ * clients of a Content App to indicate the end of a user session.
+ */
 - (void)logoutWithParams:(MTRAccountLoginClusterLogoutParams * _Nullable)params
               completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)logoutWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
@@ -12642,8 +13552,9 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Electrical Measurement
- *    Attributes related to the electrical properties of a device. This cluster is used by power outlets and other devices that need
- * to provide instantaneous data as opposed to metrology data which should be retrieved from the metering cluster..
+ *
+ * Attributes related to the electrical properties of a device. This cluster is used by power outlets and other devices that need to
+ * provide instantaneous data as opposed to metrology data which should be retrieved from the metering cluster..
  */
 @interface MTRBaseClusterElectricalMeasurement : MTRCluster
 
@@ -12651,9 +13562,20 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command GetProfileInfoCommand
+ *
+ * A function which retrieves the power profiling information from the electrical measurement server.
+ */
 - (void)getProfileInfoCommandWithParams:(MTRElectricalMeasurementClusterGetProfileInfoCommandParams * _Nullable)params
                              completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)getProfileInfoCommandWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command GetMeasurementProfileCommand
+ *
+ * A function which retrieves an electricity measurement profile from the electricity measurement server for a specific attribute Id
+ * requested.
+ */
 - (void)getMeasurementProfileCommandWithParams:(MTRElectricalMeasurementClusterGetMeasurementProfileCommandParams *)params
                                     completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 
@@ -14376,7 +15298,8 @@ MTR_NEWLY_AVAILABLE
 
 /**
  * Cluster Unit Testing
- *    The Test Cluster is meant to validate the generated code
+ *
+ * The Test Cluster is meant to validate the generated code
  */
 MTR_NEWLY_AVAILABLE
 @interface MTRBaseClusterUnitTesting : MTRCluster
@@ -14385,74 +15308,207 @@ MTR_NEWLY_AVAILABLE
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER MTR_NEWLY_AVAILABLE;
 
+/**
+ * Command Test
+ *
+ * Simple command without any parameters and without a specific response
+ */
 - (void)testWithParams:(MTRUnitTestingClusterTestParams * _Nullable)params
             completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)testWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestNotHandled
+ *
+ * Simple command without any parameters and without a specific response not handled by the server
+ */
 - (void)testNotHandledWithParams:(MTRUnitTestingClusterTestNotHandledParams * _Nullable)params
                       completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)testNotHandledWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestSpecific
+ *
+ * Simple command without any parameters and with a specific response
+ */
 - (void)testSpecificWithParams:(MTRUnitTestingClusterTestSpecificParams * _Nullable)params
                     completion:(void (^)(MTRUnitTestingClusterTestSpecificResponseParams * _Nullable data,
                                    NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
 - (void)testSpecificWithCompletion:(void (^)(MTRUnitTestingClusterTestSpecificResponseParams * _Nullable data,
                                        NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestUnknownCommand
+ *
+ * Simple command that should not be added to the server.
+ */
 - (void)testUnknownCommandWithParams:(MTRUnitTestingClusterTestUnknownCommandParams * _Nullable)params
                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)testUnknownCommandWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestAddArguments
+ *
+ * Command that takes two arguments and returns their sum.
+ */
 - (void)testAddArgumentsWithParams:(MTRUnitTestingClusterTestAddArgumentsParams *)params
                         completion:(void (^)(MTRUnitTestingClusterTestAddArgumentsResponseParams * _Nullable data,
                                        NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestSimpleArgumentRequest
+ *
+ * Command that takes an argument which is bool
+ */
 - (void)testSimpleArgumentRequestWithParams:(MTRUnitTestingClusterTestSimpleArgumentRequestParams *)params
                                  completion:(void (^)(MTRUnitTestingClusterTestSimpleArgumentResponseParams * _Nullable data,
                                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestStructArrayArgumentRequest
+ *
+ * Command that takes various arguments that are arrays, including an array of structs which have a list member.
+ */
 - (void)testStructArrayArgumentRequestWithParams:(MTRUnitTestingClusterTestStructArrayArgumentRequestParams *)params
                                       completion:
                                           (void (^)(MTRUnitTestingClusterTestStructArrayArgumentResponseParams * _Nullable data,
                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestStructArgumentRequest
+ *
+ * Command that takes an argument which is struct.  The response echoes the
+        'b' field of the single arg.
+ */
 - (void)testStructArgumentRequestWithParams:(MTRUnitTestingClusterTestStructArgumentRequestParams *)params
                                  completion:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
                                                 NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestNestedStructArgumentRequest
+ *
+ * Command that takes an argument which is nested struct.  The response
+        echoes the 'b' field of ar1.c.
+ */
 - (void)testNestedStructArgumentRequestWithParams:(MTRUnitTestingClusterTestNestedStructArgumentRequestParams *)params
                                        completion:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
                                                       NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestListStructArgumentRequest
+ *
+ * Command that takes an argument which is a list of structs.  The response
+        returns false if there is some struct in the list whose 'b' field is
+        false, and true otherwise (including if the list is empty).
+ */
 - (void)testListStructArgumentRequestWithParams:(MTRUnitTestingClusterTestListStructArgumentRequestParams *)params
                                      completion:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
                                                     NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestListInt8UArgumentRequest
+ *
+ * Command that takes an argument which is a list of INT8U.  The response
+        returns false if the list contains a 0 in it, true otherwise (including
+        if the list is empty).
+ */
 - (void)testListInt8UArgumentRequestWithParams:(MTRUnitTestingClusterTestListInt8UArgumentRequestParams *)params
                                     completion:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
                                                    NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestNestedStructListArgumentRequest
+ *
+ * Command that takes an argument which is a Nested Struct List.  The
+        response returns false if there is some struct in arg1 (either directly
+        in arg1.c or in the arg1.d list) whose 'b' field is false, and true
+        otherwise.
+ */
 - (void)testNestedStructListArgumentRequestWithParams:(MTRUnitTestingClusterTestNestedStructListArgumentRequestParams *)params
                                            completion:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
                                                           NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestListNestedStructListArgumentRequest
+ *
+ * Command that takes an argument which is a list of Nested Struct List.
+        The response returns false if there is some struct in arg1 (either
+        directly in as the 'c' field of an entry 'd' list of an entry) whose 'b'
+        field is false, and true otherwise (including if the list is empty).
+ */
 - (void)testListNestedStructListArgumentRequestWithParams:
             (MTRUnitTestingClusterTestListNestedStructListArgumentRequestParams *)params
                                                completion:(void (^)(MTRUnitTestingClusterBooleanResponseParams * _Nullable data,
                                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestListInt8UReverseRequest
+ *
+ * Command that takes an argument which is a list of INT8U and expects a
+        response that reverses the list.
+ */
 - (void)testListInt8UReverseRequestWithParams:(MTRUnitTestingClusterTestListInt8UReverseRequestParams *)params
                                    completion:(void (^)(MTRUnitTestingClusterTestListInt8UReverseResponseParams * _Nullable data,
                                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestEnumsRequest
+ *
+ * Command that sends a vendor id and an enum.  The server is expected to
+        echo them back.
+ */
 - (void)testEnumsRequestWithParams:(MTRUnitTestingClusterTestEnumsRequestParams *)params
                         completion:(void (^)(MTRUnitTestingClusterTestEnumsResponseParams * _Nullable data,
                                        NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestNullableOptionalRequest
+ *
+ * Command that takes an argument which is nullable and optional.  The
+        response returns a boolean indicating whether the argument was present,
+        if that's true a boolean indicating whether the argument was null, and
+        if that' false the argument it received.
+ */
 - (void)testNullableOptionalRequestWithParams:(MTRUnitTestingClusterTestNullableOptionalRequestParams * _Nullable)params
                                    completion:(void (^)(MTRUnitTestingClusterTestNullableOptionalResponseParams * _Nullable data,
                                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestComplexNullableOptionalRequest
+ *
+ * Command that takes various arguments which can be nullable and/or optional.  The
+        response returns information about which things were received and what
+        their state was.
+ */
 - (void)testComplexNullableOptionalRequestWithParams:(MTRUnitTestingClusterTestComplexNullableOptionalRequestParams *)params
                                           completion:
                                               (void (^)(
                                                   MTRUnitTestingClusterTestComplexNullableOptionalResponseParams * _Nullable data,
                                                   NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command SimpleStructEchoRequest
+ *
+ * Command that takes an argument which is a struct.  The response echoes
+        the struct back.
+ */
 - (void)simpleStructEchoRequestWithParams:(MTRUnitTestingClusterSimpleStructEchoRequestParams *)params
                                completion:(void (^)(MTRUnitTestingClusterSimpleStructResponseParams * _Nullable data,
                                               NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TimedInvokeRequest
+ *
+ * Command that just responds with a success status if the timed invoke
+        conditions are met.
+ */
 - (void)timedInvokeRequestWithParams:(MTRUnitTestingClusterTimedInvokeRequestParams * _Nullable)params
                           completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
 - (void)timedInvokeRequestWithCompletion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestSimpleOptionalArgumentRequest
+ *
+ * Command that takes an optional argument which is bool. It responds with a success value if the optional is set to any value.
+ */
 - (void)testSimpleOptionalArgumentRequestWithParams:(MTRUnitTestingClusterTestSimpleOptionalArgumentRequestParams * _Nullable)params
                                          completion:(MTRStatusCompletion)completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestEmitTestEventRequest
+ *
+ * Command that takes identical arguments to the fields of the TestEvent and logs the TestEvent to the buffer.  Command returns an
+ * event ID as the response.
+ */
 - (void)testEmitTestEventRequestWithParams:(MTRUnitTestingClusterTestEmitTestEventRequestParams *)params
                                 completion:(void (^)(MTRUnitTestingClusterTestEmitTestEventResponseParams * _Nullable data,
                                                NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
+/**
+ * Command TestEmitTestFabricScopedEventRequest
+ *
+ * Command that takes identical arguments to the fields of the TestFabricScopedEvent and logs the TestFabricScopedEvent to the
+ * buffer.  Command returns an event ID as the response.
+ */
 - (void)
     testEmitTestFabricScopedEventRequestWithParams:(MTRUnitTestingClusterTestEmitTestFabricScopedEventRequestParams *)params
                                         completion:


### PR DESCRIPTION
The changeset that added these initially was reverted, then when re-landing this part of the change was removed to make review easier.

The changes are all comment-only.
