### PR TITLE
Make sure we don't use the Matter dispatch queue when it's not running.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRClusterStateCacheContainer_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRClusterStateCacheContainer_Internal.h
@@ -27,10 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRClusterStateCacheContainer ()
 
 @property (atomic, readwrite, nullable) chip::app::ClusterStateCache * cppClusterStateCache;
-@property (nonatomic, readwrite, copy) NSNumber * deviceID;
-@property (nonatomic, readwrite, weak, nullable) MTRDeviceControllerXPCConnection * xpcConnection;
-@property (nonatomic, readwrite, strong, nullable) id<NSCopying> xpcControllerID;
-@property (atomic, readwrite) BOOL shouldUseXPC;
+@property (nonatomic, readwrite, nullable) MTRBaseDevice * baseDevice;
 
 @end
 

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
@@ -181,7 +181,7 @@ reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value
 + (void) read{{>attribute}}WithClusterStateCache:(MTRClusterStateCacheContainer *)clusterStateCacheContainer endpoint:(NSNumber *)endpoint  queue:(dispatch_queue_t)queue completion:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))completion
 {
     auto * bridge = new MTR{{>attribute_data_callback_name}}CallbackBridge(queue, completion);
-    std::move(*bridge).DispatchLocalAction(^({{>attribute_data_callback_name}}Callback successCb, MTRErrorCallback failureCb) {
+    std::move(*bridge).DispatchLocalAction(clusterStateCacheContainer.baseDevice, ^({{>attribute_data_callback_name}}Callback successCb, MTRErrorCallback failureCb) {
           if (clusterStateCacheContainer.cppClusterStateCache) {
               chip::app::ConcreteAttributePath path;
               using TypeInfo = {{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::TypeInfo;


### PR DESCRIPTION
We've had issues where things get queued to the Matter dispatch queue while it's not running, and then when we start it up again those things run too early in startup and break in interesting ways.

The fix is to make sure we only queue things to the Matter dispatch queue when they're associated with a currently-running controller.

Fixes https://github.com/project-chip/connectedhomeip/issues/22847

