### PR TITLE
Cleanup devcontainer Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,9 +25,10 @@ ENV LANG en_US.utf8
 
 # these are installed for terminal/dev convenience.  If more tooling for build is required, please
 #  add them to chip-build (in integrations/docker/images/chip-build)
-RUN apt-get update
-RUN apt-get install -y locales && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-RUN apt-get -fy install git vim emacs sudo \
+RUN apt-get update \
+    && apt-get install -y locales \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
+    && apt-get -fy install git vim emacs sudo \
     apt-utils dialog zsh \
     iproute2 procps lsb-release \
     bash-completion \
@@ -36,49 +37,31 @@ RUN apt-get -fy install git vim emacs sudo \
     docker.io \
     iputils-ping net-tools \
     libncurses5 \
-    libpython2.7
+    libpython2.7 \
+    && :
 
-RUN groupadd -g $USER_GID $USERNAME
-RUN useradd -s /bin/bash -u $USER_UID -g $USER_GID -G docker -m $USERNAME
-RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME
-RUN chmod 0440 /etc/sudoers.d/$USERNAME
+RUN groupadd -g $USER_GID $USERNAME \
+    && useradd -s /bin/bash -u $USER_UID -g $USER_GID -G docker,sudo -m $USERNAME \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    && :
 
-RUN mkdir -p /var/downloads
-RUN cd /var/downloads
-RUN curl -JL https://github.com/microsoft/vscode-cpptools/releases/download/0.27.0/cpptools-linux.vsix > extension.zip
-RUN unzip extension.zip
-RUN mkdir -p /home/$USERNAME/.vscode-server/extensions
-RUN mv extension /home/$USERNAME/.vscode-server/extensions/ms-vscode.cpptools-0.27.0
-RUN mkdir -p /home/$USERNAME/bin
-RUN curl https://raw.githubusercontent.com/restyled-io/restyler/master/bin/restyle-path -o /home/$USERNAME/bin/restyle-path
-RUN chmod +x /home/$USERNAME/bin/restyle-path
-RUN chown -R $USERNAME:$USERNAME /home/$USERNAME
-RUN echo "PATH=/home/$USERNAME/bin:${PATH}" >> /home/$USERNAME/.bashrc
+RUN curl https://raw.githubusercontent.com/restyled-io/restyler/master/bin/restyle-path -o /usr/local/bin/restyle-path \
+    && chmod +x /usr/local/bin/restyle-path \
+    && :
 
-# $USERNAME needs to own the esp-idf and tools for the examples to build
-RUN chown -R $USERNAME:$USERNAME /opt/espressif/esp-idf
-RUN chown -R $USERNAME:$USERNAME /opt/espressif/tools
-
-# $USERNAME needs to own west configuration to build nRF Connect examples
-RUN chown -R $USERNAME:$USERNAME /opt/NordicSemiconductor/nrfconnect/
-
-# allow read/write access to header and libraries
-RUN chown -R $USERNAME:$USERNAME /opt/ubuntu-21.04-aarch64-sysroot/usr/
-
-# allow licenses to be accepted
-RUN chown -R $USERNAME:$USERNAME /opt/android/sdk
-
-# AmebaD requires access to change build_info.h
-RUN chown -R $USERNAME:$USERNAME /opt/ameba/ambd_sdk_with_chip_non_NDA/
-
-# NXP uses a patch_sdk script to change SDK files
-RUN mkdir -p /opt/sdk/sdks/
-RUN chown -R $USERNAME:$USERNAME /opt/sdk/sdks/
-
-RUN chown -R $USERNAME:$USERNAME /opt/fsl-imx-xwayland/5.15-kirkstone/
-
-# Add access to openocd for VSCode debugging
-RUN chown -R $USERNAME:$USERNAME /opt/openocd
+RUN mkdir -p /opt/sdk/sdks/ \
+    && chown -R $USERNAME:$USERNAME \
+    /opt/sdk/sdks/ `# NXP uses a patch_sdk script to change SDK files` \
+    /opt/espressif/esp-idf `# $USERNAME needs to own the esp-idf and tools for the examples to build` \
+    /opt/espressif/tools \
+    /opt/NordicSemiconductor/nrfconnect/ `# $USERNAME needs to own west configuration to build nRF Connect examples` \
+    /opt/ubuntu-21.04-aarch64-sysroot/usr/ `# allow read/write access to header and libraries` \
+    /opt/android/sdk `# allow licenses to be accepted` \
+    /opt/ameba/ambd_sdk_with_chip_non_NDA/ `# AmebaD requires access to change build_info.h` \
+    /opt/fsl-imx-xwayland/5.15-kirkstone/ \
+    /opt/openocd \
+    && :
 
 # Fix Tizen SDK paths for new user
 RUN sed -i '/^TIZEN_SDK_DATA_PATH/d' $TIZEN_SDK_ROOT/sdk.info \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,6 +34,7 @@
         "maelvalais.autoconf",
         "marus25.cortex-debug",
         "ms-azuretools.vscode-docker",
+        "ms-vscode.cpptools",
         "msedge-dev.gnls",
         "redhat.vscode-yaml",
         "vadimcn.vscode-lldb",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -15,6 +15,7 @@
         "maelvalais.autoconf",
         "marus25.cortex-debug",
         "ms-azuretools.vscode-docker",
+        "ms-vscode.cpptools",
         "msedge-dev.gnls",
         "redhat.vscode-yaml",
         "vadimcn.vscode-lldb",


### PR DESCRIPTION
why:
- there was a lot of layers created in the devcontainer Dockerfile
- some instructions were changing nothing (e.g. creating /var/downloads)
- to unify the multiline style with last-line noop for cleaner diffing with other Matter Dockerfiles

special considerations:
- it should be tested on MacOS as manual installation of cpptools was done due to some issue on this platform (commits from 2 years ago so I assumed it *might* be fixed- but cant verify this)

whats done:
- group similiar things into single layers (e.g. apt-get stuff, creating user and setting it up or chowning everything in /opt)
- move cpptools installation to devcontainer.json instead of current manual installation in the dockerfile
- adds noop : on end of each multi-line RUN
- move restyle-path binary to /usr/local/bin rather than add a new location to the PATH
- add cpptools to recommended extensions for vscode
