### PR TITLE
Remove emberAfSetDeviceEnabled.

### DIFF
--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -303,16 +303,6 @@ void emberAfCopyLongString(uint8_t * dest, const uint8_t * src, size_t size);
  */
 bool emberAfIsDeviceIdentifying(chip::EndpointId endpoint);
 
-/**
- * @brief Function that enables or disables an endpoint.
- *
- * By calling this function, you turn off all processing of incoming traffic
- * for a given endpoint.
- *
- * @param endpoint Zigbee endpoint number
- */
-void emberAfSetDeviceEnabled(chip::EndpointId endpoint, bool enabled);
-
 /** @} END Device Control */
 
 /** @name Miscellaneous */

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -242,7 +242,6 @@ EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, EndpointId id, const Emb
 
     // Now enable the endpoint.
     emberAfEndpointEnableDisable(id, true);
-    emberAfSetDeviceEnabled(id, true);
 
     return EMBER_ZCL_STATUS_SUCCESS;
 }
@@ -257,7 +256,6 @@ EndpointId emberAfClearDynamicEndpoint(uint16_t index)
         (emberAfEndpointIndexIsEnabled(index)))
     {
         ep = emAfEndpoints[index].endpoint;
-        emberAfSetDeviceEnabled(ep, false);
         emberAfEndpointEnableDisable(ep, false);
         emAfEndpoints[index].endpoint = kInvalidEndpointId;
     }

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -41,9 +41,6 @@ using namespace chip;
 //------------------------------------------------------------------------------
 // Globals
 
-// Storage and functions for turning on and off devices
-bool afDeviceEnabled[MAX_ENDPOINT_COUNT];
-
 #ifdef EMBER_AF_ENABLE_STATISTICS
 // a variable containing the number of messages send from the utilities
 // since emberAfInit was called.
@@ -82,21 +79,6 @@ EMBER_AF_GENERATED_PLUGIN_TICK_FUNCTION_DECLARATIONS
 #endif
 
 //------------------------------------------------------------------------------
-
-// Device enabled/disabled functions
-
-void emberAfSetDeviceEnabled(EndpointId endpoint, bool enabled)
-{
-    uint16_t index = emberAfIndexFromEndpoint(endpoint);
-    if (index != 0xFFFF && index < sizeof(afDeviceEnabled))
-    {
-        afDeviceEnabled[index] = enabled;
-    }
-#ifdef ZCL_USING_BASIC_CLUSTER_DEVICE_ENABLED_ATTRIBUTE
-    emberAfWriteServerAttribute(endpoint, app::Clusters::Basic::Id, ZCL_DEVICE_ENABLED_ATTRIBUTE_ID, (uint8_t *) &enabled,
-                                ZCL_BOOLEAN_ATTRIBUTE_TYPE);
-#endif
-}
 
 // Is the device identifying?
 bool emberAfIsDeviceIdentifying(EndpointId endpoint)
@@ -166,8 +148,6 @@ void emberAfInit(chip::Messaging::ExchangeManager * exchangeMgr)
         emberAfInitializeAttributes(EMBER_BROADCAST_ENDPOINT);
         // emberAfPopNetworkIndex();
     }
-
-    memset(afDeviceEnabled, true, emberAfEndpointCount());
 
     MATTER_PLUGINS_INIT
 


### PR DESCRIPTION
This function does two things:

1) Write to afDeviceEnabled, which nothing reads.
2) If needed set the ZCL_DEVICE_ENABLED_ATTRIBUTE_ID attribute, which does not
   exist in Matter.


