### PR TITLE
[jsontlv] TlvToJson returns null for empty array instead of an empty …

### DIFF
--- a/src/lib/support/jsontlv/BUILD.gn
+++ b/src/lib/support/jsontlv/BUILD.gn
@@ -16,7 +16,6 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/jsoncpp.gni")
 
 config("jsontlv_config") {
-  cflags = [ "-Wno-implicit-fallthrough" ]
 }
 
 static_library("jsontlv") {

--- a/src/lib/support/jsontlv/TlvJson.cpp
+++ b/src/lib/support/jsontlv/TlvJson.cpp
@@ -113,8 +113,6 @@ std::string JsonToString(Json::Value & json)
 
 CHIP_ERROR TlvToJson(TLV::TLVReader & reader, KeyContext context, Json::Value & parent)
 {
-    bool isStruct = false;
-
     switch (reader.GetType())
     {
     case TLV::kTLVType_UnsignedInteger: {
@@ -178,46 +176,46 @@ CHIP_ERROR TlvToJson(TLV::TLVReader & reader, KeyContext context, Json::Value & 
         break;
     }
 
-    case TLV::kTLVType_Structure:
-        isStruct = true;
-
-        //
-        // Fall-through to the case below since
-        // arrays and structs are handled similarly with
-        // just a small difference in terms of handling of field IDs vs.
-        // list indices of the elements in the respective collections.
-        //
-
-    case TLV::kTLVType_Array: {
+    case TLV::kTLVType_Structure: {
         TLV::TLVType containerType;
-
         ReturnErrorOnFailure(reader.EnterContainer(containerType));
 
         CHIP_ERROR err;
         Json::Value value;
-        size_t listIndex = 0;
 
         while ((err = reader.Next()) == CHIP_NO_ERROR)
         {
-            if (isStruct)
-            {
-                VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
-                KeyContext context2(static_cast<chip::FieldId>(TLV::TagNumFromTag(reader.GetTag())));
+            VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
+            KeyContext context2(static_cast<chip::FieldId>(TLV::TagNumFromTag(reader.GetTag())));
 
-                //
-                // Recursively convert to JSON the encompassing item within the struct.
-                //
-                ReturnErrorOnFailure(TlvToJson(reader, context2, value));
-            }
-            else
-            {
-                KeyContext context2(static_cast<chip::ListIndex>(listIndex++));
+            //
+            // Recursively convert to JSON the encompassing item within the struct.
+            //
+            ReturnErrorOnFailure(TlvToJson(reader, context2, value));
+        }
 
-                //
-                // Recursively convert to JSON the encompassing item within the array.
-                //
-                ReturnErrorOnFailure(TlvToJson(reader, context2, value));
-            }
+        VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+        ReturnErrorOnFailure(reader.ExitContainer(containerType));
+        InsertKeyValue(parent, context, value);
+        break;
+    }
+
+    case TLV::kTLVType_Array: {
+        TLV::TLVType containerType;
+        ReturnErrorOnFailure(reader.EnterContainer(containerType));
+
+        CHIP_ERROR err;
+        Json::Value value = Json::Value(Json::arrayValue);
+        size_t listIndex  = 0;
+
+        while ((err = reader.Next()) == CHIP_NO_ERROR)
+        {
+            KeyContext context2(static_cast<chip::ListIndex>(listIndex++));
+
+            //
+            // Recursively convert to JSON the encompassing item within the array.
+            //
+            ReturnErrorOnFailure(TlvToJson(reader, context2, value));
         }
 
         VerifyOrReturnError(err == CHIP_END_OF_TLV, err);

--- a/src/lib/support/tests/TestTlvToJson.cpp
+++ b/src/lib/support/tests/TestTlvToJson.cpp
@@ -188,6 +188,18 @@ void TestConverter(nlTestSuite * inSuite, void * inContext)
                       "   \"value\" : [ 1, 2, 3, 4 ]\n"
                       "}\n");
 
+    int8uList = {};
+    EncodeAndValidate(int8uList,
+                      "{\n"
+                      "   \"value\" : []\n"
+                      "}\n");
+
+    DataModel::Nullable<DataModel::List<uint8_t>> nullValueList;
+    EncodeAndValidate(nullValueList,
+                      "{\n"
+                      "   \"value\" : null\n"
+                      "}\n");
+
     Clusters::UnitTesting::Structs::SimpleStruct::Type structListData[2] = { structVal, structVal };
     DataModel::List<Clusters::UnitTesting::Structs::SimpleStruct::Type> structList;
 


### PR DESCRIPTION
…array

#### Problem

When an array is empty but not null (because this is not a nullable field for example), `TlvToJson` converter returns `null` instead of an empty array.

