### PR TITLE
Update Test_TC_BRBINFO_1_1.yaml

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_BRBINFO_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BRBINFO_1_1.yaml
@@ -17,6 +17,9 @@ name:
     130.1.1. [TC-BRBINFO-1.1] Global Attributes for Bridged Device Basic
     Information Cluster Cluster [DUT-Server]
 
+PICS:
+    - BRBINFO.S
+
 config:
     nodeId: 0x12344321
     cluster: "Bridged Device Basic"


### PR DESCRIPTION
this test case is listed on TH 2.6 even when the cluster is not supported, this test case is only applicable when the BRBINFO server is supported

