### PR TITLE
Squelch -Wuninitialized in TestStateMachine.cpp

### DIFF
--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -64,7 +64,7 @@ chip_test_suite("tests") {
     "-Wconversion",
 
     # TODO(#21255): work-around for SimpleStateMachine constructor issue.
-    "-Wno-error=uninitialized",
+    "-Wno-uninitialized",
   ]
 
   public_deps = [


### PR DESCRIPTION
This warning has not been fixed. Squelch it to remove noisy output in the build log.

The underlying issue is tracked at #21255