### PR TITLE
Stop using the "cd", "paa", "certs" abbreviations in Darwin APIs.

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -124,7 +124,7 @@ CHIP_ERROR CHIPCommandBridge::MaybeSetUpStack()
     NSArray<NSData *> * paaCertResults;
     ReturnLogErrorOnFailure(GetPAACertsFromFolder(&paaCertResults));
     if ([paaCertResults count] > 0) {
-        params.paaCerts = paaCertResults;
+        params.productAttestationAuthorityCertificates = paaCertResults;
     }
 
     NSError * error;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.h
@@ -21,6 +21,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <Matter/MTRCertificates.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -52,16 +53,21 @@ MTR_NEWLY_AVAILABLE
 
 /*
  * The Product Attestation Authority certificates that are trusted to sign
- * device attestation information.  Defaults to nil.
+ * device attestation information (and in particular to sign Product Attestation
+ * Intermediate certificates, which then sign Device Attestation Certificates).
  *
+ * Defaults to nil.
  */
-@property (nonatomic, copy, nullable) NSArray<NSData *> * paaCerts;
+@property (nonatomic, copy, nullable) NSArray<MTRCertificateDERBytes> * productAttestationAuthorityCertificates;
 /*
- * The Certificate Declaration certificates that are trusted to sign
- * device attestation information.  Defaults to nil.
+ * The Certification Declaration certificates whose public keys correspond to
+ * private keys that are trusted to sign certification declarations.  Defaults
+ * to nil.
  *
+ * These certificates are used in addition to, not replacing, the default set of
+ * well-known certification declaration signing keys.
  */
-@property (nonatomic, copy, nullable) NSArray<NSData *> * cdCerts;
+@property (nonatomic, copy, nullable) NSArray<MTRCertificateDERBytes> * certificationDeclarationCertificates;
 /*
  * The network port to bind to.  If not specified, an ephemeral port will be
  * used.
@@ -145,7 +151,11 @@ MTR_NEWLY_DEPRECATED("Please use MTRDeviceControllerFactoryParams")
 @interface MTRControllerFactoryParams : MTRDeviceControllerFactoryParams
 @property (nonatomic, strong, readonly) id<MTRPersistentStorageDelegate> storageDelegate MTR_NEWLY_DEPRECATED(
     "Please use the storage property");
-@property (nonatomic, assign) BOOL startServer;
+@property (nonatomic, assign) BOOL startServer MTR_NEWLY_DEPRECATED("Please use shouldStartServer");
+@property (nonatomic, copy, nullable)
+    NSArray<NSData *> * paaCerts MTR_NEWLY_DEPRECATED("Please use productAttestationAuthorityCertificates");
+@property (nonatomic, copy, nullable)
+    NSArray<NSData *> * cdCerts MTR_NEWLY_DEPRECATED("Please use certificationDeclarationCertificates");
 @end
 
 MTR_NEWLY_DEPRECATED("Please use MTRDeviceControllerFactory")

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -324,8 +324,9 @@ static NSString * const kErrorOtaProviderInit = @"Init failure while creating an
 
         // Initialize device attestation verifier
         const Credentials::AttestationTrustStore * trustStore;
-        if (startupParams.paaCerts) {
-            _attestationTrustStoreBridge = new MTRAttestationTrustStoreBridge(startupParams.paaCerts);
+        if (startupParams.productAttestationAuthorityCertificates) {
+            _attestationTrustStoreBridge
+                = new MTRAttestationTrustStoreBridge(startupParams.productAttestationAuthorityCertificates);
             if (_attestationTrustStoreBridge == nullptr) {
                 MTR_LOG_ERROR("Error: %@", kErrorAttestationTrustStoreInit);
                 errorCode = CHIP_ERROR_NO_MEMORY;
@@ -343,7 +344,7 @@ static NSString * const kErrorOtaProviderInit = @"Init failure while creating an
             return;
         }
 
-        if (startupParams.cdCerts) {
+        if (startupParams.certificationDeclarationCertificates) {
             auto cdTrustStore = _deviceAttestationVerifier->GetCertificationDeclarationTrustStore();
             if (cdTrustStore == nullptr) {
                 MTR_LOG_ERROR("Error: %@", kErrorCDCertStoreInit);
@@ -351,7 +352,7 @@ static NSString * const kErrorOtaProviderInit = @"Init failure while creating an
                 return;
             }
 
-            for (NSData * cdSigningCert in startupParams.cdCerts) {
+            for (NSData * cdSigningCert in startupParams.certificationDeclarationCertificates) {
                 errorCode = cdTrustStore->AddTrustedKey(AsByteSpan(cdSigningCert));
                 if (errorCode != CHIP_NO_ERROR) {
                     MTR_LOG_ERROR("Error: %@", kErrorCDCertStoreInit);
@@ -771,8 +772,8 @@ static NSString * const kErrorOtaProviderInit = @"Init failure while creating an
 
     _storage = storage;
     _otaProviderDelegate = nil;
-    _paaCerts = nil;
-    _cdCerts = nil;
+    _productAttestationAuthorityCertificates = nil;
+    _certificationDeclarationCertificates = nil;
     _port = nil;
     _shouldStartServer = NO;
 
@@ -843,6 +844,26 @@ static NSString * const kErrorOtaProviderInit = @"Init failure while creating an
 - (void)setStartServer:(BOOL)startServer
 {
     self.shouldStartServer = startServer;
+}
+
+- (nullable NSArray<NSData *> *)paaCerts
+{
+    return self.productAttestationAuthorityCertificates;
+}
+
+- (void)setPaaCerts:(nullable NSArray<NSData *> *)paaCerts
+{
+    self.productAttestationAuthorityCertificates = paaCerts;
+}
+
+- (nullable NSArray<NSData *> *)cdCerts
+{
+    return self.certificationDeclarationCertificates;
+}
+
+- (void)setCdCerts:(nullable NSArray<NSData *> *)cdCerts
+{
+    self.certificationDeclarationCertificates = cdCerts;
 }
 
 @end


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/23915
