### PR TITLE
[tlv] Optimize code size of processing context tags

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -1437,7 +1437,7 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
     uint8_t buffer[1024];
     writer.Init(buffer, sizeof(buffer));
 
-    CHIP_ERROR error = originalData.Encode(writer, chip::TLV::Tag(1));
+    CHIP_ERROR error = originalData.Encode(writer, chip::TLV::CommonTag(1));
     if (error != CHIP_NO_ERROR) {
         MTR_LOG_ERROR("Error: Data encoding failed: %s", error.AsString());
         return nil;
@@ -1456,8 +1456,9 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
         return nil;
     }
     __auto_type tag = reader.GetTag();
-    if (tag != chip::TLV::Tag(1)) {
-        MTR_LOG_ERROR("Error: TLV reader did not read the tag correctly: %llu", tag.mVal);
+    if (tag != chip::TLV::CommonTag(1)) {
+        MTR_LOG_ERROR("Error: TLV reader did not read the tag correctly: %x.%u", chip::TLV::ProfileIdFromTag(tag),
+            chip::TLV::TagNumFromTag(tag));
         return nil;
     }
     MTRDataValueDictionaryDecodableType decodedData;

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -749,7 +749,7 @@ CHIP_ERROR TLVReader::VerifyElement()
     }
     else
     {
-        if (mElemTag == UnknownImplicitTag)
+        if (mElemTag == UnknownImplicitTag())
             return CHIP_ERROR_UNKNOWN_IMPLICIT_TLV_TAG;
         switch (mContainerType)
         {
@@ -806,11 +806,11 @@ Tag TLVReader::ReadTag(TLVTagControl tagControl, const uint8_t *& p) const
         return CommonTag(LittleEndian::Read32(p));
     case TLVTagControl::ImplicitProfile_2Bytes:
         if (ImplicitProfileId == kProfileIdNotSpecified)
-            return UnknownImplicitTag;
+            return UnknownImplicitTag();
         return ProfileTag(ImplicitProfileId, LittleEndian::Read16(p));
     case TLVTagControl::ImplicitProfile_4Bytes:
         if (ImplicitProfileId == kProfileIdNotSpecified)
-            return UnknownImplicitTag;
+            return UnknownImplicitTag();
         return ProfileTag(ImplicitProfileId, LittleEndian::Read32(p));
     case TLVTagControl::FullyQualified_6Bytes:
         vendorId   = LittleEndian::Read16(p);

--- a/src/lib/core/CHIPTLVTags.h
+++ b/src/lib/core/CHIPTLVTags.h
@@ -32,6 +32,13 @@ namespace TLV {
 class Tag
 {
 public:
+    enum SpecialTagNumber : uint32_t
+    {
+        kContextTagMaxNum = UINT8_MAX,
+        kAnonymousTagNum,
+        kUnknownImplicitTagNum
+    };
+
     Tag() = default;
 
     constexpr bool operator==(const Tag & other) const { return mVal == other.mVal; }
@@ -66,22 +73,15 @@ private:
     static constexpr uint32_t kProfileNumShift     = 32;
     static constexpr uint32_t kSpecialTagProfileId = 0xFFFFFFFF;
 
-    enum SpecialTagNumber : uint32_t
-    {
-        kContextTagMaxNum = UINT8_MAX,
-        kAnonymousTagNum,
-        kUnknownImplicitTagNum
-    };
-
-    // The API representation of the tag uses the following encoding:
+    // The storage of the tag value uses the following encoding:
     //
-    //  63                     47                       31
-    // +-----------------------+-----------------------+----------------------------------------------+
-    // | Vendor id (negated)   | Profile num (negated) | Tag number                                   |
-    // +-----------------------+-----------------------+----------------------------------------------+
+    //  63                              47                              31
+    // +-------------------------------+-------------------------------+----------------------------------------------+
+    // | Vendor id (bitwise-negated)   | Profile num (bitwise-negated) | Tag number                                   |
+    // +-------------------------------+-------------------------------+----------------------------------------------+
     //
-    // Vendor id and profile number are negated in order to optimize the code size when using
-    // context tags, the most commonly used tags in the SDK.
+    // Vendor id and profile number are bitwise-negated in order to optimize the code size when
+    // using context tags, the most commonly used tags in the SDK.
     uint64_t mVal;
 };
 

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -629,24 +629,21 @@ CHIP_ERROR TLVWriter::WriteElementHead(TLVElementType elemType, Tag tag, uint64_
     else
         p = stagingBuf;
 
-    if (IsSpecialTag(tag))
+    if (IsContextTag(tag))
     {
-        if (tagNum <= kContextTagMaxNum)
-        {
-            if (mContainerType != kTLVType_Structure && mContainerType != kTLVType_List)
-                return CHIP_ERROR_INVALID_TLV_TAG;
+        if (mContainerType != kTLVType_Structure && mContainerType != kTLVType_List)
+            return CHIP_ERROR_INVALID_TLV_TAG;
 
-            Write8(p, TLVTagControl::ContextSpecific | elemType);
-            Write8(p, static_cast<uint8_t>(tagNum));
-        }
-        else
-        {
-            if (elemType != TLVElementType::EndOfContainer && mContainerType != kTLVType_NotSpecified &&
-                mContainerType != kTLVType_Array && mContainerType != kTLVType_List)
-                return CHIP_ERROR_INVALID_TLV_TAG;
+        Write8(p, TLVTagControl::ContextSpecific | elemType);
+        Write8(p, static_cast<uint8_t>(tagNum));
+    }
+    else if (IsSpecialTag(tag))
+    {
+        if (elemType != TLVElementType::EndOfContainer && mContainerType != kTLVType_NotSpecified &&
+            mContainerType != kTLVType_Array && mContainerType != kTLVType_List)
+            return CHIP_ERROR_INVALID_TLV_TAG;
 
-            Write8(p, TLVTagControl::Anonymous | elemType);
-        }
+        Write8(p, TLVTagControl::Anonymous | elemType);
     }
     else
     {

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -629,21 +629,24 @@ CHIP_ERROR TLVWriter::WriteElementHead(TLVElementType elemType, Tag tag, uint64_
     else
         p = stagingBuf;
 
-    if (IsContextTag(tag))
+    if (IsSpecialTag(tag))
     {
-        if (mContainerType != kTLVType_Structure && mContainerType != kTLVType_List)
-            return CHIP_ERROR_INVALID_TLV_TAG;
+        if (tagNum <= Tag::kContextTagMaxNum)
+        {
+            if (mContainerType != kTLVType_Structure && mContainerType != kTLVType_List)
+                return CHIP_ERROR_INVALID_TLV_TAG;
 
-        Write8(p, TLVTagControl::ContextSpecific | elemType);
-        Write8(p, static_cast<uint8_t>(tagNum));
-    }
-    else if (IsSpecialTag(tag))
-    {
-        if (elemType != TLVElementType::EndOfContainer && mContainerType != kTLVType_NotSpecified &&
-            mContainerType != kTLVType_Array && mContainerType != kTLVType_List)
-            return CHIP_ERROR_INVALID_TLV_TAG;
+            Write8(p, TLVTagControl::ContextSpecific | elemType);
+            Write8(p, static_cast<uint8_t>(tagNum));
+        }
+        else
+        {
+            if (elemType != TLVElementType::EndOfContainer && mContainerType != kTLVType_NotSpecified &&
+                mContainerType != kTLVType_Array && mContainerType != kTLVType_List)
+                return CHIP_ERROR_INVALID_TLV_TAG;
 
-        Write8(p, TLVTagControl::Anonymous | elemType);
+            Write8(p, TLVTagControl::Anonymous | elemType);
+        }
     }
     else
     {


### PR DESCRIPTION
TLV tag is represented as uint64_t that encodes the following components:
- 16-bit vendor ID
- 16-bit profile number
- 32-bit tag number
    
Context tags, which account for vast majority of tag usage in the SDK, are encoded as having both vendor ID and profile
number equal to 0xFFFF. Anonymous tags are encoded in the same way, but using 0xFFFFFFFF tag number.
This is correct because vendor IDs higher than 0xFFF0 shall not be assigned to real manufacturers, but constructing
0xFF... constants in hundreds of places adds non-negligible overhead to the flash usage.

Make the internal representation of Tag private so that it is easier and safer to change it.
Encode profile ID in the negated form internally to optimize the code size when using special tags.