### PR TITLE
ESP32: Remove the initial call to esp_wifi_set_config()

### DIFF
--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -104,11 +104,6 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision(void)
 {
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
-        wifi_config_t stationConfig;
-
-        memset(&stationConfig, 0, sizeof(stationConfig));
-        esp_wifi_set_config(WIFI_IF_STA, &stationConfig);
-
         DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL);
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP
         DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);


### PR DESCRIPTION
- Problem
The initial call to esp_wifi_set_config() isn't required with zeroed out config. We don't need to clear config using set_config, in fact this may lead to issues

- Solution
Remove the call to esp_wifi_set_config()

