### PR TITLE
[nrfconnect] Bump nRF Connect SDK version in Docker

### DIFF
--- a/integrations/docker/images/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrf-platform/Dockerfile
@@ -1,50 +1,44 @@
 ARG VERSION=latest
+
+# ==================================================
+# Temporary image for SDK and dependencies download
+# ==================================================
+
 FROM connectedhomeip/chip-build:${VERSION} as build
-
 # Compatible Nordic Connect SDK revision.
-ARG NCS_REVISION=v2.1.1
-
-RUN set -x \
-    && apt-get update \
-    && apt-get install --no-install-recommends -fy \
-    curl \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/ \
-    && : # last line
-
-# ==================================================
-# nRF Connect SDK dependencies
-# ==================================================
+ARG NCS_REVISION=v2.2.0
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+WORKDIR /opt/NordicSemiconductor/nRF5_tools
 RUN set -x \
-    && mkdir -p /opt/NordicSemiconductor/nRF5_tools/ \
-    && curl --location https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-command-line-tools/sw/versions-10-x-x/10-12-1/nrfcommandlinetools10121linuxamd64.tar.gz \
+    && curl --location https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-command-line-tools/sw/versions-10-x-x/10-18-1/nrf-command-line-tools-10.18.1_linux-amd64.tar.gz \
     | tar zxvf - \
-    && tar xvf JLink_Linux_V688a_x86_64.tgz -C /opt/NordicSemiconductor/nRF5_tools/ \
-    && tar xvf nRF-Command-Line-Tools_10_12_1.tar -C /opt/NordicSemiconductor/nRF5_tools/ \
+    && tar xvf JLink_Linux_V780c_x86_64.tgz \
+    && rm JLink_Linux_V780c_x86_64.* \
+    && curl --location https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.2/zephyr-sdk-0.15.2_linux-x86_64_minimal.tar.gz \
+    | tar zxvf - \
+    && zephyr-sdk-0.15.2/setup.sh -t arm-zephyr-eabi \
     && : # last line
 
 WORKDIR /opt/NordicSemiconductor/nrfconnect
 RUN set -x \
-    && python3 -m pip install -U --no-cache-dir \
-    west==0.13.1 \
-    && west init -m https://github.com/nrfconnect/sdk-nrf \
-    && git -C nrf fetch origin "$NCS_REVISION" \
-    && git -C nrf checkout FETCH_HEAD \
+    && python3 -m pip install -U --no-cache-dir west==0.14.0 \
+    && west init -m https://github.com/nrfconnect/sdk-nrf --mr "$NCS_REVISION" \
     && west config update.narrow true \
     && west config update.fetch smart \
     && west update -o=--depth=1 -n -f smart \
     && : # last line
+
+# ==================================================
+# nRF Connect SDK final image
+# ==================================================
 
 FROM connectedhomeip/chip-build:${VERSION}
 
 # Tools for building, flashing and accessing device logs
 RUN set -x \
     && apt-get update \
-    && apt-get install --no-install-recommends -fy \
-    device-tree-compiler=1.5.1-1 \
-    ccache=3.7.7-1 \
+    && apt-get install --no-install-recommends -fy device-tree-compiler=1.5.1-1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line
@@ -52,24 +46,22 @@ RUN set -x \
 COPY --from=build /opt/NordicSemiconductor/nRF5_tools/ /opt/NordicSemiconductor/nRF5_tools/
 COPY --from=build /opt/NordicSemiconductor/nrfconnect/ /opt/NordicSemiconductor/nrfconnect/
 
-# ==================================================
-# nRF Connect SDK
-# ==================================================
-
 RUN set -x \
     # python3-yaml package conflicts with nRF Python requirements
     && (apt-get remove -fy python3-yaml && apt-get autoremove || exit 0) \
-    && python3 -m pip install -U --no-cache-dir cmake==3.22.5 \
-    && python3 -m pip install --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/zephyr/scripts/requirements.txt \
+    && python3 -m pip install -U --no-cache-dir cmake==3.25.0 \
+    && python3 -m pip install --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/zephyr/scripts/requirements-base.txt \
     && python3 -m pip install --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/nrf/scripts/requirements-build.txt \
     && python3 -m pip install --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/bootloader/mcuboot/scripts/requirements.txt \
     && : # last line
 
 ENV NRF5_TOOLS_ROOT=/opt/NordicSemiconductor/nRF5_tools
-ENV PATH=${NRF5_TOOLS_ROOT}/JLink_Linux_V688a_x86_64:${PATH}
-ENV PATH=${NRF5_TOOLS_ROOT}/mergehex:${NRF5_TOOLS_ROOT}/nrfjprog:${PATH}
-ENV LD_LIBRARY_PATH=${NRF5_TOOLS_ROOT}/JLink_Linux_V688a_x86_64:${LD_LIBRARY_PATH}
+ENV PATH=${NRF5_TOOLS_ROOT}/JLink_Linux_V780c_x86_64:${PATH}
+ENV PATH=${NRF5_TOOLS_ROOT}/nrf-command-line-tools/bin:${PATH}
+ENV LD_LIBRARY_PATH=${NRF5_TOOLS_ROOT}/JLink_Linux_V780c_x86_64:${LD_LIBRARY_PATH}
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV ZEPHYR_BASE=/opt/NordicSemiconductor/nrfconnect/zephyr
-ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
+ENV ZEPHYR_SDK_INSTALL_DIR=${NRF5_TOOLS_ROOT}/zephyr-sdk-0.15.2
+ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+ENV ZEPHYR_TOOLCHAIN_PATH=${ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.19 Version bump reason: [Ameba] Support reading and decoding factory data from flash
+0.6.20 Version bump reason: [nrfconnect] Bump nRF Connect SDK version


### PR DESCRIPTION
Bump NCS to 2.2.
Update all related tools.
Add Zephyr SDK which is required for building recent Zephyr revisions.