### PR TITLE
[idl parser / zapxml] The field index for structs that does not expli…

### DIFF
--- a/scripts/idl/test_xml_parser.py
+++ b/scripts/idl/test_xml_parser.py
@@ -97,15 +97,15 @@ class TestXmlParser(unittest.TestCase):
                                  structs=[
                                      Struct(name='GetSomeDataRequest',
                                             fields=[
-                                                Field(data_type=DataType(name='INT8U'), code=1, name='firstInput'),
-                                                Field(data_type=DataType(name='INT16U'), code=2, name='secondInput')
+                                                Field(data_type=DataType(name='INT8U'), code=0, name='firstInput'),
+                                                Field(data_type=DataType(name='INT16U'), code=1, name='secondInput')
                                             ],
                                             tag=StructTag.REQUEST),
                                      Struct(name='GetSomeDataResponse',
                                             fields=[
-                                                Field(data_type=DataType(name='INT8U'), code=1,
+                                                Field(data_type=DataType(name='INT8U'), code=0,
                                                       name='dataPoint1'),
-                                                Field(data_type=DataType(name='INT8U'), code=2, name='dataPoint2',
+                                                Field(data_type=DataType(name='INT8U'), code=1, name='dataPoint2',
                                                       qualities=FieldQuality.OPTIONAL)
                                             ],
                                             tag=StructTag.RESPONSE, code=0x44)
@@ -226,8 +226,8 @@ class TestXmlParser(unittest.TestCase):
             name='SomeStruct',
             qualities=StructQuality.FABRIC_SCOPED,
             fields=[
-                Field(data_type=DataType(name='int16u'), code=1, name='FirstMember'),
-                Field(data_type=DataType(name='int32u'), code=2, name='SecondMember')
+                Field(data_type=DataType(name='int16u'), code=0, name='FirstMember'),
+                Field(data_type=DataType(name='int32u'), code=1, name='SecondMember')
             ]
         )
         self.assertEqual(idl,

--- a/scripts/idl/zapxml/handlers/handlers.py
+++ b/scripts/idl/zapxml/handlers/handlers.py
@@ -183,18 +183,19 @@ class StructHandler(BaseHandler, IdlPostProcessor):
             )
 
             if 'fieldId' in attrs:
-                self._field_index = ParseInt(attrs['fieldId'])
+                field_index = ParseInt(attrs['fieldId'])
             else:
                 # NOTE: code does NOT exist, so the number is incremental here
                 #       this seems a defficiency in XML format.
-                self._field_index += 1
+                field_index = self._field_index
+            self._field_index = field_index + 1
 
             if 'length' in attrs:
                 data_type.max_length = ParseInt(attrs['length'])
 
             field = Field(
                 data_type=data_type,
-                code=self._field_index,
+                code=field_index,
                 name=attrs['name'],
                 is_list=(attrs.get('array', 'false').lower() == 'true'),
             )
@@ -384,14 +385,14 @@ class CommandHandler(BaseHandler):
         if 'length' in attrs:
             data_type.max_length = ParseInt(attrs['length'])
 
-        self._field_index += 1
-
         field = Field(
             data_type=data_type,
             code=self._field_index,
             name=attrs['name'],
             is_list=(attrs.get('array', 'false') == 'true')
         )
+
+        self._field_index += 1
 
         if attrs.get('optional', "false").lower() == 'true':
             field.qualities |= FieldQuality.OPTIONAL


### PR DESCRIPTION
…citely declares a field id is offset by 1

For struct items that does not explicitly declares a field id, the field index is off by 1 compared to what is generated for the C++ version (`cluster-objects.h`). 

