### PR TITLE
Update Test_TC_BRBINFO_2_2.yaml

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_BRBINFO_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BRBINFO_2_2.yaml
@@ -15,9 +15,12 @@
 
 name: 3.2.2. [TC-BRBINFO-2.2] Events [DUT-Server]
 
+PICS:
+    - BRBINFO.S
+
 config:
     nodeId: 0x12344321
-    cluster: "Basic"
+    cluster: "Bridged Device Basic Information"
     endpoint: 0
 
 tests:


### PR DESCRIPTION
this test case is listed on TH 2.6 even when the cluster is not supported, this test case is only applicable when the BRBINFO server is supported

