### PR TITLE
Fix ChipLog* calls in darwin-framework-tool itself to work right.

### DIFF
--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -246,3 +246,9 @@ if (chip_codesign) {
     outputs = [ "${root_build_dir}/${output_name}" ]
   }
 }
+
+# Make sure we only build darwin-framework-tool, and not extraneous
+# things like address-resolve, by default.
+group("default") {
+  deps = [ ":darwin-framework-tool" ]
+}

--- a/examples/darwin-framework-tool/logging/logging.mm
+++ b/examples/darwin-framework-tool/logging/logging.mm
@@ -20,45 +20,68 @@
 
 #import "logging.h"
 
+#include <algorithm>
 #include <cstdio>
+#include <lib/support/logging/CHIPLogging.h>
 #include <pthread.h>
 
 namespace dft {
 namespace logging {
 
-    void Setup()
+    void LogMessage(MTRLogType type, NSString * component, NSString * message)
     {
         auto kLoggingColorError = @"\033[1;31m";
         auto kLoggingColorProgress = @"\033[0;32m";
         auto kLoggingColorDetail = @"\033[0;34m";
         auto kLoggingColorEnd = @"\033[0m";
 
+        NSString * loggingColor = nil;
+
+        switch (type) {
+        case MTRLogTypeError:
+            loggingColor = kLoggingColorError;
+            break;
+        case MTRLogTypeProgress:
+            loggingColor = kLoggingColorProgress;
+            break;
+        case MTRLogTypeDetail:
+            loggingColor = kLoggingColorDetail;
+            break;
+        }
+
+        auto formatter = [[NSDateFormatter alloc] init];
+        formatter.dateFormat = @"yyyy-MM-dd HH:mm:ss.SSS";
+        auto formattedDate = [formatter stringFromDate:[NSDate date]];
+
+        int pid = [[NSProcessInfo processInfo] processIdentifier];
+
+        auto tid = pthread_mach_thread_np(pthread_self());
+
+        fprintf(stdout, "%s%s [%d:%u] [%s]: %s%s\n", loggingColor.UTF8String, formattedDate.UTF8String, pid, tid,
+            component.UTF8String, message.UTF8String, kLoggingColorEnd.UTF8String);
+    }
+
+    void LogRedirectCallback(const char * moduleName, uint8_t category, const char * format, va_list args)
+    {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+        // Note: Format using NSString so that '%@' placeholders are supported
+        NSString * message = [[NSString alloc] initWithFormat:@(format) arguments:args];
+#pragma clang diagnostic pop
+
+        auto type = std::min(static_cast<MTRLogType>(category), MTRLogTypeDetail);
+        LogMessage(type, @(moduleName), message);
+    }
+
+    void Setup()
+    {
         MTRSetLogCallback(MTRLogTypeDetail, ^(MTRLogType type, NSString * component, NSString * message) {
-            NSString * loggingColor = nil;
-
-            switch (type) {
-            case MTRLogTypeError:
-                loggingColor = kLoggingColorError;
-                break;
-            case MTRLogTypeProgress:
-                loggingColor = kLoggingColorProgress;
-                break;
-            case MTRLogTypeDetail:
-                loggingColor = kLoggingColorDetail;
-                break;
-            }
-
-            auto formatter = [[NSDateFormatter alloc] init];
-            formatter.dateFormat = @"yyyy-MM-dd HH:mm:ss.SSS";
-            auto formattedDate = [formatter stringFromDate:[NSDate date]];
-
-            int pid = [[NSProcessInfo processInfo] processIdentifier];
-
-            auto tid = pthread_mach_thread_np(pthread_self());
-
-            fprintf(stdout, "%s%s [%d:%u] [%s]: %s%s\n", loggingColor.UTF8String, formattedDate.UTF8String, pid, tid,
-                component.UTF8String, message.UTF8String, kLoggingColorEnd.UTF8String);
+            LogMessage(type, component, message);
         });
+
+        // We also have a second copy of the logging core floating around, so
+        // need to set up a logging redirect on that too.
+        chip::Logging::SetLogRedirectCallback(&LogRedirectCallback);
     }
 
 }


### PR DESCRIPTION
REVIEW NOTE: A whitespace-ignoring diff is a lot easier to review.

darwin-framework-tool ends up linking in two copies of CHIPLogging, so the redirect we were setting up was only capturing ChipLog* calls that happened inside Matter.framework.  The calls from
darwin-framework-tool itself were getting dropped after being logged via os_log, and not showing up on stdout.

Also includes a drive-by fix to stop building address-resolve-tool every time we build darwin-framework-tool.

Fixes https://github.com/project-chip/connectedhomeip/issues/24194
