### PR TITLE
Fix C++20-incompatible instances of aggregate initialization

### DIFF
--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -451,8 +451,6 @@ enum
  */
 struct EmberBindingTableEntry
 {
-    EmberBindingTableEntry() = default;
-
     static EmberBindingTableEntry ForNode(chip::FabricIndex fabric, chip::NodeId node, chip::EndpointId localEndpoint,
                                           chip::EndpointId remoteEndpoint, chip::Optional<chip::ClusterId> cluster)
     {


### PR DESCRIPTION
In C++20, types that declare or delete any constructors are no longer aggregates, breaking compilation of many existing uses of aggregate initialization.

Fix this for EmberBindingTableEntry by removing the explicitly defaulted constructor.