### PR TITLE
Implement support for renaming fields in Darwin codegen.

### DIFF
--- a/.github/workflows/zap_regeneration.yaml
+++ b/.github/workflows/zap_regeneration.yaml
@@ -28,7 +28,7 @@ jobs:
 
         runs-on: ubuntu-20.04
         container:
-            image: connectedhomeip/chip-build:0.6.24
+            image: connectedhomeip/chip-build:0.6.25
         defaults:
             run:
                 shell: sh

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -29,7 +29,7 @@ jobs:
 
         runs-on: ubuntu-20.04
         container:
-            image: connectedhomeip/chip-build:0.6.24
+            image: connectedhomeip/chip-build:0.6.25
         defaults:
             run:
                 shell: sh

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -85,6 +85,12 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 typedef NS_ENUM({{asUnderlyingZclType name}}, {{objCEnumName clusterName enumName}}) {
    {{#zcl_enum_items}}
    {{objCEnumName ../clusterName ../enumName}}{{objCEnumItemLabel label}} {{availability ../clusterName enum=../enumName enumValue=(objCEnumItemLabel label) deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../../name preserveAcronyms=true) ../label) (objCEnumItemLabel label))}} = {{asHex value 2}},
+   {{#*inline "oldNameItemDecl"}}
+   {{#if oldItemName}}
+   {{objCEnumName ../clusterName ../enumName}}{{objCEnumItemLabel oldItemName}} {{availability ../clusterName enum=../enumName enumValue=oldItemName deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../../name preserveAcronyms=true) ../label) (objCEnumItemLabel label))}} = {{asHex value 2}},
+   {{/if}}
+   {{/inline}}
+   {{> oldNameItemDecl oldItemName=(oldName ../clusterName enum=../enumName enumValue=(objCEnumItemLabel label))}}
    {{/zcl_enum_items}}
 }
 {{/inline}}
@@ -113,6 +119,12 @@ typedef NS_ENUM({{asUnderlyingZclType name}}, {{objCEnumName clusterName enumNam
 typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName bitmapName}}) {
    {{#zcl_bitmap_items}}
    {{objCEnumName ../clusterName ../bitmapName}}{{objCEnumItemLabel label}} {{availability ../clusterName bitmap=../bitmapName bitmapValue=(objCEnumItemLabel label) deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../../name preserveAcronyms=true) ../label) (objCEnumItemLabel label))}} = {{asHex mask}},
+   {{#*inline "oldNameItemDecl"}}
+   {{#if oldItemName}}
+   {{objCEnumName ../clusterName ../bitmapName}}{{objCEnumItemLabel oldItemName}} {{availability ../clusterName bitmap=../enumName bitmapValue=oldItemName deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../../name preserveAcronyms=true) ../label) (objCEnumItemLabel label))}} = {{asHex value 2}},
+   {{/if}}
+   {{/inline}}
+   {{> oldNameItemDecl oldItemName=(oldName ../clusterName bitmap=../bitmapName bitmapValue=(objCEnumItemLabel label))}}
    {{/zcl_bitmap_items}}
 }
 {{/inline}}

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -82,32 +82,58 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 {{#zcl_clusters}}
 {{#zcl_enums}}
 {{#*inline "enumDef"}}
-typedef NS_ENUM({{asUnderlyingZclType name}}, {{objCEnumName clusterName label}}) {
+typedef NS_ENUM({{asUnderlyingZclType name}}, {{objCEnumName clusterName enumName}}) {
    {{#zcl_enum_items}}
-   {{objCEnumName ../clusterName ../label}}{{objCEnumItemLabel label}} {{availability ../clusterName enum=(asUpperCamelCase ../label preserveAcronyms=true) enumValue=(objCEnumItemLabel label) deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../../name preserveAcronyms=true) ../label) (objCEnumItemLabel label))}} = {{asHex value 2}},
+   {{objCEnumName ../clusterName ../enumName}}{{objCEnumItemLabel label}} {{availability ../clusterName enum=../enumName enumValue=(objCEnumItemLabel label) deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../../name preserveAcronyms=true) ../label) (objCEnumItemLabel label))}} = {{asHex value 2}},
    {{/zcl_enum_items}}
 }
 {{/inline}}
-{{> enumDef name=name clusterName=(asUpperCamelCase ../name preserveAcronyms=true) label=label}} {{availability (asUpperCamelCase ../name preserveAcronyms=true) enum=(asUpperCamelCase label preserveAcronyms=true)}};
-{{#unless (isStrEqual (asUpperCamelCase ../name preserveAcronyms=true) (compatClusterNameRemapping ../name))}}
+{{> enumDef name=name clusterName=(asUpperCamelCase ../name preserveAcronyms=true) enumName=(asUpperCamelCase label preserveAcronyms=true)}} {{availability (asUpperCamelCase ../name preserveAcronyms=true) enum=(asUpperCamelCase label preserveAcronyms=true)}};
+{{! Takes the name of the enum to use as enumName. }}
+{{#*inline "oldNameDecl"}}
 
-{{> enumDef name=name clusterName=(compatClusterNameRemapping ../name) label=label}} {{availability (compatClusterNameRemapping ../name) enum=(asUpperCamelCase label preserveAcronyms=true) deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../name preserveAcronyms=true) label))}};
-{{/unless}}
+{{> enumDef name=name clusterName=(compatClusterNameRemapping ../name) enumName=enumName}} {{availability (compatClusterNameRemapping ../name) enum=enumName deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../name preserveAcronyms=true) label))}};
+{{/inline}}
+{{! Takes the old name of the enum, if any, as oldEnumName. }}
+{{#*inline "oldNameCheck"}}
+{{#if (or oldEnumName
+          (hasOldName (asUpperCamelCase ../name preserveAcronyms=true)))}}
+{{#if oldEnumName}}
+{{> oldNameDecl enumName=oldEnumName}}
+{{else}}
+{{> oldNameDecl enumName=(asUpperCamelCase label preserveAcronyms=true)}}
+{{/if}}
+{{/if}}
+{{/inline}}
+{{> oldNameCheck oldEnumName=(oldName (asUpperCamelCase ../name preserveAcronyms=true) enum=(asUpperCamelCase label preserveAcronyms=true))}}
 
 {{/zcl_enums}}
 {{#zcl_bitmaps}}
 {{#*inline "bitmapDef"}}
-typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName label}}) {
+typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName bitmapName}}) {
    {{#zcl_bitmap_items}}
-   {{objCEnumName ../clusterName ../label}}{{objCEnumItemLabel label}} {{availability ../clusterName bitmap=(asUpperCamelCase ../label preserveAcronyms=true) bitmapValue=(objCEnumItemLabel label) deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../../name preserveAcronyms=true) ../label) (objCEnumItemLabel label))}} = {{asHex mask}},
+   {{objCEnumName ../clusterName ../bitmapName}}{{objCEnumItemLabel label}} {{availability ../clusterName bitmap=../bitmapName bitmapValue=(objCEnumItemLabel label) deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../../name preserveAcronyms=true) ../label) (objCEnumItemLabel label))}} = {{asHex mask}},
    {{/zcl_bitmap_items}}
 }
 {{/inline}}
-{{> bitmapDef name=name clusterName=(asUpperCamelCase ../name preserveAcronyms=true) label=label}} {{availability (asUpperCamelCase ../name preserveAcronyms=true) bitmap=(asUpperCamelCase label preserveAcronyms=true)}};
-{{#unless (isStrEqual (asUpperCamelCase ../name preserveAcronyms=true) (compatClusterNameRemapping ../name))}}
+{{> bitmapDef name=name clusterName=(asUpperCamelCase ../name preserveAcronyms=true) bitmapName=(asUpperCamelCase label preserveAcronyms=true)}} {{availability (asUpperCamelCase ../name preserveAcronyms=true) bitmap=(asUpperCamelCase label preserveAcronyms=true)}};
+{{! Takes the name of the bitmap to use as bitmapName. }}
+{{#*inline "oldNameDecl"}}
 
-{{> bitmapDef name=name clusterName=(compatClusterNameRemapping ../name) label=label}} {{availability (compatClusterNameRemapping ../name) bitmap=(asUpperCamelCase label preserveAcronyms=true) deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../name preserveAcronyms=true) label))}};
-{{/unless}}
+{{> bitmapDef name=name clusterName=(compatClusterNameRemapping ../name) bitmapName=bitmapName}} {{availability (compatClusterNameRemapping ../name) bitmap=bitmapName deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../name preserveAcronyms=true) label))}};
+{{/inline}}
+{{! Takes the old name of the bitmap, if any, as oldBitmapName. }}
+{{#*inline "oldNameCheck"}}
+{{#if (or oldBitmapName
+          (hasOldName (asUpperCamelCase ../name preserveAcronyms=true)))}}
+{{#if oldBitmapName}}
+{{> oldNameDecl bitmapName=oldBitmapName}}
+{{else}}
+{{> oldNameDecl bitmapName=(asUpperCamelCase label preserveAcronyms=true)}}
+{{/if}}
+{{/if}}
+{{/inline}}
+{{> oldNameCheck oldBitmapName=(oldName (asUpperCamelCase ../name preserveAcronyms=true) bitmap=(asUpperCamelCase label preserveAcronyms=true))}}
 
 
 {{/zcl_bitmaps}}

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
@@ -44,6 +44,13 @@ NS_ASSUME_NONNULL_BEGIN
   NSString *descriptionString = [NSString stringWithFormat:@"<%@: {{#zcl_command_arguments}}{{asStructPropertyName label}}:%@; {{/zcl_command_arguments}}>", NSStringFromClass([self class]) {{#zcl_command_arguments}},{{#if isArray}}_{{asStructPropertyName label}}{{else if (isOctetString type)}}[_{{asStructPropertyName label}} base64EncodedStringWithOptions:0]{{else}}_{{asStructPropertyName label}}{{/if}}{{/zcl_command_arguments}}];
   return descriptionString;
 }
+{{#zcl_command_arguments}}
+{{#if (and includeRenamedProperties
+           (hasOldName ../cluster command=../command commandField=(asStructPropertyName label)))}}
+
+{{> renamed_struct_field_impl cluster=parent.parent.name type=type newName=label oldName=(oldName ../cluster command=../command commandField=(asStructPropertyName label))}}
+{{/if}}
+{{/zcl_command_arguments}}
 
 @end
 {{/unless}}
@@ -51,19 +58,41 @@ NS_ASSUME_NONNULL_BEGIN
 {{#*inline "oldNameImpl"}}
 
 @implementation MTR{{cluster}}Cluster{{command}}Params
+{{#zcl_command_arguments}}
+{{#if (hasOldName (asUpperCamelCase parent.parent.name preserveAcronyms=true) command=(asUpperCamelCase parent.name preserveAcronyms=true) commandField=(asStructPropertyName label))}}
+
+{{> renamed_struct_field_impl cluster=parent.parent.name type=type newName=label oldName=(oldName (asUpperCamelCase parent.parent.name preserveAcronyms=true) command=(asUpperCamelCase parent.name preserveAcronyms=true) commandField=(asStructPropertyName label))}}
+{{/if}}
+{{/zcl_command_arguments}}
 @end
 {{/inline}}
 {{#if (not (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true)))}}
 {{> completeImpl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
-                 command=(asUpperCamelCase name preserveAcronyms=true)}}
+                 command=(asUpperCamelCase name preserveAcronyms=true)
+                 includeRenamedProperties=false}}
 {{#if (or (not (isStrEqual (asUpperCamelCase parent.name preserveAcronyms=true) (compatClusterNameRemapping parent.name)))
           (not (isStrEqual (asUpperCamelCase name preserveAcronyms=true) (compatCommandNameRemapping parent.name name))))}}
 {{> oldNameImpl cluster=(compatClusterNameRemapping parent.name)
                 command=(compatCommandNameRemapping parent.name name)}}
+{{else if (hasRenamedFields (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#*inline "deprecatedImpl"}}
+
+@implementation MTR{{cluster}}Cluster{{command}}Params (Deprecated)
+{{#zcl_command_arguments}}
+{{#if (hasOldName ../cluster command=../command commandField=(asStructPropertyName label))}}
+
+{{> renamed_struct_field_impl cluster=parent.parent.name type=type newName=label oldName=(oldName ../cluster command=../command commandField=(asStructPropertyName label))}}
+{{/if}}
+{{/zcl_command_arguments}}
+@end
+{{/inline}}
+{{> deprecatedImpl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
+                   command=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/if}}
 {{else}}
 {{> completeImpl cluster=(compatClusterNameRemapping parent.name)
-                 command=(compatCommandNameRemapping parent.name name)}}
+                 command=(compatCommandNameRemapping parent.name name)
+                 includeRenamedProperties=true}}
 {{/if}}
 {{/zcl_commands}}
 {{/zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
@@ -14,9 +14,15 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTR{{cluster}}Cluster{{command}}Params : NSObject <NSCopying>
 {{#zcl_command_arguments}}
 
-{{! Override the getter name because some of our properties start with things
-    like "new" or "init" }}
-@property (nonatomic, copy{{#unless (isStrEqual (asGetterName label) (asStructPropertyName label))}}, getter={{asGetterName label}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName label}} {{availability ../cluster command=../command commandField=(asStructPropertyName label)}};
+{{> struct_field_decl cluster=parent.parent.name type=type label=label}} {{availability ../cluster command=../command commandField=(asStructPropertyName label)}};
+{{#*inline "oldNameFieldDecl"}}
+
+{{> struct_field_decl cluster=parent.parent.name type=type label=commandField}} {{availability ../cluster command=../command commandField=commandField deprecationMessage=(concat "Please use " (asStructPropertyName label))}};
+{{/inline}}
+{{#if (and includeRenamedProperties
+           (hasOldName ../cluster command=../command commandField=(asStructPropertyName label)))}}
+{{> oldNameFieldDecl commandField=(oldName ../cluster command=../command commandField=(asStructPropertyName label))}}
+{{/if}}
 {{/zcl_command_arguments}}
 {{#if (isStrEqual source "client")}}
 /**
@@ -60,20 +66,48 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{availability cluster command=command deprecationMessage=(concat "Please use MTR" (asUpperCamelCase parent.name preserveAcronyms=true) "Cluster" (asUpperCamelCase name preserveAcronyms=true) "Params")}}
 @interface MTR{{cluster}}Cluster{{command}}Params : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name}}Params
+{{#zcl_command_arguments}}
+{{#*inline "oldNameFieldDecl"}}
+
+{{> struct_field_decl cluster=parent.parent.name type=type label=commandField}} {{availability ../cluster command=../command commandField=commandField deprecationMessage=(concat "Please use " (asStructPropertyName label))}};
+{{/inline}}
+{{#if (hasOldName (asUpperCamelCase parent.parent.name preserveAcronyms=true) command=(asUpperCamelCase parent.name preserveAcronyms=true) commandField=(asStructPropertyName label))}}
+{{> oldNameFieldDecl commandField=(oldName (asUpperCamelCase parent.parent.name preserveAcronyms=true) command=(asUpperCamelCase parent.name preserveAcronyms=true) commandField=(asStructPropertyName label))}}
+{{/if}}
+{{/zcl_command_arguments}}
 @end
 
 {{/inline}}
 {{#if (not (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true)))}}
 {{> completeDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
-                 command=(asUpperCamelCase name preserveAcronyms=true)}}
+                 command=(asUpperCamelCase name preserveAcronyms=true)
+                 includeRenamedProperties=false}}
 {{#if (or (not (isStrEqual (asUpperCamelCase parent.name preserveAcronyms=true) (compatClusterNameRemapping parent.name)))
           (not (isStrEqual (asUpperCamelCase name preserveAcronyms=true) (compatCommandNameRemapping parent.name name))))}}
 {{> oldNameDecl cluster=(compatClusterNameRemapping parent.name)
                 command=(compatCommandNameRemapping parent.name name)}}
+{{else if (hasRenamedFields (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#*inline "deprecatedDecl"}}
+
+@interface MTR{{cluster}}Cluster{{command}}Params (Deprecated)
+{{#zcl_command_arguments}}
+{{#*inline "oldNameFieldDecl"}}
+
+{{> struct_field_decl cluster=parent.parent.name type=type label=commandField}} {{availability ../cluster command=../command commandField=commandField deprecationMessage=(concat "Please use " (asStructPropertyName label))}};
+{{/inline}}
+{{#if (hasOldName ../cluster command=../command commandField=(asStructPropertyName label))}}
+{{> oldNameFieldDecl commandField=(oldName ../cluster command=../command commandField=(asStructPropertyName label))}}
+{{/if}}
+{{/zcl_command_arguments}}
+@end
+{{/inline}}
+{{> deprecatedDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
+                   command=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/if}}
 {{else}}
 {{> completeDecl cluster=(compatClusterNameRemapping parent.name)
-                 command=(compatCommandNameRemapping parent.name name)}}
+                 command=(compatCommandNameRemapping parent.name name)
+                 includeRenamedProperties=true}}
 {{/if}}
 {{/zcl_commands}}
 {{/zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
@@ -34,6 +34,12 @@ NS_ASSUME_NONNULL_BEGIN
   NSString *descriptionString = [NSString stringWithFormat:@"<%@: {{#zcl_struct_items}}{{asStructPropertyName label}}:%@; {{/zcl_struct_items}}>", NSStringFromClass([self class]){{#zcl_struct_items}},{{#if isArray}}_{{asStructPropertyName label}}{{else if (isOctetString type)}}[_{{asStructPropertyName label}} base64EncodedStringWithOptions:0]{{else}}_{{asStructPropertyName label}}{{/if}}{{/zcl_struct_items}}];
   return descriptionString;
 }
+{{#zcl_struct_items}}
+{{#if (hasOldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label))}}
+
+{{> renamed_struct_field_impl cluster=../../name type=type newName=label oldName=(oldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label))}}
+{{/if}}
+{{/zcl_struct_items}}
 
 @end
 {{/inline}}
@@ -83,21 +89,12 @@ NS_ASSUME_NONNULL_BEGIN
   return descriptionString;
 }
 
-{{#if (isStrEqual (asUpperCamelCase parent.name preserveAcronyms=true) "Switch")}}
-{{#if (isStrEqual (asUpperCamelCase name preserveAcronyms=true) "MultiPressComplete")}}
-{{! Workaround for the name being mis-spelled in XML previously }}
-- (void)setNewPosition:(NSNumber * _Nonnull)newPosition
-{
-  self.previousPosition = newPosition;
-}
+{{#zcl_event_fields}}
+{{#if (hasOldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
 
-- (NSNumber * _Nonnull)newPosition
-{
-  return self.previousPosition;
-}
-
+{{> renamed_struct_field_impl cluster=../parent.name type=type newName=name oldName=(oldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
 {{/if}}
-{{/if}}
+{{/zcl_event_fields}}
 @end
 {{#unless (isStrEqual (asUpperCamelCase parent.name preserveAcronyms=true) (compatClusterNameRemapping parent.name))}}
 

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
@@ -46,17 +46,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{> interfaceImpl interfaceName=(concat "MTR" (asUpperCamelCase parent.name preserveAcronyms=true) "Cluster" (asUpperCamelCase name preserveAcronyms=true))}}
 
-{{!Backwards compat for now: Add a DeviceType thing that is API-compatible with DeviceTypeStruct. }}
-{{#if (isStrEqual (asUpperCamelCase parent.name) "Descriptor")}}
-{{#if (isStrEqual (asUpperCamelCase name) "DeviceTypeStruct")}}
-{{> interfaceImpl interfaceName="MTRDescriptorClusterDeviceType"}}
-{{/if}}
-{{else}}
-{{#unless (isStrEqual (asUpperCamelCase parent.name preserveAcronyms=true) (compatClusterNameRemapping parent.name))}}
-@implementation MTR{{compatClusterNameRemapping parent.name}}Cluster{{asUpperCamelCase name}} : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}
+{{! Takes the name of the struct to use as structName. }}
+{{#*inline "oldNameImpl"}}
+@implementation MTR{{compatClusterNameRemapping parent.name}}Cluster{{structName}} : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}
 @end
-{{/unless}}
+{{/inline}}
+{{! Takes the old name of the struct, if any, as oldStructName. }}
+{{#*inline "oldNameCheck"}}
+{{#if (or oldStructName
+          (hasOldName (asUpperCamelCase parent.name preserveAcronyms=true)))}}
+{{#if oldStructName}}
+{{> oldNameImpl structName=oldStructName}}
+{{else}}
+{{> oldNameImpl structName=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/if}}
+{{/if}}
+{{/inline}}
+{{> oldNameCheck oldStructName=(oldName (asUpperCamelCase parent.name preserveAcronyms=true) struct=(asUpperCamelCase name preserveAcronyms=true))}}
 
 {{/zcl_structs}}
 
@@ -96,11 +102,24 @@ NS_ASSUME_NONNULL_BEGIN
 {{/if}}
 {{/zcl_event_fields}}
 @end
-{{#unless (isStrEqual (asUpperCamelCase parent.name preserveAcronyms=true) (compatClusterNameRemapping parent.name))}}
+{{! Takes the name of the event to use as eventName. }}
+{{#*inline "oldNameDecl"}}
 
-@implementation MTR{{compatClusterNameRemapping parent.name}}Cluster{{asUpperCamelCase name}}Event : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event
+@implementation MTR{{compatClusterNameRemapping parent.name}}Cluster{{eventName}}Event : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event
 @end
-{{/unless}}
+{{/inline}}
+{{! Takes the old name of the event, if any, as oldEventName. }}
+{{#*inline "oldNameCheck"}}
+{{#if (or oldEventName
+          (hasOldName (asUpperCamelCase parent.name preserveAcronyms=true)))}}
+{{#if oldEventName}}
+{{> oldNameDecl eventName=oldEventName}}
+{{else}}
+{{> oldNameDecl eventName=(asUpperCamelCase name preserveAcronyms=true)}}
+{{/if}}
+{{/if}}
+{{/inline}}
+{{> oldNameCheck oldEventName=(oldName (asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true))}}
 
 {{/zcl_events}}
 

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
@@ -7,10 +7,11 @@ NS_ASSUME_NONNULL_BEGIN
 {{#zcl_clusters}}
 {{#zcl_structs}}
 {{#*inline "interfaceDecl"}}
-{{! Override the getter name because some of our properties start with things
-    like "new" or "init" }}
 {{#zcl_struct_items}}
-@property (nonatomic, copy{{#unless (isStrEqual (asGetterName label) (asStructPropertyName label))}}, getter={{asGetterName label}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName label}} {{availability (asUpperCamelCase ../../name preserveAcronyms=true) struct=../struct structField=(asStructPropertyName label) deprecationMessage=(concat "Please use MTR" (asUpperCamelCase ../../name preserveAcronyms=true) "Cluster" (asUpperCamelCase ../name preserveAcronyms=true))}};
+{{> struct_field_decl cluster=parent.parent.name type=type label=label}} {{availability (asUpperCamelCase ../../name preserveAcronyms=true) struct=../struct structField=(asStructPropertyName label) deprecationMessage=(concat "Please use MTR" (asUpperCamelCase ../../name preserveAcronyms=true) "Cluster" (asUpperCamelCase ../name preserveAcronyms=true))}};
+{{#if (hasOldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label))}}
+{{> struct_field_decl cluster=../../name type=type label=(oldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label))}} {{availability (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(oldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName name)) deprecationMessage=(concat "Please use " (asStructPropertyName name))}};
+{{/if}}
 {{/zcl_struct_items}}
 {{/inline}}
 {{availability (asUpperCamelCase parent.name preserveAcronyms=true) struct=(asUpperCamelCase name preserveAcronyms=true)}}
@@ -39,14 +40,9 @@ NS_ASSUME_NONNULL_BEGIN
 {{availability (asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true)}}
 @interface MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event : NSObject <NSCopying>
 {{#zcl_event_fields}}
-@property (nonatomic, copy{{#unless (isStrEqual (asGetterName name) (asStructPropertyName name))}}, getter={{asGetterName name}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName name}} {{availability (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name)}};
-{{#if (isStrEqual (asUpperCamelCase ../parent.name preserveAcronyms=true) "Switch")}}
-{{#if (isStrEqual (asUpperCamelCase ../name preserveAcronyms=true) "MultiPressComplete")}}
-{{#if (isStrEqual (asStructPropertyName name) "previousPosition")}}
-{{! Workaround for the name being mis-spelled in XML previously }}
-@property (nonatomic, copy) NSNumber * _Nonnull newPosition {{availability (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name) eventField="newPosition" deprecationMessage="Please use previousPosition"}};
-{{/if}}
-{{/if}}
+{{> struct_field_decl cluster=parent.parent.name type=type label=name}} {{availability (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name)}};
+{{#if (hasOldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
+{{> struct_field_decl cluster=parent.parent.name type=type label=(oldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))}} {{availability (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(oldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name)) deprecationMessage=(concat "Please use " (asStructPropertyName name))}};
 {{/if}}
 {{/zcl_event_fields}}
 @end

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
@@ -19,21 +19,24 @@ NS_ASSUME_NONNULL_BEGIN
 {{> interfaceDecl struct=(asUpperCamelCase name preserveAcronyms=true)}}
 @end
 
-{{!Backwards compat for now: Add a DeviceType thing that is API-compatible with DeviceTypeStruct. }}
-{{#if (isStrEqual (asUpperCamelCase parent.name) "Descriptor")}}
-{{#if (isStrEqual (asUpperCamelCase name) "DeviceTypeStruct")}}
-{{availability (asUpperCamelCase parent.name preserveAcronyms=true) struct="DeviceType" deprecationMessage="Please use MTRDescriptorClusterDeviceTypeStruct"}}
-@interface MTRDescriptorClusterDeviceType : NSObject <NSCopying>
-{{> interfaceDecl struct="DeviceType"}}
+{{! Takes the name of the struct to use as structName. }}
+{{#*inline "oldNameDecl"}}
+{{availability (compatClusterNameRemapping parent.name) struct=structName deprecationMessage=(concat "Please use MTR" (asUpperCamelCase parent.name preserveAcronyms=true) "Cluster" (asUpperCamelCase name preserveAcronyms=true))}}
+@interface MTR{{compatClusterNameRemapping parent.name}}Cluster{{structName}} : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}
 @end
-{{/if}}
+{{/inline}}
+{{! Takes the old name of the struct, if any, as oldStructName. }}
+{{#*inline "oldNameCheck"}}
+{{#if (or oldStructName
+          (hasOldName (asUpperCamelCase parent.name preserveAcronyms=true)))}}
+{{#if oldStructName}}
+{{> oldNameDecl structName=oldStructName}}
 {{else}}
-{{#unless (isStrEqual (asUpperCamelCase parent.name preserveAcronyms=true) (compatClusterNameRemapping parent.name))}}
-{{availability (compatClusterNameRemapping parent.name) struct=(asUpperCamelCase name) deprecationMessage=(concat "Please use MTR" (asUpperCamelCase parent.name preserveAcronyms=true) "Cluster" (asUpperCamelCase name preserveAcronyms=true))}}
-@interface MTR{{compatClusterNameRemapping parent.name}}Cluster{{asUpperCamelCase name}} : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name}}
-@end
-{{/unless}}
+{{> oldNameDecl structName=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/if}}
+{{/if}}
+{{/inline}}
+{{> oldNameCheck oldStructName=(oldName (asUpperCamelCase parent.name preserveAcronyms=true) struct=(asUpperCamelCase name preserveAcronyms=true))}}
 {{/zcl_structs}}
 
 {{#zcl_events}}
@@ -46,12 +49,25 @@ NS_ASSUME_NONNULL_BEGIN
 {{/if}}
 {{/zcl_event_fields}}
 @end
-{{#unless (isStrEqual (asUpperCamelCase parent.name preserveAcronyms=true) (compatClusterNameRemapping parent.name))}}
+{{! Takes the name of the event to use as eventName. }}
+{{#*inline "oldNameDecl"}}
 
-{{availability (compatClusterNameRemapping parent.name) event=(asUpperCamelCase name) deprecationMessage=(concat "Please use MTR" (asUpperCamelCase parent.name preserveAcronyms=true) "Cluster" (asUpperCamelCase name preserveAcronyms=true) "Event")}}
-@interface MTR{{compatClusterNameRemapping parent.name}}Cluster{{asUpperCamelCase name}}Event : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event
+{{availability (compatClusterNameRemapping parent.name) event=eventName deprecationMessage=(concat "Please use MTR" (asUpperCamelCase parent.name preserveAcronyms=true) "Cluster" (asUpperCamelCase name preserveAcronyms=true) "Event")}}
+@interface MTR{{compatClusterNameRemapping parent.name}}Cluster{{eventName}}Event : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event
 @end
-{{/unless}}
+{{/inline}}
+{{! Takes the old name of the event, if any, as oldEventName. }}
+{{#*inline "oldNameCheck"}}
+{{#if (or oldEventName
+          (hasOldName (asUpperCamelCase parent.name preserveAcronyms=true)))}}
+{{#if oldEventName}}
+{{> oldNameDecl eventName=oldEventName}}
+{{else}}
+{{> oldNameDecl eventName=(asUpperCamelCase name preserveAcronyms=true)}}
+{{/if}}
+{{/if}}
+{{/inline}}
+{{> oldNameCheck oldEventName=(oldName (asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true))}}
 
 {{/zcl_events}}
 

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{/if}}
 {{/zcl_struct_items}}
 {{/inline}}
-{{availability (asUpperCamelCase parent.name preserveAcronyms=true) struct=(asUpperCamelCase name preserveAcronyms=true)}}
+{{availability (asUpperCamelCase parent.name preserveAcronyms=true) struct=(asUpperCamelCase name preserveAcronyms=true) deprecationMessage="This struct is unused and will be removed"}}
 @interface MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}} : NSObject <NSCopying>
 {{> interfaceDecl struct=(asUpperCamelCase name preserveAcronyms=true)}}
 @end

--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -4542,6 +4542,10 @@
           attributes:
               Descriptor:
                   - DeviceTypeList
+  renames:
+      structs:
+          Descriptor:
+              DeviceTypeStruct: DeviceType
 
 - release: "First major API revamp"
   versions: "future"

--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -5179,3 +5179,7 @@
               PIROccupiedToUnoccupiedDelay: PirOccupiedToUnoccupiedDelay
               PIRUnoccupiedToOccupiedDelay: PirUnoccupiedToOccupiedDelay
               PIRUnoccupiedToOccupiedThreshold: PirUnoccupiedToOccupiedThreshold
+      event fields:
+          Switch:
+              MultiPressComplete:
+                  previousPosition: newPosition

--- a/src/darwin/Framework/CHIP/templates/partials/renamed_struct_field_impl.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/renamed_struct_field_impl.zapt
@@ -1,0 +1,9 @@
+- (void)set{{asUpperCamelCase oldName}}:({{asObjectiveCType type cluster}}){{asStructPropertyName oldName}}
+{
+  self.{{asStructPropertyName newName}} = {{asStructPropertyName oldName}};
+}
+
+- ({{asObjectiveCType type cluster}}){{asGetterName oldName}}
+{
+  return self.{{asStructPropertyName newName}};
+}

--- a/src/darwin/Framework/CHIP/templates/partials/struct_field_decl.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/struct_field_decl.zapt
@@ -1,0 +1,3 @@
+{{! Override the getter name because some of our properties start with things
+    like "new" or "init" }}
+@property (nonatomic, copy{{#unless (isStrEqual (asGetterName label) (asStructPropertyName label))}}, getter={{asGetterName label}}{{/unless}}) {{asObjectiveCType type cluster}} {{asStructPropertyName label}} {{! Caller provides availability~}}

--- a/src/darwin/Framework/CHIP/templates/templates.json
+++ b/src/darwin/Framework/CHIP/templates/templates.json
@@ -42,6 +42,14 @@
         {
             "name": "attribute_data_callback_name",
             "path": "partials/attribute_data_callback_name.zapt"
+        },
+        {
+            "name": "struct_field_decl",
+            "path": "partials/struct_field_decl.zapt"
+        },
+        {
+            "name": "renamed_struct_field_impl",
+            "path": "partials/renamed_struct_field_impl.zapt"
         }
     ],
     "templates": [

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
@@ -39,11 +39,7 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 MTR_NEWLY_DEPRECATED("Please use MTRDescriptorClusterDeviceTypeStruct")
-@interface MTRDescriptorClusterDeviceType : NSObject <NSCopying>
-@property (nonatomic, copy) NSNumber * _Nonnull type API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
-    MTR_NEWLY_DEPRECATED("Please use MTRDescriptorClusterDeviceTypeStruct");
-@property (nonatomic, copy) NSNumber * _Nonnull revision API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
-    MTR_NEWLY_DEPRECATED("Please use MTRDescriptorClusterDeviceTypeStruct");
+@interface MTRDescriptorClusterDeviceType : MTRDescriptorClusterDeviceTypeStruct
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
@@ -495,8 +495,8 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @interface MTRSwitchClusterMultiPressCompleteEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull previousPosition MTR_NEWLY_AVAILABLE;
-@property (nonatomic, copy) NSNumber * _Nonnull newPosition API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
-    MTR_NEWLY_DEPRECATED("Please use previousPosition");
+@property (nonatomic, copy, getter=getNewPosition) NSNumber * _Nonnull newPosition API_AVAILABLE(
+    ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) MTR_NEWLY_DEPRECATED("Please use previousPosition");
 @property (nonatomic, copy)
     NSNumber * _Nonnull totalNumberOfPressesCounted API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 @end

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
@@ -2079,11 +2079,10 @@ NS_ASSUME_NONNULL_BEGIN
     self.previousPosition = newPosition;
 }
 
-- (NSNumber * _Nonnull)newPosition
+- (NSNumber * _Nonnull)getNewPosition
 {
     return self.previousPosition;
 }
-
 @end
 
 @implementation MTROperationalCredentialsClusterFabricDescriptor

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
@@ -112,35 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@implementation MTRDescriptorClusterDeviceType
-- (instancetype)init
-{
-    if (self = [super init]) {
-
-        _type = @(0);
-
-        _revision = @(0);
-    }
-    return self;
-}
-
-- (id)copyWithZone:(NSZone * _Nullable)zone
-{
-    auto other = [[MTRDescriptorClusterDeviceType alloc] init];
-
-    other.type = self.type;
-    other.revision = self.revision;
-
-    return other;
-}
-
-- (NSString *)description
-{
-    NSString * descriptionString =
-        [NSString stringWithFormat:@"<%@: type:%@; revision:%@; >", NSStringFromClass([self class]), _type, _revision];
-    return descriptionString;
-}
-
+@implementation MTRDescriptorClusterDeviceType : MTRDescriptorClusterDeviceTypeStruct
 @end
 
 @implementation MTRBindingClusterTargetStruct


### PR DESCRIPTION
This adds support for renaming struct, event, and command fields.

Also fixes a bug that was introduced where the getter for newPosition was mis-named.

For events and structs, we just put the shims for the old name directly on the most-recent struct interface (which any deprecated versions inherit from, so they pick it up too).

For commands, we try hard to put the deprecated shims on the deprecated interface if there is one.  This is nicer in terms of the APIs it produces, but quite a bit more complex in terms of the templates.

Thoughts on which approach is better are much appreciated.

