### PR TITLE
Remove write-only variables.

### DIFF
--- a/src/app/MessageDef/AttributeStatusIBs.cpp
+++ b/src/app/MessageDef/AttributeStatusIBs.cpp
@@ -47,8 +47,7 @@ AttributeStatusIBs::Builder & AttributeStatusIBs::Builder::EndOfAttributeStatuse
 #if CHIP_CONFIG_IM_PRETTY_PRINT
 CHIP_ERROR AttributeStatusIBs::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err            = CHIP_NO_ERROR;
-    size_t NumAttributeStatus = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("AttributeStatusIBs =");
@@ -68,8 +67,6 @@ CHIP_ERROR AttributeStatusIBs::Parser::PrettyPrint() const
             ReturnErrorOnFailure(status.PrettyPrint());
             PRETTY_PRINT_DECDEPTH();
         }
-
-        ++NumAttributeStatus;
     }
 
     PRETTY_PRINT("],");

--- a/src/app/MessageDef/EventPathIBs.cpp
+++ b/src/app/MessageDef/EventPathIBs.cpp
@@ -32,7 +32,6 @@ namespace app {
 CHIP_ERROR EventPathIBs::Parser::PrettyPrint() const
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    size_t NumPath = 0;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("EventPathIBs =");
@@ -54,8 +53,6 @@ CHIP_ERROR EventPathIBs::Parser::PrettyPrint() const
             ReturnErrorOnFailure(path.PrettyPrint());
             PRETTY_PRINT_DECDEPTH();
         }
-
-        ++NumPath;
     }
 
     PRETTY_PRINT("],");

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -211,7 +211,6 @@ struct GroupMembershipResponse
             {
                 GroupDataProvider::GroupEndpoint mapping;
                 size_t requestedCount = 0;
-                size_t matchCount     = 0;
                 ReturnErrorOnFailure(mCommandData.groupList.ComputeSize(&requestedCount));
 
                 if (0 == requestedCount)
@@ -223,7 +222,6 @@ struct GroupMembershipResponse
                         if (mapping.endpoint_id == mEndpoint)
                         {
                             ReturnErrorOnFailure(app::DataModel::Encode(writer, TLV::AnonymousTag(), mapping.group_id));
-                            matchCount++;
                             ChipLogDetail(Zcl, " 0x%02x", mapping.group_id);
                         }
                     }
@@ -238,7 +236,6 @@ struct GroupMembershipResponse
                             if (mapping.endpoint_id == mEndpoint && mapping.group_id == iter.GetValue())
                             {
                                 ReturnErrorOnFailure(app::DataModel::Encode(writer, TLV::AnonymousTag(), mapping.group_id));
-                                matchCount++;
                                 ChipLogDetail(Zcl, " 0x%02x", mapping.group_id);
                                 break;
                             }


### PR DESCRIPTION
This is triggering errors due to -Werror on some compilers.

