### PR TITLE
[Ameba] Add Macro to InitBindingHandler

### DIFF
--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -141,7 +141,9 @@ static void InitServer(intptr_t context)
         PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
     }
 
+#if CONFIG_ENABLE_CHIP_SHELL
     InitBindingHandler();
+#endif
 }
 
 extern "C" void ChipTest(void)

--- a/examples/light-switch-app/ameba/main/chipinterface.cpp
+++ b/examples/light-switch-app/ameba/main/chipinterface.cpp
@@ -116,7 +116,9 @@ static void InitServer(intptr_t context)
         PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
     }
 
+#if CONFIG_ENABLE_CHIP_SHELL
     InitBindingHandler();
+#endif
 }
 
 extern "C" void ChipTest(void)


### PR DESCRIPTION
- Fix #24360 
- Add Macro to InitBindingHandler to fix the compilation error when Matter shell is disabled.

