### PR TITLE
[Silabs] Remove pw_kvs and pw_log dependencies 

### DIFF
--- a/config/efr32/lib/pw_rpc/pw_rpc.gni
+++ b/config/efr32/lib/pw_rpc/pw_rpc.gni
@@ -17,6 +17,7 @@ import("//build_overrides/pigweed.gni")
 
 pw_log_BACKEND = "$dir_pw_log_basic"
 pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
+pw_rpc_CONFIG = "$dir_pw_rpc:disable_global_mutex"
 pw_sys_io_BACKEND =
     "${chip_root}/examples/platform/silabs/efr32/pw_sys_io:pw_sys_io_efr32"
 

--- a/examples/chef/efr32/BUILD.gn
+++ b/examples/chef/efr32/BUILD.gn
@@ -24,7 +24,6 @@ import("${efr32_sdk_build_root}/efr32_sdk.gni")
 import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 import("${chip_root}/src/platform/device.gni")
 
-import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 import("${chip_root}/src/app/chip_data_model.gni")
 
 if (chip_enable_pw_rpc) {

--- a/examples/chef/efr32/args.gni
+++ b/examples/chef/efr32/args.gni
@@ -13,17 +13,12 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/standalone/args.gni")
 import("${chip_root}/src/platform/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_ota_requestor = true
-
-pw_rpc_CONFIG = "$dir_pw_rpc:disable_global_mutex"
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
 chip_enable_openthread = true
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"

--- a/examples/chef/efr32/build_for_wifi_args.gni
+++ b/examples/chef/efr32/build_for_wifi_args.gni
@@ -12,13 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 chip_enable_openthread = false
 import("${chip_root}/src/platform/EFR32/wifi_args.gni")
 
 chip_enable_ota_requestor = true
-
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"

--- a/examples/light-switch-app/efr32/args.gni
+++ b/examples/light-switch-app/efr32/args.gni
@@ -13,17 +13,12 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/standalone/args.gni")
 import("${chip_root}/src/platform/silabs/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_ota_requestor = true
-
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
 chip_enable_openthread = true
-pw_rpc_CONFIG = "$dir_pw_rpc:disable_global_mutex"
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"

--- a/examples/light-switch-app/efr32/build_for_wifi_args.gni
+++ b/examples/light-switch-app/efr32/build_for_wifi_args.gni
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/standalone/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
@@ -20,6 +19,3 @@ chip_enable_openthread = false
 import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
 
 chip_enable_ota_requestor = true
-
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"

--- a/examples/lighting-app/silabs/SiWx917/args.gni
+++ b/examples/lighting-app/silabs/SiWx917/args.gni
@@ -13,16 +13,12 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/standalone/args.gni")
 import("${chip_root}/src/platform/silabs/SiWx917/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_ota_requestor = true
-
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
 chip_enable_openthread = true
 pw_rpc_CONFIG = "$dir_pw_rpc:disable_global_mutex"
 

--- a/examples/lighting-app/silabs/SiWx917/build_for_wifi_args.gni
+++ b/examples/lighting-app/silabs/SiWx917/build_for_wifi_args.gni
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/standalone/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
@@ -20,6 +19,3 @@ chip_enable_openthread = false
 import("${chip_root}/src/platform/silabs/SiWx917/wifi_args.gni")
 
 chip_enable_ota_requestor = true
-
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"

--- a/examples/lighting-app/silabs/efr32/args.gni
+++ b/examples/lighting-app/silabs/efr32/args.gni
@@ -13,18 +13,13 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/standalone/args.gni")
 import("${chip_root}/src/platform/silabs/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_ota_requestor = true
-
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
 chip_enable_openthread = true
-pw_rpc_CONFIG = "$dir_pw_rpc:disable_global_mutex"
 
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"

--- a/examples/lighting-app/silabs/efr32/build_for_wifi_args.gni
+++ b/examples/lighting-app/silabs/efr32/build_for_wifi_args.gni
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/standalone/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
@@ -20,6 +19,3 @@ chip_enable_openthread = false
 import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
 
 chip_enable_ota_requestor = true
-
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"

--- a/examples/lock-app/efr32/args.gni
+++ b/examples/lock-app/efr32/args.gni
@@ -13,17 +13,12 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/standalone/args.gni")
 import("${chip_root}/src/platform/silabs/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_ota_requestor = true
-
 chip_enable_openthread = true
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
-pw_rpc_CONFIG = "$dir_pw_rpc:disable_global_mutex"
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"

--- a/examples/lock-app/efr32/build_for_wifi_args.gni
+++ b/examples/lock-app/efr32/build_for_wifi_args.gni
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/standalone/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
@@ -20,6 +19,3 @@ chip_enable_openthread = false
 import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
 
 chip_enable_ota_requestor = true
-
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"

--- a/examples/persistent-storage/efr32/args.gni
+++ b/examples/persistent-storage/efr32/args.gni
@@ -13,11 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/standalone/args.gni")
 import("${chip_root}/src/platform/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
-
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"

--- a/examples/shell/efr32/args.gni
+++ b/examples/shell/efr32/args.gni
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/standalone/args.gni")
 import("${chip_root}/src/platform/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
 chip_enable_openthread = true
 chip_openthread_ftd = true
 chip_build_libshell = true

--- a/examples/thermostat/efr32/args.gni
+++ b/examples/thermostat/efr32/args.gni
@@ -13,18 +13,13 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/standalone/args.gni")
 import("${chip_root}/src/platform/silabs/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_ota_requestor = true
-
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
 chip_enable_openthread = true
-pw_rpc_CONFIG = "$dir_pw_rpc:disable_global_mutex"
 
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"

--- a/examples/thermostat/efr32/build_for_wifi_args.gni
+++ b/examples/thermostat/efr32/build_for_wifi_args.gni
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/standalone/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
@@ -20,6 +19,3 @@ chip_enable_openthread = false
 import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
 
 chip_enable_ota_requestor = true
-
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"

--- a/examples/window-app/efr32/args.gni
+++ b/examples/window-app/efr32/args.gni
@@ -13,16 +13,12 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/standalone/args.gni")
 import("${chip_root}/src/platform/silabs/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_ota_requestor = true
-
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
 chip_enable_openthread = true
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"

--- a/examples/window-app/efr32/build_for_wifi_args.gni
+++ b/examples/window-app/efr32/build_for_wifi_args.gni
@@ -12,13 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 chip_enable_openthread = false
 import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
 
 chip_enable_ota_requestor = true
-
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"

--- a/src/platform/silabs/EFR32/BUILD.gn
+++ b/src/platform/silabs/EFR32/BUILD.gn
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 
 import("${chip_root}/src/platform/device.gni")
 
@@ -84,19 +83,10 @@ static_library("EFR32") {
     ]
   }
 
-  # Add pigweed KVS
-  deps = [
-    "$dir_pw_kvs:crc16",
-    "$dir_pw_log",
-  ]
-  public_deps += [
-    "$dir_pw_checksum",
-    "$dir_pw_kvs",
-  ]
   if (chip_enable_openthread) {
     public_deps += [ "${chip_root}/third_party/openthread:openthread" ]
 
-    deps += [ "${chip_root}/third_party/openthread:openthread_cli" ]
+    deps = [ "${chip_root}/third_party/openthread:openthread_cli" ]
 
     sources += [
       "${silabs_platform_dir}/ThreadStackManagerImpl.h",

--- a/src/platform/silabs/SiWx917/BUILD.gn
+++ b/src/platform/silabs/SiWx917/BUILD.gn
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 
 import("${chip_root}/src/platform/device.gni")
 
@@ -67,16 +66,6 @@ static_library("SiWx917") {
   }
 
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
-
-  # Add pigweed KVS
-  deps = [
-    "$dir_pw_kvs:crc16",
-    "$dir_pw_log",
-  ]
-  public_deps += [
-    "$dir_pw_checksum",
-    "$dir_pw_kvs",
-  ]
 
   if (chip_enable_wifi) {
     sources += [

--- a/src/platform/silabs/SiWx917/wifi_args.gni
+++ b/src/platform/silabs/SiWx917/wifi_args.gni
@@ -46,8 +46,3 @@ chip_build_tests = false
 chip_config_memory_management = "platform"
 chip_mdns = "minimal"
 chip_enable_pw_rpc = false
-
-pw_build_LINK_DEPS = [
-  "$dir_pw_assert:impl",
-  "$dir_pw_log:impl",
-]


### PR DESCRIPTION
The pigweed pw_kvs module was used a long time ago in the Silabs KVS implementation. 
pw_kvs and pw_log dependencies aren't needed for Silabs examples and should have been removed before

This PR Removes them. pw_modules are only used for pw_rpc builds.
