### PR TITLE
[chip-tool] Add busyWaitMs optional argument to chip-tool to lock the…

### DIFF
--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -173,6 +173,8 @@ protected:
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs,
                     "If provided, do a timed invoke with the given timed interaction timeout. See \"7.6.10. Timed Interaction\" in "
                     "the Matter specification.");
+        AddArgument("busyWaitForMs", 0, UINT16_MAX, &mBusyWaitForMs,
+                    "If provided, block the main thread processing for the given time right after sending a command.");
         AddArgument("suppressResponse", 0, 1, &mSuppressResponse);
         AddArgument("repeat-count", 1, UINT16_MAX, &mRepeatCount);
         AddArgument("repeat-delay-ms", 0, UINT16_MAX, &mRepeatDelayInMs);

--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -228,6 +228,8 @@ protected:
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs,
                     "If provided, do a timed write with the given timed interaction timeout. See \"7.6.10. Timed Interaction\" in "
                     "the Matter specification.");
+        AddArgument("busyWaitForMs", 0, UINT16_MAX, &mBusyWaitForMs,
+                    "If provided, block the main thread processing for the given time right after sending a command.");
         AddArgument("data-version", 0, UINT32_MAX, &mDataVersions,
                     "Comma-separated list of data versions for the clusters being written.");
         AddArgument("suppressResponse", 0, 1, &mSuppressResponse);

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
@@ -21,6 +21,21 @@
 using namespace chip;
 using namespace chip::app;
 
+namespace chip {
+namespace test_utils {
+void BusyWaitMillis(uint16_t busyWaitForMs)
+{
+    auto & clock = chip::System::SystemClock();
+    auto start   = clock.GetMonotonicTimestamp();
+    chip::System::Clock::Milliseconds32 durationInMs(busyWaitForMs);
+    while (clock.GetMonotonicTimestamp() - start < durationInMs)
+    {
+        // nothing to do.
+    };
+}
+} // namespace test_utils
+} // namespace chip
+
 CHIP_ERROR InteractionModel::ReadAttribute(const char * identity, EndpointId endpointId, ClusterId clusterId,
                                            AttributeId attributeId, bool fabricFiltered, const Optional<DataVersion> & dataVersion)
 {

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -30,6 +30,12 @@
 
 constexpr uint8_t kMaxAllowedPaths = 10;
 
+namespace chip {
+namespace test_utils {
+void BusyWaitMillis(uint16_t busyWaitForMs);
+} // namespace test_utils
+} // namespace chip
+
 class InteractionModelConfig
 {
 public:
@@ -237,6 +243,11 @@ protected:
             ReturnErrorOnFailure(commandSender->SendCommandRequest(device->GetSecureSession().Value()));
             mCommandSender.push_back(std::move(commandSender));
 
+            if (mBusyWaitForMs.HasValue())
+            {
+                chip::test_utils::BusyWaitMillis(mBusyWaitForMs.Value());
+            }
+
             if (mRepeatDelayInMs.HasValue())
             {
                 chip::test_utils::SleepMillis(mRepeatDelayInMs.Value());
@@ -321,18 +332,32 @@ protected:
         return *this;
     }
 
+    InteractionModelCommands & SetBusyWaitForMs(uint16_t busyWaitForMs)
+    {
+        mBusyWaitForMs.SetValue(busyWaitForMs);
+        return *this;
+    }
+
+    InteractionModelCommands & SetBusyWaitForMs(const chip::Optional<uint16_t> & busyWaitForMs)
+    {
+        mBusyWaitForMs = busyWaitForMs;
+        return *this;
+    }
+
     void ResetOptions()
     {
         mTimedInteractionTimeoutMs = chip::NullOptional;
         mSuppressResponse          = chip::NullOptional;
         mRepeatCount               = chip::NullOptional;
         mRepeatDelayInMs           = chip::NullOptional;
+        mBusyWaitForMs             = chip::NullOptional;
     }
 
     chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
     chip::Optional<bool> mSuppressResponse;
     chip::Optional<uint16_t> mRepeatCount;
     chip::Optional<uint16_t> mRepeatDelayInMs;
+    chip::Optional<uint16_t> mBusyWaitForMs;
 };
 
 class InteractionModelWriter
@@ -369,6 +394,11 @@ protected:
             }
 
             ReturnErrorOnFailure(mWriteClient->SendWriteRequest(device->GetSecureSession().Value()));
+
+            if (mBusyWaitForMs.HasValue())
+            {
+                chip::test_utils::BusyWaitMillis(mBusyWaitForMs.Value());
+            }
 
             if (mRepeatDelayInMs.HasValue())
             {
@@ -487,6 +517,18 @@ protected:
         return *this;
     }
 
+    InteractionModelWriter & SetBusyWaitForMs(uint16_t busyWaitForMs)
+    {
+        mBusyWaitForMs.SetValue(busyWaitForMs);
+        return *this;
+    }
+
+    InteractionModelWriter & SetBusyWaitForMs(const chip::Optional<uint16_t> & busyWaitForMs)
+    {
+        mBusyWaitForMs = busyWaitForMs;
+        return *this;
+    }
+
     void ResetOptions()
     {
         mTimedInteractionTimeoutMs = chip::NullOptional;
@@ -494,6 +536,7 @@ protected:
         mDataVersions              = chip::NullOptional;
         mRepeatCount               = chip::NullOptional;
         mRepeatDelayInMs           = chip::NullOptional;
+        mBusyWaitForMs             = chip::NullOptional;
     }
 
     chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
@@ -501,6 +544,7 @@ protected:
     chip::Optional<bool> mSuppressResponse;
     chip::Optional<uint16_t> mRepeatCount;
     chip::Optional<uint16_t> mRepeatDelayInMs;
+    chip::Optional<uint16_t> mBusyWaitForMs;
 
 private:
     template <typename T>


### PR DESCRIPTION
… main thread and the reception of messages for a given duration once a message is sent

#### Problem

The test suite uses a hack to lock the main thread for making it possible to test timed interaction. This can not be reproduce in `chip-tool`.