### PR TITLE
Remove bugprone-assignment-in-if-condition clang tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: >
   readability-redundant-control-flow,
   readability-redundant-string-cstr,
   readability-redundant-string-init,
+  -bugprone-assignment-in-if-condition,  
   -bugprone-branch-clone,
   -bugprone-copy-constructor-init,
   -bugprone-easily-swappable-parameters,


### PR DESCRIPTION
It seems in the pigweed update in #24022 shows that `assignment in if` is a very common pattern in CHIP due to the `SuccessOrExit` macro.

https://github.com/project-chip/connectedhomeip/actions/runs/3673811014/jobs/6211326972

```
INFO    TIDY ../../src/app/util/ember-compatibility-functions.cpp: /__w/connectedhomeip/connectedhomeip/out/sanitizers/../../src/app/util/ember-compatibility-functions.cpp:1057:10: error: an assignment within an 'if' condition is bug-prone [bugprone-assignment-in-if-condition,-warnings-as-errors]
    if ((preparationError = prepareWriteData(attributeMetadata, aReader, dataLen)) != CHIP_NO_ERROR)
         ^
/__w/connectedhomeip/connectedhomeip/out/sanitizers/../../src/app/util/ember-compatibility-functions.cpp:1057:10: note: if it should be an assignment, move it out of the 'if' condition
/__w/connectedhomeip/connectedhomeip/out/sanitizers/../../src/app/util/ember-compatibility-functions.cpp:1057:10: note: if it is meant to be an equality check, change '=' to '=='

WARNING TIDY ../../src/app/util/ember-compatibility-functions.cpp: 1 warning treated as error
WARNING Tidy ../../src/app/util/ember-compatibility-functions.cpp ended with code 1
ERROR   Failed to process /__w/connectedhomeip/connectedhomeip/src/app/util/ember-compatibility-functions.cpp
INFO    TIDY ../../src/app/clusters/access-control-server/access-control-server.cpp: /__w/connectedhomeip/connectedhomeip/out/sanitizers/../../src/app/clusters/access-control-server/access-control-server.cpp:418:23: error: an assignment within an 'if' condition is bug-prone [bugprone-assignment-in-if-condition,-warnings-as-errors]
        SuccessOrExit(err = encodableEntry.Stage());
                      ^
/__w/connectedhomeip/connectedhomeip/out/sanitizers/../../src/app/clusters/access-control-server/access-control-server.cpp:418:23: note: if it should be an assignment, move it out of the 'if' condition
/__w/connectedhomeip/connectedhomeip/out/sanitizers/../../src/app/clusters/access-control-server/access-control-server.cpp:418:23: note: if it is meant to be an equality check, change '=' to '=='
/__w/connectedhomeip/connectedhomeip/out/sanitizers/../../src/app/clusters/access-control-server/access-control-server.cpp:420:23: error: an assignment within an 'if' condition is bug-prone [bugprone-assignment-in-if-condition,-warnings-as-errors]
        SuccessOrExit(err = LogEvent(event, 0, eventNumber));
        ....
```