### PR TITLE
[nrfconnect] Fix for jsonschema documentation and factory data script

### DIFF
--- a/docs/guides/nrfconnect_factory_data_configuration.md
+++ b/docs/guides/nrfconnect_factory_data_configuration.md
@@ -386,9 +386,25 @@ window indicates the validation status.
 #### Option 3: Using the nRF Connect Python script
 
 You can have the JSON file checked automatically by the Python script during the
-file generation. For this to happen, provide the path to the JSON schema file as
-an additional argument, which should replace the _<path_to_schema>_ variable in
-the following command:
+file generation. For this to happen, you must install the `jsonschema` Python module 
+in your Python environment and provide the path to the JSON schema file as
+an additional argument. To do this, complete the following steps:
+
+1. Install the `jsonschema` Python module by invoking one of the following commands from the Matter root directory:
+
+   * Install only the `jsonschema` module:
+
+     ```
+     $ python -m pip install jsonschema
+     ```
+
+   * Install the `jsonschema` module together with all dependencies for Matter:
+
+     ```
+     $ python -m pip install -r ./scripts/requirements.nrfconnect.txt
+     ```
+
+2. Run the following command (remember to replace the _<path_to_schema>_ variable):
 
 ```
 $ python generate_nrfconnect_chip_factory_data.py --schema <path_to_schema>

--- a/docs/guides/nrfconnect_factory_data_configuration.md
+++ b/docs/guides/nrfconnect_factory_data_configuration.md
@@ -386,25 +386,27 @@ window indicates the validation status.
 #### Option 3: Using the nRF Connect Python script
 
 You can have the JSON file checked automatically by the Python script during the
-file generation. For this to happen, you must install the `jsonschema` Python module 
-in your Python environment and provide the path to the JSON schema file as
-an additional argument. To do this, complete the following steps:
+file generation. For this to happen, you must install the `jsonschema` Python
+module in your Python environment and provide the path to the JSON schema file
+as an additional argument. To do this, complete the following steps:
 
-1. Install the `jsonschema` Python module by invoking one of the following commands from the Matter root directory:
+1. Install the `jsonschema` Python module by invoking one of the following
+   commands from the Matter root directory:
 
-   * Install only the `jsonschema` module:
+    - Install only the `jsonschema` module:
 
-     ```
-     $ python -m pip install jsonschema
-     ```
+        ```
+        $ python -m pip install jsonschema
+        ```
 
-   * Install the `jsonschema` module together with all dependencies for Matter:
+    - Install the `jsonschema` module together with all dependencies for Matter:
 
-     ```
-     $ python -m pip install -r ./scripts/requirements.nrfconnect.txt
-     ```
+        ```
+        $ python -m pip install -r ./scripts/requirements.nrfconnect.txt
+        ```
 
-2. Run the following command (remember to replace the _<path_to_schema>_ variable):
+2. Run the following command (remember to replace the _<path_to_schema>_
+   variable):
 
 ```
 $ python generate_nrfconnect_chip_factory_data.py --schema <path_to_schema>

--- a/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
+++ b/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
@@ -19,7 +19,6 @@ from os.path import exists
 import os
 import sys
 import json
-import jsonschema
 import secrets
 import argparse
 import subprocess
@@ -28,6 +27,13 @@ import base64
 from collections import namedtuple
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import load_der_private_key
+
+try:
+    import jsonschema
+except ImportError:
+    no_jsonschema_module = True
+else:
+    no_jsonschema_module = False
 
 # A user can not change the factory data version and must be coherent with
 # the factory data version set in the nRF Connect platform Kconfig file (CHIP_FACTORY_DATA_VERSION).
@@ -483,6 +489,12 @@ def main():
     # check if json file already exist
     if(exists(args.output) and not args.overwrite):
         log.error("Output file: {} already exist, to create a new one add argument '--overwrite'. By default overwriting is disabled".format(args.output))
+        return
+
+    if args.schema and no_jsonschema_module:
+        log.error("Requested verification of the JSON file using jsonschema, but the module is not installed. \n \
+        Install only the module by invoking: pip3 install jsonschema \n \
+        Alternatively, install it with all dependencies for Matter by invoking: pip3 install -r ./scripts/requirements.nrfconnect.txt from the Matter root directory.")
         return
 
     generator = FactoryDataGenerator(args)


### PR DESCRIPTION
In the factory data script, there was no checking if a user has jsonschema module installed. That caused an error even if the user did not want to use that way of JSON validation.

Added checking a jsonschema module in python script for generating factory data and added proper information in the documentation about how to obtain jsonschema python module.

