### PR TITLE
Fix mutex use after destroy upon stack shutdown

### DIFF
--- a/src/controller/python/chip/ChipStack.py
+++ b/src/controller/python/chip/ChipStack.py
@@ -328,7 +328,10 @@ class ChipStack(object):
             self._ChipStackLib.pychip_Stack_SetLogFunct(logFunct)
 
     def Shutdown(self):
-        self.Call(lambda: self._ChipStackLib.pychip_DeviceController_StackShutdown()).raise_on_error()
+        #
+        # Terminate Matter thread and shutdown the stack.
+        #
+        self._ChipStackLib.pychip_DeviceController_StackShutdown()
 
         #
         # We only shutdown the persistent storage layer AFTER we've shut down the stack,

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
@@ -55,23 +55,18 @@ protected:
     // OS-specific members (pthread)
     pthread_mutex_t mChipStackLock = PTHREAD_MUTEX_INITIALIZER;
 
-    enum TaskType
+    enum class State
     {
-        kExternallyManagedTask = 0,
-        kInternallyManagedTask = 1
+        kStopped  = 0,
+        kRunning  = 1,
+        kStopping = 2,
     };
 
     pthread_t mChipTask;
-    bool mHasValidChipTask = false;
-    TaskType mTaskType;
+    bool mInternallyManagedChipTask = false;
+    std::atomic<State> mState{ State::kStopped };
     pthread_cond_t mEventQueueStoppedCond;
     pthread_mutex_t mStateLock;
-
-    //
-    // TODO: This variable is very similar to mMainLoopIsStarted, track the
-    // cleanup and consolidation in this issue:
-    //
-    bool mEventQueueHasStopped = false;
 
     pthread_attr_t mChipTaskAttr;
     struct sched_param mChipTaskSchedParam;
@@ -109,7 +104,7 @@ private:
     void ProcessDeviceEvents();
 
     DeviceSafeQueue mChipEventQueue;
-    std::atomic<bool> mShouldRunEventLoop;
+    std::atomic<bool> mShouldRunEventLoop{ true };
     static void * EventLoopTaskMain(void * arg);
 };
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -59,15 +59,11 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_InitChipStack()
     // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
     ReturnErrorOnFailure(GenericPlatformManagerImpl<ImplClass>::_InitChipStack());
 
-    mShouldRunEventLoop.store(true, std::memory_order_relaxed);
-
     int ret = pthread_cond_init(&mEventQueueStoppedCond, nullptr);
     VerifyOrReturnError(ret == 0, CHIP_ERROR_POSIX(ret));
 
     ret = pthread_mutex_init(&mStateLock, nullptr);
     VerifyOrReturnError(ret == 0, CHIP_ERROR_POSIX(ret));
-
-    mHasValidChipTask = false;
 
     return CHIP_NO_ERROR;
 }
@@ -117,7 +113,11 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::_UnlockChipStack()
 template <class ImplClass>
 bool GenericPlatformManagerImpl_POSIX<ImplClass>::_IsChipStackLockedByCurrentThread() const
 {
-    return !mHasValidChipTask || (mChipStackIsLocked && (pthread_equal(pthread_self(), mChipStackLockOwnerThread)));
+    // If no Matter thread is currently running we do not have to worry about
+    // locking. Hence, this function always returns true in that case.
+    if (mState.load(std::memory_order_relaxed) == State::kStopped)
+        return true;
+    return mChipStackIsLocked && (pthread_equal(pthread_self(), mChipStackLockOwnerThread));
 }
 #endif
 
@@ -153,18 +153,16 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::_RunEventLoop()
     pthread_mutex_lock(&mStateLock);
 
     //
-    // If we haven't set mHasValidChipTask by now, it means that the application did not call StartEventLoopTask
-    // and consequently, are running the event loop from their own, externally managed task.
-    // Let's track his appropriately since we need this info later when stopping the event queues.
+    // If we haven't set mInternallyManagedChipTask by now, it means that the application did not call
+    // StartEventLoopTask and consequently, are running the event loop from their own, externally managed
+    // task.
     //
-    if (!mHasValidChipTask)
+    if (!mInternallyManagedChipTask)
     {
-        mHasValidChipTask = true;
-        mChipTask         = pthread_self();
-        mTaskType         = kExternallyManagedTask;
+        mChipTask = pthread_self();
+        mState.store(State::kRunning, std::memory_order_relaxed);
     }
 
-    mEventQueueHasStopped = false;
     pthread_mutex_unlock(&mStateLock);
 
     Impl()->LockChipStack();
@@ -187,7 +185,7 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::_RunEventLoop()
     Impl()->UnlockChipStack();
 
     pthread_mutex_lock(&mStateLock);
-    mEventQueueHasStopped = true;
+    mState.store(mInternallyManagedChipTask ? State::kStopping : State::kStopped, std::memory_order_relaxed);
     pthread_mutex_unlock(&mStateLock);
 
     //
@@ -230,8 +228,8 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StartEventLoopTask()
     err = pthread_create(&mChipTask, &mChipTaskAttr, EventLoopTaskMain, this);
     if (err == 0)
     {
-        mHasValidChipTask = true;
-        mTaskType         = kInternallyManagedTask;
+        mInternallyManagedChipTask = true;
+        mState.store(State::kRunning, std::memory_order_relaxed);
     }
 
     pthread_mutex_unlock(&mStateLock);
@@ -255,7 +253,8 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StopEventLoopTask()
     // If we're calling this from a different thread than the one running chip, then
     // we need to wait till the event queue has completely stopped before proceeding.
     //
-    if (mHasValidChipTask && (pthread_equal(pthread_self(), mChipTask) == 0))
+    auto isRunning = mState.load(std::memory_order_relaxed) == State::kRunning;
+    if (isRunning && (pthread_equal(pthread_self(), mChipTask) == 0))
     {
         pthread_mutex_unlock(&mStateLock);
 
@@ -269,7 +268,7 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StopEventLoopTask()
 
         pthread_mutex_lock(&mStateLock);
 
-        while (!mEventQueueHasStopped)
+        while (mState.load(std::memory_order_relaxed) == State::kRunning)
         {
             err = pthread_cond_wait(&mEventQueueStoppedCond, &mStateLock);
             VerifyOrExit(err == 0, );
@@ -280,7 +279,7 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StopEventLoopTask()
         //
         // Wait further for the thread to terminate if we had previously created it.
         //
-        if (mTaskType == kInternallyManagedTask)
+        if (mInternallyManagedChipTask)
         {
             err = pthread_join(mChipTask, nullptr);
             VerifyOrExit(err == 0, );
@@ -292,13 +291,20 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StopEventLoopTask()
     }
 
 exit:
-    mHasValidChipTask = false;
+    mState.store(State::kStopped, std::memory_order_relaxed);
     return CHIP_ERROR_POSIX(err);
 }
 
 template <class ImplClass>
 void GenericPlatformManagerImpl_POSIX<ImplClass>::_Shutdown()
 {
+    //
+    // We cannot shutdown the stack while the event loop is still running. This can lead
+    // to use after free errors - here we are destroying mutex and condition variable that
+    // are still in use by the event loop!
+    //
+    VerifyOrDie(mState.load(std::memory_order_relaxed) == State::kStopped);
+
     pthread_mutex_destroy(&mStateLock);
     pthread_cond_destroy(&mEventQueueStoppedCond);
 


### PR DESCRIPTION
### Problem 

Shutting down CHIP stack when the event loop is still running might lead to use after free for objects used in CHIP main event loop. This PR fixes this by not running `pychip_DeviceController_StackShutdown()` on the CHIP thread, but in the main thread of Python application. Otherwise the call will not wait for main event loop termination because of this condition:
https://github.com/project-chip/connectedhomeip/blob/master/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp#L258

### Changes

- run `pychip_DeviceController_StackShutdown()` on application main thread
- add assertion for calling `_Shutdown()` when event loop is still running
- use C++ ctor for atomic members initialization
- java: stop IO thread before shutting down controller, otherwise matter stack is teared down while the event loop is still running

### Testing

Tested manually by running `repl_tests_linux` tests (from [tests.yaml](https://github.com/project-chip/connectedhomeip/blob/master/.github/workflows/tests.yaml#L344)) with TSAN enabled for linux-x64-python-bindings. Without that patch we will face error like this:
```
[2849:2856] CHIP:CTL: Shutting down the stack...                            <<------ printed by CHIP thread [2856], so _StopEventLoopTask() will not wait
[2849:2856] CHIP:CTL: Shutting down the System State, this will teardown the CHIP Stack
....
[2849:2856] CHIP:DL: Inet Layer shutdown
[2849:2856] CHIP:DL: System Layer shutdown
INFO:root:Final result: PASS !
==================
WARNING: ThreadSanitizer: use of an invalid mutex (e.g. uninitialized or destroyed) (pid=2849)
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4165 (libtsan.so.0+0x526fc)
    #1 chip::DeviceLayer::Internal::GenericPlatformManagerImpl_POSIX<chip::DeviceLayer::PlatformManagerImpl>::_RunEventLoop() ../../src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp:189 (_ChipDeviceCtrl.so+0x71eae3)
    #2 chip::DeviceLayer::PlatformManager::RunEventLoop() <null> (_ChipDeviceCtrl.so+0x71d2fb)
    #3 chip::DeviceLayer::Internal::GenericPlatformManagerImpl_POSIX<chip::DeviceLayer::PlatformManagerImpl>::EventLoopTaskMain(void*) ../../src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp:204 (_ChipDeviceCtrl.so+0x71f16b)

  Location is global 'chip::DeviceLayer::PlatformManagerImpl::sInstance' of size 392 at 0x7f59c1e5e440 (_ChipDeviceCtrl.so+0x0000008964c8)

  Mutex M0 (0x7f59c1e5e4c8) created at:
    [failed to restore the stack]

SUMMARY: ThreadSanitizer: use of an invalid mutex (e.g. uninitialized or destroyed) ../../src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp:189 in chip::DeviceLayer::Internal::GenericPlatformManagerImpl_POSIX<chip::DeviceLayer::PlatformManagerImpl>::_RunEventLoop()
==================
```

CI should check that this PR will not cause any side effects.