### PR TITLE
Fix typo in build targets for minimal app

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -97,7 +97,7 @@ def BuildHostTarget():
     app_parts = [
         TargetPart('rpc-console', app=HostApp.RPC_CONSOLE).OnlyIfRe(f'{native_board_name}-'),
         TargetPart('all-clusters', app=HostApp.ALL_CLUSTERS),
-        TargetPart('all-clusters-minimal', app=HostApp.ALL_CLUSTERS),
+        TargetPart('all-clusters-minimal', app=HostApp.ALL_CLUSTERS_MINIMAL),
         TargetPart('chip-tool', app=HostApp.CHIP_TOOL),
         TargetPart('thermostat', app=HostApp.THERMOSTAT),
         TargetPart('java-matter-controller', app=HostApp.JAVA_MATTER_CONTROLLER),


### PR DESCRIPTION
#23874 discovered that the all-clusters-minimal app target was not valid and was building all-clustrers-app (without minimal) instead. Fix this.