### PR TITLE
[ICD] Client-side device communication notification plumbing

### DIFF
--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -108,9 +108,9 @@ private:
         return mCallback.GetHighestReceivedEventNumber(aEventNumber);
     }
 
-    void OnUnsolicitedCommunication(ReadClient * apReadClient) override
+    void OnUnsolicitedMessageFromPublisher(ReadClient * apReadClient) override
     {
-        return mCallback.OnUnsolicitedCommunication(apReadClient);
+        return mCallback.OnUnsolicitedMessageFromPublisher(apReadClient);
     }
 
     /*

--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -107,6 +107,12 @@ private:
     {
         return mCallback.GetHighestReceivedEventNumber(aEventNumber);
     }
+
+    void OnUnsolicitedCommunication(ReadClient * apReadClient) override
+    {
+        return mCallback.OnUnsolicitedCommunication(apReadClient);
+    }
+
     /*
      * Given a reader positioned at a list element, allocate a packet buffer, copy the list item where
      * the reader is positioned into that buffer and add it to our buffered list for tracking.

--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -596,9 +596,9 @@ private:
                                                      const Span<AttributePathParams> & aAttributePaths,
                                                      bool & aEncodedDataVersionList) override;
 
-    void OnUnsolicitedCommunication(ReadClient * apReadClient) override
+    void OnUnsolicitedMessageFromPublisher(ReadClient * apReadClient) override
     {
-        return mCallback.OnUnsolicitedCommunication(apReadClient);
+        return mCallback.OnUnsolicitedMessageFromPublisher(apReadClient);
     }
 
     // Commit the pending cluster data version, if there is one.

--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -596,6 +596,11 @@ private:
                                                      const Span<AttributePathParams> & aAttributePaths,
                                                      bool & aEncodedDataVersionList) override;
 
+    void OnUnsolicitedCommunication(ReadClient * apReadClient) override
+    {
+        return mCallback.OnUnsolicitedCommunication(apReadClient);
+    }
+
     // Commit the pending cluster data version, if there is one.
     void CommitPendingDataVersion();
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -633,11 +633,6 @@ Status InteractionModelEngine::OnUnsolicitedReportData(Messaging::ExchangeContex
     ReadClient * foundSubscription = nullptr;
     for (auto * readClient = mpActiveReadClientList; readClient != nullptr; readClient = readClient->GetNextClient())
     {
-        if (!readClient->IsSubscriptionActive())
-        {
-            continue;
-        }
-
         auto peer = apExchangeContext->GetSessionHandle()->GetPeer();
         if (readClient->GetFabricIndex() != peer.GetFabricIndex() || readClient->GetPeerNodeId() != peer.GetNodeId())
         {
@@ -646,6 +641,11 @@ Status InteractionModelEngine::OnUnsolicitedReportData(Messaging::ExchangeContex
 
         // Notify Subscriptions about incoming communication from node
         readClient->OnUnsolicitedMessageFromPublisher();
+
+        if (!readClient->IsSubscriptionActive())
+        {
+            continue;
+        }
 
         if (!readClient->IsMatchingSubscriptionId(subscriptionId))
         {

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -645,7 +645,7 @@ Status InteractionModelEngine::OnUnsolicitedReportData(Messaging::ExchangeContex
         }
 
         // Notify Subscriptions about incoming communication from node
-        readClient->OnUnsolicitedCommunication();
+        readClient->OnUnsolicitedMessageFromPublisher();
 
         if (!readClient->IsMatchingSubscriptionId(subscriptionId))
         {

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -236,9 +236,9 @@ public:
         }
 
         /**
-         * OnUnsolicitedCommunication will be called for a subscription ReadClient
-         * when any incoming communication happens with a matching node on
-         * the fabric.
+         * OnUnsolicitedMessageFromPublisher will be called for a subscription
+         * ReadClient when any incoming message is received from a matching
+         * node on the fabric.
          *
          * This callback will be called:
          *   - When receiving any unsolicited communication from the node
@@ -246,7 +246,7 @@ public:
          *
          * @param[in] apReadClient the ReadClient for the subscription.
          */
-        virtual void OnUnsolicitedCommunication(ReadClient * apReadClient)
+        virtual void OnUnsolicitedMessageFromPublisher(ReadClient * apReadClient)
         {
             ChipLogDetail(DataManagement, "%s ReadClient[%p]", __func__, this);
         }
@@ -304,7 +304,7 @@ public:
 
     void OnUnsolicitedReportData(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle && aPayload);
 
-    void OnUnsolicitedCommunication() { mpCallback.OnUnsolicitedCommunication(this); }
+    void OnUnsolicitedMessageFromPublisher() { mpCallback.OnUnsolicitedMessageFromPublisher(this); }
 
     auto GetSubscriptionId() const
     {

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -234,6 +234,22 @@ public:
             aEventNumber.ClearValue();
             return CHIP_NO_ERROR;
         }
+
+        /**
+         * OnUnsolicitedCommunication will be called for a subscription ReadClient
+         * when any incoming communication happens with a matching node on
+         * the fabric.
+         *
+         * This callback will be called:
+         *   - When receiving any unsolicited communication from the node
+         *   - Even for disconnected subscriptions.
+         *
+         * @param[in] apReadClient the ReadClient for the subscription.
+         */
+        virtual void OnUnsolicitedCommunication(ReadClient * apReadClient)
+        {
+            ChipLogDetail(DataManagement, "%s ReadClient[%p]", __func__, this);
+        }
     };
 
     enum class InteractionType : uint8_t
@@ -287,6 +303,8 @@ public:
     CHIP_ERROR SendRequest(ReadPrepareParams & aReadPrepareParams);
 
     void OnUnsolicitedReportData(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle && aPayload);
+
+    void OnUnsolicitedCommunication() { mpCallback.OnUnsolicitedCommunication(this); }
 
     auto GetSubscriptionId() const
     {

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
@@ -55,14 +55,14 @@ typedef void (^DataReportCallback)(NSArray * value);
 typedef void (^ErrorCallback)(NSError * error);
 typedef void (^SubscriptionEstablishedHandler)(void);
 typedef void (^OnDoneHandler)(void);
-typedef void (^UnsolicitedCommunicationHandler)(void);
+typedef void (^UnsolicitedMessageFromPublisherHandler)(void);
 
 class MTRBaseSubscriptionCallback : public chip::app::ClusterStateCache::Callback {
 public:
     MTRBaseSubscriptionCallback(DataReportCallback attributeReportCallback, DataReportCallback eventReportCallback,
         ErrorCallback errorCallback, MTRDeviceResubscriptionScheduledHandler _Nullable resubscriptionCallback,
         SubscriptionEstablishedHandler _Nullable subscriptionEstablishedHandler, OnDoneHandler _Nullable onDoneHandler,
-        UnsolicitedCommunicationHandler _Nullable unsolicitedCommunicationHandler = NULL)
+        UnsolicitedMessageFromPublisherHandler _Nullable unsolicitedMessageFromPublisherHandler = NULL)
         : mAttributeReportCallback(attributeReportCallback)
         , mEventReportCallback(eventReportCallback)
         , mErrorCallback(errorCallback)
@@ -70,7 +70,7 @@ public:
         , mSubscriptionEstablishedHandler(subscriptionEstablishedHandler)
         , mBufferedReadAdapter(*this)
         , mOnDoneHandler(onDoneHandler)
-        , mUnsolicitedCommunicationHandler(unsolicitedCommunicationHandler)
+        , mUnsolicitedMessageFromPublisherHandler(unsolicitedMessageFromPublisherHandler)
     {
     }
 
@@ -120,7 +120,7 @@ private:
 
     CHIP_ERROR OnResubscriptionNeeded(chip::app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override;
 
-    void OnUnsolicitedCommunication(chip::app::ReadClient * apReadClient) override;
+    void OnUnsolicitedMessageFromPublisher(chip::app::ReadClient * apReadClient) override;
 
     void ReportData();
 
@@ -136,7 +136,7 @@ private:
     ErrorCallback _Nullable mErrorCallback = nil;
     MTRDeviceResubscriptionScheduledHandler _Nullable mResubscriptionCallback = nil;
     SubscriptionEstablishedHandler _Nullable mSubscriptionEstablishedHandler = nil;
-    UnsolicitedCommunicationHandler _Nullable mUnsolicitedCommunicationHandler = nil;
+    UnsolicitedMessageFromPublisherHandler _Nullable mUnsolicitedMessageFromPublisherHandler = nil;
     chip::app::BufferedReadCallback mBufferedReadAdapter;
 
     // Our lifetime management is a little complicated.  On errors that don't

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
@@ -55,12 +55,14 @@ typedef void (^DataReportCallback)(NSArray * value);
 typedef void (^ErrorCallback)(NSError * error);
 typedef void (^SubscriptionEstablishedHandler)(void);
 typedef void (^OnDoneHandler)(void);
+typedef void (^UnsolicitedCommunicationHandler)(void);
 
 class MTRBaseSubscriptionCallback : public chip::app::ClusterStateCache::Callback {
 public:
     MTRBaseSubscriptionCallback(DataReportCallback attributeReportCallback, DataReportCallback eventReportCallback,
         ErrorCallback errorCallback, MTRDeviceResubscriptionScheduledHandler _Nullable resubscriptionCallback,
-        SubscriptionEstablishedHandler _Nullable subscriptionEstablishedHandler, OnDoneHandler _Nullable onDoneHandler)
+        SubscriptionEstablishedHandler _Nullable subscriptionEstablishedHandler, OnDoneHandler _Nullable onDoneHandler,
+        UnsolicitedCommunicationHandler _Nullable unsolicitedCommunicationHandler = NULL)
         : mAttributeReportCallback(attributeReportCallback)
         , mEventReportCallback(eventReportCallback)
         , mErrorCallback(errorCallback)
@@ -68,6 +70,7 @@ public:
         , mSubscriptionEstablishedHandler(subscriptionEstablishedHandler)
         , mBufferedReadAdapter(*this)
         , mOnDoneHandler(onDoneHandler)
+        , mUnsolicitedCommunicationHandler(unsolicitedCommunicationHandler)
     {
     }
 
@@ -117,6 +120,8 @@ private:
 
     CHIP_ERROR OnResubscriptionNeeded(chip::app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override;
 
+    void OnUnsolicitedCommunication(chip::app::ReadClient * apReadClient) override;
+
     void ReportData();
 
 protected:
@@ -131,6 +136,7 @@ private:
     ErrorCallback _Nullable mErrorCallback = nil;
     MTRDeviceResubscriptionScheduledHandler _Nullable mResubscriptionCallback = nil;
     SubscriptionEstablishedHandler _Nullable mSubscriptionEstablishedHandler = nil;
+    UnsolicitedCommunicationHandler _Nullable mUnsolicitedCommunicationHandler = nil;
     chip::app::BufferedReadCallback mBufferedReadAdapter;
 
     // Our lifetime management is a little complicated.  On errors that don't

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
@@ -16,6 +16,7 @@
 
 #import "MTRBaseSubscriptionCallback.h"
 #import "MTRError_Internal.h"
+#import "MTRLogging_Internal.h"
 
 #include <platform/PlatformManager.h>
 
@@ -109,6 +110,14 @@ CHIP_ERROR MTRBaseSubscriptionCallback::OnResubscriptionNeeded(ReadClient * apRe
         callback(error, delayMs);
     }
     return CHIP_NO_ERROR;
+}
+
+void MTRBaseSubscriptionCallback::OnUnsolicitedCommunication(ReadClient *)
+{
+    if (mUnsolicitedCommunicationHandler) {
+        auto unsolicitedCommunicationHandler = mUnsolicitedCommunicationHandler;
+        unsolicitedCommunicationHandler();
+    }
 }
 
 void MTRBaseSubscriptionCallback::ReportError(CHIP_ERROR aError, bool aCancelSubscription)

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
@@ -112,11 +112,11 @@ CHIP_ERROR MTRBaseSubscriptionCallback::OnResubscriptionNeeded(ReadClient * apRe
     return CHIP_NO_ERROR;
 }
 
-void MTRBaseSubscriptionCallback::OnUnsolicitedCommunication(ReadClient *)
+void MTRBaseSubscriptionCallback::OnUnsolicitedMessageFromPublisher(ReadClient *)
 {
-    if (mUnsolicitedCommunicationHandler) {
-        auto unsolicitedCommunicationHandler = mUnsolicitedCommunicationHandler;
-        unsolicitedCommunicationHandler();
+    if (mUnsolicitedMessageFromPublisherHandler) {
+        auto unsolicitedMessageFromPublisherHandler = mUnsolicitedMessageFromPublisherHandler;
+        unsolicitedMessageFromPublisherHandler();
     }
 }
 

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -199,7 +199,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceState) {
  *
  * Notifies delegate the device is currently communicating
  */
-- (void)deviceStartedCommunicating:(MTRDevice *)device;
+- (void)didReceiveCommunicationFromDevice:(MTRDevice *)device;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -193,6 +193,14 @@ typedef NS_ENUM(NSUInteger, MTRDeviceState) {
  */
 - (void)device:(MTRDevice *)device receivedEventReport:(NSArray<NSDictionary<NSString *, id> *> *)eventReport;
 
+@optional
+/**
+ * deviceIsCommunicating:
+ *
+ * Notifies delegate the device is currently communicating
+ */
+- (void)deviceIsCommunicating:(MTRDevice *)device;
+
 @end
 
 @interface MTRDevice (Deprecated)

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -195,11 +195,11 @@ typedef NS_ENUM(NSUInteger, MTRDeviceState) {
 
 @optional
 /**
- * deviceIsCommunicating:
+ * deviceStartedCommunicating:
  *
  * Notifies delegate the device is currently communicating
  */
-- (void)deviceIsCommunicating:(MTRDevice *)device;
+- (void)deviceStartedCommunicating:(MTRDevice *)device;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -114,9 +114,9 @@ public:
     SubscriptionCallback(DataReportCallback attributeReportCallback, DataReportCallback eventReportCallback,
         ErrorCallback errorCallback, MTRDeviceResubscriptionScheduledHandler resubscriptionCallback,
         SubscriptionEstablishedHandler subscriptionEstablishedHandler, OnDoneHandler onDoneHandler,
-        UnsolicitedCommunicationHandler unsolicitedCommunicationHandler)
+        UnsolicitedMessageFromPublisherHandler unsolicitedMessageFromPublisherHandler)
         : MTRBaseSubscriptionCallback(attributeReportCallback, eventReportCallback, errorCallback, resubscriptionCallback,
-            subscriptionEstablishedHandler, onDoneHandler, unsolicitedCommunicationHandler)
+            subscriptionEstablishedHandler, onDoneHandler, unsolicitedMessageFromPublisherHandler)
     {
     }
 
@@ -299,16 +299,16 @@ private:
     os_unfair_lock_unlock(&self->_lock);
 }
 
-- (void)_handleUnsolicitedCommunication
+- (void)_handleUnsolicitedMessageFromPublisher
 {
     os_unfair_lock_lock(&self->_lock);
 
     [self _changeState:MTRDeviceStateReachable];
 
     id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-    if (delegate && [delegate respondsToSelector:@selector(deviceIsCommunicating:)]) {
+    if (delegate && [delegate respondsToSelector:@selector(deviceStartedCommunicating:)]) {
         dispatch_async(_delegateQueue, ^{
-            [delegate deviceIsCommunicating:self];
+            [delegate deviceStartedCommunicating:self];
         });
     }
 
@@ -462,10 +462,10 @@ private:
                                           });
                                       },
                                       ^(void) {
-                                          MTR_LOG_INFO("%@ got unsolicited communication", self);
+                                          MTR_LOG_INFO("%@ got unsolicited message from publisher", self);
                                           dispatch_async(self.queue, ^{
-                                              // OnUnsolicitedCommunication
-                                              [self _handleUnsolicitedCommunication];
+                                              // OnUnsolicitedMessageFromPublisher
+                                              [self _handleUnsolicitedMessageFromPublisher];
                                           });
                                       });
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -113,9 +113,10 @@ class SubscriptionCallback final : public MTRBaseSubscriptionCallback {
 public:
     SubscriptionCallback(DataReportCallback attributeReportCallback, DataReportCallback eventReportCallback,
         ErrorCallback errorCallback, MTRDeviceResubscriptionScheduledHandler resubscriptionCallback,
-        SubscriptionEstablishedHandler subscriptionEstablishedHandler, OnDoneHandler onDoneHandler)
+        SubscriptionEstablishedHandler subscriptionEstablishedHandler, OnDoneHandler onDoneHandler,
+        UnsolicitedCommunicationHandler unsolicitedCommunicationHandler)
         : MTRBaseSubscriptionCallback(attributeReportCallback, eventReportCallback, errorCallback, resubscriptionCallback,
-            subscriptionEstablishedHandler, onDoneHandler)
+            subscriptionEstablishedHandler, onDoneHandler, unsolicitedCommunicationHandler)
     {
     }
 
@@ -211,6 +212,19 @@ private:
     os_unfair_lock_unlock(&self->_lock);
 }
 
+// assume lock is held
+- (void)_changeState:(MTRDeviceState)state
+{
+    MTRDeviceState lastState = _state;
+    _state = state;
+    id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
+    if (delegate && (lastState != state)) {
+        dispatch_async(_delegateQueue, ^{
+            [delegate device:self stateChanged:state];
+        });
+    }
+}
+
 - (void)_handleSubscriptionEstablished
 {
     os_unfair_lock_lock(&self->_lock);
@@ -218,13 +232,7 @@ private:
     // reset subscription attempt wait time when subscription succeeds
     _lastSubscriptionAttemptWait = 0;
 
-    _state = MTRDeviceStateReachable;
-    id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-    if (delegate) {
-        dispatch_async(_delegateQueue, ^{
-            [delegate device:self stateChanged:MTRDeviceStateReachable];
-        });
-    }
+    [self _changeState:MTRDeviceStateReachable];
 
     os_unfair_lock_unlock(&self->_lock);
 }
@@ -236,12 +244,7 @@ private:
     _subscriptionActive = NO;
     _unreportedEvents = nil;
 
-    id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-    if (delegate) {
-        dispatch_async(_delegateQueue, ^{
-            [delegate device:self stateChanged:MTRDeviceStateUnreachable];
-        });
-    }
+    [self _changeState:MTRDeviceStateUnreachable];
 
     os_unfair_lock_unlock(&self->_lock);
 }
@@ -250,14 +253,7 @@ private:
 {
     os_unfair_lock_lock(&self->_lock);
 
-    _state = MTRDeviceStateUnknown;
-
-    id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-    if (delegate) {
-        dispatch_async(_delegateQueue, ^{
-            [delegate device:self stateChanged:MTRDeviceStateUnknown];
-        });
-    }
+    [self _changeState:MTRDeviceStateUnknown];
 
     os_unfair_lock_unlock(&self->_lock);
 }
@@ -299,6 +295,26 @@ private:
         [self _setupSubscription];
         os_unfair_lock_unlock(&self->_lock);
     });
+
+    os_unfair_lock_unlock(&self->_lock);
+}
+
+- (void)_handleUnsolicitedCommunication
+{
+    os_unfair_lock_lock(&self->_lock);
+
+    [self _changeState:MTRDeviceStateReachable];
+
+    id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
+    if (delegate && [delegate respondsToSelector:@selector(deviceIsCommunicating:)]) {
+        dispatch_async(_delegateQueue, ^{
+            [delegate deviceIsCommunicating:self];
+        });
+    }
+
+    // in case this is called dyring exponential back off of subscription
+    // reestablishment, this starts the attempt right away
+    [self _setupSubscription];
 
     os_unfair_lock_unlock(&self->_lock);
 }
@@ -443,6 +459,13 @@ private:
                                           dispatch_async(self.queue, ^{
                                               // OnDone
                                               [self _handleSubscriptionReset];
+                                          });
+                                      },
+                                      ^(void) {
+                                          MTR_LOG_INFO("%@ got unsolicited communication", self);
+                                          dispatch_async(self.queue, ^{
+                                              // OnUnsolicitedCommunication
+                                              [self _handleUnsolicitedCommunication];
                                           });
                                       });
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -306,9 +306,9 @@ private:
     [self _changeState:MTRDeviceStateReachable];
 
     id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-    if (delegate && [delegate respondsToSelector:@selector(deviceStartedCommunicating:)]) {
+    if (delegate && [delegate respondsToSelector:@selector(didReceiveCommunicationFromDevice:)]) {
         dispatch_async(_delegateQueue, ^{
-            [delegate deviceStartedCommunicating:self];
+            [delegate didReceiveCommunicationFromDevice:self];
         });
     }
 


### PR DESCRIPTION
Added `OnUnsolicitedCommunication` function to ReadClient::Callback and plumbed it through for the case of unsolicited reports.

This can be re-used for other unsolicited messaging to trigger other logic at higher layers or application.