### PR TITLE
[Telink] Set max BLE RF power

### DIFF
--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -358,6 +358,9 @@ CHIP_ERROR BLEManagerImpl::_InitStack(void)
     /* Init connection mode */
     blc_ll_initConnection_module();
 
+    /*set rf power index*/
+    rf_set_power_level_index(RF_POWER_INDEX_P9p11dBm);
+
     /* Init GAP */
     err = _InitGap();
     SuccessOrExit(err);


### PR DESCRIPTION
**Problem**

Needs max BLE RF power

**Change overview**

Set max BLE RF power

**Testing**

Tested manually with chip-tool and Google Home.
Steps:

- Run: $ chip-tool pairing ble-thread <...>
- Wait till success