### PR TITLE
[SetuopCodePairer] Add a comment to explain why device discovered ove…

### DIFF
--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -272,6 +272,12 @@ void SetUpCodePairer::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj)
 
     mWaitingForDiscovery[kBLETransport] = false;
 
+    // In order to not wait for all the possible addresses discovered over mdns to
+    // be tried before trying to connect over BLE, the discovered connection object is
+    // inserted at the beginning of the list.
+    //
+    // It makes it the 'next' thing to try to connect to if there are already some
+    // discovered parameters in the list.
     mDiscoveredParameters.emplace_front(connObj);
     ConnectToDiscoveredDevice();
 }


### PR DESCRIPTION
…r BLE are using emplace_front and not emplace_back

#### Problem

The fact that ble discovered device in `SetupCodePairer.cpp` uses `emplace_front` and not `emplace_back` can be confusing and makes people things it is a bug. This PR just add a comment above to make it clearer that it is expected.

