### PR TITLE
Add a way for Resolver consumers to cancel operational resolve attempts.

### DIFF
--- a/src/controller/python/chip/discovery/NodeResolution.cpp
+++ b/src/controller/python/chip/discovery/NodeResolution.cpp
@@ -37,6 +37,7 @@ class PythonResolverDelegate : public OperationalResolveDelegate
 public:
     void OnOperationalNodeResolved(const ResolvedNodeData & nodeData) override
     {
+        Resolver::Instance().NodeIdResolutionNoLongerNeeded(nodeData.operationalData.peerId);
         if (mSuccessCallback != nullptr)
         {
             char ipAddressBuffer[128];
@@ -59,6 +60,7 @@ public:
 
     void OnOperationalNodeResolutionFailed(const PeerId & peerId, CHIP_ERROR error) override
     {
+        Resolver::Instance().NodeIdResolutionNoLongerNeeded(peerId);
         if (mFailureCallback != nullptr)
         {
             mFailureCallback(peerId.GetCompressedFabricId(), peerId.GetNodeId(), ToPyChipError(error));

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -37,6 +37,7 @@ public:
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override {}
     void SetCommissioningDelegate(CommissioningResolveDelegate * delegate) override {}
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override { return ResolveNodeIdStatus; }
+    void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override {}
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return DiscoverCommissionersStatus; }
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override
     {

--- a/src/lib/dnssd/ActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/ActiveResolveAttempts.cpp
@@ -99,10 +99,6 @@ void ActiveResolveAttempts::NodeIdResolutionNoLongerNeeded(const PeerId & peerId
         if (item.attempt.Matches(peerId))
         {
             item.attempt.ConsumerRemoved();
-            if (item.attempt.ResolveData().consumerCount == 0)
-            {
-                item.attempt.Clear();
-            }
             return;
         }
     }

--- a/src/lib/dnssd/ActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/ActiveResolveAttempts.cpp
@@ -92,6 +92,22 @@ CHIP_ERROR ActiveResolveAttempts::CompleteAllBrowses()
     return CHIP_NO_ERROR;
 }
 
+void ActiveResolveAttempts::NodeIdResolutionNoLongerNeeded(const PeerId & peerId)
+{
+    for (auto & item : mRetryQueue)
+    {
+        if (item.attempt.Matches(peerId))
+        {
+            item.attempt.ConsumerRemoved();
+            if (item.attempt.ResolveData().consumerCount == 0)
+            {
+                item.attempt.Clear();
+            }
+            return;
+        }
+    }
+}
+
 void ActiveResolveAttempts::MarkPending(const chip::PeerId & peerId)
 {
     MarkPending(ScheduledAttempt(peerId, /* firstSend */ true));
@@ -172,6 +188,7 @@ void ActiveResolveAttempts::MarkPending(ScheduledAttempt && attempt)
         ChipLogError(Discovery, "Re-using pending resolve entry before reply was received.");
     }
 
+    attempt.WillCoalesceWith(entryToUse->attempt);
     entryToUse->attempt        = attempt;
     entryToUse->queryDueTime   = mClock->GetMonotonicTimestamp();
     entryToUse->nextRetryDelay = System::Clock::Seconds16(1);

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -628,10 +628,9 @@ CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(const PeerId & peerId)
 void DiscoveryImplPlatform::NodeIdResolutionNoLongerNeeded(const PeerId & peerId)
 {
     char name[Common::kInstanceNameMaxLength + 1];
-    if (MakeInstanceName(name, sizeof(name), peerId) == CHIP_NO_ERROR)
-    {
-        ChipDnssdResolveNoLongerNeeded(name);
-    }
+    ReturnOnFailure(MakeInstanceName(name, sizeof(name), peerId));
+
+    ChipDnssdResolveNoLongerNeeded(name);
 }
 
 CHIP_ERROR DiscoveryImplPlatform::DiscoverCommissionableNodes(DiscoveryFilter filter)
@@ -700,10 +699,9 @@ CHIP_ERROR ResolverProxy::ResolveNodeId(const PeerId & peerId)
 void ResolverProxy::NodeIdResolutionNoLongerNeeded(const PeerId & peerId)
 {
     char name[Common::kInstanceNameMaxLength + 1];
-    if (MakeInstanceName(name, sizeof(name), peerId) == CHIP_NO_ERROR)
-    {
-        ChipDnssdResolveNoLongerNeeded(name);
-    }
+    ReturnOnFailure(MakeInstanceName(name, sizeof(name), peerId));
+
+    ChipDnssdResolveNoLongerNeeded(name);
 }
 
 ResolverProxy::~ResolverProxy()

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -55,6 +55,7 @@ public:
         mResolverProxy.SetCommissioningDelegate(delegate);
     }
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override;
+    void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override;
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR StopDiscovery() override;

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -369,10 +369,30 @@ public:
      * This will trigger a DNSSD query.
      *
      * When the operation succeeds or fails, and a resolver delegate has been registered,
-     * the result of the operation is passed to the delegate's `OnNodeIdResolved` or
-     * `OnNodeIdResolutionFailed` method, respectively.
+     * the result of the operation is passed to the delegate's `OnOperationalNodeResolved` or
+     * `OnOperationalNodeResolutionFailed` method, respectively.
+     *
+     * Multiple calls to ResolveNodeId may be coalesced by the implementation
+     * and lead to just one call to
+     * OnOperationalNodeResolved/OnOperationalNodeResolutionFailed, as long as
+     * the later calls cause the underlying querying mechanism to re-query as if
+     * there were no coalescing.
+     *
+     * A single call to ResolveNodeId may lead to multiple calls to
+     * OnOperationalNodeResolved with different IP addresses.
+     *
+     * @see NodeIdResolutionNoLongerNeeded.
      */
     virtual CHIP_ERROR ResolveNodeId(const PeerId & peerId) = 0;
+
+    /*
+     * Notify the resolver that one of the consumers that called ResolveNodeId
+     * successfully no longer needs the resolution result (e.g. because it got
+     * the result, or got an error, or no longer cares about future updates).
+     * There must be a NodeIdResolutionNoLongerNeeded call that matches every
+     * successful ResolveNodeId call.
+     */
+    virtual void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) = 0;
 
     /**
      * Finds all commissionable nodes matching the given filter.

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -388,9 +388,16 @@ public:
     /*
      * Notify the resolver that one of the consumers that called ResolveNodeId
      * successfully no longer needs the resolution result (e.g. because it got
-     * the result, or got an error, or no longer cares about future updates).
+     * the result via OnOperationalNodeResolved, or got an via
+     * OnOperationalNodeResolutionFailed, or no longer cares about future
+     * updates).
+     *
      * There must be a NodeIdResolutionNoLongerNeeded call that matches every
-     * successful ResolveNodeId call.
+     * successful ResolveNodeId call.  In particular, implementations of
+     * OnOperationalNodeResolved and OnOperationalNodeResolutionFailed must call
+     * NodeIdResolutionNoLongerNeeded once for each prior successful call to
+     * ResolveNodeId for the relevant PeerId that has not yet had a matching
+     * NodeIdResolutionNoLongerNeeded call made.
      */
     virtual void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) = 0;
 

--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -150,6 +150,7 @@ public:
     }
 
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override;
+    void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override;
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR StopDiscovery() override;

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -279,6 +279,7 @@ public:
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override { mOperationalDelegate = delegate; }
     void SetCommissioningDelegate(CommissioningResolveDelegate * delegate) override { mCommissioningDelegate = delegate; }
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override;
+    void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override;
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR StopDiscovery() override;
@@ -659,6 +660,11 @@ CHIP_ERROR MinMdnsResolver::ResolveNodeId(const PeerId & peerId)
     return SendAllPendingQueries();
 }
 
+void MinMdnsResolver::NodeIdResolutionNoLongerNeeded(const PeerId & peerId)
+{
+    mActiveResolves.NodeIdResolutionNoLongerNeeded(peerId);
+}
+
 CHIP_ERROR MinMdnsResolver::ScheduleRetries()
 {
     ReturnErrorCodeIf(mSystemLayer == nullptr, CHIP_ERROR_INCORRECT_STATE);
@@ -708,6 +714,11 @@ CHIP_ERROR ResolverProxy::ResolveNodeId(const PeerId & peerId)
                     ChipLogValueX64(peerId.GetCompressedFabricId()), ChipLogValueX64(peerId.GetNodeId()));
     chip::Dnssd::Resolver::Instance().SetOperationalDelegate(mDelegate);
     return chip::Dnssd::Resolver::Instance().ResolveNodeId(peerId);
+}
+
+void ResolverProxy::NodeIdResolutionNoLongerNeeded(const PeerId & peerId)
+{
+    return chip::Dnssd::Resolver::Instance().NodeIdResolutionNoLongerNeeded(peerId);
 }
 
 CHIP_ERROR ResolverProxy::DiscoverCommissionableNodes(DiscoveryFilter filter)

--- a/src/lib/dnssd/Resolver_ImplNone.cpp
+++ b/src/lib/dnssd/Resolver_ImplNone.cpp
@@ -37,6 +37,10 @@ public:
         ChipLogError(Discovery, "Failed to resolve node ID: dnssd resolving not available");
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
+    void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override
+    {
+        ChipLogError(Discovery, "Failed to stop resolving node ID: dnssd resolving not available");
+    }
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
@@ -67,6 +71,8 @@ CHIP_ERROR ResolverProxy::ResolveNodeId(const PeerId & peerId)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
+
+void ResolverProxy::NodeIdResolutionNoLongerNeeded(const PeerId & peerId) {}
 
 CHIP_ERROR ResolverProxy::DiscoverCommissionableNodes(DiscoveryFilter filter)
 {

--- a/src/lib/dnssd/platform/Dnssd.h
+++ b/src/lib/dnssd/platform/Dnssd.h
@@ -246,6 +246,13 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId
                             void * context);
 
 /**
+ * This function notifies the implementation that a resolve result is no longer
+ * needed by some consumer, to allow implementations to stop unnecessary resolve
+ * work.
+ */
+void ChipDnssdResolveNoLongerNeeded(const char * instanceName);
+
+/**
  * This function asks the mdns daemon to asynchronously reconfirm an address that appears to be out of date.
  *
  * @param[in] hostname      The hostname the address belongs to.

--- a/src/platform/Ameba/DnssdImpl.cpp
+++ b/src/platform/Ameba/DnssdImpl.cpp
@@ -114,5 +114,7 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * /*service*/, chip::Inet::InterfaceId 
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
+void ChipDnssdResolveNoLongerNeeded(const char * instanceName) {}
+
 } // namespace Dnssd
 } // namespace chip

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -344,11 +344,11 @@ static CHIP_ERROR Resolve(void * context, DnssdResolveCallback callback, uint32_
     ChipLogDetail(Discovery, "Resolve type=%s name=%s interface=%" PRIu32, StringOrNullMarker(type), StringOrNullMarker(name),
                   interfaceId);
 
-    // This is a little silly, in that resolves for the sane name, type, etc get
+    // This is a little silly, in that resolves for the same name, type, etc get
     // coalesced by the underlying mDNSResponder anyway.  But we need to keep
     // track of our context/callback/etc, (even though in practice it's always
     // exactly the same) and the interface id (which might actually be different
-    // for different Resolve calls).  So for now just keep using a
+    // for different Resolve calls). So for now just keep using a
     // ResolveContext to track all that.
     std::shared_ptr<uint32_t> counterHolder;
     if (auto existingCtx = MdnsContexts::GetInstance().GetExistingResolveForInstanceName(name))
@@ -474,15 +474,8 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId inte
 void ChipDnssdResolveNoLongerNeeded(const char * instanceName)
 {
     auto existingCtx = MdnsContexts::GetInstance().GetExistingResolveForInstanceName(instanceName);
-    if (!existingCtx)
-    {
-        return;
-    }
-
-    if (*existingCtx->consumerCounter == 0)
-    {
-        return;
-    }
+    VerifyOrReturn(existingCtx != nullptr);
+    VerifyOrReturn(*existingCtx->consumerCounter != 0);
 
     (*existingCtx->consumerCounter)--;
 

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -344,7 +344,23 @@ static CHIP_ERROR Resolve(void * context, DnssdResolveCallback callback, uint32_
     ChipLogDetail(Discovery, "Resolve type=%s name=%s interface=%" PRIu32, StringOrNullMarker(type), StringOrNullMarker(name),
                   interfaceId);
 
-    auto sdCtx = chip::Platform::New<ResolveContext>(context, callback, addressType);
+    // This is a little silly, in that resolves for the sane name, type, etc get
+    // coalesced by the underlying mDNSResponder anyway.  But we need to keep
+    // track of our context/callback/etc, (even though in practice it's always
+    // exactly the same) and the interface id (which might actually be different
+    // for different Resolve calls).  So for now just keep using a
+    // ResolveContext to track all that.
+    std::shared_ptr<uint32_t> counterHolder;
+    if (auto existingCtx = MdnsContexts::GetInstance().GetExistingResolveForInstanceName(name))
+    {
+        counterHolder = existingCtx->consumerCounter;
+    }
+    else
+    {
+        counterHolder = std::make_shared<uint32_t>(0);
+    }
+
+    auto sdCtx = chip::Platform::New<ResolveContext>(context, callback, addressType, name, std::move(counterHolder));
     VerifyOrReturnError(nullptr != sdCtx, CHIP_ERROR_NO_MEMORY);
 
     auto err = DNSServiceCreateConnection(&sdCtx->serviceRef);
@@ -354,7 +370,12 @@ static CHIP_ERROR Resolve(void * context, DnssdResolveCallback callback, uint32_
     err            = DNSServiceResolve(&sdRefCopy, kResolveFlags, interfaceId, name, type, kLocalDot, OnResolve, sdCtx);
     VerifyOrReturnError(kDNSServiceErr_NoError == err, sdCtx->Finalize(err));
 
-    return MdnsContexts::GetInstance().Add(sdCtx, sdCtx->serviceRef);
+    CHIP_ERROR retval = MdnsContexts::GetInstance().Add(sdCtx, sdCtx->serviceRef);
+    if (retval == CHIP_NO_ERROR)
+    {
+        (*(sdCtx->consumerCounter))++;
+    }
+    return retval;
 }
 
 } // namespace
@@ -448,6 +469,34 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId inte
     auto regtype     = GetFullType(service);
     auto interfaceId = GetInterfaceId(interface);
     return Resolve(context, callback, interfaceId, service->mAddressType, regtype.c_str(), service->mName);
+}
+
+void ChipDnssdResolveNoLongerNeeded(const char * instanceName)
+{
+    auto existingCtx = MdnsContexts::GetInstance().GetExistingResolveForInstanceName(instanceName);
+    if (!existingCtx)
+    {
+        return;
+    }
+
+    if (*existingCtx->consumerCounter == 0)
+    {
+        return;
+    }
+
+    (*existingCtx->consumerCounter)--;
+
+    if (*existingCtx->consumerCounter == 0)
+    {
+        // No more consumers; clear out all of these resolves so they don't
+        // stick around.  Dispatch timeout failure on all of them to make sure
+        // whatever kicked them off cleans up resources as needed.
+        do
+        {
+            existingCtx->Finalize(kDNSServiceErr_Timeout);
+            existingCtx = MdnsContexts::GetInstance().GetExistingResolveForInstanceName(instanceName);
+        } while (existingCtx != nullptr);
+    }
 }
 
 CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)

--- a/src/platform/ESP32/DnssdImpl.cpp
+++ b/src/platform/ESP32/DnssdImpl.cpp
@@ -511,6 +511,8 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId inte
     return error;
 }
 
+void ChipDnssdResolveNoLongerNeeded(const char * instanceName) {}
+
 CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -872,6 +872,8 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId
                                             browseResult->mAddressType, Inet::IPAddressType::kAny, interface, callback, context);
 }
 
+void ChipDnssdResolveNoLongerNeeded(const char * instanceName) {}
+
 CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/OpenThread/DnssdImpl.cpp
+++ b/src/platform/OpenThread/DnssdImpl.cpp
@@ -122,6 +122,7 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, Inet::InterfaceId inter
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT && CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT
 }
 
+void ChipDnssdResolveNoLongerNeeded(const char * instanceName) {}
 CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -820,6 +820,8 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId
     return DnssdTizen::GetInstance().Resolve(*browseResult, interface, callback, context);
 }
 
+void ChipDnssdResolveNoLongerNeeded(const char * instanceName) {}
+
 CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -241,6 +241,8 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * service, Inet::InterfaceId interface,
     return CHIP_NO_ERROR;
 }
 
+void ChipDnssdResolveNoLongerNeeded(const char * instanceName) {}
+
 CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/bouffalolab/BL602/DnssdImpl.cpp
+++ b/src/platform/bouffalolab/BL602/DnssdImpl.cpp
@@ -313,6 +313,8 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * /*service*/, chip::Inet::InterfaceId 
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
+void ChipDnssdResolveNoLongerNeeded(const char * instanceName) {}
+
 CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/fake/DnssdImpl.cpp
+++ b/src/platform/fake/DnssdImpl.cpp
@@ -132,6 +132,8 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
+void ChipDnssdResolveNoLongerNeeded(const char * instanceName) {}
+
 CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/mt793x/DnssdImpl.cpp
+++ b/src/platform/mt793x/DnssdImpl.cpp
@@ -540,6 +540,8 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId inte
     return error;
 }
 
+void ChipDnssdResolveNoLongerNeeded(const char * instanceName) {}
+
 CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/webos/DnssdImpl.cpp
+++ b/src/platform/webos/DnssdImpl.cpp
@@ -869,6 +869,8 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId
                                             browseResult->mAddressType, Inet::IPAddressType::kAny, interface, callback, context);
 }
 
+void ChipDnssdResolveNoLongerNeeded(const char * instanceName) {}
+
 CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;


### PR DESCRIPTION
Adds a way for consumers to notify Resolver when they no longer care about an operational resolve, so a Resolver implementation can keep track of how many consumers are interested and stop work as desired if no one is interested.

Fixes https://github.com/project-chip/connectedhomeip/issues/23881



