### PR TITLE
Fix up cert bins docker script.

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -252,7 +252,7 @@ RUN case ${TARGETPLATFORM} in \
         *) ;; \
     esac
 
-RUN cd third_party/zap/repo && npm ci
+RUN npm --prefix third_party/zap/repo/ ci
 RUN scripts/examples/gn_build_test_example.sh app1
 
 RUN source scripts/activate.sh && scripts/build_python.sh -m platform -d true -i no

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -199,13 +199,16 @@ from chip-build-cert as chip-build-cert-bins
 SHELL ["/bin/bash", "-c"]
 # Records Matter SDK commit hash to include in the image.
 RUN git rev-parse HEAD > /root/.sdk-sha-version
+
+# TODO: below the build of linux-arm64-all-clusters-minimal-ipv6only/linux-x64-all-clusters-minimal-ipv6only
+#       is NOT performed because the given SHA does not build minimal and
+#       builds the regular all-clusters app instead.
 RUN case ${TARGETPLATFORM} in \
         "linux/amd64") \
             set -x \
 			&& source scripts/activate.sh \
 			&& scripts/build/build_examples.py \
 			--target linux-x64-all-clusters-ipv6only \
-			--target linux-x64-all-clusters-minimal-ipv6only \
 			--target linux-x64-bridge-ipv6only \
 			--target linux-x64-tv-app-ipv6only \
 			--target linux-x64-tv-casting-app-ipv6only \
@@ -216,7 +219,6 @@ RUN case ${TARGETPLATFORM} in \
 			--target linux-x64-lock-ipv6only \
 			build \
 			&& mv out/linux-x64-all-clusters-ipv6only/chip-all-clusters-app out/chip-all-clusters-app \
-			&& mv out/linux-x64-all-clusters-minimal-ipv6only/chip-all-clusters-app out/chip-all-clusters-minimal-app \
             && mv out/linux-x64-bridge-ipv6only/chip-bridge-app out/chip-bridge-app \
 			&& mv out/linux-x64-tv-app-ipv6only/chip-tv-app out/chip-tv-app \
 			&& mv out/linux-x64-tv-casting-app-ipv6only/chip-tv-casting-app out/chip-tv-casting-app \
@@ -231,7 +233,6 @@ RUN case ${TARGETPLATFORM} in \
 			&& source scripts/activate.sh \
 			&& scripts/build/build_examples.py \
 			--target linux-arm64-all-clusters-ipv6only \
-			--target linux-arm64-all-clusters-minimal-ipv6only \
 			--target linux-arm64-bridge-ipv6only \
 			--target linux-arm64-tv-app-ipv6only \
 			--target linux-arm64-tv-casting-app-ipv6only \
@@ -242,7 +243,6 @@ RUN case ${TARGETPLATFORM} in \
 			--target linux-arm64-lock-ipv6only \
 			build \
 			&& mv out/linux-arm64-all-clusters-ipv6only/chip-all-clusters-app out/chip-all-clusters-app \
-			&& mv out/linux-arm64-all-clusters-minimal-ipv6only/chip-all-clusters-app out/chip-all-clusters-minimal-app \
             && mv out/linux-arm64-bridge-ipv6only/chip-bridge-app out/chip-bridge-app \
 			&& mv out/linux-arm64-tv-app-ipv6only/chip-tv-app out/chip-tv-app \
 			&& mv out/linux-arm64-tv-casting-app-ipv6only/chip-tv-casting-app out/chip-tv-casting-app \
@@ -272,7 +272,6 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/out/debug/chip-tool chip-
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/debug/chip-shell chip-shell
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/debug/chip-cert chip-cert
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-all-clusters-app chip-all-clusters-app
-COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-all-clusters-minimal-app chip-all-clusters-minimal-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-lighting-app chip-lighting-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-tv-casting-app chip-tv-casting-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-tv-app chip-tv-app

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -216,8 +216,8 @@ RUN case ${TARGETPLATFORM} in \
 			--target linux-x64-lock-ipv6only \
 			build \
 			&& mv out/linux-x64-all-clusters-ipv6only/chip-all-clusters-app out/chip-all-clusters-app \
-			&& mv out/linux-x64-all-clusters-minimal-ipv6only/chip-all-clusters-minimal-app out/chip-all-clusters-minimal-app \
-                        && mv out/linux-x64-bridge-ipv6only/chip-bridge-app out/chip-bridge-app \
+			&& mv out/linux-x64-all-clusters-minimal-ipv6only/chip-all-clusters-app out/chip-all-clusters-minimal-app \
+            && mv out/linux-x64-bridge-ipv6only/chip-bridge-app out/chip-bridge-app \
 			&& mv out/linux-x64-tv-app-ipv6only/chip-tv-app out/chip-tv-app \
 			&& mv out/linux-x64-tv-casting-app-ipv6only/chip-tv-casting-app out/chip-tv-casting-app \
 			&& mv out/linux-x64-light-ipv6only/chip-lighting-app out/chip-lighting-app \
@@ -242,8 +242,8 @@ RUN case ${TARGETPLATFORM} in \
 			--target linux-arm64-lock-ipv6only \
 			build \
 			&& mv out/linux-arm64-all-clusters-ipv6only/chip-all-clusters-app out/chip-all-clusters-app \
-			&& mv out/linux-arm64-all-clusters-minimal-ipv6only/chip-all-clusters-minimal-app out/chip-all-clusters-minimal-app \
-                        && mv out/linux-arm64-bridge-ipv6only/chip-bridge-app out/chip-bridge-app \
+			&& mv out/linux-arm64-all-clusters-minimal-ipv6only/chip-all-clusters-app out/chip-all-clusters-minimal-app \
+            && mv out/linux-arm64-bridge-ipv6only/chip-bridge-app out/chip-bridge-app \
 			&& mv out/linux-arm64-tv-app-ipv6only/chip-tv-app out/chip-tv-app \
 			&& mv out/linux-arm64-tv-casting-app-ipv6only/chip-tv-casting-app out/chip-tv-casting-app \
 			&& mv out/linux-arm64-light-ipv6only/chip-lighting-app out/chip-lighting-app \

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -186,7 +186,8 @@ RUN mkdir /root/connectedhomeip
 RUN git clone https://github.com/project-chip/connectedhomeip.git /root/connectedhomeip
 WORKDIR /root/connectedhomeip/
 RUN git checkout ${COMMITHASH}
-RUN scripts/build/gn_bootstrap.sh \
+RUN ./scripts/checkout_submodules.py --shallow --platform linux \
+    && scripts/build/gn_bootstrap.sh \
     && gn gen out/debug --args='chip_mdns="platform" chip_inet_config_enable_ipv4=false' \
     && ninja -C out/debug
 

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -255,7 +255,18 @@ RUN case ${TARGETPLATFORM} in \
         *) ;; \
     esac
 
-RUN npm --prefix third_party/zap/repo/ ci
+# Install a known ZAP release
+# Only keep the cli version, since `zap` is 143MB and not usable (UI)
+ENV ZAP_VERSION=v2022.11.29-nightly
+RUN set -x \
+    && mkdir -p /opt/zap-${ZAP_VERSION} \
+    && cd /opt/zap-${ZAP_VERSION} \
+    && wget https://github.com/project-chip/zap/releases/download/${ZAP_VERSION}/zap-linux.zip \
+    && unzip zap-linux.zip \
+    && rm zap-linux.zip \
+    && rm zap \
+    && ln -s /opt/zap-${ZAP_VERSION}/zap-cli /usr/bin/ \
+    && : # last line
 RUN scripts/examples/gn_build_test_example.sh app1
 
 RUN source scripts/activate.sh && scripts/build_python.sh -m platform -d true -i no

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:22.04 as chip-build-cert
 ARG TARGETPLATFORM
 # COMMITHASH defines the target commit to build from. May be passed in using --build-arg.
-ARG COMMITHASH=e556daac2e1ed3a141034a6dcc7e410e4cd1f8f6
+ARG COMMITHASH=21245f42393e63dbb16fb4d99d8bf96aef7ae0fc
 
 # Ensure TARGETPLATFORM is set
 RUN case ${TARGETPLATFORM} in \
@@ -252,6 +252,7 @@ RUN case ${TARGETPLATFORM} in \
         *) ;; \
     esac
 
+RUN cd third_party/zap/repo && npm ci
 RUN scripts/examples/gn_build_test_example.sh app1
 
 RUN source scripts/activate.sh && scripts/build_python.sh -m platform -d true -i no

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -8,20 +8,20 @@ ARG COMMITHASH=21245f42393e63dbb16fb4d99d8bf96aef7ae0fc
 RUN case ${TARGETPLATFORM} in \
         "linux/amd64") \
             echo "Building for linux/amd64" \
-	    ;; \
+        ;; \
         "linux/arm64") \
             echo "Building for linux/arm64" \
-	    ;; \
+        ;; \
         *) \
-	    if [ -z "$TARGETPLATFORM" ] ;\
-	    then \
-	        echo "TARGETPLATFORM not defined! Please run from buildkit (buildx)." \
-		&& return 1 ;\
-	    else \
-	        echo "Unsupported platform ${TARGETPLATFORM}." \
-		&& return 1 ;\
-	    fi \
-	    ;; \
+        if [ -z "$TARGETPLATFORM" ] ;\
+        then \
+            echo "TARGETPLATFORM not defined! Please run from buildkit (buildx)." \
+        && return 1 ;\
+        else \
+            echo "Unsupported platform ${TARGETPLATFORM}." \
+        && return 1 ;\
+        fi \
+        ;; \
     esac
 
 # Below should be the same as chip-build except arm64 logic for cmake and node.
@@ -108,9 +108,9 @@ RUN case ${TARGETPLATFORM} in \
             && exec bash \
             ;; \
         *) \
-	    test -n "$TARGETPLATFORM" \
-	    echo "Unsupported platform ${TARGETPLATFORM}" \
-	;; \
+        test -n "$TARGETPLATFORM" \
+        echo "Unsupported platform ${TARGETPLATFORM}" \
+    ;; \
     esac
 
 # Python 3 and PIP
@@ -156,28 +156,28 @@ RUN set -x \
 RUN case ${TARGETPLATFORM} in \
         "linux/amd64") \
             set -x \
-			&& mkdir node_js \
-			&& cd node_js \
-			&& wget https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-x64.tar.xz \
-			&& tar xfvJ node-v12.19.0-linux-x64.tar.xz \
-			&& mv node-v12.19.0-linux-x64 /opt/ \
-			&& ln -s /opt/node-v12.19.0-linux-x64 /opt/node \
-			&& ln -s /opt/node/bin/* /usr/bin \
-			&& cd .. \
-			&& rm -rf node_js \
-			;; \
+            && mkdir node_js \
+            && cd node_js \
+            && wget https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-x64.tar.xz \
+            && tar xfvJ node-v12.19.0-linux-x64.tar.xz \
+            && mv node-v12.19.0-linux-x64 /opt/ \
+            && ln -s /opt/node-v12.19.0-linux-x64 /opt/node \
+            && ln -s /opt/node/bin/* /usr/bin \
+            && cd .. \
+            && rm -rf node_js \
+            ;; \
         "linux/arm64")\
             set -x \
-			&& mkdir node_js \
-			&& cd node_js \
-			&& wget https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-arm64.tar.xz \
-			&& tar xfvJ node-v12.19.0-linux-arm64.tar.xz \
-			&& mv node-v12.19.0-linux-arm64 /opt/ \
-			&& ln -s /opt/node-v12.19.0-linux-arm64 /opt/node \
-			&& ln -s /opt/node/bin/* /usr/bin \
-			&& cd .. \
-			&& rm -rf node_js \
-			;; \
+            && mkdir node_js \
+            && cd node_js \
+            && wget https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-arm64.tar.xz \
+            && tar xfvJ node-v12.19.0-linux-arm64.tar.xz \
+            && mv node-v12.19.0-linux-arm64 /opt/ \
+            && ln -s /opt/node-v12.19.0-linux-arm64 /opt/node \
+            && ln -s /opt/node/bin/* /usr/bin \
+            && cd .. \
+            && rm -rf node_js \
+            ;; \
         *) ;; \
     esac
 
@@ -206,52 +206,52 @@ RUN git rev-parse HEAD > /root/.sdk-sha-version
 RUN case ${TARGETPLATFORM} in \
         "linux/amd64") \
             set -x \
-			&& source scripts/activate.sh \
-			&& scripts/build/build_examples.py \
-			--target linux-x64-all-clusters-ipv6only \
-			--target linux-x64-bridge-ipv6only \
-			--target linux-x64-tv-app-ipv6only \
-			--target linux-x64-tv-casting-app-ipv6only \
-			--target linux-x64-light-ipv6only \
-			--target linux-x64-thermostat-ipv6only \
-			--target linux-x64-ota-provider-ipv6only \
-			--target linux-x64-ota-requestor-ipv6only \
-			--target linux-x64-lock-ipv6only \
-			build \
-			&& mv out/linux-x64-all-clusters-ipv6only/chip-all-clusters-app out/chip-all-clusters-app \
+            && source scripts/activate.sh \
+            && scripts/build/build_examples.py \
+            --target linux-x64-all-clusters-ipv6only \
+            --target linux-x64-bridge-ipv6only \
+            --target linux-x64-tv-app-ipv6only \
+            --target linux-x64-tv-casting-app-ipv6only \
+            --target linux-x64-light-ipv6only \
+            --target linux-x64-thermostat-ipv6only \
+            --target linux-x64-ota-provider-ipv6only \
+            --target linux-x64-ota-requestor-ipv6only \
+            --target linux-x64-lock-ipv6only \
+            build \
+            && mv out/linux-x64-all-clusters-ipv6only/chip-all-clusters-app out/chip-all-clusters-app \
             && mv out/linux-x64-bridge-ipv6only/chip-bridge-app out/chip-bridge-app \
-			&& mv out/linux-x64-tv-app-ipv6only/chip-tv-app out/chip-tv-app \
-			&& mv out/linux-x64-tv-casting-app-ipv6only/chip-tv-casting-app out/chip-tv-casting-app \
-			&& mv out/linux-x64-light-ipv6only/chip-lighting-app out/chip-lighting-app \
-			&& mv out/linux-x64-thermostat-ipv6only/thermostat-app out/thermostat-app \
-			&& mv out/linux-x64-ota-provider-ipv6only/chip-ota-provider-app out/chip-ota-provider-app \
-			&& mv out/linux-x64-ota-requestor-ipv6only/chip-ota-requestor-app out/chip-ota-requestor-app \
-			&& mv out/linux-x64-lock-ipv6only/chip-lock-app out/chip-lock-app \
-		        ;; \
+            && mv out/linux-x64-tv-app-ipv6only/chip-tv-app out/chip-tv-app \
+            && mv out/linux-x64-tv-casting-app-ipv6only/chip-tv-casting-app out/chip-tv-casting-app \
+            && mv out/linux-x64-light-ipv6only/chip-lighting-app out/chip-lighting-app \
+            && mv out/linux-x64-thermostat-ipv6only/thermostat-app out/thermostat-app \
+            && mv out/linux-x64-ota-provider-ipv6only/chip-ota-provider-app out/chip-ota-provider-app \
+            && mv out/linux-x64-ota-requestor-ipv6only/chip-ota-requestor-app out/chip-ota-requestor-app \
+            && mv out/linux-x64-lock-ipv6only/chip-lock-app out/chip-lock-app \
+                ;; \
         "linux/arm64")\
             set -x \
-			&& source scripts/activate.sh \
-			&& scripts/build/build_examples.py \
-			--target linux-arm64-all-clusters-ipv6only \
-			--target linux-arm64-bridge-ipv6only \
-			--target linux-arm64-tv-app-ipv6only \
-			--target linux-arm64-tv-casting-app-ipv6only \
-			--target linux-arm64-light-ipv6only \
-			--target linux-arm64-thermostat-ipv6only \
-			--target linux-arm64-ota-provider-ipv6only \
-			--target linux-arm64-ota-requestor-ipv6only \
-			--target linux-arm64-lock-ipv6only \
-			build \
-			&& mv out/linux-arm64-all-clusters-ipv6only/chip-all-clusters-app out/chip-all-clusters-app \
+            && source scripts/activate.sh \
+            && scripts/build/build_examples.py \
+            --target linux-arm64-all-clusters-ipv6only \
+            --target linux-arm64-bridge-ipv6only \
+            --target linux-arm64-tv-app-ipv6only \
+            --target linux-arm64-tv-casting-app-ipv6only \
+            --target linux-arm64-light-ipv6only \
+            --target linux-arm64-thermostat-ipv6only \
+            --target linux-arm64-ota-provider-ipv6only \
+            --target linux-arm64-ota-requestor-ipv6only \
+            --target linux-arm64-lock-ipv6only \
+            build \
+            && mv out/linux-arm64-all-clusters-ipv6only/chip-all-clusters-app out/chip-all-clusters-app \
             && mv out/linux-arm64-bridge-ipv6only/chip-bridge-app out/chip-bridge-app \
-			&& mv out/linux-arm64-tv-app-ipv6only/chip-tv-app out/chip-tv-app \
-			&& mv out/linux-arm64-tv-casting-app-ipv6only/chip-tv-casting-app out/chip-tv-casting-app \
-			&& mv out/linux-arm64-light-ipv6only/chip-lighting-app out/chip-lighting-app \
-			&& mv out/linux-arm64-thermostat-ipv6only/thermostat-app out/thermostat-app \
-			&& mv out/linux-arm64-ota-provider-ipv6only/chip-ota-provider-app out/chip-ota-provider-app \
-			&& mv out/linux-arm64-ota-requestor-ipv6only/chip-ota-requestor-app out/chip-ota-requestor-app \
-			&& mv out/linux-arm64-lock-ipv6only/chip-lock-app out/chip-lock-app \
-			;; \
+            && mv out/linux-arm64-tv-app-ipv6only/chip-tv-app out/chip-tv-app \
+            && mv out/linux-arm64-tv-casting-app-ipv6only/chip-tv-casting-app out/chip-tv-casting-app \
+            && mv out/linux-arm64-light-ipv6only/chip-lighting-app out/chip-lighting-app \
+            && mv out/linux-arm64-thermostat-ipv6only/thermostat-app out/thermostat-app \
+            && mv out/linux-arm64-ota-provider-ipv6only/chip-ota-provider-app out/chip-ota-provider-app \
+            && mv out/linux-arm64-ota-requestor-ipv6only/chip-ota-requestor-app out/chip-ota-requestor-app \
+            && mv out/linux-arm64-lock-ipv6only/chip-lock-app out/chip-lock-app \
+            ;; \
         *) ;; \
     esac
 

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -186,8 +186,9 @@ RUN mkdir /root/connectedhomeip
 RUN git clone https://github.com/project-chip/connectedhomeip.git /root/connectedhomeip
 WORKDIR /root/connectedhomeip/
 RUN git checkout ${COMMITHASH}
-RUN ./scripts/checkout_submodules.py --shallow --platform linux \
-    && scripts/build/gn_bootstrap.sh \
+RUN ./scripts/checkout_submodules.py --shallow --platform linux
+RUN scripts/build/gn_bootstrap.sh
+RUN source scripts/activate.sh \
     && gn gen out/debug --args='chip_mdns="platform" chip_inet_config_enable_ipv4=false' \
     && ninja -C out/debug
 

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -186,9 +186,9 @@ RUN mkdir /root/connectedhomeip
 RUN git clone https://github.com/project-chip/connectedhomeip.git /root/connectedhomeip
 WORKDIR /root/connectedhomeip/
 RUN git checkout ${COMMITHASH}
-RUN scripts/build/gn_bootstrap.sh
-RUN gn gen out/debug --args='chip_mdns="platform" chip_inet_config_enable_ipv4=false'
-RUN ninja -C out/debug
+RUN scripts/build/gn_bootstrap.sh \
+    && gn gen out/debug --args='chip_mdns="platform" chip_inet_config_enable_ipv4=false' \
+    && ninja -C out/debug
 
 # Stage 2: Build.
 from chip-build-cert as chip-build-cert-bins

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -188,7 +188,9 @@ WORKDIR /root/connectedhomeip/
 RUN git checkout ${COMMITHASH}
 RUN ./scripts/checkout_submodules.py --shallow --platform linux
 RUN scripts/build/gn_bootstrap.sh
-RUN source scripts/activate.sh \
+SHELL ["/bin/bash", "-c"]
+RUN set -x && \
+    source scripts/activate.sh \
     && gn gen out/debug --args='chip_mdns="platform" chip_inet_config_enable_ipv4=false' \
     && ninja -C out/debug
 


### PR DESCRIPTION
Fixes #23869
This updates the chip-cert-bins to be compilable again. Updates include:

- use a new SHA by default (as in the bug report)
- use `activate.sh` to build local items
- add back a missing zap setup since this script is used on old SHA which still has zap checkouts
- remove `all-clusters-minimal-app` from the build since the build targets seem buggy and minimal app is in fact NOT being built
- Install zap as part of the cert bins script, so that generate.py works and test app 1 can be built.
- replace tabs with spaces.

