### PR TITLE
[Silabs] Si917 SOC disconnection issue fix

### DIFF
--- a/examples/platform/silabs/SiWx917/SiWx917/rsi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/rsi_if.c
@@ -58,10 +58,10 @@ StaticTask_t driverRsiTaskBuffer;
 StaticEventGroup_t rsiDriverEventGroup;
 
 /* Declare a flag to differentiate between after boot-up first IP connection or reconnection */
-bool is_wifi_disconnection_event = false;
+static bool is_wifi_disconnection_event = false;
 
 /* Declare a variable to hold connection time intervals */
-uint32_t retryInterval = WLAN_MIN_RETRY_TIMER_MS;
+static uint32_t retryInterval = WLAN_MIN_RETRY_TIMER_MS;
 
 bool hasNotifiedIPV6 = false;
 #if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
@@ -185,6 +185,8 @@ static void wfx_rsi_join_cb(uint16_t status, const uint8_t * buf, const uint16_t
 #endif
         wfx_rsi.join_retries = 0;
         retryInterval        = WLAN_MIN_RETRY_TIMER_MS;
+        if (is_wifi_disconnection_event)
+            is_wifi_disconnection_event = false;
     }
 }
 

--- a/examples/platform/silabs/SiWx917/SiWx917/rsi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/rsi_if.c
@@ -57,6 +57,12 @@ StaticTask_t driverRsiTaskBuffer;
 /* Declare a variable to hold the data associated with the created event group. */
 StaticEventGroup_t rsiDriverEventGroup;
 
+/* Declare a flag to differentiate between after boot-up first IP connection or reconnection */
+bool is_wifi_disconnection_event = false;
+
+/* Declare a variable to hold connection time intervals */
+uint32_t retryInterval = WLAN_MIN_RETRY_TIMER_MS;
+
 bool hasNotifiedIPV6 = false;
 #if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
 bool hasNotifiedIPV4 = false;
@@ -162,12 +168,9 @@ static void wfx_rsi_join_cb(uint16_t status, const uint8_t * buf, const uint16_t
          * We should enable retry.. (Need config variable for this)
          */
         WFX_RSI_LOG("%s: failed. retry: %d", __func__, wfx_rsi.join_retries);
-#if (WFX_RSI_CONFIG_MAX_JOIN != 0)
-        if (++wfx_rsi.join_retries < WFX_RSI_CONFIG_MAX_JOIN)
-#endif
-        {
+        wfx_retry_interval_handler(is_wifi_disconnection_event, wfx_rsi.join_retries++);
+        if (is_wifi_disconnection_event || wfx_rsi.join_retries <= WFX_RSI_CONFIG_MAX_JOIN)
             xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_START_JOIN);
-        }
     }
     else
     {
@@ -180,6 +183,8 @@ static void wfx_rsi_join_cb(uint16_t status, const uint8_t * buf, const uint16_t
 #else
         xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_CONN);
 #endif
+        wfx_rsi.join_retries = 0;
+        retryInterval        = WLAN_MIN_RETRY_TIMER_MS;
     }
 }
 
@@ -195,9 +200,10 @@ static void wfx_rsi_join_cb(uint16_t status, const uint8_t * buf, const uint16_t
  *********************************************************************/
 static void wfx_rsi_join_fail_cb(uint16_t status, uint8_t * buf, uint32_t len)
 {
-    WFX_RSI_LOG("%s: error: failed status: %02x on try %d", __func__, status, wfx_rsi.join_retries);
+    WFX_RSI_LOG("%s: error: failed status: %02x", __func__, status);
     wfx_rsi.join_retries += 1;
-    wfx_rsi.dev_state &= ~WFX_RSI_ST_STA_CONNECTING;
+    wfx_rsi.dev_state &= ~(WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED);
+    is_wifi_disconnection_event = true;
     xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_START_JOIN);
 }
 #ifdef RS911X_SOCKETS
@@ -420,16 +426,19 @@ static void wfx_rsi_do_join(void)
          */
         wfx_rsi.dev_state |= WFX_RSI_ST_STA_CONNECTING;
 
-        /* Try to connect Wifi with given Credentials
-         * until there is a success or maximum number of tries allowed
-         */
-        while (++wfx_rsi.join_retries < WFX_RSI_CONFIG_MAX_JOIN)
+        if ((status = rsi_wlan_register_callbacks(RSI_JOIN_FAIL_CB, wfx_rsi_join_fail_cb)) != RSI_SUCCESS)
         {
+            WFX_RSI_LOG("%s: RSI callback register join failed with status: %02x", __func__, status);
+        }
 
+        /* Try to connect Wifi with given Credentials
+         * untill there is a success or maximum number of tries allowed
+         */
+        while (is_wifi_disconnection_event || wfx_rsi.join_retries <= WFX_RSI_CONFIG_MAX_JOIN)
+        {
             /* Call rsi connect call with given ssid and password
              * And check there is a success
              */
-
             if ((status = rsi_wlan_connect_async((int8_t *) &wfx_rsi.sec.ssid[0], (rsi_security_mode_t) wfx_rsi.sec.security,
                                                  &wfx_rsi.sec.passkey[0], wfx_rsi_join_cb)) != RSI_SUCCESS)
             {
@@ -437,21 +446,16 @@ static void wfx_rsi_do_join(void)
                 wfx_rsi.dev_state &= ~WFX_RSI_ST_STA_CONNECTING;
                 WFX_RSI_LOG("%s: rsi_wlan_connect_async failed with status: %02x on try %d", __func__, status,
                             wfx_rsi.join_retries);
-                vTaskDelay(400);
-                /* TODO - Start a timer.. to retry */
+
+                wfx_retry_interval_handler(is_wifi_disconnection_event, wfx_rsi.join_retries);
+                wfx_rsi.join_retries++;
             }
             else
             {
+                WFX_RSI_LOG("%s: starting JOIN to %s after %d tries\n", __func__, (char *) &wfx_rsi.sec.ssid[0],
+                            wfx_rsi.join_retries);
                 break; // exit while loop
             }
-        }
-        if (wfx_rsi.join_retries == MAX_JOIN_RETRIES_COUNT)
-        {
-            WFX_RSI_LOG("Connect failed after %d tries", wfx_rsi.join_retries);
-        }
-        else
-        {
-            WFX_RSI_LOG("%s: starting JOIN to %s after %d tries\n", __func__, (char *) &wfx_rsi.sec.ssid[0], wfx_rsi.join_retries);
         }
         WFX_RSI_LOG("Returning the do join");
     }
@@ -833,6 +837,48 @@ int32_t wfx_rsi_init_platform()
     }
 
     return status;
+}
+
+/********************************************************************************************
+ * @fn  void wfx_retry_interval_handler(bool is_wifi_disconnection_event, uint16_t retryJoin)
+ * @brief
+ *      Based on condition will delay for a certain period of time.
+ * @param[in] is_wifi_disconnection_event
+ * @param[in] retryJoin
+ * @return None
+ ********************************************************************************************/
+void wfx_retry_interval_handler(bool is_wifi_disconnection_event, uint16_t retryJoin)
+{
+    if (!is_wifi_disconnection_event)
+    {
+        /* After the reboot or a commissioning time device failed to connect with AP.
+         * Device will retry to connect with AP upto WFX_RSI_CONFIG_MAX_JOIN retries.
+         */
+        if (retryJoin < MAX_JOIN_RETRIES_COUNT)
+        {
+            SILABS_LOG("%s: Next attempt after %d Seconds", __func__, CONVERT_MS_TO_SEC(WLAN_RETRY_TIMER_MS));
+            vTaskDelay(pdMS_TO_TICKS(WLAN_RETRY_TIMER_MS));
+        }
+        else
+        {
+            SILABS_LOG("Connect failed after max %d tries", retryJoin);
+        }
+    }
+    else
+    {
+        /* After disconnection
+         * At the telescopic time interval device try to reconnect with AP, upto WLAN_MAX_RETRY_TIMER_MS intervals
+         * are telescopic. If interval exceed WLAN_MAX_RETRY_TIMER_MS then it will try to reconnect at
+         * WLAN_MAX_RETRY_TIMER_MS intervals.
+         */
+        if (retryInterval > WLAN_MAX_RETRY_TIMER_MS)
+        {
+            retryInterval = WLAN_MAX_RETRY_TIMER_MS;
+        }
+        SILABS_LOG("%s: Next attempt after %d Seconds", __func__, CONVERT_MS_TO_SEC(retryInterval));
+        vTaskDelay(pdMS_TO_TICKS(retryInterval));
+        retryInterval += retryInterval;
+    }
 }
 
 struct wfx_rsi wfx_rsi;

--- a/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
+++ b/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
@@ -53,6 +53,12 @@
 #define WLAN_DRIVER_TASK_PRIORITY 2
 #define MAX_JOIN_RETRIES_COUNT 5
 
+// WLAN retry time intervals in milli seconds
+#define WLAN_MAX_RETRY_TIMER_MS 30000
+#define WLAN_MIN_RETRY_TIMER_MS 1000
+#define WLAN_RETRY_TIMER_MS 5000
+#define CONVERT_MS_TO_SEC(TimeInMS) (TimeInMS / 1000)
+
 // WLAN related Macros
 #define ETH_FRAME 0
 #define CMP_SUCCESS 0
@@ -276,6 +282,8 @@ void * wfx_rsi_alloc_pkt(void);
 void wfx_rsi_pkt_add_data(void * p, uint8_t * buf, uint16_t len, uint16_t off);
 int32_t wfx_rsi_send_data(void * p, uint16_t len);
 #endif /* RS911X_WIFI */
+
+void wfx_retry_interval_handler(bool is_wifi_disconnection_event, uint16_t retryJoin);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
In current scenario if AP goes offline more than 25 seconds, at that time device not able to reconnect with AP. This is because in current routine when disconnection event happen device start trying (maximum 5 retries) to reconnect with AP after every 5 seconds. If AP came online during retries then only device reconnect to AP else device remain disconnected.

Above issue resolved in this fix and on below combinations fix are tested.