### PR TITLE
Update silabs efr32 lighting-app README

### DIFF
--- a/examples/lighting-app/silabs/efr32/README.md
+++ b/examples/lighting-app/silabs/efr32/README.md
@@ -141,7 +141,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/lighting-app/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4161A
+          $ export silabs_board=BRD4161A
           $ gn gen out/debug
           $ ninja -C out/debug
 
@@ -167,7 +167,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/lighting-app/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4161A
+          $ export silabs_board=BRD4161A
           $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
           $ ninja -C out/debug
 


### PR DESCRIPTION
Fixes #24002. Missing variable silabs_board.  `gn gen out/debug` was failing:
```
ERROR at //third_party/connectedhomeip/third_party/silabs/silabs_board.gni:24:1: Assertion failed.
assert(silabs_board != "", "silabs_board must be specified")
```
