### PR TITLE
Bump job timeout for Darwin tests build apps part.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -287,7 +287,7 @@ jobs:
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
             - name: Build Apps
-              timeout-minutes: 60
+              timeout-minutes: 75
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \


### PR DESCRIPTION
It keeps timing out at 60 mins, and when it passes it's around 55-58 mins.

