### PR TITLE
Darwin: Expose MTRBaseDevice.sessionTransportType

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -43,17 +43,6 @@
 
 #define NOT_APPLICABLE_STRING @"N/A"
 
-@interface MTRDeviceController (ToDoRemove)
-
-/**
- * TODO: Temporary until PairingDelegate is fixed to clearly communicate this
- * information to consumers.
- * This should be migrated over to the proper pairing delegate path
- */
-- (BOOL)_deviceBeingCommissionedOverBLE:(uint64_t)deviceId;
-
-@end
-
 @interface QRCodeViewController ()
 
 @property (nonatomic, strong) AVCaptureSession * captureSession;
@@ -497,8 +486,8 @@
     } else {
         MTRDeviceController * controller = InitializeMTR();
         uint64_t deviceId = MTRGetLastPairedDeviceId();
-        if ([controller respondsToSelector:@selector(_deviceBeingCommissionedOverBLE:)] &&
-            [controller _deviceBeingCommissionedOverBLE:deviceId]) {
+        MTRBaseDevice * device = [controller deviceBeingCommissionedWithNodeID:@(deviceId) error:NULL];
+        if (device.sessionTransportType == MTRTransportTypeBLE) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 [self->_deviceList refreshDeviceList];
                 [self retrieveAndSendWiFiCredentials];

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -122,6 +122,13 @@ extern NSString * const MTRArrayValueType;
 @class MTRReadParams;
 @class MTRSubscribeParams;
 
+typedef NS_ENUM(uint8_t, MTRTransportType) {
+    MTRTransportTypeUndefined = 0,
+    MTRTransportTypeUDP,
+    MTRTransportTypeBLE,
+    MTRTransportTypeTCP,
+} MTR_NEWLY_AVAILABLE;
+
 @interface MTRBaseDevice : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -134,6 +141,12 @@ extern NSString * const MTRArrayValueType;
  * (asynchronously) in that case.
  */
 + (instancetype)deviceWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller MTR_NEWLY_AVAILABLE;
+
+/**
+ * The transport used by the current session with this device, or
+ * `MTRTransportTypeUndefined` if no session is currently active.
+ */
+@property (readonly) MTRTransportType sessionTransportType MTR_NEWLY_AVAILABLE;
 
 /**
  * Subscribe to receive attribute reports for everything (all endpoints, all

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -268,6 +268,11 @@ static void CauseReadClientFailure(
     return [controller baseDeviceForNodeID:nodeID];
 }
 
+- (MTRTransportType)sessionTransportType
+{
+    return [self.deviceController sessionTransportTypeForDevice:self];
+}
+
 - (void)invalidateCASESession
 {
     if (self.isPASEDevice) {

--- a/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
@@ -27,6 +27,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+static inline MTRTransportType MTRMakeTransportType(chip::Transport::Type type)
+{
+    static_assert(MTRTransportTypeUndefined == (uint8_t) chip::Transport::Type::kUndefined, "MTRTransportType != Transport::Type");
+    static_assert(MTRTransportTypeUDP == (uint8_t) chip::Transport::Type::kUdp, "MTRTransportType != Transport::Type");
+    static_assert(MTRTransportTypeBLE == (uint8_t) chip::Transport::Type::kBle, "MTRTransportType != Transport::Type");
+    static_assert(MTRTransportTypeTCP == (uint8_t) chip::Transport::Type::kTcp, "MTRTransportType != Transport::Type");
+    return static_cast<MTRTransportType>(type);
+}
+
 @interface MTRBaseDevice ()
 
 - (instancetype)initWithPASEDevice:(chip::DeviceProxy *)device controller:(MTRDeviceController *)controller;
@@ -54,9 +63,6 @@ NS_ASSUME_NONNULL_BEGIN
  * session, this is set to the device id of the PASE device.
  */
 @property (nonatomic, assign, readonly) chip::NodeId nodeID;
-
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
 
 /**
  * Initialize the device object as a CASE device with the given node id and

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -44,7 +44,7 @@ namespace Controller {
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MTRDeviceController (InternalMethods)
+@interface MTRDeviceController ()
 
 #pragma mark - MTRDeviceControllerFactory methods
 
@@ -138,6 +138,12 @@ NS_ASSUME_NONNULL_BEGIN
  * happens, the completion will be invoked with an error on the Matter queue.
  */
 - (void)getSessionForCommissioneeDevice:(chip::NodeId)deviceID completion:(MTRInternalDeviceConnectionCallback)completion;
+
+/**
+ * Returns the transport used by the current session with the given device,
+ * or `MTRTransportTypeUndefined` if no session is currently active.
+ */
+- (MTRTransportType)sessionTransportTypeForDevice:(MTRBaseDevice *)device;
 
 /**
  * Invalidate the CASE session for the given node ID.  This is a temporary thing


### PR DESCRIPTION
Expose MTRBaseDevice.sessionTransportType

- Use it in iOS CHIPTool
- Remove _deviceBeingCommissionedOverBLE
