### PR TITLE
Accelerate cloud build by replacing docker image 'chip-build-vscode' with 'chip-build'

### DIFF
--- a/integrations/cloudbuild/build-coverage.yaml
+++ b/integrations/cloudbuild/build-coverage.yaml
@@ -7,7 +7,7 @@ steps:
           - "--recursive"
       id: Submodules
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.17"
+    - name: "connectedhomeip/chip-build:0.6.17"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -22,7 +22,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.17"
+    - name: "connectedhomeip/chip-build:0.6.17"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:


### PR DESCRIPTION
Build coverage does not use the add-on features of docker image chip-build-vscode, this image is 25 GB large, replace it with light weight chip-build docker image which is only 5 GB

