### PR TITLE
[darwin-framework-tool] The stack is not properly turned off on timeout

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -41,7 +41,8 @@ CHIP_ERROR CHIPCommandBridge::Run()
     ReturnErrorOnFailure(MaybeSetUpStack());
     SetIdentity(mCommissionerName.HasValue() ? mCommissionerName.Value() : kIdentityAlpha);
     ReturnLogErrorOnFailure(RunCommand());
-    ReturnLogErrorOnFailure(StartWaiting(GetWaitDuration()));
+
+    auto err = StartWaiting(GetWaitDuration());
 
     bool deferCleanup = (IsInteractive() && DeferInteractiveCleanup());
 
@@ -54,7 +55,7 @@ CHIP_ERROR CHIPCommandBridge::Run()
     }
     MaybeTearDownStack();
 
-    return CHIP_NO_ERROR;
+    return err;
 }
 
 CHIP_ERROR CHIPCommandBridge::GetPAACertsFromFolder(NSArray<NSData *> * __autoreleasing * paaCertsResult)


### PR DESCRIPTION
#### Problem

When a command timeouts, e.g:
```
./out/debug/standalone-dft/darwin-framework-tool onoff toggle 0xDEADBEEF 1
```

If ends up crashing with the following error:
```
...
 [Default] ../../../examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm:223: Error 0x00000032 at ../../../examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm:44
2022-12-16 16:29:30.840562+0100 darwin-framework-tool[86667:6578707] [chipTool] Run command failure: ../../../examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm:223: Error 0x00000032
2022-12-16 16:29:30.845339+0100 darwin-framework-tool[86667:6578707] [Support] VerifyOrDie failure at ../../../../../../../../../../src/lib/support/IntrusiveList.h:290: Empty()
```

It happens before instead of properly turning off the stack and reporting the error, the code returns early.

