### PR TITLE
[ESP32] Support rotating device id in bluedroid stack

### DIFF
--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -222,6 +222,10 @@ private:
     static void HandleGATTEvent(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t * param);
     static void HandleGAPEvent(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t * param);
 
+#ifdef CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
+    void HandleC3CharRead(esp_ble_gatts_cb_param_t * param);
+#endif
+
 #elif CONFIG_BT_NIMBLE_ENABLED
     void HandleRXCharRead(struct ble_gatt_char_context * param);
     void HandleRXCharWrite(struct ble_gatt_char_context * param);

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -329,7 +329,7 @@ bool BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
     err = MapBLEError(esp_ble_gatts_close(mAppIf, conId));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gatts_close() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gatts_close() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // Release the associated connection state record.
@@ -364,7 +364,7 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
     err = MapBLEError(esp_ble_gatts_send_indicate(mAppIf, conId, mTXCharAttrHandle, data->DataLength(), data->Start(), false));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gatts_send_indicate() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gatts_send_indicate() failed: %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -375,7 +375,7 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "BLEManagerImpl::SendIndication() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "BLEManagerImpl::SendIndication() failed: %" CHIP_ERROR_FORMAT, err.Format());
         return false;
     }
     return true;
@@ -447,7 +447,7 @@ void BLEManagerImpl::DriveBLEState(void)
         err = MapBLEError(esp_ble_gatts_app_register(CHIPoBLEAppId));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_ble_gatts_app_register() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_ble_gatts_app_register() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
 
@@ -462,7 +462,7 @@ void BLEManagerImpl::DriveBLEState(void)
         err = MapBLEError(esp_ble_gatts_create_attr_tab(CHIPoBLEGATTAttrs, mAppIf, CHIPoBLEGATTAttrCount, 0));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_ble_gatts_create_attr_tab() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_ble_gatts_create_attr_tab() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
 
@@ -477,7 +477,7 @@ void BLEManagerImpl::DriveBLEState(void)
         err = MapBLEError(esp_ble_gatts_start_service(mServiceAttrHandle));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_ble_gatts_start_service() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_ble_gatts_start_service() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
 
@@ -522,7 +522,7 @@ void BLEManagerImpl::DriveBLEState(void)
             err = MapBLEError(esp_ble_gap_stop_advertising());
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(DeviceLayer, "esp_ble_gap_stop_advertising() failed: %s", ErrorStr(err));
+                ChipLogError(DeviceLayer, "esp_ble_gap_stop_advertising() failed: %" CHIP_ERROR_FORMAT, err.Format());
                 ExitNow();
             }
 
@@ -540,7 +540,7 @@ void BLEManagerImpl::DriveBLEState(void)
         err = MapBLEError(esp_ble_gatts_stop_service(mServiceAttrHandle));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_ble_gatts_stop_service() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_ble_gatts_stop_service() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
 
@@ -552,7 +552,7 @@ void BLEManagerImpl::DriveBLEState(void)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }
@@ -570,7 +570,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
         err = MapBLEError(esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_bt_controller_mem_release() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_bt_controller_mem_release() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
 
@@ -579,7 +579,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
         err                               = MapBLEError(esp_bt_controller_init(&bt_cfg));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_bt_controller_init() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_bt_controller_init() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
     }
@@ -590,7 +590,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
         err = MapBLEError(esp_bt_controller_enable(ESP_BT_MODE_BLE));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_bt_controller_enable() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_bt_controller_enable() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
     }
@@ -601,7 +601,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
         err = MapBLEError(esp_bluedroid_init());
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_bluedroid_init() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_bluedroid_init() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
     }
@@ -612,7 +612,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
         err = MapBLEError(esp_bluedroid_enable());
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_bluedroid_enable() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_bluedroid_enable() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
     }
@@ -621,7 +621,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     err = MapBLEError(esp_ble_gatts_register_callback(HandleGATTEvent));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gatts_register_callback() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gatts_register_callback() failed: %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -629,7 +629,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     err = MapBLEError(esp_ble_gap_register_callback(HandleGAPEvent));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gap_register_callback() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gap_register_callback() failed: %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -637,7 +637,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     err = MapBLEError(esp_ble_gatt_set_local_mtu(ESP_GATT_MAX_MTU_SIZE));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gatt_set_local_mtu() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gatt_set_local_mtu() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
@@ -668,7 +668,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     err = MapBLEError(esp_ble_gap_set_device_name(mDeviceName));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gap_set_device_name() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gap_set_device_name() failed: %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -685,7 +685,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(deviceIdInfo);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "GetBLEDeviceIdentificationInfo(): %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "GetBLEDeviceIdentificationInfo(): %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -703,7 +703,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     err = MapBLEError(esp_ble_gap_config_adv_data_raw(advData, sizeof(advData)));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gap_config_adv_data_raw(<raw_data>) failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gap_config_adv_data_raw(<raw_data>) failed: %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -753,7 +753,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     err = MapBLEError(esp_ble_gap_start_advertising(&advertParams));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gap_start_advertising() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gap_start_advertising() failed: %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -860,7 +860,7 @@ void BLEManagerImpl::HandleGATTControlEvent(esp_gatts_cb_event_t event, esp_gatt
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
     if (controlOpComplete)
@@ -995,7 +995,7 @@ void BLEManagerImpl::HandleRXCharWrite(esp_ble_gatts_cb_param_t * param)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
         if (needResp)
         {
             esp_ble_gatts_send_response(mAppIf, param->write.conn_id, param->write.trans_id, ESP_GATT_INTERNAL_ERROR, NULL);
@@ -1017,7 +1017,7 @@ void BLEManagerImpl::HandleTXCharRead(esp_ble_gatts_cb_param_t * param)
     err = MapBLEError(esp_ble_gatts_send_response(mAppIf, param->read.conn_id, param->read.trans_id, ESP_GATT_OK, &rsp));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gatts_send_response() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gatts_send_response() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -1044,7 +1044,7 @@ void BLEManagerImpl::HandleTXCharCCCDRead(esp_ble_gatts_cb_param_t * param)
                                                   (conState != NULL) ? ESP_GATT_OK : ESP_GATT_INTERNAL_ERROR, &rsp));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gatts_send_response() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gatts_send_response() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -1101,16 +1101,10 @@ void BLEManagerImpl::HandleC3CharRead(esp_ble_gatts_cb_param_t * param)
     err = MapBLEError(esp_ble_gatts_send_response(mAppIf, param->read.conn_id, param->read.trans_id,
                                                   (conState != NULL) ? ESP_GATT_OK : ESP_GATT_INTERNAL_ERROR, &rsp));
 
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "esp_ble_gatts_send_response() failed: %s", ErrorStr(err));
-    }
-    return;
-
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Failed to generate TLV encoded Additional Data (%s)", __func__);
+        ChipLogError(DeviceLayer, "Failed to generate TLV encoded Additional Data, err:%" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 #endif
@@ -1156,7 +1150,7 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(esp_ble_gatts_cb_param_t * param)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
         if (needResp)
         {
             esp_ble_gatts_send_response(mAppIf, param->write.conn_id, param->write.trans_id, ESP_GATT_INTERNAL_ERROR, NULL);
@@ -1402,7 +1396,7 @@ void BLEManagerImpl::HandleGAPEvent(esp_gap_ble_cb_event_t event, esp_ble_gap_cb
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         sInstance.mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
     PlatformMgr().ScheduleWork(DriveBLEState, 0);


### PR DESCRIPTION
#### Problem
C3 characteristic is missing in BTP GATT service when using bluedroid stack. This means it also lacks the support for rotating device identifier.

#### Change Overview
Added Matter C3 characteristic and support for rotational device identifier.

#### Tests
Enabled below configuration options and was able to read the C3 characteristic. It contained rotational device identifier.
```
CONFIG_BLUEDROID_ENABLED=y
CONFIG_ENABLE_ROTATING_DEVICE_ID=y
```