### PR TITLE
Fix code to enable dmalloc & disable it

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,7 +78,7 @@ jobs:
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
             - name: Setup Build
-              run: scripts/build/gn_gen.sh --args="chip_config_memory_debug_checks=true chip_config_memory_debug_dmalloc=true"
+              run: scripts/build/gn_gen.sh --args="chip_config_memory_debug_checks=true chip_config_memory_debug_dmalloc=false"
             - name: Run Build
               timeout-minutes: 20
               run: scripts/run_in_build_env.sh "ninja -C ./out"

--- a/scripts/tests/gn_tests.sh
+++ b/scripts/tests/gn_tests.sh
@@ -25,11 +25,20 @@ CHIP_ROOT="$(dirname "$0")/../.."
 source "$CHIP_ROOT/scripts/activate.sh"
 
 dmalloc=$(gn --root="$CHIP_ROOT" args "$CHIP_ROOT/out/$BUILD_TYPE" --short --list=chip_config_memory_debug_dmalloc)
-if [ "x$dmalloc" == "xchip_config_memory_debug_dmalloc = true" ]; then
-    eval "$(dmalloc -b -l DMALLOC_LOG -i 1 high)"
-    export G_SLICE
-    G_SLICE=always-malloc # required for dmalloc compatibility
-fi
+
+case "$dmalloc" in
+    "chip_config_memory_debug_dmalloc = true")
+        eval "$(dmalloc -b -i 1 high)"
+        export G_SLICE
+        G_SLICE=always-malloc # required for dmalloc compatibility
+        ;;
+    "chip_config_memory_debug_dmalloc = false") ;;
+
+    *)
+        echo >&2 "Invalid output: \"$dmalloc\""
+        exit 1
+        ;;
+esac
 
 env
 

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -47,7 +47,6 @@ template("chip_data_model") {
     # Assume that IDL name is the same as the zap file name, but instead of
     # '.zap' use '.matter' as extension. This is currently the case in the
     # sample apps, but may change in the future
-    print("AUTO-DETECTING input matter IDL file.")
     _idl = string_replace(invoker.zap_file, ".zap", ".matter")
   }
 


### PR DESCRIPTION
Currently dmalloc is disabled because of a stray print from GN combined with a strict comparison of GN's output in configuring this checker. This caused tests to timeout and fail in a previous attempt to remove the print in #23687.

This checker is extremely expensive, especially for tests with more allocations. For one test, it increases the cost from 1 second to 1 hour:

```
% time ./out/tests/TestCommissionerDUTVectors
./out/tests/TestCommissionerDUTVectors  3325.35s user 0.05s system 99% cpu 55:25.65 total

% unset DMALLOC_OPTIONS
% time ./out/tests/TestCommissionerDUTVectors
./out/tests/TestCommissionerDUTVectors  1.24s user 0.01s system 99% cpu 1.249 total
```

This is much too costly to be enabled for all unit tests in presubmit, so disable it. Other tools such as ASAN have much lower overhead.