### PR TITLE
Make sure the Neighbor Table averageRSSI and LastRSSI are valid.

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1152,8 +1152,23 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
                 app::DataModel::Nullable<int8_t> averageRssi;
                 app::DataModel::Nullable<int8_t> lastRssi;
 
-                averageRssi.SetNonNull(neighInfo.mAverageRssi);
-                lastRssi.SetNonNull(neighInfo.mLastRssi);
+                if (neighInfo.mAverageRssi == OT_RADIO_RSSI_INVALID)
+                {
+                    averageRssi.SetNull();
+                }
+                else
+                {
+                    averageRssi.SetNonNull(((neighInfo.mAverageRssi > 0) ? 0 : neighInfo.mAverageRssi));
+                }
+
+                if (neighInfo.mAverageRssi == OT_RADIO_RSSI_INVALID)
+                {
+                    lastRssi.SetNull();
+                }
+                else
+                {
+                    lastRssi.SetNonNull(((neighInfo.mLastRssi > 0) ? 0 : neighInfo.mLastRssi));
+                }
 
                 neighborTable.averageRssi      = averageRssi;
                 neighborTable.lastRssi         = lastRssi;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1158,7 +1158,8 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
                 }
                 else
                 {
-                    averageRssi.SetNonNull(((neighInfo.mAverageRssi > 0) ? 0 : neighInfo.mAverageRssi));
+                    // Thread average calculation already restrict mAverageRssi to be between -128 and 0
+                    averageRssi.SetNonNull(neighInfo.mAverageRssi);
                 }
 
                 if (neighInfo.mAverageRssi == OT_RADIO_RSSI_INVALID)


### PR DESCRIPTION
Add some checks to make sure the average RSSI and LastRSSI obtained in the neighbour table info are valid and not greater than 0 to respect the matter spec.

We have seen some rare cases in a lab environment where the reported LastRSSI was slightly greater than 0

