### PR TITLE
Fix management of the mNumReportsInFlight count in reporting engine.

### DIFF
--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -252,6 +252,8 @@ private:
      *  @retval #Others If fails to send report data
      *  @retval #CHIP_NO_ERROR On success.
      *
+     *  If an error is returned, the ReadHandler guarantees that it is not in
+     *  a state where it's waiting for a response.
      */
     CHIP_ERROR SendReportData(System::PacketBufferHandle && aPayload, bool aMoreChunks);
 

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -848,6 +848,10 @@ CHIP_ERROR Engine::SendReport(ReadHandler * apReadHandler, System::PacketBufferH
     // We can only have 1 report in flight for any given read - increment and break out.
     mNumReportsInFlight++;
     err = apReadHandler->SendReportData(std::move(aPayload), aHasMoreChunks);
+    if (err != CHIP_NO_ERROR)
+    {
+        --mNumReportsInFlight;
+    }
     return err;
 }
 


### PR DESCRIPTION
If a ReadHandler failed out of SendReportData (e.g. because the session it's on had been marked as defunct), we would increment mNumReportsInFlight and never decrement it.  After this happened CHIP_IM_MAX_REPORTS_IN_FLIGHT times (4 by default), we would stop being able to send out any more data reports.

This situation is pretty easy to trigger as follows:

1. Use chip-tool to commission a device with node id 17.
2. Start chip-tool interactive mode.
3. Run the following commands in interactive mode:
    ```
    onoff subscribe on-off 0 60 17 1 --keepSubscriptions true
    onoff subscribe on-off 0 60 17 1 --keepSubscriptions true
    onoff subscribe on-off 0 60 17 1 --keepSubscriptions true
    onoff subscribe on-off 0 60 17 1 --keepSubscriptions true
    onoff subscribe on-off 0 2 17 1 --keepSubscriptions true
    ```
4. quit interactive mode (Ctrl-C or quit() command).
5. Wait 60 seconds for all the subscriptions to error out.

After this the device will no longer respond with data reports to any read or subscribe requests.
