### PR TITLE
[ESP32] Add matter shell support for USB Serial JTAG

### DIFF
--- a/examples/platform/esp32/shell_extension/launch.cpp
+++ b/examples/platform/esp32/shell_extension/launch.cpp
@@ -41,7 +41,12 @@ void LaunchShell()
 #if CONFIG_HEAP_TRACING_STANDALONE || CONFIG_HEAP_TASK_TRACKING
     idf::chip::RegisterHeapTraceCommands();
 #endif // CONFIG_HEAP_TRACING_STANDALONE || CONFIG_HEAP_TASK_TRACKING
+#if CONFIG_ESP_CONSOLE_UART_DEFAULT
     xTaskCreate(&MatterShellTask, "chip_cli", 2048, NULL, 5, NULL);
+#elif CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+    // Increase task stack size when using usb serial jtag
+    xTaskCreate(&MatterShellTask, "chip_cli", 2560, NULL, 5, NULL);
+#endif
 }
 
 } // namespace chip

--- a/src/lib/shell/streamer_esp32.cpp
+++ b/src/lib/shell/streamer_esp32.cpp
@@ -18,7 +18,6 @@
 #include <lib/shell/Engine.h>
 #include <lib/shell/streamer.h>
 
-#include "driver/uart.h"
 #include "esp_console.h"
 #include "esp_vfs_dev.h"
 #include "linenoise/linenoise.h"
@@ -26,6 +25,13 @@
 #include <lib/core/CHIPError.h>
 #include <stdio.h>
 #include <string.h>
+#if CONFIG_ESP_CONSOLE_UART_DEFAULT
+#include "driver/uart.h"
+#endif
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#include "driver/usb_serial_jtag.h"
+#include "esp_vfs_usb_serial_jtag.h"
+#endif
 
 namespace chip {
 namespace Shell {
@@ -49,6 +55,7 @@ int streamer_esp32_init(streamer_t * streamer)
     fflush(stdout);
     fsync(fileno(stdout));
     setvbuf(stdin, NULL, _IONBF, 0);
+#if CONFIG_ESP_CONSOLE_UART_DEFAULT
     esp_vfs_dev_uart_port_set_rx_line_endings(CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CR);
     esp_vfs_dev_uart_port_set_tx_line_endings(CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CRLF);
     if (!uart_is_driver_installed(CONFIG_ESP_CONSOLE_UART_NUM))
@@ -70,6 +77,23 @@ int streamer_esp32_init(streamer_t * streamer)
     };
     ESP_ERROR_CHECK(uart_param_config(CONFIG_ESP_CONSOLE_UART_NUM, &uart_config));
     esp_vfs_dev_uart_use_driver(0);
+#endif // CONFIG_ESP_CONSOLE_UART_DEFAULT
+
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+    esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
+    esp_vfs_dev_usb_serial_jtag_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
+
+    fcntl(fileno(stdout), F_SETFL, O_NONBLOCK);
+    fcntl(fileno(stdin), F_SETFL, O_NONBLOCK);
+
+    usb_serial_jtag_driver_config_t usb_serial_jtag_config = {
+        .tx_buffer_size = 256,
+        .rx_buffer_size = 256,
+    };
+    usb_serial_jtag_driver_install(&usb_serial_jtag_config);
+    esp_vfs_usb_serial_jtag_use_driver();
+    esp_vfs_dev_uart_register();
+#endif // CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
     esp_console_config_t console_config = {
         .max_cmdline_length = 256,
         .max_cmdline_args   = 32,
@@ -97,7 +121,12 @@ ssize_t streamer_esp32_read(streamer_t * streamer, char * buf, size_t len)
 
 ssize_t streamer_esp32_write(streamer_t * streamer, const char * buf, size_t len)
 {
+#if CONFIG_ESP_CONSOLE_UART_DEFAULT
     return uart_write_bytes(CONFIG_ESP_CONSOLE_UART_NUM, buf, len);
+#endif
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+    return usb_serial_jtag_write_bytes(buf, len, 0);
+#endif
 }
 
 static streamer_t streamer_stdio = {


### PR DESCRIPTION
### Problem
The matter shell cannot work on USB Serial JTAG console for ESP32 platform.

### Solution
Add the initializing of USB JTAG when the USB Serial JTAG console is selected. And increase the shell task stack size for it.

