### PR TITLE
[OIS] Temporarily disable integration tests

### DIFF
--- a/.github/workflows/examples-openiotsdk.yaml
+++ b/.github/workflows/examples-openiotsdk.yaml
@@ -94,13 +94,15 @@ jobs:
                   scripts/examples/openiotsdk_example.sh unit-tests
 
             - name: Test shell example
-              if: steps.build_shell.outcome == 'success'
+              # Temporarily disable test due to performance issue with FVP
+              if: false #steps.build_shell.outcome == 'success'
               timeout-minutes: 5
               run: |
                   scripts/examples/openiotsdk_example.sh -C test shell
 
             - name: Test lock-app example
-              if: steps.build_lock_app.outcome == 'success'
+              # Temporarily disable test due to performance issue with FVP
+              if: false #steps.build_lock_app.outcome == 'success'
               timeout-minutes: 5
               run: |
                   scripts/setup/openiotsdk/network_setup.sh -n $TEST_NETWORK_NAME up
@@ -108,7 +110,8 @@ jobs:
                   scripts/setup/openiotsdk/network_setup.sh -n $TEST_NETWORK_NAME down
             
             - name: Run unit tests
-              if: steps.build_unit_tests.outcome == 'success' && github.event_name == 'pull_request'
+              # Temporarily disable test due to performance issue with FVP
+              if: false #steps.build_unit_tests.outcome == 'success' && github.event_name == 'pull_request'
               timeout-minutes: 90
               run: |
                   scripts/examples/openiotsdk_example.sh -C run unit-tests


### PR DESCRIPTION
Temporarily disable integration tests due to performance issues with FVP.
We're currently working on improvement in this area.

