### PR TITLE
basic_information: change the name of emberAfBasicInformationClusterServerInitCallback

### DIFF
--- a/src/app/clusters/basic-information/basic-information.cpp
+++ b/src/app/clusters/basic-information/basic-information.cpp
@@ -406,7 +406,7 @@ bool IsLocalConfigDisabled()
 } // namespace app
 } // namespace chip
 
-void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint) {}
+void emberAfBasicInformationClusterServerInitCallback(chip::EndpointId endpoint) {}
 
 void MatterBasicInformationPluginServerInitCallback()
 {

--- a/src/app/clusters/basic-information/basic-information.h
+++ b/src/app/clusters/basic-information/basic-information.h
@@ -33,12 +33,3 @@ bool IsLocalConfigDisabled();
 } // namespace Clusters
 } // namespace app
 } // namespace chip
-
-/** @brief Basic Cluster Server Init
- *
- * This function is called at startup for a given endpoint to initialize
- * attributes of the Basic Cluster.
- *
- * @param endpoint Endpoint that is being initialized  Ver.: always
- */
-void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint);


### PR DESCRIPTION
The name of `emberAfBasicClusterServerInitCallback` was not changed in #24124 . And we should also remove the declaration in `basic-information.h` since this function has been declared in `zzz_generated/app-common/app-common/zap-generated/callback.h`
