### PR TITLE
Fix if condition/wrong member used

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1162,7 +1162,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
                     averageRssi.SetNonNull(neighInfo.mAverageRssi);
                 }
 
-                if (neighInfo.mAverageRssi == OT_RADIO_RSSI_INVALID)
+                if (neighInfo.mLastRssi == OT_RADIO_RSSI_INVALID)
                 {
                     lastRssi.SetNull();
                 }


### PR DESCRIPTION
In my PR last week #23914 a copy/paste error slipped through. `mAverageRssi` is used from the previous if condition when it should be `mLastRssi`. This pr fix my mistake
