### PR TITLE
[chip-tool] Allow the string 'null' to be used for TypedComplexArgume…

### DIFF
--- a/examples/chip-tool/commands/clusters/ComplexArgument.h
+++ b/examples/chip-tool/commands/clusters/ComplexArgument.h
@@ -29,7 +29,8 @@
 
 #include "JsonParser.h"
 
-constexpr uint8_t kMaxLabelLength = 100;
+constexpr uint8_t kMaxLabelLength  = 100;
+constexpr const char kNullString[] = "null";
 
 class ComplexArgumentParser
 {
@@ -326,7 +327,11 @@ public:
     CHIP_ERROR Parse(const char * label, const char * json)
     {
         Json::Value value;
-        if (!JsonParser::ParseComplexArgument(label, json, value))
+        if (strcmp(kNullString, json) == 0)
+        {
+            value = Json::nullValue;
+        }
+        else if (!JsonParser::ParseComplexArgument(label, json, value))
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }


### PR DESCRIPTION
…nt of Nullable type

#### Problem

The following command does not work:
`./out/debug/standalone/chip-tool doorlock clear-credential null 0x12344321 1 --timedInteractionTimeoutMs 10000 `

