### PR TITLE
[jsontlv] Add a prefix for octet strings encoded as base64

### DIFF
--- a/src/lib/support/tests/TestTlvToJson.cpp
+++ b/src/lib/support/tests/TestTlvToJson.cpp
@@ -147,7 +147,7 @@ void TestConverter(nlTestSuite * inSuite, void * inContext)
     ByteSpan byteSpan(byteBuf);
     EncodeAndValidate(byteSpan,
                       "{\n"
-                      "   \"value\" : \"AQIDBP/+mYjdzQ==\"\n"
+                      "   \"value\" : \"base64:AQIDBP/+mYjdzQ==\"\n"
                       "}\n");
 
     DataModel::Nullable<uint8_t> nullValue;
@@ -170,7 +170,7 @@ void TestConverter(nlTestSuite * inSuite, void * inContext)
                       "      \"0\" : 20,\n"
                       "      \"1\" : true,\n"
                       "      \"2\" : 0,\n"
-                      "      \"3\" : \"AQIDBP/+mYjdzQ==\",\n"
+                      "      \"3\" : \"base64:AQIDBP/+mYjdzQ==\",\n"
                       "      \"4\" : \"hello\",\n"
                       "      \"5\" : 0,\n"
                       "      \"6\" : 1.0,\n"
@@ -200,7 +200,7 @@ void TestConverter(nlTestSuite * inSuite, void * inContext)
                       "         \"0\" : 20,\n"
                       "         \"1\" : true,\n"
                       "         \"2\" : 0,\n"
-                      "         \"3\" : \"AQIDBP/+mYjdzQ==\",\n"
+                      "         \"3\" : \"base64:AQIDBP/+mYjdzQ==\",\n"
                       "         \"4\" : \"hello\",\n"
                       "         \"5\" : 0,\n"
                       "         \"6\" : 1.0,\n"
@@ -210,7 +210,7 @@ void TestConverter(nlTestSuite * inSuite, void * inContext)
                       "         \"0\" : 20,\n"
                       "         \"1\" : true,\n"
                       "         \"2\" : 0,\n"
-                      "         \"3\" : \"AQIDBP/+mYjdzQ==\",\n"
+                      "         \"3\" : \"base64:AQIDBP/+mYjdzQ==\",\n"
                       "         \"4\" : \"hello\",\n"
                       "         \"5\" : 0,\n"
                       "         \"6\" : 1.0,\n"


### PR DESCRIPTION
##### Problem

`TlvToJson` silently converts octet string to base64, this is OK as one may infer the type from the data model, but it not obvious at first sight and makes it hard to differentiate from regular strings, for example `lowUPPER` is a string but also a valid base64 octet string.
It would be nice for users to tell them that the string is encoded, and what is the format, without having them to look at the implementation. This PR just adds a `base64:` prefix for those strings.