### PR TITLE
Use argparse instead of optparse to parse pairing arguments

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -471,7 +471,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
-                     --tool-args "--nodeid 1 --setup-payload 20202021 --discriminator 3840 -t 1000" \
+                     --tool-args "onnetwork-long --nodeid 1 --setup-payload 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
                   '
             - name: Uploading core files


### PR DESCRIPTION
optparse is deprecated now, https://docs.python.org/3/library/optparse.html says "Deprecated since version 3.2".

Use argparse instead of optparse to parse pairing arguments