### PR TITLE
[crypto] Add Operational Keystore for PSA crypto API

### DIFF
--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -116,7 +116,12 @@ if (chip_crypto == "openssl") {
   import("//build_overrides/mbedtls.gni")
 
   source_set("cryptopal_psa") {
-    sources = [ "CHIPCryptoPALPSA.cpp" ]
+    sources = [
+      "CHIPCryptoPALPSA.cpp",
+      "CHIPCryptoPALPSA.h",
+      "PSAOperationalKeystore.cpp",
+      "PSAOperationalKeystore.h",
+    ]
     public_deps = [ ":public_headers" ]
 
     external_mbedtls = current_os == "zephyr"

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -471,7 +471,7 @@ public:
     /** Release resources associated with this key pair */
     void Clear();
 
-private:
+protected:
     P256PublicKey mPublicKey;
     mutable P256KeypairContext mKeypair;
     bool mInitialized = false;

--- a/src/crypto/CHIPCryptoPALPSA.h
+++ b/src/crypto/CHIPCryptoPALPSA.h
@@ -15,15 +15,48 @@
  *    limitations under the License.
  */
 
+/**
+ *    @file
+ *      Public constants and structures used by the crypto backend based on PSA crypto API
+ */
+
 #pragma once
 
 #include "CHIPCryptoPAL.h"
+#include <lib/core/DataModelTypes.h>
 #include <lib/support/SafePointerCast.h>
 
 #include <psa/crypto.h>
 
 namespace chip {
 namespace Crypto {
+
+/**
+ *  @def CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE
+ *
+ *  @brief
+ *    Base for PSA key identifier range used by Matter.
+ *
+ *  Cryptographic keys stored in the PSA Internal Trusted Storage must have
+ *  a user-assigned identifer from the range PSA_KEY_ID_USER_MIN to
+ *  PSA_KEY_ID_USER_MAX. This option allows to override the base used to derive
+ *  key identifiers used by Matter to avoid overlapping with other firmware
+ *  components that also use PSA crypto API. The default value was selected
+ *  not to interfere with OpenThread's default base that is 0x20000.
+ */
+#ifndef CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE
+#define CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE 0x30000
+#endif // CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE
+
+enum class KeyIdBase : psa_key_id_t
+{
+    Operational = CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE
+};
+
+constexpr psa_key_id_t MakeOperationalKeyId(FabricIndex fabricIndex)
+{
+    return to_underlying(KeyIdBase::Operational) + fabricIndex;
+}
 
 struct PSAP256KeypairContext
 {

--- a/src/crypto/CHIPCryptoPALPSA.h
+++ b/src/crypto/CHIPCryptoPALPSA.h
@@ -48,6 +48,10 @@ namespace Crypto {
 #define CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE 0x30000
 #endif // CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE
 
+static_assert(CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE >= PSA_KEY_ID_USER_MIN &&
+                  CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE <= PSA_KEY_ID_USER_MAX,
+              "PSA key ID base out of allowed range");
+
 enum class KeyIdBase : psa_key_id_t
 {
     Operational = CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE

--- a/src/crypto/CHIPCryptoPALPSA.h
+++ b/src/crypto/CHIPCryptoPALPSA.h
@@ -1,0 +1,44 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "CHIPCryptoPAL.h"
+#include <lib/support/SafePointerCast.h>
+
+#include <psa/crypto.h>
+
+namespace chip {
+namespace Crypto {
+
+struct PSAP256KeypairContext
+{
+    psa_key_id_t key_id;
+};
+
+static inline PSAP256KeypairContext & toPSAContext(P256KeypairContext & context)
+{
+    return *SafePointerCast<PSAP256KeypairContext *>(&context);
+}
+
+static inline const PSAP256KeypairContext & toConstPSAContext(const P256KeypairContext & context)
+{
+    return *SafePointerCast<const PSAP256KeypairContext *>(&context);
+}
+
+} // namespace Crypto
+} // namespace chip

--- a/src/crypto/CHIPCryptoPALPSA.h
+++ b/src/crypto/CHIPCryptoPALPSA.h
@@ -1,6 +1,7 @@
 /*
  *
  *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,11 +14,6 @@
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
- */
-
-/**
- *    @file
- *      Public constants and structures used by the crypto backend based on PSA crypto API
  */
 
 #pragma once
@@ -43,6 +39,9 @@ namespace Crypto {
  *  key identifiers used by Matter to avoid overlapping with other firmware
  *  components that also use PSA crypto API. The default value was selected
  *  not to interfere with OpenThread's default base that is 0x20000.
+ *
+ *  Note that volatile keys like ephemeral keys used for ECDH have identifiers
+ *  auto-assigned by the PSA backend.
  */
 #ifndef CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE
 #define CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE 0x30000
@@ -54,12 +53,13 @@ static_assert(CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE >= PSA_KEY_ID_USER_MIN &&
 
 enum class KeyIdBase : psa_key_id_t
 {
+    // Define key ID range for Node Operational Certificate private keys
     Operational = CHIP_CONFIG_CRYPTO_PSA_KEY_ID_BASE
 };
 
 constexpr psa_key_id_t MakeOperationalKeyId(FabricIndex fabricIndex)
 {
-    return to_underlying(KeyIdBase::Operational) + fabricIndex;
+    return to_underlying(KeyIdBase::Operational) + static_cast<psa_key_id_t>(fabricIndex);
 }
 
 struct PSAP256KeypairContext

--- a/src/crypto/PSAOperationalKeystore.cpp
+++ b/src/crypto/PSAOperationalKeystore.cpp
@@ -66,7 +66,7 @@ CHIP_ERROR PSAOperationalKeystore::PersistentP256Keypair::Generate()
     psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
     psa_set_key_bits(&attributes, kP256_PrivateKey_Length * 8);
     psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
-    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_SIGN_MESSAGE);
+    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_MESSAGE);
     psa_set_key_lifetime(&attributes, PSA_KEY_LIFETIME_PERSISTENT);
     psa_set_key_id(&attributes, GetKeyId());
 

--- a/src/crypto/PSAOperationalKeystore.cpp
+++ b/src/crypto/PSAOperationalKeystore.cpp
@@ -1,0 +1,213 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "PSAOperationalKeystore.h"
+
+#include <lib/support/CHIPMem.h>
+
+#include <psa/crypto.h>
+
+namespace chip {
+namespace Crypto {
+
+PSAOperationalKeystore::PersistentP256Keypair::PersistentP256Keypair(FabricIndex fabricIndex)
+{
+    toPSAContext(mKeypair).key_id = MakeOperationalKeyId(fabricIndex);
+    mInitialized                  = true;
+}
+
+PSAOperationalKeystore::PersistentP256Keypair::~PersistentP256Keypair()
+{
+    // This class requires explicit control of the key lifetime. Therefore, clear the key ID
+    // to prevent it from being destroyed by the base class destructor.
+    toPSAContext(mKeypair).key_id = 0;
+}
+
+inline psa_key_id_t PSAOperationalKeystore::PersistentP256Keypair::GetKeyId() const
+{
+    return toConstPSAContext(mKeypair).key_id;
+}
+
+bool PSAOperationalKeystore::PersistentP256Keypair::Exists() const
+{
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    psa_status_t status             = psa_get_key_attributes(GetKeyId(), &attributes);
+
+    psa_reset_key_attributes(&attributes);
+
+    return status == PSA_SUCCESS;
+}
+
+CHIP_ERROR PSAOperationalKeystore::PersistentP256Keypair::Generate()
+{
+    CHIP_ERROR error                = CHIP_NO_ERROR;
+    psa_status_t status             = PSA_SUCCESS;
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    psa_key_id_t keyId              = 0;
+    size_t publicKeyLength;
+
+    Destroy();
+
+    // Type based on ECC with the elliptic curve SECP256r1 -> PSA_ECC_FAMILY_SECP_R1
+    psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
+    psa_set_key_bits(&attributes, kP256_PrivateKey_Length * 8);
+    psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
+    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_SIGN_MESSAGE);
+    psa_set_key_lifetime(&attributes, PSA_KEY_LIFETIME_PERSISTENT);
+    psa_set_key_id(&attributes, GetKeyId());
+
+    status = psa_generate_key(&attributes, &keyId);
+    VerifyOrExit(status == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
+
+    status = psa_export_public_key(keyId, mPublicKey.Bytes(), mPublicKey.Length(), &publicKeyLength);
+    VerifyOrExit(status == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(publicKeyLength == kP256_PublicKey_Length, error = CHIP_ERROR_INTERNAL);
+
+exit:
+    psa_reset_key_attributes(&attributes);
+
+    return error;
+}
+
+CHIP_ERROR PSAOperationalKeystore::PersistentP256Keypair::Destroy()
+{
+    psa_status_t status = psa_destroy_key(GetKeyId());
+
+    ReturnErrorCodeIf(status == PSA_ERROR_INVALID_HANDLE, CHIP_ERROR_INVALID_FABRIC_INDEX);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    return CHIP_NO_ERROR;
+}
+
+bool PSAOperationalKeystore::HasPendingOpKeypair() const
+{
+    return mPendingFabricIndex != kUndefinedFabricIndex;
+}
+
+bool PSAOperationalKeystore::HasOpKeypairForFabric(FabricIndex fabricIndex) const
+{
+    VerifyOrReturnError(IsValidFabricIndex(fabricIndex), false);
+
+    if (mPendingFabricIndex == fabricIndex)
+    {
+        return mIsPendingKeypairActive;
+    }
+
+    return PersistentP256Keypair(fabricIndex).Exists();
+}
+
+CHIP_ERROR PSAOperationalKeystore::NewOpKeypairForFabric(FabricIndex fabricIndex, MutableByteSpan & outCertificateSigningRequest)
+{
+    VerifyOrReturnError(IsValidFabricIndex(fabricIndex), CHIP_ERROR_INVALID_FABRIC_INDEX);
+
+    if (HasPendingOpKeypair())
+    {
+        VerifyOrReturnError(fabricIndex == mPendingFabricIndex, CHIP_ERROR_INVALID_FABRIC_INDEX);
+    }
+
+    if (mPendingKeypair == nullptr)
+    {
+        mPendingKeypair = Platform::New<PersistentP256Keypair>(fabricIndex);
+    }
+
+    VerifyOrReturnError(mPendingKeypair != nullptr, CHIP_ERROR_NO_MEMORY);
+    ReturnErrorOnFailure(mPendingKeypair->Generate());
+
+    size_t csrLength = outCertificateSigningRequest.size();
+    ReturnErrorOnFailure(mPendingKeypair->NewCertificateSigningRequest(outCertificateSigningRequest.data(), csrLength));
+    outCertificateSigningRequest.reduce_size(csrLength);
+    mPendingFabricIndex = fabricIndex;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PSAOperationalKeystore::ActivateOpKeypairForFabric(FabricIndex fabricIndex, const Crypto::P256PublicKey & nocPublicKey)
+{
+    VerifyOrReturnError(IsValidFabricIndex(fabricIndex) && mPendingFabricIndex == fabricIndex, CHIP_ERROR_INVALID_FABRIC_INDEX);
+    VerifyOrReturnError(mPendingKeypair->Pubkey().Matches(nocPublicKey), CHIP_ERROR_INVALID_PUBLIC_KEY);
+    mIsPendingKeypairActive = true;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PSAOperationalKeystore::CommitOpKeypairForFabric(FabricIndex fabricIndex)
+{
+    VerifyOrReturnError(IsValidFabricIndex(fabricIndex) && mPendingFabricIndex == fabricIndex, CHIP_ERROR_INVALID_FABRIC_INDEX);
+    VerifyOrReturnError(mIsPendingKeypairActive, CHIP_ERROR_INCORRECT_STATE);
+
+    ReleasePendingKeypair();
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PSAOperationalKeystore::RemoveOpKeypairForFabric(FabricIndex fabricIndex)
+{
+    VerifyOrReturnError(IsValidFabricIndex(fabricIndex), CHIP_ERROR_INVALID_FABRIC_INDEX);
+
+    if (mPendingFabricIndex == fabricIndex)
+    {
+        RevertPendingKeypair();
+        return CHIP_NO_ERROR;
+    }
+
+    return PersistentP256Keypair(fabricIndex).Destroy();
+}
+
+void PSAOperationalKeystore::RevertPendingKeypair()
+{
+    VerifyOrReturn(HasPendingOpKeypair());
+    mPendingKeypair->Destroy();
+    ReleasePendingKeypair();
+}
+
+CHIP_ERROR PSAOperationalKeystore::SignWithOpKeypair(FabricIndex fabricIndex, const ByteSpan & message,
+                                                     Crypto::P256ECDSASignature & outSignature) const
+{
+    VerifyOrReturnError(IsValidFabricIndex(fabricIndex), CHIP_ERROR_INVALID_FABRIC_INDEX);
+
+    if (mPendingFabricIndex == fabricIndex)
+    {
+        VerifyOrReturnError(mIsPendingKeypairActive, CHIP_ERROR_INVALID_FABRIC_INDEX);
+        return mPendingKeypair->ECDSA_sign_msg(message.data(), message.size(), outSignature);
+    }
+
+    PersistentP256Keypair keypair(fabricIndex);
+    VerifyOrReturnError(keypair.Exists(), CHIP_ERROR_INVALID_FABRIC_INDEX);
+
+    return keypair.ECDSA_sign_msg(message.data(), message.size(), outSignature);
+}
+
+Crypto::P256Keypair * PSAOperationalKeystore::AllocateEphemeralKeypairForCASE()
+{
+    return Platform::New<Crypto::P256Keypair>();
+}
+
+void PSAOperationalKeystore::ReleaseEphemeralKeypair(Crypto::P256Keypair * keypair)
+{
+    Platform::Delete(keypair);
+}
+
+void PSAOperationalKeystore::ReleasePendingKeypair()
+{
+    Platform::Delete(mPendingKeypair);
+    mPendingKeypair         = nullptr;
+    mPendingFabricIndex     = kUndefinedFabricIndex;
+    mIsPendingKeypairActive = false;
+}
+
+} // namespace Crypto
+} // namespace chip

--- a/src/crypto/PSAOperationalKeystore.h
+++ b/src/crypto/PSAOperationalKeystore.h
@@ -38,7 +38,7 @@ public:
     Crypto::P256Keypair * AllocateEphemeralKeypairForCASE() override;
     void ReleaseEphemeralKeypair(Crypto::P256Keypair * keypair) override;
 
-private:
+protected:
     class PersistentP256Keypair : private P256Keypair
     {
     public:

--- a/src/crypto/PSAOperationalKeystore.h
+++ b/src/crypto/PSAOperationalKeystore.h
@@ -1,0 +1,62 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <crypto/CHIPCryptoPALPSA.h>
+#include <crypto/OperationalKeystore.h>
+
+namespace chip {
+namespace Crypto {
+
+class PSAOperationalKeystore final : public OperationalKeystore
+{
+public:
+    bool HasPendingOpKeypair() const override;
+    bool HasOpKeypairForFabric(FabricIndex fabricIndex) const override;
+    CHIP_ERROR NewOpKeypairForFabric(FabricIndex fabricIndex, MutableByteSpan & outCertificateSigningRequest) override;
+    CHIP_ERROR ActivateOpKeypairForFabric(FabricIndex fabricIndex, const Crypto::P256PublicKey & nocPublicKey) override;
+    CHIP_ERROR CommitOpKeypairForFabric(FabricIndex fabricIndex) override;
+    CHIP_ERROR RemoveOpKeypairForFabric(FabricIndex fabricIndex) override;
+    void RevertPendingKeypair() override;
+    CHIP_ERROR SignWithOpKeypair(FabricIndex fabricIndex, const ByteSpan & message,
+                                 Crypto::P256ECDSASignature & outSignature) const override;
+    Crypto::P256Keypair * AllocateEphemeralKeypairForCASE() override;
+    void ReleaseEphemeralKeypair(Crypto::P256Keypair * keypair) override;
+
+private:
+    class PersistentP256Keypair : public P256Keypair
+    {
+    public:
+        explicit PersistentP256Keypair(FabricIndex fabricIndex);
+        ~PersistentP256Keypair();
+
+        psa_key_id_t GetKeyId() const;
+        bool Exists() const;
+        CHIP_ERROR Generate();
+        CHIP_ERROR Destroy();
+    };
+
+    void ReleasePendingKeypair();
+
+    PersistentP256Keypair * mPendingKeypair = nullptr;
+    FabricIndex mPendingFabricIndex         = kUndefinedFabricIndex;
+    bool mIsPendingKeypairActive            = false;
+};
+
+} // namespace Crypto
+} // namespace chip

--- a/src/crypto/PSAOperationalKeystore.h
+++ b/src/crypto/PSAOperationalKeystore.h
@@ -39,11 +39,15 @@ public:
     void ReleaseEphemeralKeypair(Crypto::P256Keypair * keypair) override;
 
 private:
-    class PersistentP256Keypair : public P256Keypair
+    class PersistentP256Keypair : private P256Keypair
     {
     public:
         explicit PersistentP256Keypair(FabricIndex fabricIndex);
-        ~PersistentP256Keypair();
+        ~PersistentP256Keypair() override;
+
+        using P256Keypair::ECDSA_sign_msg;
+        using P256Keypair::NewCertificateSigningRequest;
+        using P256Keypair::Pubkey;
 
         psa_key_id_t GetKeyId() const;
         bool Exists() const;

--- a/src/crypto/crypto.gni
+++ b/src/crypto/crypto.gni
@@ -21,5 +21,6 @@ declare_args() {
   chip_external_mbedtls = false
 }
 
-assert(!chip_external_mbedtls || chip_crypto == "mbedtls",
-       "Use of external mbedtls requires the mbedtls crypto impl")
+assert(
+    !chip_external_mbedtls || chip_crypto == "mbedtls" || chip_crypto == "psa",
+    "Use of external mbedtls requires the mbedtls or psa crypto impl")

--- a/src/crypto/tests/BUILD.gn
+++ b/src/crypto/tests/BUILD.gn
@@ -17,6 +17,7 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
+import("${chip_root}/src/crypto/crypto.gni")
 
 chip_test_suite("tests") {
   output_name = "libChipCryptoTests"
@@ -43,10 +44,13 @@ chip_test_suite("tests") {
     "TestCryptoLayer.h",
   ]
 
-  test_sources = [
-    "TestGroupOperationalCredentials.cpp",
-    "TestPersistentStorageOpKeyStore.cpp",
-  ]
+  test_sources = [ "TestGroupOperationalCredentials.cpp" ]
+
+  if (chip_crypto == "psa") {
+    test_sources += [ "TestPSAOpKeyStore.cpp" ]
+  } else {
+    test_sources += [ "TestPersistentStorageOpKeyStore.cpp" ]
+  }
 
   if (chip_device_platform == "esp32" || chip_device_platform == "nrfconnect" ||
       chip_device_platform == "efr32" || chip_device_platform == "openiotsdk") {

--- a/src/crypto/tests/TestPSAOpKeyStore.cpp
+++ b/src/crypto/tests/TestPSAOpKeyStore.cpp
@@ -1,0 +1,219 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <inttypes.h>
+
+#include <crypto/PSAOperationalKeystore.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/Span.h>
+#include <lib/support/UnitTestExtendedAssertions.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <nlunit-test.h>
+
+using namespace chip;
+using namespace chip::Crypto;
+
+namespace {
+
+void TestBasicLifeCycle(nlTestSuite * inSuite, void * inContext)
+{
+    PSAOperationalKeystore opKeystore;
+
+    FabricIndex kFabricIndex    = 111;
+    FabricIndex kBadFabricIndex = static_cast<FabricIndex>(kFabricIndex + 10u);
+
+    // Can generate a key and get a CSR
+    uint8_t csrBuf[kMAX_CSR_Length];
+    MutableByteSpan csrSpan{ csrBuf };
+    CHIP_ERROR err = opKeystore.NewOpKeypairForFabric(kFabricIndex, csrSpan);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasPendingOpKeypair() == true);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasOpKeypairForFabric(kFabricIndex) == false);
+
+    P256PublicKey csrPublicKey1;
+    err = VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), csrPublicKey1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Can regenerate a second CSR and it has different PK
+    csrSpan = MutableByteSpan{ csrBuf };
+    err     = opKeystore.NewOpKeypairForFabric(kFabricIndex, csrSpan);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasPendingOpKeypair() == true);
+
+    P256PublicKey csrPublicKey2;
+    err = VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), csrPublicKey2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, !csrPublicKey1.Matches(csrPublicKey2));
+
+    // Cannot NewOpKeypair for a different fabric if one already pending
+    uint8_t badCsrBuf[kMAX_CSR_Length];
+    MutableByteSpan badCsrSpan{ badCsrBuf };
+    err = opKeystore.NewOpKeypairForFabric(kBadFabricIndex, badCsrSpan);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_FABRIC_INDEX);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasPendingOpKeypair() == true);
+
+    // Fail to generate CSR for invalid fabrics
+    csrSpan = MutableByteSpan{ csrBuf };
+    err     = opKeystore.NewOpKeypairForFabric(kUndefinedFabricIndex, csrSpan);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_FABRIC_INDEX);
+
+    csrSpan = MutableByteSpan{ csrBuf };
+    err     = opKeystore.NewOpKeypairForFabric(kMaxValidFabricIndex + 1, csrSpan);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_FABRIC_INDEX);
+
+    // No storage done by NewOpKeypairForFabric
+    NL_TEST_ASSERT(inSuite, opKeystore.HasOpKeypairForFabric(kFabricIndex) == false);
+
+    // Even after error, the previous valid pending keypair stays valid.
+    NL_TEST_ASSERT(inSuite, opKeystore.HasPendingOpKeypair() == true);
+
+    // Activating with mismatching fabricIndex and matching public key fails
+    err = opKeystore.ActivateOpKeypairForFabric(kBadFabricIndex, csrPublicKey2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_FABRIC_INDEX);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasPendingOpKeypair() == true);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasOpKeypairForFabric(kFabricIndex) == false);
+
+    // Activating with matching fabricIndex and mismatching public key fails
+    err = opKeystore.ActivateOpKeypairForFabric(kFabricIndex, csrPublicKey1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_PUBLIC_KEY);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasPendingOpKeypair() == true);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasOpKeypairForFabric(kFabricIndex) == false);
+
+    // Before successful activation, cannot sign
+    uint8_t message[] = { 1, 2, 3, 4 };
+    P256ECDSASignature sig1;
+    err = opKeystore.SignWithOpKeypair(kFabricIndex, ByteSpan{ message }, sig1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_FABRIC_INDEX);
+
+    // Activating with matching fabricIndex and matching public key succeeds
+    err = opKeystore.ActivateOpKeypairForFabric(kFabricIndex, csrPublicKey2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Activating does not store, and keeps pending
+    NL_TEST_ASSERT(inSuite, opKeystore.HasPendingOpKeypair() == true);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasOpKeypairForFabric(kFabricIndex) == true);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasOpKeypairForFabric(kBadFabricIndex) == false);
+
+    // Can't sign for wrong fabric after activation
+    P256ECDSASignature sig2;
+    err = opKeystore.SignWithOpKeypair(kBadFabricIndex, ByteSpan{ message }, sig2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_FABRIC_INDEX);
+
+    // Can sign after activation
+    err = opKeystore.SignWithOpKeypair(kFabricIndex, ByteSpan{ message }, sig2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Signature matches pending key
+    err = csrPublicKey2.ECDSA_validate_msg_signature(message, sizeof(message), sig2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Signature does not match a previous pending key
+    err = csrPublicKey1.ECDSA_validate_msg_signature(message, sizeof(message), sig2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_SIGNATURE);
+
+    // Committing with mismatching fabric fails, leaves pending
+    err = opKeystore.CommitOpKeypairForFabric(kBadFabricIndex);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_FABRIC_INDEX);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasPendingOpKeypair() == true);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasOpKeypairForFabric(kFabricIndex) == true);
+
+    // Committing key resets pending state
+    err = opKeystore.CommitOpKeypairForFabric(kFabricIndex);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasPendingOpKeypair() == false);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasOpKeypairForFabric(kFabricIndex) == true);
+
+    // After committing, signing works with the key that was pending
+    P256ECDSASignature sig3;
+    uint8_t message2[] = { 10, 11, 12, 13 };
+    err                = opKeystore.SignWithOpKeypair(kFabricIndex, ByteSpan{ message2 }, sig3);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = csrPublicKey2.ECDSA_validate_msg_signature(message2, sizeof(message2), sig3);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Let's remove the opkey for a fabric, it disappears
+    err = opKeystore.RemoveOpKeypairForFabric(kFabricIndex);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasPendingOpKeypair() == false);
+    NL_TEST_ASSERT(inSuite, opKeystore.HasOpKeypairForFabric(kFabricIndex) == false);
+}
+
+void TestEphemeralKeys(nlTestSuite * inSuite, void * inContext)
+{
+    PSAOperationalKeystore opKeyStore;
+
+    Crypto::P256ECDSASignature sig;
+    uint8_t message[] = { 'm', 's', 'g' };
+
+    Crypto::P256Keypair * ephemeralKeypair = opKeyStore.AllocateEphemeralKeypairForCASE();
+    NL_TEST_ASSERT(inSuite, ephemeralKeypair != nullptr);
+    NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Initialize(Crypto::ECPKeyTarget::ECDSA));
+
+    NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->ECDSA_sign_msg(message, sizeof(message), sig));
+    NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Pubkey().ECDSA_validate_msg_signature(message, sizeof(message), sig));
+
+    opKeyStore.ReleaseEphemeralKeypair(ephemeralKeypair);
+}
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+static const nlTest sTests[] = { NL_TEST_DEF("Test Basic Lifecycle of PersistentStorageOperationalKeystore", TestBasicLifeCycle),
+                                 NL_TEST_DEF("Test ephemeral key management", TestEphemeralKeys), NL_TEST_SENTINEL() };
+
+/**
+ *  Set up the test suite.
+ */
+int Test_Setup(void * inContext)
+{
+    CHIP_ERROR error = chip::Platform::MemoryInit();
+    VerifyOrReturnError(error == CHIP_NO_ERROR, FAILURE);
+
+#if CHIP_CRYPTO_PSA
+    psa_crypto_init();
+#endif
+
+    return SUCCESS;
+}
+
+/**
+ *  Tear down the test suite.
+ */
+int Test_Teardown(void * inContext)
+{
+    chip::Platform::MemoryShutdown();
+    return SUCCESS;
+}
+
+} // namespace
+
+/**
+ *  Main
+ */
+int TestPSAOperationalKeystore()
+{
+    nlTestSuite theSuite = { "PSAOperationalKeystore tests", &sTests[0], Test_Setup, Test_Teardown };
+
+    // Run test suite againt one context.
+    nlTestRunner(&theSuite, nullptr);
+    return nlTestRunnerStats(&theSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestPSAOperationalKeystore)


### PR DESCRIPTION
Add `OperationalKeystore` implementation targeted at "psa" crypto backend.
Namely, it allows to securely generate NOC key pairs without exposing the private keys to the application.

Fixes #23955