### PR TITLE
Set the cache-flush bit for "unique" records in minimal mdns.

### DIFF
--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -488,7 +488,10 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
         return CHIP_ERROR_NO_MEMORY;
     }
 
-    if (!operationalAllocator->AddResponder<SrvResponder>(SrvResourceRecord(instanceName, hostName, params.GetPort()))
+    // We are the sole owner of our instanceName, so records keyed on the
+    // instanceName should have the cache-flush bit set.
+    if (!operationalAllocator
+             ->AddResponder<SrvResponder>(SrvResourceRecord(instanceName, hostName, params.GetPort()).SetCacheFlush(true))
              .SetReportAdditional(hostName)
              .IsValid())
     {
@@ -497,7 +500,8 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
     }
 
     if (!operationalAllocator
-             ->AddResponder<TxtResponder>(TxtResourceRecord(instanceName, GetOperationalTxtEntries(operationalAllocator, params)))
+             ->AddResponder<TxtResponder>(
+                 TxtResourceRecord(instanceName, GetOperationalTxtEntries(operationalAllocator, params)).SetCacheFlush(true))
              .SetReportAdditional(hostName)
              .IsValid())
     {

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -490,20 +490,17 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
 
     // We are the sole owner of our instanceName, so records keyed on the
     // instanceName should have the cache-flush bit set.
-    if (!operationalAllocator
-             ->AddResponder<SrvResponder>(SrvResourceRecord(instanceName, hostName, params.GetPort()).SetCacheFlush(true))
-             .SetReportAdditional(hostName)
-             .IsValid())
+    SrvResourceRecord srvRecord(instanceName, hostName, params.GetPort());
+    srvRecord.SetCacheFlush(true);
+    if (!operationalAllocator->AddResponder<SrvResponder>(srvRecord).SetReportAdditional(hostName).IsValid())
     {
         ChipLogError(Discovery, "Failed to add SRV record mDNS responder");
         return CHIP_ERROR_NO_MEMORY;
     }
 
-    if (!operationalAllocator
-             ->AddResponder<TxtResponder>(
-                 TxtResourceRecord(instanceName, GetOperationalTxtEntries(operationalAllocator, params)).SetCacheFlush(true))
-             .SetReportAdditional(hostName)
-             .IsValid())
+    TxtResourceRecord txtRecord(instanceName, GetOperationalTxtEntries(operationalAllocator, params));
+    txtRecord.SetCacheFlush(true);
+    if (!operationalAllocator->AddResponder<TxtResponder>(txtRecord).SetReportAdditional(hostName).IsValid())
     {
         ChipLogError(Discovery, "Failed to add TXT record mDNS responder");
         return CHIP_ERROR_NO_MEMORY;

--- a/src/lib/dnssd/minimal_mdns/responders/IP.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/IP.cpp
@@ -40,6 +40,9 @@ void IPv4Responder::AddAllResponses(const chip::Inet::IPPacketInfo * source, Res
         assert(addr.IsIPv4());
 
         IPResourceRecord record(GetQName(), addr);
+        // We're the only thing around with our hostname, so we should set the
+        // cache-flush bit.
+        record.SetCacheFlush(true);
         configuration.Adjust(record);
         delegate->AddResponse(record);
     }
@@ -59,6 +62,9 @@ void IPv6Responder::AddAllResponses(const chip::Inet::IPPacketInfo * source, Res
         assert(addr.IsIPv6());
 
         IPResourceRecord record(GetQName(), addr);
+        // We're the only thing around with our hostname, so we should set the
+        // cache-flush bit.
+        record.SetCacheFlush(true);
         configuration.Adjust(record);
         delegate->AddResponse(record);
     }

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
@@ -42,7 +42,7 @@ public:
     {
 
         NL_TEST_ASSERT(mSuite, (record.GetType() == QType::A) || (record.GetType() == QType::AAAA));
-        NL_TEST_ASSERT(mSuite, record.GetClass() == QClass::IN);
+        NL_TEST_ASSERT(mSuite, record.GetClass() == QClass::IN_FLUSH);
         NL_TEST_ASSERT(mSuite, record.GetName() == kNames);
     }
 


### PR DESCRIPTION
There should only be one entity around with a given Matter instance name or Matter hostname, so all records which have those as the QName are part of the unique set.

Fixes https://github.com/project-chip/connectedhomeip/issues/23918

