### PR TITLE
Switch to having just one typedef for MTRCertificateDERBytes.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-typedef NSData * MTRCertificateDERBytes;
+#import <Matter/MTRCertificates.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Having two typedefs leads to some compilers complaining if they see both, even though they are identical.
