### PR TITLE
Allow markdown in issue template descriptions.

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yaml
@@ -11,12 +11,14 @@ body:
       attributes:
           label: Reproduction steps
           description: "How do you trigger this bug? Please walk us through it step by step."
-          value: |
-              1.
-              2.
-              3.
-              ...
-          render: bash
+          placeholder: |
+            Please list reproduction steps step by step.
+            Place shell commands between ```.
+            Attach logs as files instead of pasting them in.
+            1.
+            2.
+            3.
+            ...
       validations:
           required: true
     - type: input

--- a/.github/ISSUE_TEMPLATE/100-documentation-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/100-documentation-issue.yaml
@@ -16,7 +16,6 @@ body:
               2.
               3.
               ...
-          render: bash
       validations:
           required: true
     - type: dropdown

--- a/.github/ISSUE_TEMPLATE/2-1.0-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/2-1.0-issue.yaml
@@ -11,12 +11,14 @@ body:
       attributes:
           label: Reproduction steps
           description: "How do you trigger this bug? Please walk us through it step by step."
-          value: |
-              1.
-              2.
-              3.
-              ...
-          render: bash
+          placeholder: |
+            Please list reproduction steps step by step.
+            Place shell commands between ```.
+            Attach logs as files instead of pasting them in.
+            1.
+            2.
+            3.
+            ...
       validations:
           required: true
     - type: input

--- a/.github/ISSUE_TEMPLATE/3-sve-1.0-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/3-sve-1.0-issue.yaml
@@ -11,12 +11,14 @@ body:
       attributes:
           label: Reproduction steps
           description: "How do you trigger this bug? Please walk us through it step by step."
-          value: |
-              1.
-              2.
-              3.
-              ...
-          render: bash
+          placeholder: |
+            Please list reproduction steps step by step.
+            Place shell commands between ```.
+            Attach logs as files instead of pasting them in.
+            1.
+            2.
+            3.
+            ...
       validations:
           required: true
     - type: input

--- a/.github/ISSUE_TEMPLATE/50-tooling-fix.yaml
+++ b/.github/ISSUE_TEMPLATE/50-tooling-fix.yaml
@@ -11,12 +11,14 @@ body:
       attributes:
           label: Reproduction steps / Feature
           description: "How do you trigger this issue and/or can you please explain this new feature? Please walk us through it step by step."
-          value: |
-              1.
-              2.
-              3.
-              ...
-          render: bash
+          placeholder: |
+            Please list reproduction steps step by step.
+            Place shell commands between ```.
+            Attach logs as files instead of pasting them in.
+            1.
+            2.
+            3.
+            ...
       validations:
           required: true
     - type: dropdown

--- a/.github/ISSUE_TEMPLATE/60-platform-fix.yaml
+++ b/.github/ISSUE_TEMPLATE/60-platform-fix.yaml
@@ -11,12 +11,14 @@ body:
       attributes:
           label: Reproduction steps
           description: "How do you trigger this issue? Please walk us through it step by step."
-          value: |
-              1.
-              2.
-              3.
-              ...
-          render: bash
+          placeholder: |
+            Please list reproduction steps step by step.
+            Place shell commands between ```.
+            Attach logs as files instead of pasting them in.
+            1.
+            2.
+            3.
+            ...
       validations:
           required: true
     - type: dropdown

--- a/.github/ISSUE_TEMPLATE/70-trivial-fix.yaml
+++ b/.github/ISSUE_TEMPLATE/70-trivial-fix.yaml
@@ -23,12 +23,6 @@ body:
       attributes:
           label: Explanation
           description: "(Optional) If other, why do you think this is trivial?"
-          value: |
-              1.
-              2.
-              3.
-              ...
-          render: bash
       validations:
           required: false
     - type: dropdown

--- a/.github/ISSUE_TEMPLATE/80-feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/80-feature-request.yaml
@@ -13,7 +13,6 @@ body:
           description: "What feature are you looking to add? Please walk us through it!"
           value: |
               ...
-          render: bash
       validations:
           required: true
     - type: dropdown

--- a/.github/ISSUE_TEMPLATE/99-github-workflow-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/99-github-workflow-issue.yaml
@@ -16,7 +16,6 @@ body:
               2.
               3.
               ...
-          render: bash
       validations:
           required: true
     - type: dropdown


### PR DESCRIPTION
Instead of forcing preformatting on the text people type as their reproduction steps, allow them to type markdown and nudge toward using proper formatting and attaching logs as files via the placeholder.

