### PR TITLE
[Darwin / BLE] Add some code to scan without a discriminator in order to prewarm for commissioning

### DIFF
--- a/examples/darwin-framework-tool/commands/pairing/Commands.h
+++ b/examples/darwin-framework-tool/commands/pairing/Commands.h
@@ -22,6 +22,7 @@
 
 #include "OpenCommissioningWindowCommand.h"
 #include "PairingCommandBridge.h"
+#include "PrepareCommissioningCommand.h"
 
 class PairCode : public PairingCommandBridge
 {
@@ -71,6 +72,7 @@ void registerCommandsPairing(Commands & commands)
         make_unique<PairBleThread>(),
         make_unique<Unpair>(),
         make_unique<OpenCommissioningWindowCommand>(),
+        make_unique<PrepareCommissioningCommand>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/darwin-framework-tool/commands/pairing/PrepareCommissioningCommand.h
+++ b/examples/darwin-framework-tool/commands/pairing/PrepareCommissioningCommand.h
@@ -1,0 +1,53 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#import <Matter/Matter.h>
+
+#include "../common/CHIPCommandBridge.h"
+
+#import "MTRError_Utils.h"
+
+class PrepareCommissioningCommand : public CHIPCommandBridge {
+public:
+    PrepareCommissioningCommand()
+        : CHIPCommandBridge("prepare-commissioning")
+    {
+    }
+
+protected:
+    /////////// CHIPCommandBridge Interface /////////
+    CHIP_ERROR RunCommand() override
+    {
+        auto * controller = CurrentCommissioner();
+        NSError * error;
+        if (![controller prepareCommissioningSession:&error]) {
+            auto err = MTRErrorToCHIPErrorCode(error);
+            SetCommandExitStatus(err);
+            return err;
+        }
+
+        // In interactive mode, we don't want to block the UI until the end of `GetWaitDuration`. So returns early.
+        if (IsInteractive()) {
+            SetCommandExitStatus(CHIP_NO_ERROR);
+        }
+        return CHIP_NO_ERROR;
+    }
+
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(30); }
+};

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -103,6 +103,16 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
                                                         error:(NSError * __autoreleasing *)error MTR_NEWLY_AVAILABLE;
 
 /**
+ * Prepare the controller for setting up a commissioning session.
+ *
+ * This method is intended to be used when it is known that a setting up a commissioning session
+ * will happen soon.
+ * For example it may ask different subsystems to look for useful informations onto the network
+ * ahead of commissioning that may then be re-used during commissioning.
+ */
+- (BOOL)prepareCommissioningSession:(NSError * __autoreleasing *)error MTR_NEWLY_AVAILABLE;
+
+/**
  * Controllers are created via the MTRDeviceControllerFactory object.
  */
 - (instancetype)init NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -64,6 +64,7 @@ static NSString * const kErrorPartialDacVerifierInit = @"Init failure while crea
 static NSString * const kErrorPairDevice = @"Failure while pairing the device";
 static NSString * const kErrorUnpairDevice = @"Failure while unpairing the device";
 static NSString * const kErrorStopPairing = @"Failure while trying to stop the pairing process";
+static NSString * const kErrorPrepareCommissioning = @"Failure while trying to prepare the commissioning process";
 static NSString * const kErrorOpenPairingWindow = @"Open Pairing Window failed";
 static NSString * const kErrorGetPairedDevice = @"Failure while trying to retrieve a paired device";
 static NSString * const kErrorNotRunning = @"Controller is not running. Call startup first.";
@@ -485,6 +486,19 @@ static NSString * const kErrorSpake2pVerifierSerializationFailed = @"PASE verifi
         auto errorCode = self.cppCommissioner->StopPairing([nodeID unsignedLongLongValue]);
         success = ![MTRDeviceController checkForError:errorCode logMsg:kErrorStopPairing error:error];
     });
+    return success;
+}
+
+- (BOOL)prepareCommissioningSession:(NSError * __autoreleasing *)error
+{
+    __block BOOL success = NO;
+    dispatch_sync(_chipWorkQueue, ^{
+        VerifyOrReturn([self checkIsRunning:error]);
+
+        auto errorCode = chip::DeviceLayer::PlatformMgrImpl().PrepareCommissioning();
+        success = ![MTRDeviceController checkForError:errorCode logMsg:kErrorPrepareCommissioning error:error];
+    });
+
     return success;
 }
 

--- a/src/platform/Darwin/BLEManagerImpl.cpp
+++ b/src/platform/Darwin/BLEManagerImpl.cpp
@@ -88,6 +88,16 @@ void BLEManagerImpl::_Shutdown()
     }
 }
 
+CHIP_ERROR BLEManagerImpl::PrepareConnection()
+{
+    if (mConnectionDelegate)
+    {
+        static_cast<BleConnectionDelegateImpl *>(mConnectionDelegate)->PrepareConnection();
+        return CHIP_NO_ERROR;
+    }
+    return CHIP_ERROR_INCORRECT_STATE;
+}
+
 bool BLEManagerImpl::_IsAdvertisingEnabled()
 {
     ChipLogDetail(DeviceLayer, "%s", __FUNCTION__);

--- a/src/platform/Darwin/BLEManagerImpl.h
+++ b/src/platform/Darwin/BLEManagerImpl.h
@@ -42,6 +42,7 @@ class BLEManagerImpl final : public BLEManager, private BleLayer
 
 public:
     CHIP_ERROR ConfigureBle(uint32_t aNodeId, bool aIsCentral) { return CHIP_NO_ERROR; }
+    CHIP_ERROR PrepareConnection();
 
 private:
     // ===== Members that implement the BLEManager internal interface.

--- a/src/platform/Darwin/BleConnectionDelegate.h
+++ b/src/platform/Darwin/BleConnectionDelegate.h
@@ -26,6 +26,7 @@ namespace Internal {
 class BleConnectionDelegateImpl : public Ble::BleConnectionDelegate
 {
 public:
+    void PrepareConnection();
     virtual void NewConnection(Ble::BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator);
     virtual CHIP_ERROR CancelConnection();
 };

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -161,5 +161,14 @@ bool PlatformManagerImpl::_IsChipStackLockedByCurrentThread() const
 };
 #endif
 
+CHIP_ERROR PlatformManagerImpl::PrepareCommissioning()
+{
+    auto error = CHIP_NO_ERROR;
+#if CONFIG_NETWORK_LAYER_BLE
+    error = Internal::BLEMgrImpl().PrepareConnection();
+#endif // CONFIG_NETWORK_LAYER_BLE
+    return error;
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -54,6 +54,8 @@ public:
         return mWorkQueue;
     }
 
+    CHIP_ERROR PrepareCommissioning();
+
     System::Clock::Timestamp GetStartTime() { return mStartTime; }
 
 private:


### PR DESCRIPTION
#### Problem

This PR add a command to darwin to launch some internal task in advance when we know a commissioning session will happens.
Here it specifically bootstrap the ble stack to scan for devices.