### PR TITLE
[Telink] Update Telink Docker with fixes: mcu_boot, OTA, zephyr blob.

### DIFF
--- a/integrations/docker/images/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/chip-build-telink/Dockerfile
@@ -23,7 +23,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=2901439a086f8202e63dc6f66a590021bb8e15d3
+ARG ZEPHYR_REVISION=7e93d9eeb7d2796d678a069558c251cf94dd0c2e
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \
@@ -35,9 +35,7 @@ RUN set -x \
     && west init -l \
     && cd .. \
     && west update -o=--depth=1 -n -f smart \
-    && cd modules/hal/telink \
-    && git submodule update --init \
-    && cd ../../../ \
+    && west blobs fetch hal_telink \
     && west zephyr-export \
     && : # last line
 

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.17 Version bump reason: [nrfconnect] Update external url to nRF Command Line Tools.
+0.6.18 Version bump reason: [Telink] Update Telink Docker with fixes: mcu_boot, OTA, zephyr blob.


### PR DESCRIPTION
**Problem**
Need fixes for mcu_boot (doesn't work OTA) and fix for zephyr blob.

**Change overview**
Fix: mcu_boot, OTA, zephyr blob.

**Testing**
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully