### PR TITLE
Explicitly list out renames due to acronym casing changes.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -5156,6 +5156,15 @@
       clusters:
           UnitTesting: TestCluster
           BasicInformation: Basic
+          OTASoftwareUpdateProvider: OtaSoftwareUpdateProvider
+          OTASoftwareUpdateRequestor: OtaSoftwareUpdateRequestor
+          WakeOnLAN: WakeOnLan
       attributes:
           Descriptor:
               DeviceTypeList: DeviceList
+          AccessControl:
+              ACL: Acl
+          OccupancySensing:
+              PIROccupiedToUnoccupiedDelay: PirOccupiedToUnoccupiedDelay
+              PIRUnoccupiedToOccupiedDelay: PirUnoccupiedToOccupiedDelay
+              PIRUnoccupiedToOccupiedThreshold: PirUnoccupiedToOccupiedThreshold


### PR DESCRIPTION
This will let us avoid generating incorrect backwards-compat shims for things that get added after our big API update but have a name that includes acronyms.


