### PR TITLE
Stop calling into the device attestation delegate on the Matter work queue

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
@@ -60,6 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
  * An optional delegate that can be notified upon completion of device
  * attestation.  See documentation for MTRDeviceAttestationDelegate for
  * details.
+ *
+ * The delegate methods will be invoked on an arbitrary thread.
  */
 @property (nonatomic, strong, nullable) id<MTRDeviceAttestationDelegate> deviceAttestationDelegate;
 /**
@@ -68,7 +70,6 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * If nil, the fail-safe will not be extended before calling into the
  * deviceAttestationDelegate.
-
  */
 @property (nonatomic, copy, nullable) NSNumber * failSafeExpiryTimeout MTR_NEWLY_AVAILABLE;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.h
@@ -30,9 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 /**
- * The protocol definition for the MTRDeviceAttestationDelegate
- *
- * All delegate methods will be called on the callers queue.
+ * The protocol definition for the MTRDeviceAttestationDelegate.
  */
 @protocol MTRDeviceAttestationDelegate <NSObject>
 @optional

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.h
@@ -28,12 +28,12 @@ NS_ASSUME_NONNULL_BEGIN
 class MTRDeviceAttestationDelegateBridge : public chip::Credentials::DeviceAttestationDelegate {
 public:
     MTRDeviceAttestationDelegateBridge(MTRDeviceController * deviceController,
-        id<MTRDeviceAttestationDelegate> deviceAttestationDelegate, dispatch_queue_t queue,
-        chip::Optional<uint16_t> expiryTimeoutSecs, bool shouldWaitAfterDeviceAttestation = false)
+        id<MTRDeviceAttestationDelegate> deviceAttestationDelegate, chip::Optional<uint16_t> expiryTimeoutSecs,
+        bool shouldWaitAfterDeviceAttestation = false)
         : mResult(chip::Credentials::AttestationVerificationResult::kSuccess)
         , mDeviceController(deviceController)
         , mDeviceAttestationDelegate(deviceAttestationDelegate)
-        , mQueue(queue)
+        , mQueue(dispatch_queue_create("com.csa.matter.framework.device_attestation.workqueue", DISPATCH_QUEUE_SERIAL))
         , mExpiryTimeoutSecs(expiryTimeoutSecs)
         , mShouldWaitAfterDeviceAttestation(shouldWaitAfterDeviceAttestation)
     {

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -439,7 +439,7 @@ static NSString * const kErrorSpake2pVerifierSerializationFailed = @"PASE verifi
                 shouldWaitAfterDeviceAttestation = YES;
             }
             _deviceAttestationDelegateBridge = new MTRDeviceAttestationDelegateBridge(
-                self, commissioningParams.deviceAttestationDelegate, _chipWorkQueue, timeoutSecs, shouldWaitAfterDeviceAttestation);
+                self, commissioningParams.deviceAttestationDelegate, timeoutSecs, shouldWaitAfterDeviceAttestation);
             params.SetDeviceAttestationDelegate(_deviceAttestationDelegateBridge);
         }
 

--- a/src/darwin/Framework/CHIP/MTRKeypair.h
+++ b/src/darwin/Framework/CHIP/MTRKeypair.h
@@ -20,6 +20,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * This protocol is used by the Matter framework to sign messages with a private
+ * key and verify signatures with a public key.
+ *
+ * The Matter framework may call keypair methods from arbitrary threads and
+ * concurrently.
+ *
+ * Implementations of the keypair methods must not call into any Matter
+ * framework APIs.
+ */
 @protocol MTRKeypair <NSObject>
 @required
 /**

--- a/src/darwin/Framework/CHIP/MTRStorage.h
+++ b/src/darwin/Framework/CHIP/MTRStorage.h
@@ -24,6 +24,9 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * The Matter framework may call storage methods from arbitrary threads, but
  * will not call storage methods concurrently.
+ *
+ * Implementations of the storage methods must not call into any Matter
+ * framework APIs.
  */
 MTR_NEWLY_AVAILABLE
 @protocol MTRStorage <NSObject>


### PR DESCRIPTION
Also add some documentation to MTRStorage and MTRKeypair about expected callee behavior.

Fixes https://github.com/project-chip/connectedhomeip/issues/23277

