### PR TITLE
[v1.0 cherrypick] Update LevelControl to allow for disabling transition time and OnOff feature

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -1027,20 +1027,6 @@ void emberAfOnOffClusterLevelControlEffectCallback(EndpointId endpoint, bool new
         return;
     }
 
-    // if the OnOff feature is not supported, the effect on LevelControl is ignored
-    if (!HasFeature(endpoint, chip::app::Clusters::LevelControl::LevelControlFeature::kOnOff))
-    {
-        emberAfLevelControlClusterPrintln("OnOff feature not supported, ignore LevelControlEffect");
-        if (!newValue)
-        {
-            // OnOff server expects LevelControl to handle the OnOff attribute change,
-            // when going to off state. The attribute is set directly rather
-            // than using setOnOff function to avoid misleading comments in log.
-            OnOff::Attributes::OnOff::Set(endpoint, OnOff::Commands::Off::Id);
-        }
-        return;
-    }
-
     uint8_t minimumLevelAllowedForTheDevice = state->minLevel;
 
     // "Temporarily store CurrentLevel."
@@ -1255,7 +1241,7 @@ static bool areStartUpLevelControlServerAttributesNonVolatile(EndpointId endpoin
 
 void emberAfPluginLevelControlClusterServerPostInitCallback(EndpointId endpoint) {}
 
-bool HasFeature(chip::EndpointId endpoint, chip::app::Clusters::LevelControl::LevelControlFeature feature)
+bool LevelControlHasFeature(EndpointId endpoint, LevelControlFeature feature)
 {
     bool success;
     uint32_t featureMap;

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -654,6 +654,7 @@ static EmberAfStatus moveToLevelHandler(EndpointId endpoint, CommandId commandId
         actualStepSize    = static_cast<uint8_t>(currentLevel.Value() - state->moveToLevel);
     }
 
+#ifndef IGNORE_LEVEL_CONTROL_CLUSTER_TRANSITION
     // If the Transition time field takes the value null, then the time taken
     // to move to the new level shall instead be determined by the On/Off
     // Transition Time attribute.  If On/Off Transition Time, which is an
@@ -693,6 +694,12 @@ static EmberAfStatus moveToLevelHandler(EndpointId endpoint, CommandId commandId
         // Time) as tenths of a second, but we work in milliseconds.
         state->transitionTimeMs = (transitionTimeDs.Value() * MILLISECOND_TICKS_PER_SECOND / 10);
     }
+#else
+    // Transition is not supported so always use fastest transition time and ignore
+    // both the provided transition time as well as OnOffTransitionTime.
+    emberAfLevelControlClusterPrintln("Device does not support transition, ignoring transition time");
+    state->transitionTimeMs = FASTEST_TRANSITION_TIME_MS;
+#endif // IGNORE_LEVEL_CONTROL_CLUSTER_TRANSITION
 
     // The duration between events will be the transition time divided by the
     // distance we must move.
@@ -794,6 +801,7 @@ static void moveHandler(EndpointId endpoint, CommandId commandId, uint8_t moveMo
         }
     }
 
+#ifndef IGNORE_LEVEL_CONTROL_CLUSTER_TRANSITION
     // If the Rate field is null, the device should move at the default move rate, if available,
     // Otherwise, move as fast as possible
     if (rate.IsNull())
@@ -820,6 +828,12 @@ static void moveHandler(EndpointId endpoint, CommandId commandId, uint8_t moveMo
     {
         state->eventDurationMs = MILLISECOND_TICKS_PER_SECOND / rate.Value();
     }
+#else
+    // Transition/rate is not supported so always use fastest transition time and ignore
+    // both the provided transition time as well as OnOffTransitionTime.
+    emberAfLevelControlClusterPrintln("Device does not support transition, ignoring rate");
+    state->eventDurationMs = FASTEST_TRANSITION_TIME_MS;
+#endif // IGNORE_LEVEL_CONTROL_CLUSTER_TRANSITION
 
     state->transitionTimeMs = difference * state->eventDurationMs;
     state->elapsedTimeMs    = 0;
@@ -925,6 +939,7 @@ static void stepHandler(EndpointId endpoint, CommandId commandId, uint8_t stepMo
         }
     }
 
+#ifndef IGNORE_LEVEL_CONTROL_CLUSTER_TRANSITION
     // If the Transition Time field is null, the device should move as fast as
     // it is able.
     if (transitionTimeDs.IsNull())
@@ -944,6 +959,12 @@ static void stepHandler(EndpointId endpoint, CommandId commandId, uint8_t stepMo
             state->transitionTimeMs = (state->transitionTimeMs * actualStepSize / stepSize);
         }
     }
+#else
+    // Transition is not supported so always use fastest transition time and ignore
+    // both the provided transition time as well as OnOffTransitionTime.
+    emberAfLevelControlClusterPrintln("Device does not support transition, ignoring transition time");
+    state->transitionTimeMs = FASTEST_TRANSITION_TIME_MS;
+#endif // IGNORE_LEVEL_CONTROL_CLUSTER_TRANSITION
 
     // The duration between events will be the transition time divided by the
     // distance we must move.
@@ -1003,6 +1024,20 @@ void emberAfOnOffClusterLevelControlEffectCallback(EndpointId endpoint, bool new
     if (state == nullptr)
     {
         emberAfLevelControlClusterPrintln("ERR: Level control cluster not available on ep%d", endpoint);
+        return;
+    }
+
+    // if the OnOff feature is not supported, the effect on LevelControl is ignored
+    if (!HasFeature(endpoint, chip::app::Clusters::LevelControl::LevelControlFeature::kOnOff))
+    {
+        emberAfLevelControlClusterPrintln("OnOff feature not supported, ignore LevelControlEffect");
+        if (!newValue)
+        {
+            // OnOff server expects LevelControl to handle the OnOff attribute change,
+            // when going to off state. The attribute is set directly rather
+            // than using setOnOff function to avoid misleading comments in log.
+            OnOff::Attributes::OnOff::Set(endpoint, OnOff::Commands::Off::Id);
+        }
         return;
     }
 
@@ -1219,5 +1254,14 @@ static bool areStartUpLevelControlServerAttributesNonVolatile(EndpointId endpoin
 #endif // IGNORE_LEVEL_CONTROL_CLUSTER_START_UP_CURRENT_LEVEL
 
 void emberAfPluginLevelControlClusterServerPostInitCallback(EndpointId endpoint) {}
+
+bool HasFeature(chip::EndpointId endpoint, chip::app::Clusters::LevelControl::LevelControlFeature feature)
+{
+    bool success;
+    uint32_t featureMap;
+    success = (Attributes::FeatureMap::Get(endpoint, &featureMap) == EMBER_ZCL_STATUS_SUCCESS);
+
+    return success ? ((featureMap & to_underlying(feature)) != 0) : false;
+}
 
 void MatterLevelControlPluginServerInitCallback() {}

--- a/src/app/clusters/level-control/level-control.h
+++ b/src/app/clusters/level-control/level-control.h
@@ -49,16 +49,21 @@
 
 #include <stdint.h>
 
-#include <app-common/zap-generated/cluster-objects.h>
+#include <app-common/zap-generated/cluster-enums.h>
 #include <app/util/basic-types.h>
 
-/** @brief On/off Cluster Server Post Init
+/** @brief Level Control Cluster Server Post Init
  *
- * Following resolution of the On/Off state at startup for this endpoint, perform any
+ * Following resolution of the Level Control state at startup for this endpoint, perform any
  * additional initialization needed; e.g., synchronize hardware state.
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
 void emberAfPluginLevelControlClusterServerPostInitCallback(chip::EndpointId endpoint);
 
-bool HasFeature(chip::EndpointId endpoint, chip::app::Clusters::LevelControl::LevelControlFeature feature);
+/**
+ * Check whether the instance of the Level Control cluster on the given endpoint
+ * has the given feature.  The implementation is allowed to assume there is in
+ * fact an instance of Level Control on the given endpoint.
+ */
+bool LevelControlHasFeature(chip::EndpointId endpoint, chip::app::Clusters::LevelControl::LevelControlFeature feature);

--- a/src/app/clusters/level-control/level-control.h
+++ b/src/app/clusters/level-control/level-control.h
@@ -49,6 +49,7 @@
 
 #include <stdint.h>
 
+#include <app-common/zap-generated/cluster-objects.h>
 #include <app/util/basic-types.h>
 
 /** @brief On/off Cluster Server Post Init
@@ -59,3 +60,5 @@
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
 void emberAfPluginLevelControlClusterServerPostInitCallback(chip::EndpointId endpoint);
+
+bool HasFeature(chip::EndpointId endpoint, chip::app::Clusters::LevelControl::LevelControlFeature feature);

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -51,6 +51,10 @@
 #include <app/clusters/scenes/scenes.h>
 #endif // EMBER_AF_PLUGIN_SCENES
 
+#ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
+#include <app/clusters/level-control/level-control.h>
+#endif // EMBER_AF_PLUGIN_LEVEL_CONTROL
+
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::OnOff;
@@ -99,6 +103,18 @@ EmberAfStatus OnOffServer::getOnOffValue(chip::EndpointId endpoint, bool * curre
 
     return status;
 }
+
+#ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
+static bool LevelControlWithOnOffFeaturePresent(EndpointId endpoint)
+{
+    if (!emberAfContainsServer(endpoint, LevelControl::Id))
+    {
+        return false;
+    }
+
+    return LevelControlHasFeature(endpoint, LevelControl::LevelControlFeature::kOnOff);
+}
+#endif // EMBER_AF_PLUGIN_LEVEL_CONTROL
 
 /** @brief On/off Cluster Set Value
  *
@@ -176,7 +192,7 @@ EmberAfStatus OnOffServer::setOnOffValue(chip::EndpointId endpoint, uint8_t comm
 #ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
         // If initiatedByLevelChange is false, then we assume that the level change
         // ZCL stuff has not happened and we do it here
-        if (!initiatedByLevelChange && emberAfContainsServer(endpoint, LevelControl::Id))
+        if (!initiatedByLevelChange && LevelControlWithOnOffFeaturePresent(endpoint))
         {
             emberAfOnOffClusterLevelControlEffectCallback(endpoint, newValue);
         }
@@ -206,7 +222,7 @@ EmberAfStatus OnOffServer::setOnOffValue(chip::EndpointId endpoint, uint8_t comm
 #ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
         // If initiatedByLevelChange is false, then we assume that the level change
         // ZCL stuff has not happened and we do it here
-        if (!initiatedByLevelChange && emberAfContainsServer(endpoint, LevelControl::Id))
+        if (!initiatedByLevelChange && LevelControlWithOnOffFeaturePresent(endpoint))
         {
             emberAfOnOffClusterLevelControlEffectCallback(endpoint, newValue);
         }


### PR DESCRIPTION
This is a cherrypick of https://github.com/project-chip/connectedhomeip/pull/23679 and https://github.com/project-chip/connectedhomeip/pull/23820 in order to allow level control cluster to:

1. Ignore transition times
2. Disable the linking to the OnOff cluster

The full description is available in https://github.com/project-chip/connectedhomeip/pull/23679