### PR TITLE
Pigweed roll with fixes for compilation

### DIFF
--- a/third_party/mbedtls/mbedtls.gni
+++ b/third_party/mbedtls/mbedtls.gni
@@ -31,7 +31,10 @@ template("mbedtls_target") {
     ]
 
     if (is_clang) {
-      cflags += [ "-Wno-shorten-64-to-32" ]
+      cflags += [ 
+        "-Wno-shorten-64-to-32",
+        "-Wno-unused-but-set-variable", # bignum.c: variable 't' set but not used
+      ]
     }
   }
 

--- a/third_party/mbedtls/mbedtls.gni
+++ b/third_party/mbedtls/mbedtls.gni
@@ -31,9 +31,10 @@ template("mbedtls_target") {
     ]
 
     if (is_clang) {
-      cflags += [ 
+      cflags += [
         "-Wno-shorten-64-to-32",
-        "-Wno-unused-but-set-variable", # bignum.c: variable 't' set but not used
+        "-Wno-unused-but-set-variable",  # bignum.c: variable 't' set but not
+                                         # used
       ]
     }
   }


### PR DESCRIPTION
In #24060 we noticed that clang was updated from version 14 to 15 in pigweed, resulting in more strict compile errors.

This PR bumps up pigweed but also fixes compilation.