### PR TITLE
[SED] Fix Commissioning with Long Idle time

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -100,6 +100,7 @@ void CommissioningWindowManager::ResetState()
 
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
     DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(false);
+    mSEDActiveModeEnabled = false;
 #endif
 
     UpdateWindowStatus(CommissioningWindowStatus::kWindowNotOpen);
@@ -227,7 +228,11 @@ CHIP_ERROR CommissioningWindowManager::AdvertiseAndListenForPASE()
     mPairingSession.Clear();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
-    DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(true);
+    if (!mSEDActiveModeEnabled)
+    {
+        mSEDActiveModeEnabled = true;
+        DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(true);
+    }
 #endif
 
     ReturnErrorOnFailure(mServer->GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -99,8 +99,11 @@ void CommissioningWindowManager::ResetState()
     mECMSaltLength    = 0;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
-    DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(false);
-    mSEDActiveModeEnabled = false;
+    if (mSEDActiveModeEnabled)
+    {
+        DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(false);
+        mSEDActiveModeEnabled = false;
+    }
 #endif
 
     UpdateWindowStatus(CommissioningWindowStatus::kWindowNotOpen);

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -98,6 +98,10 @@ void CommissioningWindowManager::ResetState()
     mECMIterations    = 0;
     mECMSaltLength    = 0;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_SED
+    DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(false);
+#endif
+
     UpdateWindowStatus(CommissioningWindowStatus::kWindowNotOpen);
 
     UpdateOpenerFabricIndex(NullNullable);
@@ -223,10 +227,7 @@ CHIP_ERROR CommissioningWindowManager::AdvertiseAndListenForPASE()
     mPairingSession.Clear();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
-    if (!mIsBLE && !mListeningForPASE)
-    {
-        DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(true);
-    }
+    DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(true);
 #endif
 
     ReturnErrorOnFailure(mServer->GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(
@@ -454,13 +455,6 @@ CHIP_ERROR CommissioningWindowManager::StartAdvertisement()
 CHIP_ERROR CommissioningWindowManager::StopAdvertisement(bool aShuttingDown)
 {
     RestoreDiscriminator();
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    if (!mIsBLE && mListeningForPASE)
-    {
-        DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(false);
-    }
-#endif
 
     mServer->GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::PBKDFParamRequest);
     mListeningForPASE = false;

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -203,6 +203,10 @@ private:
     uint32_t mECMSaltLength              = 0;
     uint8_t mECMSalt[kSpake2p_Max_PBKDF_Salt_Length];
 
+#if CHIP_DEVICE_CONFIG_ENABLE_SED
+    bool mSEDActiveModeEnabled = false;
+#endif
+
     // For tests only, so that we can test the commissioning window timeout
     // without having to wait 3 minutes.
     Optional<System::Clock::Seconds16> mMinCommissioningTimeoutOverride;


### PR DESCRIPTION
Commissioning fails with long Sleep period because device goes into Idle mode prior to completing the commissioning.

Fix that by always enabling Active mode at the start of the commissioning process and always disabling it at the end. Without any condition whatsoever. 
