### PR TITLE
Create dispatch queues in the Darwin framework more consistently.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -162,7 +162,8 @@ private:
         _nodeID = [nodeID copy];
         _fabricIndex = controller.fabricIndex;
         _deviceController = controller;
-        _queue = dispatch_queue_create("com.apple.matter.framework.device.workqueue", DISPATCH_QUEUE_SERIAL);
+        _queue
+            = dispatch_queue_create("com.csa-iot.matter.framework.device.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         _readCache = [NSMutableDictionary dictionary];
         _expectedValueCache = [NSMutableDictionary dictionary];
         _asyncCallbackWorkQueue = [[MTRAsyncCallbackWorkQueue alloc] initWithContext:self queue:_queue];

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -163,7 +163,7 @@ private:
         _fabricIndex = controller.fabricIndex;
         _deviceController = controller;
         _queue
-            = dispatch_queue_create("com.csa-iot.matter.framework.device.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+            = dispatch_queue_create("org.csa-iot.matter.framework.device.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         _readCache = [NSMutableDictionary dictionary];
         _expectedValueCache = [NSMutableDictionary dictionary];
         _asyncCallbackWorkQueue = [[MTRAsyncCallbackWorkQueue alloc] initWithContext:self queue:_queue];

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.h
@@ -33,7 +33,8 @@ public:
         : mResult(chip::Credentials::AttestationVerificationResult::kSuccess)
         , mDeviceController(deviceController)
         , mDeviceAttestationDelegate(deviceAttestationDelegate)
-        , mQueue(dispatch_queue_create("com.csa.matter.framework.device_attestation.workqueue", DISPATCH_QUEUE_SERIAL))
+        , mQueue(dispatch_queue_create(
+              "com.csa-iot.matter.framework.device_attestation.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL))
         , mExpiryTimeoutSecs(expiryTimeoutSecs)
         , mShouldWaitAfterDeviceAttestation(shouldWaitAfterDeviceAttestation)
     {

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.h
@@ -34,7 +34,7 @@ public:
         , mDeviceController(deviceController)
         , mDeviceAttestationDelegate(deviceAttestationDelegate)
         , mQueue(dispatch_queue_create(
-              "com.csa-iot.matter.framework.device_attestation.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL))
+              "org.csa-iot.matter.framework.device_attestation.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL))
         , mExpiryTimeoutSecs(expiryTimeoutSecs)
         , mShouldWaitAfterDeviceAttestation(shouldWaitAfterDeviceAttestation)
     {

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.mm
@@ -32,7 +32,7 @@ static void SetupXPCQueue(void)
 {
     dispatch_once(&workQueueInitOnceToken, ^{
         globalWorkQueue
-            = dispatch_queue_create("com.csa-iot.matter.framework.xpc.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+            = dispatch_queue_create("org.csa-iot.matter.framework.xpc.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
     });
 }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.mm
@@ -31,7 +31,8 @@ static dispatch_queue_t globalWorkQueue;
 static void SetupXPCQueue(void)
 {
     dispatch_once(&workQueueInitOnceToken, ^{
-        globalWorkQueue = dispatch_queue_create("com.apple.matter.framework.xpc.workqueue", DISPATCH_QUEUE_SERIAL);
+        globalWorkQueue
+            = dispatch_queue_create("com.csa-iot.matter.framework.xpc.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
     });
 }
 

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -420,7 +420,7 @@ static NSInteger const kOtaProviderEndpoint = 0;
 MTROTAProviderDelegateBridge::MTROTAProviderDelegateBridge(id<MTROTAProviderDelegate> delegate)
     : mDelegate(delegate)
     , mDelegateNotificationQueue(
-          dispatch_queue_create("com.csa-iot.matter.framework.otaprovider.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL))
+          dispatch_queue_create("org.csa-iot.matter.framework.otaprovider.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL))
 {
     gOtaSender.SetDelegate(delegate, mDelegateNotificationQueue);
     Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, this);

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -419,7 +419,8 @@ static NSInteger const kOtaProviderEndpoint = 0;
 
 MTROTAProviderDelegateBridge::MTROTAProviderDelegateBridge(id<MTROTAProviderDelegate> delegate)
     : mDelegate(delegate)
-    , mDelegateNotificationQueue(dispatch_queue_create("com.csa.matter.framework.otaprovider.workqueue", DISPATCH_QUEUE_SERIAL))
+    , mDelegateNotificationQueue(
+          dispatch_queue_create("com.csa-iot.matter.framework.otaprovider.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL))
 {
     gOtaSender.SetDelegate(delegate, mDelegateNotificationQueue);
     Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, this);

--- a/src/darwin/Framework/CHIP/MTRPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRPersistentStorageDelegateBridge.mm
@@ -23,7 +23,8 @@
 
 MTRPersistentStorageDelegateBridge::MTRPersistentStorageDelegateBridge(id<MTRStorage> delegate)
     : mDelegate(delegate)
-    , mWorkQueue(dispatch_queue_create("com.csa.matter.framework.storage.workqueue", DISPATCH_QUEUE_SERIAL))
+    , mWorkQueue(
+          dispatch_queue_create("com.csa-iot.matter.framework.storage.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL))
 {
 }
 

--- a/src/darwin/Framework/CHIP/MTRPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRPersistentStorageDelegateBridge.mm
@@ -24,7 +24,7 @@
 MTRPersistentStorageDelegateBridge::MTRPersistentStorageDelegateBridge(id<MTRStorage> delegate)
     : mDelegate(delegate)
     , mWorkQueue(
-          dispatch_queue_create("com.csa-iot.matter.framework.storage.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL))
+          dispatch_queue_create("org.csa-iot.matter.framework.storage.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL))
 {
 }
 

--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -140,7 +140,7 @@ namespace DeviceLayer {
     if (self) {
         self.shortServiceUUID = [UUIDHelper GetShortestServiceUUID:&chip::Ble::CHIP_BLE_SVC_ID];
         _workQueue
-            = dispatch_queue_create("com.csa-iot.matter.framework.ble.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+            = dispatch_queue_create("org.csa-iot.matter.framework.ble.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         _chipWorkQueue = chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue();
         _timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _workQueue);
         _centralManager = [CBCentralManager alloc];

--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -139,7 +139,8 @@ namespace DeviceLayer {
     self = [super init];
     if (self) {
         self.shortServiceUUID = [UUIDHelper GetShortestServiceUUID:&chip::Ble::CHIP_BLE_SVC_ID];
-        _workQueue = dispatch_queue_create("com.chip.ble.work_queue", DISPATCH_QUEUE_SERIAL);
+        _workQueue
+            = dispatch_queue_create("com.csa-iot.matter.framework.ble.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         _chipWorkQueue = chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue();
         _timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _workQueue);
         _centralManager = [CBCentralManager alloc];

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -26,7 +26,7 @@
 #include <dispatch/dispatch.h>
 #include <platform/internal/GenericPlatformManagerImpl.h>
 
-static constexpr const char * const CHIP_CONTROLLER_QUEUE = "com.csa-iot.matter.framework.controller.workqueue";
+static constexpr const char * const CHIP_CONTROLLER_QUEUE = "org.csa-iot.matter.framework.controller.workqueue";
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -26,7 +26,7 @@
 #include <dispatch/dispatch.h>
 #include <platform/internal/GenericPlatformManagerImpl.h>
 
-static constexpr const char * const CHIP_CONTROLLER_QUEUE = "com.csa.matter.framework.controller.workqueue";
+static constexpr const char * const CHIP_CONTROLLER_QUEUE = "com.csa-iot.matter.framework.controller.workqueue";
 
 namespace chip {
 namespace DeviceLayer {
@@ -47,7 +47,7 @@ public:
     {
         if (mWorkQueue == nullptr)
         {
-            mWorkQueue = dispatch_queue_create(CHIP_CONTROLLER_QUEUE, DISPATCH_QUEUE_SERIAL);
+            mWorkQueue = dispatch_queue_create(CHIP_CONTROLLER_QUEUE, DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
             dispatch_suspend(mWorkQueue);
             mIsWorkQueueSuspended = true;
         }


### PR DESCRIPTION
* Use a common prefix for all the queue labels ("com.csa-iot.matter.framework").
* Use DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL for all the queues.
* Use a common suffix ("workqueue") for all work queues.



