### PR TITLE
Go back to using the storage key 1.0 used for group fabric info.

### DIFF
--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -33,7 +33,15 @@ using GroupEndpoint = GroupDataProvider::GroupEndpoint;
 using EpochKey      = GroupDataProvider::EpochKey;
 using KeySet        = GroupDataProvider::KeySet;
 using GroupSession  = GroupDataProvider::GroupSession;
-using FabricList    = CommonPersistentData::FabricList;
+
+struct FabricList : public CommonPersistentData::FabricList
+{
+    CHIP_ERROR UpdateKey(StorageKeyName & key) override
+    {
+        key = DefaultStorageKeyAllocator::GroupFabricList();
+        return CHIP_NO_ERROR;
+    }
+};
 
 constexpr size_t kPersistentBufferMax = 128;
 

--- a/src/lib/support/CommonPersistentData.h
+++ b/src/lib/support/CommonPersistentData.h
@@ -76,11 +76,8 @@ struct StoredDataList : public PersistentData<kMaxSerializedSize>
 constexpr size_t kPersistentFabricBufferMax = 32;
 struct FabricList : StoredDataList<FabricIndex, kPersistentFabricBufferMax>
 {
-    CHIP_ERROR UpdateKey(StorageKeyName & key) override
-    {
-        key = DefaultStorageKeyAllocator::FabricList();
-        return CHIP_NO_ERROR;
-    }
+    // Subclasses need to define UpdateKey to be whatever fabric list key they
+    // care about.
 
     void Clear() override
     {

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -102,9 +102,6 @@ public:
     static StorageKeyName FabricMetadata(FabricIndex fabric) { return StorageKeyName::Formatted("f/%x/m", fabric); }
     static StorageKeyName FabricOpKey(FabricIndex fabric) { return StorageKeyName::Formatted("f/%x/o", fabric); }
 
-    // Fabric List
-    static StorageKeyName FabricList() { return StorageKeyName::FromConst("g/fl"); }
-
     // Fail-safe handling
     static StorageKeyName FailSafeCommitMarkerKey() { return StorageKeyName::FromConst("g/fs/c"); }
     static StorageKeyName FailSafeNetworkConfig() { return StorageKeyName::FromConst("g/fs/n"); }
@@ -147,6 +144,7 @@ public:
     // Group Data Provider
 
     // List of fabric indices that have endpoint-to-group associations defined.
+    static StorageKeyName GroupFabricList() { return StorageKeyName::FromConst("g/gfl"); }
     static StorageKeyName FabricGroups(chip::FabricIndex fabric) { return StorageKeyName::Formatted("f/%x/g", fabric); }
     static StorageKeyName FabricGroup(chip::FabricIndex fabric, chip::GroupId group)
     {


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/23409 changed the key under which we store group fabric info, which breaks reception of group messages if a node updates from before that change to after that change.

We should just keep using the same key name, especially because sharing a single storage key for all possible fabric lists (groups and whatever else will want to store lists of fabric indices) does not necessarily make sense.

Fixes https://github.com/project-chip/connectedhomeip/issues/24161
