### PR TITLE
ESP32: Reduce the Wi-Fi reconnection interval

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -319,7 +319,7 @@ menu "CHIP Device Layer"
         config WIFI_STATION_RECONNECT_INTERVAL
             int "WiFi Station Interface Reconnect Interval (ms)"
             range 0 65535
-            default 5000
+            default 100
             depends on ENABLE_WIFI_STATION
             help
                 The interval at which the CHIP platform will attempt to reconnect to the configured WiFi network (in milliseconds).


### PR DESCRIPTION
- Problem
Commissioning can take a lot of time as the Wi-Fi reconnection in case of a failure happens after 5 sec

- Solution
The Wi-Fi connection retry interval for reconnection need not be so high. Changing this value to 100 ms. This will help in reduced time and an improved experience during commissioning
