### PR TITLE
[chip-tool] Add support for hex:/str: prefixed OCTET_STRING for compl…

### DIFF
--- a/examples/chip-tool/commands/clusters/JsonParser.h
+++ b/examples/chip-tool/commands/clusters/JsonParser.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "../common/CustomStringPrefix.h"
+
 #include <json/json.h>
 #include <lib/core/Optional.h>
 

--- a/examples/chip-tool/commands/common/CustomStringPrefix.h
+++ b/examples/chip-tool/commands/common/CustomStringPrefix.h
@@ -1,0 +1,35 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+static constexpr char kHexStringPrefix[] = "hex:";
+constexpr size_t kHexStringPrefixLen     = ArraySize(kHexStringPrefix) - 1; // Don't count the null
+
+static constexpr char kStrStringPrefix[] = "str:";
+constexpr size_t kStrStringPrefixLen     = ArraySize(kStrStringPrefix) - 1; // Don't count the null
+
+inline bool IsHexString(const char * str)
+{
+    return strncmp(str, kHexStringPrefix, kHexStringPrefixLen) == 0;
+}
+
+inline bool IsStrString(const char * str)
+{
+    return strncmp(str, kStrStringPrefix, kStrStringPrefixLen) == 0;
+}


### PR DESCRIPTION
…ex arguments instead of always assuming this is an hex string

For compatibility reason the default behavior of assuming this is an hex string is preserved.

#### Problem

`chip-tool` parses `OCTET_STRING` argument using the `hex:` prefix, but for "complex" argument that needs to be passed as a json value, passing `hex:` result into an error.
Furthermore, there is also a way to pass normal string for regular argument using the `str:` prefix but it is not allowed for "complex" argument too.


