### PR TITLE
Add flake8 checker to chip-build Docker image

### DIFF
--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -95,7 +95,22 @@ RUN set -x \
     && : # last line
 
 RUN set -x \
-    && pip3 install attrs coloredlogs PyGithub pygit future portpicker mobly click cxxfilt ghapi pandas tabulate \
+    && pip3 install \
+    attrs \
+    click \
+    coloredlogs \
+    cxxfilt \
+    flake8 \
+    future \
+    ghapi \
+    mobly \
+    pandas \
+    portpicker \
+    pygit \
+    PyGithub \
+    tabulate \
+    # Cleanup
+    && pip3 cache purge \
     && : # last line
 
 # build and install gn

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.25 Version bump reason: Updating ZAP to v2022.12.20-nightly
+0.6.26 Version bump reason: Add flake8 to base image


### PR DESCRIPTION
### Problem

Quality of Python files can be improved by using static analysis - flake8. Unfortunately, such tool is not available in chip-build image which is used by our CI.

### Changes

- added flake8 to chip-build image
- remove pip cache after install (which saves ~30MB :D)