### PR TITLE
[mdns] Added two nullptr checks to prevent falling into hard fault

### DIFF
--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -878,6 +878,7 @@ void AdvertiserMinMdns::AdvertiseRecords(BroadcastAdvertiseType type)
     }
 
     UniquePtr<ListenIterator> allInterfaces = GetAddressPolicy()->GetListenEndpoints();
+    VerifyOrDieWithMsg(allInterfaces != nullptr, Discovery, "Failed to allocate memory for endpoints.");
 
     chip::Inet::InterfaceId interfaceId;
     chip::Inet::IPAddressType addressType;
@@ -885,6 +886,7 @@ void AdvertiserMinMdns::AdvertiseRecords(BroadcastAdvertiseType type)
     while (allInterfaces->Next(&interfaceId, &addressType))
     {
         UniquePtr<IpAddressIterator> allIps = GetAddressPolicy()->GetIpAddressesForEndpoint(interfaceId, addressType);
+        VerifyOrDieWithMsg(allIps != nullptr, Discovery, "Failed to allocate memory for ip addresses.");
 
         Inet::IPAddress ipAddress;
         while (allIps->Next(ipAddress))


### PR DESCRIPTION
In mDNS code there isn't a check that would verify if memory was allocated successfully using new. In case it didn't the application will fall into hard fault due to usage of non-allocated memory.

Added two checks verifying that memory was allocated successfully before using.

