### PR TITLE
Make some more safety improvements to dispatch to the Matter queue.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -137,7 +137,7 @@ static void PurgeReadClientContainers(
 
     // Destroy read clients in the work queue
     [controller
-        asyncDispatchToMatterQueue:^(Controller::DeviceCommissioner * commissioner) {
+        asyncDispatchToMatterQueue:^() {
             for (MTRReadClientContainer * container in listToDelete) {
                 if (container.readClientPtr) {
                     Platform::Delete(container.readClientPtr);
@@ -193,7 +193,7 @@ static void CauseReadClientFailure(
     [readClientContainersLock unlock];
 
     [controller
-        asyncDispatchToMatterQueue:^(Controller::DeviceCommissioner * commissioner) {
+        asyncDispatchToMatterQueue:^() {
             for (MTRReadClientContainer * container in listToFail) {
                 // Send auto resubscribe request again by read clients, which must fail.
                 chip::app::ReadPrepareParams readParams;
@@ -1373,7 +1373,7 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
     }
 
     [self.deviceController
-        asyncDispatchToMatterQueue:^(Controller::DeviceCommissioner * commissioner) {
+        asyncGetCommissionerOnMatterQueue:^(Controller::DeviceCommissioner * commissioner) {
             auto resultCallback = ^(CHIP_ERROR status, const SetupPayload & payload) {
                 if (status != CHIP_NO_ERROR) {
                     dispatch_async(queue, ^{

--- a/src/darwin/Framework/CHIP/MTRCallbackBridgeBase_internal.h
+++ b/src/darwin/Framework/CHIP/MTRCallbackBridgeBase_internal.h
@@ -139,7 +139,7 @@ public:
         LogRequestStart();
 
         [device.deviceController
-            asyncDispatchToMatterQueue:^(chip::Controller::DeviceCommissioner *) {
+            asyncDispatchToMatterQueue:^() {
                 CHIP_ERROR err = action(mSuccess, mFailure);
                 if (err != CHIP_NO_ERROR) {
                     NSLog(@"Failure performing action. C++-mangled success callback type: '%s', error: %s", typeid(T).name(),
@@ -159,31 +159,22 @@ public:
     {
         LogRequestStart();
 
-        BOOL ok = [device.deviceController
-            getSessionForCommissioneeDevice:device.nodeID
-                                 completion:^(chip::Messaging::ExchangeManager * exchangeManager,
-                                     const chip::Optional<chip::SessionHandle> & session, NSError * error) {
-                                     MaybeDoAction(exchangeManager, session, error);
-                                 }];
-
-        if (ok == NO) {
-            OnFailureFn(this, CHIP_ERROR_INCORRECT_STATE);
-        }
+        [device.deviceController getSessionForCommissioneeDevice:device.nodeID
+                                                      completion:^(chip::Messaging::ExchangeManager * exchangeManager,
+                                                          const chip::Optional<chip::SessionHandle> & session, NSError * error) {
+                                                          MaybeDoAction(exchangeManager, session, error);
+                                                      }];
     }
 
     void ActionWithNodeID(chip::NodeId nodeID, MTRDeviceController * controller)
     {
         LogRequestStart();
 
-        BOOL ok = [controller getSessionForNode:nodeID
-                                     completion:^(chip::Messaging::ExchangeManager * exchangeManager,
-                                         const chip::Optional<chip::SessionHandle> & session, NSError * error) {
-                                         MaybeDoAction(exchangeManager, session, error);
-                                     }];
-
-        if (ok == NO) {
-            OnFailureFn(this, CHIP_ERROR_INCORRECT_STATE);
-        }
+        [controller getSessionForNode:nodeID
+                           completion:^(chip::Messaging::ExchangeManager * exchangeManager,
+                               const chip::Optional<chip::SessionHandle> & session, NSError * error) {
+                               MaybeDoAction(exchangeManager, session, error);
+                           }];
     }
 
     void LogRequestStart()

--- a/src/darwin/Framework/CHIP/MTRClusterStateCacheContainer.mm
+++ b/src/darwin/Framework/CHIP/MTRClusterStateCacheContainer.mm
@@ -137,7 +137,7 @@ static CHIP_ERROR AppendAttributeValueToArray(
     }
 
     [self.baseDevice.deviceController
-        asyncDispatchToMatterQueue:^(Controller::DeviceCommissioner *) {
+        asyncDispatchToMatterQueue:^() {
             if (endpointID == nil && clusterID == nil) {
                 MTR_LOG_ERROR(
                     "Error: currently read from attribute cache does not support wildcards for both endpoint and cluster");

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -160,7 +160,7 @@ private:
 
         auto completionHandler = ^(NSError * _Nullable error) {
             [controller
-                asyncDispatchToMatterQueue:^(chip::Controller::DeviceCommissioner *) {
+                asyncDispatchToMatterQueue:^() {
                     assertChipStackLockedByCurrentThread();
 
                     if (!mInitialized || mTransferGeneration != transferGeneration) {
@@ -264,7 +264,7 @@ private:
 
         auto completionHandler = ^(NSData * _Nullable data, BOOL isEOF) {
             [controller
-                asyncDispatchToMatterQueue:^(chip::Controller::DeviceCommissioner *) {
+                asyncDispatchToMatterQueue:^() {
                     assertChipStackLockedByCurrentThread();
 
                     if (!mInitialized || mTransferGeneration != transferGeneration) {
@@ -552,7 +552,7 @@ void MTROTAProviderDelegateBridge::HandleQueryImage(
     auto completionHandler
         = ^(MTROTASoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data, NSError * _Nullable error) {
               [controller
-                  asyncDispatchToMatterQueue:^(chip::Controller::DeviceCommissioner *) {
+                  asyncDispatchToMatterQueue:^() {
                       assertChipStackLockedByCurrentThread();
 
                       CommandHandler * handler = EnsureValidState(handle, cachedCommandPath, "QueryImage", data, error);
@@ -646,7 +646,7 @@ void MTROTAProviderDelegateBridge::HandleApplyUpdateRequest(CommandHandler * com
     auto completionHandler
         = ^(MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data, NSError * _Nullable error) {
               [controller
-                  asyncDispatchToMatterQueue:^(chip::Controller::DeviceCommissioner *) {
+                  asyncDispatchToMatterQueue:^() {
                       assertChipStackLockedByCurrentThread();
 
                       CommandHandler * handler = EnsureValidState(handle, cachedCommandPath, "ApplyUpdateRequest", data, error);
@@ -707,7 +707,7 @@ void MTROTAProviderDelegateBridge::HandleNotifyUpdateApplied(CommandHandler * co
 
     auto completionHandler = ^(NSError * _Nullable error) {
         [controller
-            asyncDispatchToMatterQueue:^(chip::Controller::DeviceCommissioner *) {
+            asyncDispatchToMatterQueue:^() {
                 assertChipStackLockedByCurrentThread();
 
                 CommandHandler * handler = EnsureValidState(handle, cachedCommandPath, "NotifyUpdateApplied", error);

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
@@ -69,8 +69,6 @@ public:
         return mCppCommissioner == nullptr ? chip::NullOptional : mCppCommissioner->GetCommissioningParameters();
     }
 
-    void setChipWorkQueue(dispatch_queue_t chipWorkQueue) { mChipWorkQueue = chipWorkQueue; }
-
     void SetOperationalCertificateIssuer(
         id<MTROperationalCertificateIssuer> operationalCertificateIssuer, dispatch_queue_t operationalCertificateIssuerQueue)
     {
@@ -156,7 +154,6 @@ private:
     chip::Controller::DeviceCommissioner * _Nullable mCppCommissioner = nullptr;
     id<MTROperationalCertificateIssuer> _Nullable mOperationalCertificateIssuer;
     dispatch_queue_t _Nullable mOperationalCertificateIssuerQueue;
-    dispatch_queue_t _Nullable mChipWorkQueue;
     chip::Callback::Callback<chip::Controller::OnNOCChainGeneration> * _Nullable mOnNOCCompletionCallback = nullptr;
 };
 


### PR DESCRIPTION
The idea is to minimize the number of places that have to have isRunning checks, and direct access to the Matter queue, by having APIs that do those for you.
