### PR TITLE
[CI] Add testing for discovering commissionables devices

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -462,7 +462,7 @@ jobs:
                       --target linux-x64-java-matter-controller \
                       build \
                    "
-            - name: Run Tests
+            - name: Run Discover Tests
               timeout-minutes: 65
               run: |
                   scripts/run_in_build_env.sh \
@@ -471,9 +471,12 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "discover" \
-                     --tool-args "--nodeid 1 --fabricid 1" \
+                     --tool-args "commissionables" \
                      --factoryreset \
                   '
+            - name: Run Pairing Tests
+              timeout-minutes: 65
+              run: |
                   scripts/run_in_build_env.sh \
                   './scripts/tests/run_java_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -470,6 +470,15 @@ jobs:
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
+                     --tool-cluster "discover" \
+                     --tool-args "--nodeid 1 --fabricid 1" \
+                     --factoryreset \
+                  '
+                  scripts/run_in_build_env.sh \
+                  './scripts/tests/run_java_test.py \
+                     --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
+                     --app-args "--discriminator 3840 --interface-id -1" \
+                     --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "onnetwork-long --nodeid 1 --setup-payload 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \

--- a/scripts/tests/java/commissioning_test.py
+++ b/scripts/tests/java/commissioning_test.py
@@ -71,5 +71,6 @@ class CommissioningTest:
         if self.command_name == 'onnetwork-long':
             code = self.TestCmdOnnetworkLong(self.nodeid, self.setup_payload, self.discriminator, self.timeout)
             if code != 0:
-                logging.error(f"Testing onnetwork-long pairing failed with error {code}")
-                raise Exception("Failed to pair onnetwork device")
+                raise Exception(f"Testing onnetwork-long pairing failed with error {code}")
+        else:
+            raise Exception(f"Unsupported command {self.command_name}")

--- a/scripts/tests/java/commissioning_test.py
+++ b/scripts/tests/java/commissioning_test.py
@@ -69,10 +69,7 @@ class CommissioningTest:
     def RunTest(self):
         logging.info("Testing onnetwork-long pairing")
         if self.command_name == 'onnetwork-long':
-            java_exit_code = self.TestCmdOnnetworkLong(self.nodeid, self.setup_payload, self.discriminator, self.timeout)
-            if java_exit_code != 0:
-                logging.error("Testing onnetwork-long pairing failed with error %r" % java_exit_code)
-                return java_exit_code
-
-        # Testing complete without errors
-        return 0
+            code = self.TestCmdOnnetworkLong(self.nodeid, self.setup_payload, self.discriminator, self.timeout)
+            if code != 0:
+                logging.error(f"Testing onnetwork-long pairing failed with error {code}")
+                raise Exception("Failed to pair onnetwork device")

--- a/scripts/tests/java/commissioning_test.py
+++ b/scripts/tests/java/commissioning_test.py
@@ -17,7 +17,6 @@
 #    limitations under the License.
 #
 
-# Commissioning test.
 import logging
 import os
 import sys

--- a/scripts/tests/java/commissioning_test.py
+++ b/scripts/tests/java/commissioning_test.py
@@ -59,7 +59,7 @@ class CommissioningTest:
 
         logging.basicConfig(level=logging.INFO)
 
-    def TestOnnetworkLong(self, nodeid, setuppin, discriminator, timeout):
+    def TestCmdOnnetworkLong(self, nodeid, setuppin, discriminator, timeout):
         java_command = self.command + ['pairing', 'onnetwork-long', nodeid, setuppin, discriminator, timeout]
         logging.info(f"Execute: {java_command}")
         java_process = subprocess.Popen(
@@ -70,7 +70,7 @@ class CommissioningTest:
     def RunTest(self):
         logging.info("Testing onnetwork-long pairing")
         if self.command_name == 'onnetwork-long':
-            java_exit_code = self.TestOnnetworkLong(self.nodeid, self.setup_payload, self.discriminator, self.timeout)
+            java_exit_code = self.TestCmdOnnetworkLong(self.nodeid, self.setup_payload, self.discriminator, self.timeout)
             if java_exit_code != 0:
                 logging.error("Testing onnetwork-long pairing failed with error %r" % java_exit_code)
                 return java_exit_code

--- a/scripts/tests/java/discover_test.py
+++ b/scripts/tests/java/discover_test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Discovery test.
+import logging
+import os
+import sys
+import asyncio
+import queue
+import subprocess
+import threading
+import typing
+from optparse import OptionParser
+from colorama import Fore, Style
+from java.base import DumpProgramOutputToQueue
+
+
+class DiscoverTest:
+    def __init__(self, thread_list: typing.List[threading.Thread], queue: queue.Queue, cmd: [], args: str):
+        self.thread_list = thread_list
+        self.queue = queue
+        self.command = cmd
+
+        optParser = OptionParser()
+        optParser.add_option(
+            "--nodeid",
+            action="store",
+            dest="nodeid",
+            default='1',
+            type='str',
+            help="DNS-SD name corresponding with the given node ID",
+            metavar="<nodeid>"
+        )
+        optParser.add_option(
+            "--fabricid",
+            action="store",
+            dest="fabricid",
+            default='1',
+            type='str',
+            help="DNS-SD name corresponding with the given fabric ID",
+            metavar="<nodeid>"
+        )
+        optParser.add_option(
+            "-p",
+            "--paa-trust-store-path",
+            action="store",
+            dest="paaTrustStorePath",
+            default='',
+            type='str',
+            help="Path that contains valid and trusted PAA Root Certificates.",
+            metavar="<paa-trust-store-path>"
+        )
+
+        (options, remainingArgs) = optParser.parse_args(args.split())
+
+        self.nodeid = options.nodeid
+        self.fabricid = options.fabricid
+
+        logging.basicConfig(level=logging.INFO)
+
+    def TestCmdCommissionables(self):
+        java_command = self.command + ['discover', 'commissionables']
+        print(java_command)
+        logging.info(f"Execute: {java_command}")
+        java_process = subprocess.Popen(
+            java_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        DumpProgramOutputToQueue(self.thread_list, Fore.GREEN + "JAVA " + Style.RESET_ALL, java_process, self.queue)
+        return java_process.wait()
+
+    def RunTest(self):
+        logging.info("Testing discovering commissionables devices")
+        java_exit_code = self.TestCmdCommissionables()
+        if java_exit_code != 0:
+            logging.error("Testing command commissionables failed with error %r" % java_exit_code)
+            return java_exit_code
+
+        # Testing complete without errors
+        return 0

--- a/scripts/tests/java/discover_test.py
+++ b/scripts/tests/java/discover_test.py
@@ -64,10 +64,7 @@ class DiscoverTest:
         logging.info("Testing discovering commissionables devices")
 
         if self.command_name == 'commissionables':
-            java_exit_code = self.TestCmdCommissionables()
-            if java_exit_code != 0:
-                logging.error("Testing command commissionables failed with error %r" % java_exit_code)
-                return java_exit_code
-
-        # Testing complete without errors
-        return 0
+            code = self.TestCmdCommissionables()
+            if code != 0:
+                logging.error(f"Testing command commissionables failed with error {code}")
+                raise Exception("Failed to discover commissionables devices")

--- a/scripts/tests/java/discover_test.py
+++ b/scripts/tests/java/discover_test.py
@@ -66,5 +66,6 @@ class DiscoverTest:
         if self.command_name == 'commissionables':
             code = self.TestCmdCommissionables()
             if code != 0:
-                logging.error(f"Testing command commissionables failed with error {code}")
-                raise Exception("Failed to discover commissionables devices")
+                raise Exception(f"Testing command commissionables failed with error {code}")
+        else:
+            raise Exception(f"Unsupported command {self.command_name}")

--- a/scripts/tests/run_java_test.py
+++ b/scripts/tests/run_java_test.py
@@ -90,7 +90,8 @@ def main(app: str, app_args: str, tool_path: str, tool_cluster: str, tool_args: 
         test = CommissioningTest(log_cooking_threads, log_queue, command, tool_args)
         try:
             test.RunTest()
-        except Exception:
+        except Exception as e:
+            logging.error(e)
             sys.exit(1)
     elif tool_cluster == 'discover':
         logging.info("Testing discover cluster")
@@ -98,7 +99,8 @@ def main(app: str, app_args: str, tool_path: str, tool_cluster: str, tool_args: 
         test = DiscoverTest(log_cooking_threads, log_queue, command, tool_args)
         try:
             test.RunTest()
-        except Exception:
+        except Exception as e:
+            logging.error(e)
             sys.exit(1)
 
     app_exit_code = 0

--- a/scripts/tests/run_java_test.py
+++ b/scripts/tests/run_java_test.py
@@ -28,6 +28,7 @@ import subprocess
 import sys
 from java.base import DumpProgramOutputToQueue
 from java.commissioning_test import CommissioningTest
+from java.discover_test import DiscoverTest
 from colorama import Fore, Style
 
 
@@ -87,6 +88,14 @@ def main(app: str, app_args: str, tool_path: str, tool_cluster: str, tool_args: 
         logging.info("Testing pairing cluster")
 
         test = CommissioningTest(log_cooking_threads, log_queue, command, tool_args)
+        controller_exit_code = test.RunTest()
+
+        if controller_exit_code != 0:
+            logging.error("Test script exited with error %r" % test_script_exit_code)
+    elif tool_cluster == 'discover':
+        logging.info("Testing discover cluster")
+
+        test = DiscoverTest(log_cooking_threads, log_queue, command, tool_args)
         controller_exit_code = test.RunTest()
 
         if controller_exit_code != 0:

--- a/scripts/tests/run_java_test.py
+++ b/scripts/tests/run_java_test.py
@@ -88,18 +88,18 @@ def main(app: str, app_args: str, tool_path: str, tool_cluster: str, tool_args: 
         logging.info("Testing pairing cluster")
 
         test = CommissioningTest(log_cooking_threads, log_queue, command, tool_args)
-        controller_exit_code = test.RunTest()
-
-        if controller_exit_code != 0:
-            logging.error("Test script exited with error %r" % test_script_exit_code)
+        try:
+            test.RunTest()
+        except Exception:
+            sys.exit(1)
     elif tool_cluster == 'discover':
         logging.info("Testing discover cluster")
 
         test = DiscoverTest(log_cooking_threads, log_queue, command, tool_args)
-        controller_exit_code = test.RunTest()
-
-        if controller_exit_code != 0:
-            logging.error("Test script exited with error %r" % test_script_exit_code)
+        try:
+            test.RunTest()
+        except Exception:
+            sys.exit(1)
 
     app_exit_code = 0
     if app_process:
@@ -112,11 +112,8 @@ def main(app: str, app_args: str, tool_path: str, tool_cluster: str, tool_args: 
     for thread in log_cooking_threads:
         thread.join()
 
-    if controller_exit_code != 0:
-        sys.exit(controller_exit_code)
-    else:
-        # We expect both app and controller should exit with 0
-        sys.exit(app_exit_code)
+    # We expect app should exit with 0
+    sys.exit(app_exit_code)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently, we don't have check for discovering commissionables devices against Matter Java API yet.  Add testing for discovering commissionables devices using java-matter-controller and all-clusters-app in CI.
