### PR TITLE
controller: Add non-concurrent commissioning

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -68,10 +68,12 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
     return err;
 }
 
-CommissioningParameters PairingCommand::GetCommissioningParameters()
+CommissioningParameters PairingCommand::GetCommissioningParameters(NodeId remoteId)
 {
     auto params = CommissioningParameters();
     params.SetSkipCommissioningComplete(mSkipCommissioningComplete.ValueOr(false));
+    params.SetNonConcurrentCommissioning(mNonConcurrent.ValueOr(false));
+    params.SetRemoteNodeId(remoteId);
 
     switch (mNetworkType)
     {
@@ -98,7 +100,7 @@ CHIP_ERROR PairingCommand::PaseWithCode(NodeId remoteId)
 
 CHIP_ERROR PairingCommand::PairWithCode(NodeId remoteId)
 {
-    CommissioningParameters commissioningParams = GetCommissioningParameters();
+    CommissioningParameters commissioningParams = GetCommissioningParameters(remoteId);
 
     // If no network discovery behavior and no network credentials are provided, assume that the pairing command is trying to pair
     // with an on-network device.
@@ -124,7 +126,7 @@ CHIP_ERROR PairingCommand::Pair(NodeId remoteId, PeerAddress address)
     }
     else
     {
-        auto commissioningParams = GetCommissioningParameters();
+        auto commissioningParams = GetCommissioningParameters(remoteId);
         err                      = CurrentCommissioner().PairDevice(remoteId, params, commissioningParams);
     }
     return err;

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -142,7 +142,9 @@ public:
         }
 
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
-        AddArgument("non-concurrent", 0, 1, &mNonConcurrent);
+        AddArgument("non-concurrent", 0, 1, &mNonConcurrent,
+                    "Enable Non-concurrent commissioning flow. ChipTool will terminal the commissioning channel after the device "
+                    "is connected to the operational network if enabling this Option");
     }
 
     /////////// CHIPCommand Interface /////////

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -142,6 +142,7 @@ public:
         }
 
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
+        AddArgument("non-concurrent", 0, 1, &mNonConcurrent);
     }
 
     /////////// CHIPCommand Interface /////////
@@ -165,7 +166,7 @@ private:
     CHIP_ERROR PairWithCode(NodeId remoteId);
     CHIP_ERROR PaseWithCode(NodeId remoteId);
     CHIP_ERROR Unpair(NodeId remoteId);
-    chip::Controller::CommissioningParameters GetCommissioningParameters();
+    chip::Controller::CommissioningParameters GetCommissioningParameters(NodeId remoteId);
 
     const PairingMode mPairingMode;
     const PairingNetworkType mNetworkType;
@@ -177,6 +178,7 @@ private:
     chip::Optional<bool> mUseOnlyOnNetworkDiscovery;
     chip::Optional<bool> mPaseOnly;
     chip::Optional<bool> mSkipCommissioningComplete;
+    chip::Optional<bool> mNonConcurrent;
     uint16_t mRemotePort;
     uint16_t mDiscriminator;
     uint32_t mSetupPINCode;

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -154,11 +154,8 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
         mParams.SetSkipCommissioningComplete(params.GetSkipCommissioningComplete().Value());
     }
 
-    if (params.GetNonConcurrentCommissioning().HasValue())
-    {
-        ChipLogProgress(Controller, "Setting Non-Concurrent commissioning from parameters");
-        mParams.SetNonConcurrentCommissioning(params.GetNonConcurrentCommissioning().Value());
-    }
+    ChipLogProgress(Controller, "Setting Non-Concurrent commissioning from parameters");
+    mParams.SetNonConcurrentCommissioning(params.GetNonConcurrentCommissioning());
 
     return CHIP_NO_ERROR;
 }
@@ -438,7 +435,7 @@ Optional<System::Clock::Timeout> AutoCommissioner::GetCommandTimeout(DeviceProxy
         break;
     }
 
-    if (!mParams.GetNonConcurrentCommissioning().ValueOr(false))
+    if (device)
     {
         // Adjust the timeout for our session transport latency, if we have access
         // to a session.
@@ -626,7 +623,7 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
                                      report.Get<NocChain>().ipk, report.Get<NocChain>().adminSubject);
         case CommissioningStage::kWiFiNetworkEnable:
         case CommissioningStage::kThreadNetworkEnable:
-            if (mParams.GetNonConcurrentCommissioning().ValueOr(false))
+            if (mParams.GetNonConcurrentCommissioning())
             {
                 mCommissioneeDeviceProxy = nullptr;
             }
@@ -677,7 +674,7 @@ DeviceProxy * AutoCommissioner::GetDeviceProxyForStep(CommissioningStage nextSta
 CHIP_ERROR AutoCommissioner::PerformStep(CommissioningStage nextStage)
 {
     DeviceProxy * proxy = GetDeviceProxyForStep(nextStage);
-    if ((!mParams.GetNonConcurrentCommissioning().ValueOr(false) || nextStage != CommissioningStage::kFindOperational) &&
+    if ((!mParams.GetNonConcurrentCommissioning() || nextStage != CommissioningStage::kFindOperational) &&
         proxy == nullptr)
     {
         ChipLogError(Controller, "Invalid device for commissioning");

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -674,8 +674,7 @@ DeviceProxy * AutoCommissioner::GetDeviceProxyForStep(CommissioningStage nextSta
 CHIP_ERROR AutoCommissioner::PerformStep(CommissioningStage nextStage)
 {
     DeviceProxy * proxy = GetDeviceProxyForStep(nextStage);
-    if ((!mParams.GetNonConcurrentCommissioning() || nextStage != CommissioningStage::kFindOperational) &&
-        proxy == nullptr)
+    if ((!mParams.GetNonConcurrentCommissioning() || nextStage != CommissioningStage::kFindOperational) && proxy == nullptr)
     {
         ChipLogError(Controller, "Invalid device for commissioning");
         return CHIP_ERROR_INCORRECT_STATE;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1652,7 +1652,7 @@ void DeviceCommissioner::CommissioningStageComplete(CHIP_ERROR err, Commissionin
             proxy  = mDeviceBeingCommissioned;
             if (mCommissioningStage == kThreadNetworkEnable || mCommissioningStage == kWiFiNetworkEnable)
             {
-                ReleaseCommissioneeDevice(reinterpret_cast<CommissioneeDeviceProxy *>(proxy));
+                ReleaseCommissioneeDevice(FindCommissioneeDevice(nodeId));
                 proxy = nullptr;
             }
         }

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -415,6 +415,13 @@ public:
         return *this;
     }
 
+    Optional<bool> GetNonConcurrentCommissioning() const { return mNonConcurrentCommissioning; }
+    CommissioningParameters & SetNonConcurrentCommissioning(bool nonConcurrentCommissioning)
+    {
+        mNonConcurrentCommissioning = MakeOptional(nonConcurrentCommissioning);
+        return *this;
+    }
+
     // Check for matching fabric on target device by reading fabric list and looking for a
     // fabricId and RootCert match. If a match is detected, then use GetNodeId() to
     // access the nodeId for the device on the matching fabric.
@@ -457,6 +464,7 @@ private:
     Optional<bool> mAttemptWiFiNetworkScan;
     Optional<bool> mAttemptThreadNetworkScan; // This automatically gets set to false when a ThreadOperationalDataset is set
     Optional<bool> mSkipCommissioningComplete;
+    Optional<bool> mNonConcurrentCommissioning;
     bool mCheckForMatchingFabric = false;
 };
 

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -415,10 +415,10 @@ public:
         return *this;
     }
 
-    Optional<bool> GetNonConcurrentCommissioning() const { return mNonConcurrentCommissioning; }
+    bool GetNonConcurrentCommissioning() const { return mNonConcurrentCommissioning; }
     CommissioningParameters & SetNonConcurrentCommissioning(bool nonConcurrentCommissioning)
     {
-        mNonConcurrentCommissioning = MakeOptional(nonConcurrentCommissioning);
+        mNonConcurrentCommissioning = nonConcurrentCommissioning;
         return *this;
     }
 
@@ -464,7 +464,7 @@ private:
     Optional<bool> mAttemptWiFiNetworkScan;
     Optional<bool> mAttemptThreadNetworkScan; // This automatically gets set to false when a ThreadOperationalDataset is set
     Optional<bool> mSkipCommissioningComplete;
-    Optional<bool> mNonConcurrentCommissioning;
+    bool mNonConcurrentCommissioning = false;
     bool mCheckForMatchingFabric = false;
 };
 

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -465,7 +465,7 @@ private:
     Optional<bool> mAttemptThreadNetworkScan; // This automatically gets set to false when a ThreadOperationalDataset is set
     Optional<bool> mSkipCommissioningComplete;
     bool mNonConcurrentCommissioning = false;
-    bool mCheckForMatchingFabric = false;
+    bool mCheckForMatchingFabric     = false;
 };
 
 struct RequestedCertificate


### PR DESCRIPTION
### Problem
According to SPEC, for non-concurrent commissioning we should terminate the commissioning channel successful step 12 (trigger joining of operational network at Commissionee) and then find the operational node, establish CASE Session, and send commissioning-complete.

### Solution
Release the commissionee device proxy after receiving the success response of connect-network.

### Test
Tested chip-tool, used it to pairing ESP32 with BLE.
When using concurrent commissioning, the chip-tool will close the BLE connection after sending commissioning-complete.
When using non-concurrent commissioning, the chip-tool will close the BLE connection after receiving the success response of connect-network.

