### PR TITLE
Update ZAP to tip.

### DIFF
--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -163,7 +163,7 @@ RUN set -x \
 
 # Install a known ZAP release
 # Only keep the cli version, since `zap` is 143MB and not usable (UI)
-ENV ZAP_VERSION=v2022.12.15-nightly
+ENV ZAP_VERSION=v2022.12.16-nightly
 RUN set -x \
     && mkdir -p /opt/zap-${ZAP_VERSION} \
     && cd /opt/zap-${ZAP_VERSION} \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.21 Version bump reason: Updating ZAP to v2022.12.15-nightly
+0.6.22 Version bump reason: Updating ZAP to v2022.12.16-nightly


### PR DESCRIPTION
Pulls in workaround for clang-format bug.


