### PR TITLE
Update several build_examples targets

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -164,7 +164,7 @@ def BuildEsp32Target():
     target.AppendFixedTargets([
         TargetPart('all-clusters', app=Esp32App.ALL_CLUSTERS),
         TargetPart('all-clusters-minimal', app=Esp32App.ALL_CLUSTERS_MINIMAL),
-        TargetPart('ota-requestor', app=Esp32App.OTA_REQUESTOR),
+        TargetPart('ota-provider', app=Esp32App.OTA_PROVIDER),
         TargetPart('ota-requestor', app=Esp32App.OTA_REQUESTOR),
         TargetPart('shell', app=Esp32App.SHELL),
         TargetPart('light', app=Esp32App.LIGHT),
@@ -257,6 +257,7 @@ def BuildNrfTarget():
         TargetPart('shell', app=NrfApp.SHELL),
         TargetPart('pump', app=NrfApp.PUMP),
         TargetPart('pump-controller', app=NrfApp.PUMP_CONTROLLER),
+        TargetPart('window-covering', app=NrfApp.WINDOW_COVERING),
     ])
 
     target.AppendModifier('rpc', enable_rpcs=True)
@@ -353,6 +354,7 @@ def BuildAmebaTarget():
         TargetPart('all-clusters', app=AmebaApp.ALL_CLUSTERS),
         TargetPart('all-clusters-minimal', app=AmebaApp.ALL_CLUSTERS_MINIMAL),
         TargetPart('light', app=AmebaApp.LIGHT),
+        TargetPart('light-switch', app=AmebaApp.LIGHT_SWITCH),
         TargetPart('pigweed', app=AmebaApp.PIGWEED),
     ])
 

--- a/scripts/build/builders/ameba.py
+++ b/scripts/build/builders/ameba.py
@@ -27,6 +27,7 @@ class AmebaApp(Enum):
     ALL_CLUSTERS_MINIMAL = auto()
     LIGHT = auto()
     PIGWEED = auto()
+    LIGHT_SWITCH = auto()
 
     @property
     def ExampleName(self):
@@ -36,6 +37,8 @@ class AmebaApp(Enum):
             return 'all-clusters-minimal-app'
         elif self == AmebaApp.LIGHT:
             return 'lighting-app'
+        elif self == AmebaApp.LIGHT_SWITCH:
+            return 'light-switch-app'
         elif self == AmebaApp.PIGWEED:
             return 'pigweed-app'
         else:
@@ -49,6 +52,8 @@ class AmebaApp(Enum):
             return 'chip-ameba-all-clusters-minimal-app'
         elif self == AmebaApp.LIGHT:
             return 'chip-ameba-lighting-app'
+        elif self == AmebaApp.LIGHT_SWITCH:
+            return 'chip-ameba-light-switch-app'
         elif self == AmebaApp.PIGWEED:
             return 'chip-ameba-pigweed-app'
         else:

--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -37,6 +37,7 @@ class Esp32App(Enum):
     TEMPERATURE_MEASUREMENT = auto()
     TESTS = auto()
     OTA_REQUESTOR = auto()
+    OTA_PROVIDER = auto()
 
     @property
     def ExamplePath(self):
@@ -56,6 +57,8 @@ class Esp32App(Enum):
             return 'examples/temperature-measurement-app'
         elif self == Esp32App.OTA_REQUESTOR:
             return 'examples/ota-requestor-app'
+        elif self == Esp32App.OTA_PROVIDER:
+            return 'examples/ota-provider-app'
         elif self == Esp32App.TESTS:
             return 'src/test_driver'
         else:
@@ -79,6 +82,8 @@ class Esp32App(Enum):
             return 'chip-temperature-measurement-app'
         elif self == Esp32App.OTA_REQUESTOR:
             return 'chip-ota-requestor-app'
+        elif self == Esp32App.OTA_PROVIDER:
+            return 'chip-ota-provider-app'
         elif self == Esp32App.TESTS:
             return None
         else:
@@ -95,7 +100,7 @@ class Esp32App(Enum):
         if board == Esp32Board.QEMU:
             return self == Esp32App.TESTS
         elif board == Esp32Board.M5Stack:
-            return self == Esp32App.ALL_CLUSTERS or self == Esp32App.ALL_CLUSTERS_MINIMAL or self == Esp32App.OTA_REQUESTOR
+            return self == Esp32App.ALL_CLUSTERS or self == Esp32App.ALL_CLUSTERS_MINIMAL or self == Esp32App.OTA_REQUESTOR or self == Esp32App.OTA_PROVIDER
         elif board == Esp32Board.C3DevKit:
             return self == Esp32App.ALL_CLUSTERS or self == Esp32App.ALL_CLUSTERS_MINIMAL
         else:
@@ -107,6 +112,7 @@ def DefaultsFileName(board: Esp32Board, app: Esp32App, enable_rpcs: bool):
                         Esp32App.ALL_CLUSTERS_MINIMAL,
                         Esp32App.LIGHT,
                         Esp32App.OTA_REQUESTOR,
+                        Esp32App.OTA_PROVIDER,
                         Esp32App.TEMPERATURE_MEASUREMENT]
     if app == Esp32App.TESTS:
         return 'sdkconfig_qemu.defaults'

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -40,7 +40,7 @@ class NrfApp(Enum):
         elif self == NrfApp.LIGHT:
             return 'examples/lighting-app'
         elif self == NrfApp.SWITCH:
-            return 'light-switch-app'
+            return 'examples/light-switch-app'
         elif self == NrfApp.LOCK:
             return 'examples/lock-app'
         elif self == NrfApp.SHELL:

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -4,7 +4,7 @@ bouffalolab-{bl602-iot-matter-v1,bl602-iot-dvk-3s,bl602-night-light,xt-zb6-devki
 cc13x2x7_26x2x7-{all-clusters,all-clusters-minimal,lock,pump,pump-controller,shell}[-ftd][-mtd]
 cyw30739-cyw930739m2evb_01-{light,lock,ota-requestor}[-no-progress-logging]
 efr32-{brd4161a,brd4187c,brd4163a,brd4164a,brd4166a,brd4170a,brd4186a,brd4187a,brd4304a}-{window-covering,switch,unit-test,light,lock}[-rpc][-with-ota-requestor][-sed][-low-power][-shell][-no_logging][-openthread_mtd][-enable_heap_monitoring][-no_openthread_cli][-show_qr_code][-wifi][-rs911x][-wf200][-wifi_ipv4][-additional_data_advertising][-use_ot_lib][-use_ot_coap_lib]
-esp32-{m5stack,c3devkit,devkitc,qemu}-{all-clusters,all-clusters-minimal,ota-requestor,ota-requestor,shell,light,lock,bridge,temperature-measurement,ota-requestor,tests}[-rpc][-ipv6only]
+esp32-{m5stack,c3devkit,devkitc,qemu}-{all-clusters,all-clusters-minimal,ota-provider,ota-requestor,shell,light,lock,bridge,temperature-measurement,ota-requestor,tests}[-rpc][-ipv6only]
 genio-lighting-app
 linux-fake-tests[-mbedtls][-boringssl][-asan][-tsan][-libfuzzer][-coverage][-dmalloc][-clang]
 linux-{x64,arm64}-{rpc-console,all-clusters,all-clusters-minimal,chip-tool,thermostat,java-matter-controller,minmdns,light,lock,shell,ota-provider,ota-requestor,python-bindings,tv-app,tv-casting-app,bridge,dynamic-bridge,tests,chip-cert,address-resolve-tool}[-nodeps][-platform-mdns][-minmdns-verbose][-libnl][-same-event-loop][-no-interactive][-ipv6only][-no-ble][-no-wifi][-no-thread][-mbedtls][-boringssl][-asan][-tsan][-libfuzzer][-coverage][-dmalloc][-clang][-test][-rpc]

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -1,4 +1,4 @@
-ameba-amebad-{all-clusters,all-clusters-minimal,light,pigweed}
+ameba-amebad-{all-clusters,all-clusters-minimal,light,light-switch,pigweed}
 android-{arm,arm64,x86,x64,androidstudio-arm,androidstudio-arm64,androidstudio-x86,androidstudio-x64}-{chip-tool,chip-test,tv-server,tv-casting-app,java-matter-controller}
 bouffalolab-{bl602-iot-matter-v1,bl602-iot-dvk-3s,bl602-night-light,xt-zb6-devkit,bl706-iot-dvk,bl706-night-light}-light[-shell][-115200][-rpc]
 cc13x2x7_26x2x7-{all-clusters,all-clusters-minimal,lock,pump,pump-controller,shell}[-ftd][-mtd]
@@ -14,7 +14,7 @@ infineon-psoc6-{lock,light,all-clusters,all-clusters-minimal}[-ota][-updateimage
 k32w-{light,shell,lock,contact}[-se05x][-no-ble][-no-ota][-low-power][-nologs]
 mbed-cy8cproto_062_4343w-{lock,light,all-clusters,all-clusters-minimal,pigweed,shell}[-release][-develop][-debug]
 mw320-all-clusters-app
-nrf-{nrf5340dk,nrf52840dk,nrf52840dongle}-{all-clusters,all-clusters-minimal,lock,light,light-switch,shell,pump,pump-controller}[-rpc]
+nrf-{nrf5340dk,nrf52840dk,nrf52840dongle}-{all-clusters,all-clusters-minimal,lock,light,light-switch,shell,pump,pump-controller,window-covering}[-rpc]
 nrf-native-posix-64-tests
 qpg-qpg6105-{lock,light,shell,persistent-storage}
 tizen-arm-{all-clusters,all-clusters-minimal,chip-tool,light}[-no-ble][-no-wifi][-asan]


### PR DESCRIPTION
While looking to test 'compile time codegen' I found some non-working/invalid/missing targets. Specifically:

- Fixed typo in OTA_REQUESTOR for esp32 (target did not even exist .. added it)
- added WINDOW_COVERING to nrf
- added LIGHT_SWITCH to ameba
- fixed LIGHT_SWITCH path for nrf (it did not compile before)