### PR TITLE
[Silabs] Adds fix for wifi diagnostics attributes

### DIFF
--- a/examples/platform/silabs/efr32/wf200/host_if.cpp
+++ b/examples/platform/silabs/efr32/wf200/host_if.cpp
@@ -357,6 +357,8 @@ static void sl_wfx_connect_callback(sl_wfx_connect_ind_body_t connect_indication
 {
     uint8_t * mac   = connect_indication_body.mac;
     uint32_t status = connect_indication_body.status;
+    ap_info.chan = connect_indication_body.channel;
+    memcpy(&ap_info.security, &wifi_provision.security,sizeof(wifi_provision.security));
     switch (status)
     {
     case WFM_STATUS_SUCCESS: {

--- a/examples/platform/silabs/efr32/wf200/host_if.cpp
+++ b/examples/platform/silabs/efr32/wf200/host_if.cpp
@@ -357,8 +357,8 @@ static void sl_wfx_connect_callback(sl_wfx_connect_ind_body_t connect_indication
 {
     uint8_t * mac   = connect_indication_body.mac;
     uint32_t status = connect_indication_body.status;
-    ap_info.chan = connect_indication_body.channel;
-    memcpy(&ap_info.security, &wifi_provision.security,sizeof(wifi_provision.security));
+    ap_info.chan    = connect_indication_body.channel;
+    memcpy(&ap_info.security, &wifi_provision.security, sizeof(wifi_provision.security));
     switch (status)
     {
     case WFM_STATUS_SUCCESS: {

--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -479,6 +479,18 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiOverrunCount(uint64_t & overrunCou
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBeaconRxCount(uint32_t & beaconRxCount)
+{
+    wfx_wifi_scan_ext_t extra_info;
+    int32_t err = wfx_get_ap_ext(&extra_info);
+    if (err == 0)
+    {
+        beaconRxCount = extra_info.beacon_rx_count;
+        return CHIP_NO_ERROR;
+    }
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
 CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
 {
     int32_t err = wfx_reset_counts();

--- a/src/platform/silabs/DiagnosticDataProviderImpl.h
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.h
@@ -63,6 +63,7 @@ public:
     CHIP_ERROR GetWiFiChannelNumber(uint16_t & channelNumber) override;
     CHIP_ERROR GetWiFiRssi(int8_t & rssi) override;
     CHIP_ERROR GetWiFiBeaconLostCount(uint32_t & beaconLostCount) override;
+    CHIP_ERROR GetWiFiBeaconRxCount(uint32_t & beaconRxCount) override;
     CHIP_ERROR GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount) override;
     CHIP_ERROR GetWiFiPacketMulticastTxCount(uint32_t & packetMulticastTxCount) override;
     CHIP_ERROR GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount) override;


### PR DESCRIPTION
What is being Fixed?

Added Fix for below Wi-Fi diagnostics Attributes

- beacon_rx_count for both RS9116 and WF200
- channel number and security type for WF200

Testing:
Manually tested on MG24-RS9116/WF200 and MG12WF200/RS9116
Commissioning, TC-DGWIFI*