### PR TITLE
Fix support for 0-length hex-encoded octet strings in chip-tool.

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -58,6 +58,7 @@ static_library("chip-tool-utils") {
     "commands/common/Commands.cpp",
     "commands/common/Commands.h",
     "commands/common/CredentialIssuerCommands.h",
+    "commands/common/HexConversion.h",
     "commands/discover/DiscoverCommand.cpp",
     "commands/discover/DiscoverCommissionablesCommand.cpp",
     "commands/discover/DiscoverCommissionersCommand.cpp",

--- a/examples/chip-tool/commands/clusters/ComplexArgument.h
+++ b/examples/chip-tool/commands/clusters/ComplexArgument.h
@@ -218,6 +218,7 @@ public:
                     return buffer;
                 },
                 &size);
+
             if (err != CHIP_NO_ERROR)
             {
                 if (buffer != nullptr)

--- a/examples/chip-tool/commands/common/HexConversion.h
+++ b/examples/chip-tool/commands/common/HexConversion.h
@@ -1,0 +1,65 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/BytesToHex.h>
+#include <lib/support/Span.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+/**
+ * Utility for converting a hex string to bytes, with the right error checking
+ * and allocation size computation.
+ *
+ * Takes a functor to allocate the buffer to use for the hex bytes.  The functor
+ * is expected to return uint8_t *.  The caller is responsible for cleaning up
+ * this buffer as needed.
+ *
+ * On success, *octetCount is filled with the number of octets placed in the
+ * buffer.  On failure, the value of *octetCount is undefined.
+ */
+template <typename F>
+CHIP_ERROR HexToBytes(chip::CharSpan hex, F bufferAllocator, size_t * octetCount)
+{
+    *octetCount = 0;
+
+    if (hex.size() % 2 != 0)
+    {
+        ChipLogError(chipTool, "Error while encoding '%.*s' as an octet string: Odd number of characters.",
+                     static_cast<int>(hex.size()), hex.data());
+        return CHIP_ERROR_INVALID_STRING_LENGTH;
+    }
+
+    const size_t bufferSize = hex.size() / 2;
+    uint8_t * buffer        = bufferAllocator(bufferSize);
+    if (buffer == nullptr)
+    {
+        ChipLogError(chipTool, "Failed to allocate buffer of size: %llu", static_cast<unsigned long long>(bufferSize));
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    size_t byteCount = chip::Encoding::HexToBytes(hex.data(), hex.size(), buffer, bufferSize);
+    if (byteCount == 0 && hex.size() != 0)
+    {
+        ChipLogError(chipTool, "Error while encoding '%.*s' as an octet string.", static_cast<int>(hex.size()), hex.data());
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    *octetCount = byteCount;
+    return CHIP_NO_ERROR;
+}

--- a/examples/chip-tool/commands/common/HexConversion.h
+++ b/examples/chip-tool/commands/common/HexConversion.h
@@ -47,7 +47,7 @@ CHIP_ERROR HexToBytes(chip::CharSpan hex, F bufferAllocator, size_t * octetCount
 
     const size_t bufferSize = hex.size() / 2;
     uint8_t * buffer        = bufferAllocator(bufferSize);
-    if (buffer == nullptr)
+    if (buffer == nullptr && bufferSize != 0)
     {
         ChipLogError(chipTool, "Failed to allocate buffer of size: %llu", static_cast<unsigned long long>(bufferSize));
         return CHIP_ERROR_NO_MEMORY;

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -124,6 +124,7 @@ executable("darwin-framework-tool") {
     "${chip_root}/examples/chip-tool/commands/common/Command.h",
     "${chip_root}/examples/chip-tool/commands/common/Commands.cpp",
     "${chip_root}/examples/chip-tool/commands/common/Commands.h",
+    "${chip_root}/examples/chip-tool/commands/common/HexConversion.h",
     "${chip_root}/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp",
     "commands/clusters/ClusterCommandBridge.h",
     "commands/clusters/ModelCommandBridge.mm",

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -43,6 +43,7 @@ chip_data_model("tv-casting-common") {
     "${chip_root}/examples/chip-tool/commands/common/Commands.cpp",
     "${chip_root}/examples/chip-tool/commands/common/Commands.h",
     "${chip_root}/examples/chip-tool/commands/common/CredentialIssuerCommands.h",
+    "${chip_root}/examples/chip-tool/commands/common/HexConversion.h",
     "${chip_root}/src/controller/ExamplePersistentStorage.cpp",
     "${chip_root}/src/controller/ExamplePersistentStorage.h",
     "${chip_root}/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp",


### PR DESCRIPTION
Without this fix, these commands all fail to parse:

  chip-tool unittesting write struct-attr '{"a": 1, "b": true, "c": 0, "d":"", "e": "abc", "f": 0, "g": 0, "h": 0}' 17 1
  chip-tool unittesting write struct-attr '{"a": 1, "b": true, "c": 0, "d":"hex:", "e": "abc", "f": 0, "g": 0, "h": 0}' 17 1
  chip-tool unittesting write octet-string "hex:" 17 1
  chip-tool unittesting write-by-id 0 "hex:" 17 1

and with this fix they parse and send correct payloads.

Fixes https://github.com/project-chip/connectedhomeip/issues/24054
