### PR TITLE
[silabs] wi-fi provisioning for efr32 in build command

### DIFF
--- a/examples/light-switch-app/silabs/efr32/BUILD.gn
+++ b/examples/light-switch-app/silabs/efr32/BUILD.gn
@@ -63,6 +63,12 @@ declare_args() {
 
   # Argument to force enable WPA3 security
   rs91x_wpa3_only = false
+
+  #default WiFi SSID
+  chip_default_wifi_ssid = ""
+
+  #default Wifi Password
+  chip_default_wifi_psk = ""
 }
 
 declare_args() {
@@ -90,8 +96,21 @@ if (silabs_board == "BRD4166A" || silabs_board == "BRD2601B" ||
   disable_lcd = true
 }
 
+defines = []
+
 # WiFi settings
 if (chip_enable_wifi) {
+  if (chip_default_wifi_ssid != "") {
+    defines += [
+      "CHIP_ONNETWORK_PAIRING=1",
+      "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
+    ]
+  }
+  if (chip_default_wifi_psk != "") {
+    assert(chip_default_wifi_ssid != "",
+           "ssid can't be null if psk is provided")
+    defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
+  }
   wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
   efr32_lwip_defs = [ "LWIP_NETIF_API=1" ]
   if (lwip_ipv4) {
@@ -140,7 +159,7 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
-  defines = [
+  defines += [
     "BOARD_ID=${silabs_board}",
     "OTA_PERIODIC_TIMEOUT=${OTA_periodic_query_timeout}",
   ]

--- a/examples/lighting-app/silabs/efr32/BUILD.gn
+++ b/examples/lighting-app/silabs/efr32/BUILD.gn
@@ -63,6 +63,12 @@ declare_args() {
 
   # Argument to force enable WPA3 security on rs91x
   rs91x_wpa3_only = false
+
+  #default WiFi SSID
+  chip_default_wifi_ssid = ""
+
+  #default Wifi Password
+  chip_default_wifi_psk = ""
 }
 
 declare_args() {
@@ -90,12 +96,25 @@ if (silabs_board == "BRD4166A" || silabs_board == "BRD2601B" ||
   disable_lcd = true
 }
 
+defines = []
+
 # WiFi settings
 if (chip_enable_wifi) {
   # disabling LCD for MG24 for wifi
   if (silabs_board == "BRD4186A" || silabs_board == "BRD4187A") {
     show_qr_code = false
     disable_lcd = true
+  }
+  if (chip_default_wifi_ssid != "") {
+    defines += [
+      "CHIP_ONNETWORK_PAIRING=1",
+      "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
+    ]
+  }
+  if (chip_default_wifi_psk != "") {
+    assert(chip_default_wifi_ssid != "",
+           "ssid can't be null if psk is provided")
+    defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
   }
   wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
   efr32_lwip_defs = [ "LWIP_NETIF_API=1" ]
@@ -145,7 +164,7 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
-  defines = [
+  defines += [
     "BOARD_ID=${silabs_board}",
     "OTA_PERIODIC_TIMEOUT=${OTA_periodic_query_timeout}",
   ]

--- a/examples/lock-app/silabs/efr32/BUILD.gn
+++ b/examples/lock-app/silabs/efr32/BUILD.gn
@@ -63,6 +63,12 @@ declare_args() {
 
   # Argument to force enable WPA3 security
   rs91x_wpa3_only = false
+
+  #default WiFi SSID
+  chip_default_wifi_ssid = ""
+
+  #default Wifi Password
+  chip_default_wifi_psk = ""
 }
 
 declare_args() {
@@ -90,8 +96,21 @@ if (silabs_board == "BRD4166A" || silabs_board == "BRD2601B" ||
   disable_lcd = true
 }
 
+defines = []
+
 # WiFi settings
 if (chip_enable_wifi) {
+  if (chip_default_wifi_ssid != "") {
+    defines += [
+      "CHIP_ONNETWORK_PAIRING=1",
+      "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
+    ]
+  }
+  if (chip_default_wifi_psk != "") {
+    assert(chip_default_wifi_ssid != "",
+           "ssid can't be null if psk is provided")
+    defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
+  }
   wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
   efr32_lwip_defs = [ "LWIP_NETIF_API=1" ]
   if (lwip_ipv4) {
@@ -140,7 +159,7 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
-  defines = [
+  defines += [
     "BOARD_ID=${silabs_board}",
     "OTA_PERIODIC_TIMEOUT=${OTA_periodic_query_timeout}",
   ]

--- a/examples/thermostat/efr32/BUILD.gn
+++ b/examples/thermostat/efr32/BUILD.gn
@@ -61,6 +61,12 @@ declare_args() {
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
 
+  #default WiFi SSID
+  chip_default_wifi_ssid = ""
+
+  #default Wifi Password
+  chip_default_wifi_psk = ""
+
   # Enable the temperature sensor
   # Some boards do not have a temperature sensor
   use_temp_sensor = silabs_board != "BRD2703A" && silabs_board != "BRD4319A"
@@ -91,8 +97,21 @@ if (silabs_board == "BRD4166A" || silabs_board == "BRD2601B" ||
   disable_lcd = true
 }
 
+defines = []
+
 # WiFi settings
 if (chip_enable_wifi) {
+  if (chip_default_wifi_ssid != "") {
+    defines += [
+      "CHIP_ONNETWORK_PAIRING=1",
+      "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
+    ]
+  }
+  if (chip_default_wifi_psk != "") {
+    assert(chip_default_wifi_ssid != "",
+           "ssid can't be null if psk is provided")
+    defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
+  }
   wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
   efr32_lwip_defs = [ "LWIP_NETIF_API=1" ]
   if (lwip_ipv4) {
@@ -141,7 +160,7 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
-  defines = [
+  defines += [
     "BOARD_ID=${silabs_board}",
     "OTA_PERIODIC_TIMEOUT=${OTA_periodic_query_timeout}",
   ]

--- a/examples/window-app/silabs/efr32/BUILD.gn
+++ b/examples/window-app/silabs/efr32/BUILD.gn
@@ -57,6 +57,12 @@ declare_args() {
 
   # Argument to force enable WPA3 security
   rs91x_wpa3_only = false
+
+  #default WiFi SSID
+  chip_default_wifi_ssid = ""
+
+  #default Wifi Password
+  chip_default_wifi_psk = ""
 }
 
 declare_args() {
@@ -84,12 +90,25 @@ if (silabs_board == "BRD4166A" || silabs_board == "BRD2601B" ||
   disable_lcd = true
 }
 
+defines = []
+
 # WiFi settings
 if (chip_enable_wifi) {
   # disabling LCD for MG24 for wifi
   if (silabs_board == "BRD4186C" || silabs_board == "BRD4187C") {
     show_qr_code = false
     disable_lcd = true
+  }
+  if (chip_default_wifi_ssid != "") {
+    defines += [
+      "CHIP_ONNETWORK_PAIRING=1",
+      "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
+    ]
+  }
+  if (chip_default_wifi_psk != "") {
+    assert(chip_default_wifi_ssid != "",
+           "ssid can't be null if psk is provided")
+    defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
   }
   wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
   efr32_lwip_defs = [ "LWIP_NETIF_API=1" ]
@@ -139,7 +158,7 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
-  defines = [
+  defines += [
     "BOARD_ID=${silabs_board}",
     "OTA_PERIODIC_TIMEOUT=${OTA_periodic_query_timeout}",
   ]

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -43,6 +43,16 @@ CHIP_ERROR SlWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChangeC
     mpScanCallback        = nullptr;
     mpConnectCallback     = nullptr;
 
+#ifdef CHIP_ONNETWORK_PAIRING
+    memcpy(&mSavedNetwork.ssid[0], CHIP_WIFI_SSID, sizeof(CHIP_WIFI_SSID));
+    memcpy(&mSavedNetwork.credentials[0], CHIP_WIFI_PSK, sizeof(CHIP_WIFI_PSK));
+    credentialsLen               = sizeof(CHIP_WIFI_PSK);
+    ssidLen                      = sizeof(CHIP_WIFI_SSID);
+    mSavedNetwork.credentialsLen = credentialsLen;
+    mSavedNetwork.ssidLen        = ssidLen;
+    mStagingNetwork              = mSavedNetwork;
+    err                          = CHIP_NO_ERROR;
+#else
     // If reading fails, wifi is not provisioned, no need to go further.
     err = SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_WiFiSSID, mSavedNetwork.ssid, sizeof(mSavedNetwork.ssid),
                                            ssidLen);
@@ -55,7 +65,7 @@ CHIP_ERROR SlWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChangeC
     mSavedNetwork.credentialsLen = credentialsLen;
     mSavedNetwork.ssidLen        = ssidLen;
     mStagingNetwork              = mSavedNetwork;
-
+#endif
     ConnectWiFiNetwork(mSavedNetwork.ssid, ssidLen, mSavedNetwork.credentials, credentialsLen);
     return err;
 }


### PR DESCRIPTION
What is being Added?

Fix to provide the Wi-Fi credentials (ssid, psk) in build command.

Testing:

- Manually tested sanity (commissioning, unicast, multicast, OTA, multiadmin)on below apps for all combos successfully,

MG12/MG24+RS9116(lighting, lock, light-switch, window, thermostat)
MG12/MG24+WF200 (lighting, lock, light-switch, window, thermostat)

- Build below apps for all combos successfully,

MG12/MG24+RS9116(lighting, lock, light-switch, window, thermostat)
MG12/MG24+WF200 (lighting, lock, light-switch, window, thermostat)