### PR TITLE
[chip-tool] Simplify the interaction model APIs to make it easier to maintain/review

### DIFF
--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -45,16 +45,14 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        return InteractionModelCommands::SendCommand(device, endpointIds.at(0), mClusterId, mCommandId, mPayload,
-                                                     mTimedInteractionTimeoutMs, mSuppressResponse, mRepeatCount, mRepeatDelayInMs);
+        return InteractionModelCommands::SendCommand(device, endpointIds.at(0), mClusterId, mCommandId, mPayload);
     }
 
     template <class T>
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, chip::EndpointId endpointId, chip::ClusterId clusterId,
                            chip::CommandId commandId, const T & value)
     {
-        return InteractionModelCommands::SendCommand(device, endpointId, clusterId, commandId, value, mTimedInteractionTimeoutMs,
-                                                     mSuppressResponse, mRepeatCount, mRepeatDelayInMs);
+        return InteractionModelCommands::SendCommand(device, endpointId, clusterId, commandId, value);
     }
 
     CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
@@ -184,10 +182,6 @@ protected:
 private:
     chip::ClusterId mClusterId;
     chip::CommandId mCommandId;
-    chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
-    chip::Optional<bool> mSuppressResponse;
-    chip::Optional<uint16_t> mRepeatCount;
-    chip::Optional<uint16_t> mRepeatDelayInMs;
 
     CHIP_ERROR mError = CHIP_NO_ERROR;
     CustomArgument mPayload;

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -209,7 +209,7 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        return ReadCommand::ReadAttribute(device, endpointIds, mClusterIds, mAttributeIds, mFabricFiltered, mDataVersion);
+        return ReadCommand::ReadAttribute(device, endpointIds, mClusterIds, mAttributeIds);
     }
 
 private:
@@ -224,14 +224,12 @@ private:
     {
         AddArgument("fabric-filtered", 0, 1, &mFabricFiltered,
                     "Boolean indicating whether to do a fabric-filtered read. Defaults to true.");
-        AddArgument("data-version", 0, UINT32_MAX, &mDataVersion,
+        AddArgument("data-version", 0, UINT32_MAX, &mDataVersions,
                     "Comma-separated list of data versions for the clusters being read.");
     }
 
     std::vector<chip::ClusterId> mClusterIds;
     std::vector<chip::AttributeId> mAttributeIds;
-    chip::Optional<bool> mFabricFiltered;
-    chip::Optional<std::vector<chip::DataVersion>> mDataVersion;
 };
 
 class SubscribeAttribute : public SubscribeCommand
@@ -269,8 +267,7 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        return SubscribeCommand::SubscribeAttribute(device, endpointIds, mClusterIds, mAttributeIds, mMinInterval, mMaxInterval,
-                                                    mFabricFiltered, mDataVersion, mKeepSubscriptions, mAutoResubscribe);
+        return SubscribeCommand::SubscribeAttribute(device, endpointIds, mClusterIds, mAttributeIds);
     }
 
 private:
@@ -289,7 +286,7 @@ private:
                     "Server must send a report if this number of seconds has elapsed since the last report.");
         AddArgument("fabric-filtered", 0, 1, &mFabricFiltered,
                     "Boolean indicating whether to do a fabric-filtered subscription. Defaults to true.");
-        AddArgument("data-version", 0, UINT32_MAX, &mDataVersion,
+        AddArgument("data-version", 0, UINT32_MAX, &mDataVersions,
                     "Comma-separated list of data versions for the clusters being subscribed to.");
         AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions,
                     "Boolean indicating whether to keep existing subscriptions when creating the new one. Defaults to false.");
@@ -299,13 +296,6 @@ private:
 
     std::vector<chip::ClusterId> mClusterIds;
     std::vector<chip::AttributeId> mAttributeIds;
-
-    uint16_t mMinInterval;
-    uint16_t mMaxInterval;
-    chip::Optional<bool> mFabricFiltered;
-    chip::Optional<std::vector<chip::DataVersion>> mDataVersion;
-    chip::Optional<bool> mKeepSubscriptions;
-    chip::Optional<bool> mAutoResubscribe;
 };
 
 class ReadEvent : public ReadCommand
@@ -344,14 +334,12 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        return ReadCommand::ReadEvent(device, endpointIds, mClusterIds, mEventIds, mFabricFiltered, mEventNumber);
+        return ReadCommand::ReadEvent(device, endpointIds, mClusterIds, mEventIds);
     }
 
 private:
     std::vector<chip::ClusterId> mClusterIds;
     std::vector<chip::EventId> mEventIds;
-    chip::Optional<bool> mFabricFiltered;
-    chip::Optional<chip::EventNumber> mEventNumber;
 };
 
 class SubscribeEvent : public SubscribeCommand
@@ -409,21 +397,12 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        return SubscribeCommand::SubscribeEvent(device, endpointIds, mClusterIds, mEventIds, mMinInterval, mMaxInterval,
-                                                mFabricFiltered, mEventNumber, mKeepSubscriptions, mIsUrgents, mAutoResubscribe);
+        return SubscribeCommand::SubscribeEvent(device, endpointIds, mClusterIds, mEventIds);
     }
 
 private:
     std::vector<chip::ClusterId> mClusterIds;
     std::vector<chip::EventId> mEventIds;
-
-    uint16_t mMinInterval;
-    uint16_t mMaxInterval;
-    chip::Optional<bool> mFabricFiltered;
-    chip::Optional<chip::EventNumber> mEventNumber;
-    chip::Optional<bool> mKeepSubscriptions;
-    chip::Optional<std::vector<bool>> mIsUrgents;
-    chip::Optional<bool> mAutoResubscribe;
 };
 
 class ReadAll : public ReadCommand
@@ -458,18 +437,13 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        return ReadCommand::ReadAll(device, endpointIds, mClusterIds, mAttributeIds, mEventIds, mFabricFiltered, mDataVersions,
-                                    mEventNumber);
+        return ReadCommand::ReadAll(device, endpointIds, mClusterIds, mAttributeIds, mEventIds);
     }
 
 private:
     std::vector<chip::ClusterId> mClusterIds;
     std::vector<chip::AttributeId> mAttributeIds;
     std::vector<chip::EventId> mEventIds;
-
-    chip::Optional<bool> mFabricFiltered;
-    chip::Optional<std::vector<chip::DataVersion>> mDataVersions;
-    chip::Optional<chip::EventNumber> mEventNumber;
 };
 
 class SubscribeAll : public SubscribeCommand
@@ -502,18 +476,11 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        return SubscribeCommand::SubscribeAll(device, endpointIds, mClusterIds, mAttributeIds, mEventIds, mMinInterval,
-                                              mMaxInterval, mFabricFiltered, mEventNumber, mKeepSubscriptions);
+        return SubscribeCommand::SubscribeAll(device, endpointIds, mClusterIds, mAttributeIds, mEventIds);
     }
 
 private:
     std::vector<chip::ClusterId> mClusterIds;
     std::vector<chip::AttributeId> mAttributeIds;
     std::vector<chip::EventId> mEventIds;
-
-    uint16_t mMinInterval;
-    uint16_t mMaxInterval;
-    chip::Optional<bool> mFabricFiltered;
-    chip::Optional<chip::EventNumber> mEventNumber;
-    chip::Optional<bool> mKeepSubscriptions;
 };

--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -129,9 +129,7 @@ public:
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
                            std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds, const T & values)
     {
-        return InteractionModelWriter::WriteAttribute(device, endpointIds, clusterIds, attributeIds, values,
-                                                      mTimedInteractionTimeoutMs, mSuppressResponse, mDataVersions, mRepeatCount,
-                                                      mRepeatDelayInMs);
+        return InteractionModelWriter::WriteAttribute(device, endpointIds, clusterIds, attributeIds, values);
     }
 
     CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, std::vector<chip::ClusterId> clusterIds,
@@ -249,12 +247,6 @@ private:
     std::vector<chip::AttributeId> mAttributeIds;
 
     CHIP_ERROR mError = CHIP_NO_ERROR;
-    chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
-    chip::Optional<std::vector<chip::DataVersion>> mDataVersions;
-    chip::Optional<bool> mSuppressResponse;
-    chip::Optional<uint16_t> mRepeatCount;
-    chip::Optional<uint16_t> mRepeatDelayInMs;
-
     T mAttributeValues;
 };
 

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
@@ -37,8 +37,11 @@ CHIP_ERROR InteractionModel::ReadAttribute(const char * identity, EndpointId end
         dataVersions.Value().push_back(dataVersion.Value());
     }
 
-    return InteractionModelReports::ReadAttribute(device, endpointIds, clusterIds, attributeIds, Optional<bool>(fabricFiltered),
-                                                  dataVersions);
+    InteractionModelReports::ResetOptions();
+    InteractionModelReports::SetFabricFiltered(fabricFiltered);
+    InteractionModelReports::SetDataVersions(dataVersions);
+
+    return InteractionModelReports::ReadAttribute(device, endpointIds, clusterIds, attributeIds);
 }
 
 CHIP_ERROR InteractionModel::ReadEvent(const char * identity, EndpointId endpointId, ClusterId clusterId, EventId eventId,
@@ -50,8 +53,12 @@ CHIP_ERROR InteractionModel::ReadEvent(const char * identity, EndpointId endpoin
     std::vector<EndpointId> endpointIds = { endpointId };
     std::vector<ClusterId> clusterIds   = { clusterId };
     std::vector<EventId> eventIds       = { eventId };
-    return InteractionModelReports::ReadEvent(device, endpointIds, clusterIds, eventIds, Optional<bool>(fabricFiltered),
-                                              eventNumber);
+
+    InteractionModelReports::ResetOptions();
+    InteractionModelReports::SetFabricFiltered(fabricFiltered);
+    InteractionModelReports::SetEventNumber(eventNumber);
+
+    return InteractionModelReports::ReadEvent(device, endpointIds, clusterIds, eventIds);
 }
 
 CHIP_ERROR InteractionModel::SubscribeAttribute(const char * identity, EndpointId endpointId, ClusterId clusterId,
@@ -72,9 +79,15 @@ CHIP_ERROR InteractionModel::SubscribeAttribute(const char * identity, EndpointI
         dataVersions.Value().push_back(dataVersion.Value());
     }
 
-    return InteractionModelReports::SubscribeAttribute(device, endpointIds, clusterIds, attributeIds, minInterval, maxInterval,
-                                                       Optional<bool>(fabricFiltered), dataVersions, keepSubscriptions,
-                                                       autoResubscribe);
+    InteractionModelReports::ResetOptions();
+    InteractionModelReports::SetMinInterval(minInterval);
+    InteractionModelReports::SetMaxInterval(maxInterval);
+    InteractionModelReports::SetFabricFiltered(fabricFiltered);
+    InteractionModelReports::SetDataVersions(dataVersions);
+    InteractionModelReports::SetKeepSubscriptions(keepSubscriptions);
+    InteractionModelReports::SetAutoResubscribe(autoResubscribe);
+
+    return InteractionModelReports::SubscribeAttribute(device, endpointIds, clusterIds, attributeIds);
 }
 
 CHIP_ERROR InteractionModel::SubscribeEvent(const char * identity, EndpointId endpointId, ClusterId clusterId, EventId eventId,
@@ -88,9 +101,16 @@ CHIP_ERROR InteractionModel::SubscribeEvent(const char * identity, EndpointId en
     std::vector<EndpointId> endpointIds = { endpointId };
     std::vector<ClusterId> clusterIds   = { clusterId };
     std::vector<EventId> eventIds       = { eventId };
-    return InteractionModelReports::SubscribeEvent(device, endpointIds, clusterIds, eventIds, minInterval, maxInterval,
-                                                   Optional<bool>(fabricFiltered), eventNumber, keepSubscriptions, NullOptional,
-                                                   autoResubscribe);
+
+    InteractionModelReports::ResetOptions();
+    SetMinInterval(minInterval);
+    SetMaxInterval(maxInterval);
+    SetFabricFiltered(fabricFiltered);
+    SetEventNumber(eventNumber);
+    SetKeepSubscriptions(keepSubscriptions);
+    SetAutoResubscribe(autoResubscribe);
+
+    return InteractionModelReports::SubscribeEvent(device, endpointIds, clusterIds, eventIds);
 }
 
 void InteractionModel::Shutdown()
@@ -281,15 +301,11 @@ CHIP_ERROR InteractionModelConfig::GetAttributePaths(std::vector<EndpointId> end
 
 CHIP_ERROR InteractionModelReports::ReportAttribute(DeviceProxy * device, std::vector<EndpointId> endpointIds,
                                                     std::vector<ClusterId> clusterIds, std::vector<AttributeId> attributeIds,
-                                                    ReadClient::InteractionType interactionType, uint16_t minInterval,
-                                                    uint16_t maxInterval, const Optional<bool> & fabricFiltered,
-                                                    const Optional<std::vector<DataVersion>> & dataVersions,
-                                                    const Optional<bool> & keepSubscriptions,
-                                                    const Optional<bool> & autoResubscribe)
+                                                    ReadClient::InteractionType interactionType)
 {
     InteractionModelConfig::AttributePathsConfig pathsConfig;
     ReturnErrorOnFailure(
-        InteractionModelConfig::GetAttributePaths(endpointIds, clusterIds, attributeIds, dataVersions, pathsConfig));
+        InteractionModelConfig::GetAttributePaths(endpointIds, clusterIds, attributeIds, mDataVersions, pathsConfig));
 
     ChipLogProgress(chipTool,
                     "Sending %sAttribute to:", interactionType == ReadClient::InteractionType::Subscribe ? "Subscribe" : "Read");
@@ -300,12 +316,12 @@ CHIP_ERROR InteractionModelReports::ReportAttribute(DeviceProxy * device, std::v
     params.mpAttributePathParamsList    = pathsConfig.attributePathParams.get();
     params.mAttributePathParamsListSize = pathsConfig.count;
 
-    if (fabricFiltered.HasValue())
+    if (mFabricFiltered.HasValue())
     {
-        params.mIsFabricFiltered = fabricFiltered.Value();
+        params.mIsFabricFiltered = mFabricFiltered.Value();
     }
 
-    if (dataVersions.HasValue())
+    if (mDataVersions.HasValue())
     {
         params.mpDataVersionFilterList    = pathsConfig.dataVersionFilter.get();
         params.mDataVersionFilterListSize = pathsConfig.count;
@@ -313,11 +329,11 @@ CHIP_ERROR InteractionModelReports::ReportAttribute(DeviceProxy * device, std::v
 
     if (interactionType == ReadClient::InteractionType::Subscribe)
     {
-        params.mMinIntervalFloorSeconds   = minInterval;
-        params.mMaxIntervalCeilingSeconds = maxInterval;
-        if (keepSubscriptions.HasValue())
+        params.mMinIntervalFloorSeconds   = mMinInterval;
+        params.mMaxIntervalCeilingSeconds = mMaxInterval;
+        if (mKeepSubscriptions.HasValue())
         {
-            params.mKeepSubscriptions = keepSubscriptions.Value();
+            params.mKeepSubscriptions = mKeepSubscriptions.Value();
         }
     }
 
@@ -327,10 +343,10 @@ CHIP_ERROR InteractionModelReports::ReportAttribute(DeviceProxy * device, std::v
     {
         ReturnErrorOnFailure(client->SendRequest(params));
     }
-    else if (autoResubscribe.ValueOr(false))
+    else if (mAutoResubscribe.ValueOr(false))
     {
         pathsConfig.attributePathParams.release();
-        if (dataVersions.HasValue())
+        if (mDataVersions.HasValue())
         {
             pathsConfig.dataVersionFilter.release();
         }
@@ -348,16 +364,12 @@ CHIP_ERROR InteractionModelReports::ReportAttribute(DeviceProxy * device, std::v
 
 CHIP_ERROR InteractionModelReports::ReportEvent(DeviceProxy * device, std::vector<EndpointId> endpointIds,
                                                 std::vector<ClusterId> clusterIds, std::vector<EventId> eventIds,
-                                                ReadClient::InteractionType interactionType, uint16_t minInterval,
-                                                uint16_t maxInterval, const Optional<bool> & fabricFiltered,
-                                                const Optional<EventNumber> & eventNumber, const Optional<bool> & keepSubscriptions,
-                                                const Optional<std::vector<bool>> & isUrgents,
-                                                const Optional<bool> & autoResubscribe)
+                                                chip::app::ReadClient::InteractionType interactionType)
 {
     const size_t clusterCount  = clusterIds.size();
     const size_t eventCount    = eventIds.size();
     const size_t endpointCount = endpointIds.size();
-    const size_t isUrgentCount = isUrgents.HasValue() ? isUrgents.Value().size() : 0;
+    const size_t isUrgentCount = mIsUrgents.HasValue() ? mIsUrgents.Value().size() : 0;
 
     VerifyOrReturnError(clusterCount > 0 && clusterCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(eventCount > 0 && eventCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
@@ -426,37 +438,37 @@ CHIP_ERROR InteractionModelReports::ReportEvent(DeviceProxy * device, std::vecto
             eventPathParams[i].mEndpointId = endpointId;
         }
 
-        if (isUrgents.HasValue() && isUrgents.Value().size() > i)
+        if (mIsUrgents.HasValue() && mIsUrgents.Value().size() > i)
         {
-            eventPathParams[i].mIsUrgentEvent = isUrgents.Value().at(i);
+            eventPathParams[i].mIsUrgentEvent = mIsUrgents.Value().at(i);
         }
     }
 
     ReadPrepareParams params(device->GetSecureSession().Value());
     params.mpEventPathParamsList        = eventPathParams.get();
     params.mEventPathParamsListSize     = pathsCount;
-    params.mEventNumber                 = eventNumber;
+    params.mEventNumber                 = mEventNumber;
     params.mpAttributePathParamsList    = nullptr;
     params.mAttributePathParamsListSize = 0;
 
-    if (fabricFiltered.HasValue())
+    if (mFabricFiltered.HasValue())
     {
-        params.mIsFabricFiltered = fabricFiltered.Value();
+        params.mIsFabricFiltered = mFabricFiltered.Value();
     }
 
     if (interactionType == ReadClient::InteractionType::Subscribe)
     {
-        params.mMinIntervalFloorSeconds   = minInterval;
-        params.mMaxIntervalCeilingSeconds = maxInterval;
-        if (keepSubscriptions.HasValue())
+        params.mMinIntervalFloorSeconds   = mMinInterval;
+        params.mMaxIntervalCeilingSeconds = mMaxInterval;
+        if (mKeepSubscriptions.HasValue())
         {
-            params.mKeepSubscriptions = keepSubscriptions.Value();
+            params.mKeepSubscriptions = mKeepSubscriptions.Value();
         }
     }
 
     auto client = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
                                                mBufferedReadAdapter, interactionType);
-    if (autoResubscribe.ValueOr(false))
+    if (mAutoResubscribe.ValueOr(false))
     {
         eventPathParams.release();
         ReturnErrorOnFailure(client->SendAutoResubscribeRequest(std::move(params)));
@@ -479,11 +491,7 @@ void InteractionModelReports::CleanupReadClient(ReadClient * aReadClient)
 CHIP_ERROR InteractionModelReports::ReportAll(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
                                               std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
                                               std::vector<chip::EventId> eventIds,
-                                              chip::app::ReadClient::InteractionType interactionType, uint16_t minInterval,
-                                              uint16_t maxInterval, const chip::Optional<bool> & fabricFiltered,
-                                              const chip::Optional<std::vector<chip::DataVersion>> & dataVersions,
-                                              const chip::Optional<chip::EventNumber> & eventNumber,
-                                              const chip::Optional<bool> & keepSubscriptions)
+                                              chip::app::ReadClient::InteractionType interactionType)
 {
     const size_t endpointCount  = endpointIds.size();
     const size_t clusterCount   = clusterIds.size();
@@ -578,22 +586,22 @@ CHIP_ERROR InteractionModelReports::ReportAll(chip::DeviceProxy * device, std::v
     ReadPrepareParams params(device->GetSecureSession().Value());
     params.mpEventPathParamsList        = eventPathParams;
     params.mEventPathParamsListSize     = eventCount;
-    params.mEventNumber                 = eventNumber;
+    params.mEventNumber                 = mEventNumber;
     params.mpAttributePathParamsList    = attributePathParams;
     params.mAttributePathParamsListSize = attributeCount;
 
-    if (fabricFiltered.HasValue())
+    if (mFabricFiltered.HasValue())
     {
-        params.mIsFabricFiltered = fabricFiltered.Value();
+        params.mIsFabricFiltered = mFabricFiltered.Value();
     }
 
     if (interactionType == ReadClient::InteractionType::Subscribe)
     {
-        params.mMinIntervalFloorSeconds   = minInterval;
-        params.mMaxIntervalCeilingSeconds = maxInterval;
-        if (keepSubscriptions.HasValue())
+        params.mMinIntervalFloorSeconds   = mMinInterval;
+        params.mMaxIntervalCeilingSeconds = mMaxInterval;
+        if (mKeepSubscriptions.HasValue())
         {
-            params.mKeepSubscriptions = keepSubscriptions.Value();
+            params.mKeepSubscriptions = mKeepSubscriptions.Value();
         }
     }
 

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -49,91 +49,59 @@ public:
 class InteractionModelReports
 {
 public:
-    InteractionModelReports(chip::app::ReadClient::Callback * callback) : mBufferedReadAdapter(*callback) {}
+    InteractionModelReports(chip::app::ReadClient::Callback * callback) : mBufferedReadAdapter(*callback) { ResetOptions(); }
 
 protected:
     CHIP_ERROR ReadAttribute(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
-                             std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
-                             const chip::Optional<bool> & fabricFiltered                         = chip::Optional<bool>(true),
-                             const chip::Optional<std::vector<chip::DataVersion>> & dataVersions = chip::NullOptional)
+                             std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds)
     {
-        return ReportAttribute(device, endpointIds, clusterIds, attributeIds, chip::app::ReadClient::InteractionType::Read, 0, 0,
-                               fabricFiltered, dataVersions, chip::NullOptional, chip::NullOptional);
+        return ReportAttribute(device, endpointIds, clusterIds, attributeIds, chip::app::ReadClient::InteractionType::Read);
     }
 
     CHIP_ERROR SubscribeAttribute(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
-                                  std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
-                                  uint16_t minInterval, uint16_t maxInterval, const chip::Optional<bool> & fabricFiltered,
-                                  const chip::Optional<std::vector<chip::DataVersion>> & dataVersions,
-                                  const chip::Optional<bool> & keepSubscriptions, const chip::Optional<bool> & autoResubscribe)
+                                  std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds)
     {
-        return ReportAttribute(device, endpointIds, clusterIds, attributeIds, chip::app::ReadClient::InteractionType::Subscribe,
-                               minInterval, maxInterval, fabricFiltered, dataVersions, keepSubscriptions, autoResubscribe);
+        return ReportAttribute(device, endpointIds, clusterIds, attributeIds, chip::app::ReadClient::InteractionType::Subscribe);
     }
 
     CHIP_ERROR ReportAttribute(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
                                std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
-                               chip::app::ReadClient::InteractionType interactionType, uint16_t minInterval, uint16_t maxInterval,
-                               const chip::Optional<bool> & fabricFiltered,
-                               const chip::Optional<std::vector<chip::DataVersion>> & dataVersions,
-                               const chip::Optional<bool> & keepSubscriptions, const chip::Optional<bool> & autoResubscribe);
+                               chip::app::ReadClient::InteractionType interactionType);
 
     CHIP_ERROR ReadEvent(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
-                         std::vector<chip::ClusterId> clusterIds, std::vector<chip::EventId> eventIds,
-                         const chip::Optional<bool> & fabricFiltered           = chip::Optional<bool>(true),
-                         const chip::Optional<chip::EventNumber> & eventNumber = chip::NullOptional)
+                         std::vector<chip::ClusterId> clusterIds, std::vector<chip::EventId> eventIds)
     {
-        return ReportEvent(device, endpointIds, clusterIds, eventIds, chip::app::ReadClient::InteractionType::Read, 0, 0,
-                           fabricFiltered, eventNumber, chip::NullOptional, chip::NullOptional, chip::NullOptional);
+        return ReportEvent(device, endpointIds, clusterIds, eventIds, chip::app::ReadClient::InteractionType::Read);
     }
 
     CHIP_ERROR SubscribeEvent(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
-                              std::vector<chip::ClusterId> clusterIds, std::vector<chip::EventId> eventIds, uint16_t minInterval,
-                              uint16_t maxInterval, const chip::Optional<bool> & fabricFiltered,
-                              const chip::Optional<chip::EventNumber> & eventNumber, const chip::Optional<bool> & keepSubscriptions,
-                              const chip::Optional<std::vector<bool>> & isUrgents, const chip::Optional<bool> & autoResubscribe)
+                              std::vector<chip::ClusterId> clusterIds, std::vector<chip::EventId> eventIds)
     {
-        return ReportEvent(device, endpointIds, clusterIds, eventIds, chip::app::ReadClient::InteractionType::Subscribe,
-                           minInterval, maxInterval, fabricFiltered, eventNumber, keepSubscriptions, isUrgents, autoResubscribe);
+        return ReportEvent(device, endpointIds, clusterIds, eventIds, chip::app::ReadClient::InteractionType::Subscribe);
     }
 
     CHIP_ERROR ReportEvent(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
                            std::vector<chip::ClusterId> clusterIds, std::vector<chip::EventId> eventIds,
-                           chip::app::ReadClient::InteractionType interactionType, uint16_t minInterval, uint16_t maxInterval,
-                           const chip::Optional<bool> & fabricFiltered, const chip::Optional<chip::EventNumber> & eventNumber,
-                           const chip::Optional<bool> & keepSubscriptions, const chip::Optional<std::vector<bool>> & isUrgents,
-                           const chip::Optional<bool> & autoResubscribe);
+                           chip::app::ReadClient::InteractionType interactionType);
 
     CHIP_ERROR ReadAll(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
                        std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
-                       std::vector<chip::EventId> eventIds,
-                       const chip::Optional<bool> & fabricFiltered                         = chip::Optional<bool>(true),
-                       const chip::Optional<std::vector<chip::DataVersion>> & dataVersions = chip::NullOptional,
-                       const chip::Optional<chip::EventNumber> & eventNumber               = chip::NullOptional)
+                       std::vector<chip::EventId> eventIds)
     {
-        return ReportAll(device, endpointIds, clusterIds, attributeIds, eventIds, chip::app::ReadClient::InteractionType::Read, 0,
-                         0, fabricFiltered, dataVersions, eventNumber);
+        return ReportAll(device, endpointIds, clusterIds, attributeIds, eventIds, chip::app::ReadClient::InteractionType::Read);
     }
 
     CHIP_ERROR SubscribeAll(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
                             std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
-                            std::vector<chip::EventId> eventIds, uint16_t minInterval = 0, uint16_t maxInterval = 0,
-                            const chip::Optional<bool> & fabricFiltered           = chip::Optional<bool>(true),
-                            const chip::Optional<chip::EventNumber> & eventNumber = chip::NullOptional,
-                            const chip::Optional<bool> & keepSubscriptions        = chip::NullOptional)
+                            std::vector<chip::EventId> eventIds)
     {
-        return ReportAll(device, endpointIds, clusterIds, attributeIds, eventIds, chip::app::ReadClient::InteractionType::Subscribe,
-                         minInterval, maxInterval, fabricFiltered, chip::NullOptional, eventNumber, keepSubscriptions);
+        return ReportAll(device, endpointIds, clusterIds, attributeIds, eventIds,
+                         chip::app::ReadClient::InteractionType::Subscribe);
     }
 
     CHIP_ERROR ReportAll(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
                          std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
-                         std::vector<chip::EventId> eventIds, chip::app::ReadClient::InteractionType interactionType,
-                         uint16_t minInterval = 0, uint16_t maxInterval = 0,
-                         const chip::Optional<bool> & fabricFiltered                         = chip::Optional<bool>(true),
-                         const chip::Optional<std::vector<chip::DataVersion>> & dataVersions = chip::NullOptional,
-                         const chip::Optional<chip::EventNumber> & eventNumber               = chip::NullOptional,
-                         const chip::Optional<bool> & keepSubscriptions                      = chip::NullOptional);
+                         std::vector<chip::EventId> eventIds, chip::app::ReadClient::InteractionType interactionType);
 
     void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams);
 
@@ -143,6 +111,105 @@ protected:
 
     std::vector<std::unique_ptr<chip::app::ReadClient>> mReadClients;
     chip::app::BufferedReadCallback mBufferedReadAdapter;
+
+    InteractionModelReports & SetDataVersions(const std::vector<chip::DataVersion> & dataVersions)
+    {
+        mDataVersions.SetValue(dataVersions);
+        return *this;
+    }
+
+    InteractionModelReports & SetDataVersions(const chip::Optional<std::vector<chip::DataVersion>> & dataVersions)
+    {
+        mDataVersions = dataVersions;
+        return *this;
+    }
+
+    InteractionModelReports & SetIsUrgents(const std::vector<bool> isUrgents)
+    {
+        mIsUrgents.SetValue(isUrgents);
+        return *this;
+    }
+
+    InteractionModelReports & SetIsUrgents(const chip::Optional<std::vector<bool>> & isUrgents)
+    {
+        mIsUrgents = isUrgents;
+        return *this;
+    }
+
+    InteractionModelReports & SetEventNumber(const chip::Optional<chip::EventNumber> & eventNumber)
+    {
+        mEventNumber = eventNumber;
+        return *this;
+    }
+
+    InteractionModelReports & SetEventNumber(chip::EventNumber eventNumber)
+    {
+        mEventNumber.SetValue(eventNumber);
+        return *this;
+    }
+
+    InteractionModelReports & SetFabricFiltered(bool fabricFiltered)
+    {
+        mFabricFiltered.SetValue(fabricFiltered);
+        return *this;
+    }
+
+    InteractionModelReports & SetKeepSubscriptions(bool keepSubscriptions)
+    {
+        mKeepSubscriptions.SetValue(keepSubscriptions);
+        return *this;
+    }
+
+    InteractionModelReports & SetKeepSubscriptions(const chip::Optional<bool> & keepSubscriptions)
+    {
+        mKeepSubscriptions = keepSubscriptions;
+        return *this;
+    }
+
+    InteractionModelReports & SetAutoResubscribe(bool autoResubscribe)
+    {
+        mAutoResubscribe.SetValue(autoResubscribe);
+        return *this;
+    }
+
+    InteractionModelReports & SetAutoResubscribe(const chip::Optional<bool> & autoResubscribe)
+    {
+        mAutoResubscribe = autoResubscribe;
+        return *this;
+    }
+
+    InteractionModelReports & SetMinInterval(uint16_t minInterval)
+    {
+        mMinInterval = minInterval;
+        return *this;
+    }
+
+    InteractionModelReports & SetMaxInterval(uint16_t maxInterval)
+    {
+        mMaxInterval = maxInterval;
+        return *this;
+    }
+
+    void ResetOptions()
+    {
+        mDataVersions      = chip::NullOptional;
+        mIsUrgents         = chip::NullOptional;
+        mEventNumber       = chip::NullOptional;
+        mFabricFiltered    = chip::Optional<bool>(true);
+        mKeepSubscriptions = chip::NullOptional;
+        mAutoResubscribe   = chip::NullOptional;
+        mMinInterval       = 0;
+        mMaxInterval       = 0;
+    }
+
+    chip::Optional<std::vector<chip::DataVersion>> mDataVersions;
+    chip::Optional<std::vector<bool>> mIsUrgents;
+    chip::Optional<chip::EventNumber> mEventNumber;
+    chip::Optional<bool> mFabricFiltered;
+    chip::Optional<bool> mKeepSubscriptions;
+    chip::Optional<bool> mAutoResubscribe;
+    uint16_t mMinInterval;
+    uint16_t mMaxInterval;
 };
 
 class InteractionModelCommands


### PR DESCRIPTION
#### Problem

The APIs used by `chip-tool` to emit interaction model commands consumed a bunch of arguments, which makes it hard to maintain/review properly as stated in https://github.com/project-chip/connectedhomeip/pull/23886#discussion_r1038590911 and https://github.com/project-chip/connectedhomeip/pull/23886#discussion_r1038591294

This PR moves some of the members from `chip-tool` to the helper classes, so they are filled when the command arguments are parsed instead of beeing passed as arguments - which should make the API cleaner.

