### PR TITLE
[Zephyr] Avoid deleting data in NAMESPACE_COUNTERS during FactoryReset

### DIFF
--- a/src/platform/Zephyr/ZephyrConfig.cpp
+++ b/src/platform/Zephyr/ZephyrConfig.cpp
@@ -46,7 +46,7 @@ namespace Internal {
 // KeyValueStoreManagerImpl::DoFactoryReset() is called.
 #define NAMESPACE_FACTORY CHIP_DEVICE_CONFIG_SETTINGS_KEY "-fct/"
 #define NAMESPACE_CONFIG CHIP_DEVICE_CONFIG_SETTINGS_KEY "/cfg/"
-#define NAMESPACE_COUNTERS CHIP_DEVICE_CONFIG_SETTINGS_KEY "/ctr/"
+#define NAMESPACE_COUNTERS CHIP_DEVICE_CONFIG_SETTINGS_KEY "-ctr/"
 
 // Keys stored in the chip factory nam
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_SerialNum                = CONFIG_KEY(NAMESPACE_FACTORY "serial-num");


### PR DESCRIPTION
Avoid deleting data from the `NAMESPACE_COUNTERS`  when FactoryReset. 

Currently, `CHIP_DEVICE_CONFIG_SETTINGS_KEY` is a child of `CHIP_DEVICE_CONFIG_SETTINGS_KEY` because it starts with a "/". This causes data in `NAMESPACE_COUNTERS`, such as `reboot-count`, to be deleted unexpectedly, which is not appropriate.

The data in `NAMESPACE_COUNTERS`, like the data in `NAMESPACE_FACTORY`, should be retained during FactoryReset.

Only data added through `KeyValueStoreManager`, located in `NAMESPACE_CONFIG`, should be deleted.

