### PR TITLE
[nrfconnect] Removed types from Kconfig overrides

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -21,7 +21,6 @@
 if CHIP
 
 config LOG
-    bool
     default y
 
 if LOG
@@ -35,148 +34,115 @@ choice MATTER_LOG_LEVEL_CHOICE
 endchoice
 
 config LOG_DEFAULT_LEVEL
-    int
     default 2
 
 config CHIP_LOG_SIZE_OPTIMIZATION
-    bool
     default y
 
 endif
 
 config PRINTK_SYNC
-    bool
     default y
 
 config ASSERT
-    bool
     default y
 
 config HW_STACK_PROTECTION
-    bool
     default y
 
 config FPU
-    bool
     default y
 
 config SHELL
-    bool
     default y
 
 # Generic networking options
 config NET_SOCKETS_POSIX_NAMES
-    bool
     default n
 
 # Application stack size
 config MAIN_STACK_SIZE
-    int
     default 8192
 
 config INIT_STACKS
-    bool
     default y
 
 # Disable certain parts of Zephyr IPv6 stack
 config NET_IPV6_NBR_CACHE
-    bool
     default n
 
 config NET_IPV6_MLD
-    bool
     default y
 
 config NET_IF_MCAST_IPV6_ADDR_COUNT
-    int 
     default 14
 
 # Network buffers
 config NET_PKT_RX_COUNT
-    int
     default 16
 
 config NET_PKT_TX_COUNT
-    int
     default 16
 
 config NET_BUF_RX_COUNT
-    int
     default 80
 
 config NET_BUF_TX_COUNT
-    int
     default 80
 
 # Bluetooth Low Energy configs
 
 config BT
-    bool
     default y
 
 config BT_PERIPHERAL
-    bool
     default y
 
 config BT_PERIPHERAL_PREF_MIN_INT
-    int
     default 36
 
 config BT_PERIPHERAL_PREF_MAX_INT
-    int
     default 36
 
 config BT_GAP_AUTO_UPDATE_CONN_PARAMS
-    bool
     default y
 
 config BT_GATT_DYNAMIC_DB
-    bool
     default y
 
 config BT_DEVICE_NAME_DYNAMIC
-    bool
     default y
 
 config BT_DEVICE_NAME_MAX
-    int
     default 15
 
 config BT_MAX_CONN
-    int
     default 1
 
 config BT_L2CAP_TX_MTU
-    int
     default 247
 
 config BT_BUF_ACL_RX_SIZE
-    int
     default 251
 
 config BT_BUF_ACL_TX_SIZE
-    int
     default 251
 
 config BT_RX_STACK_SIZE
-    int
     default 1200
 
 # Enable NFC support
 
 config CHIP_NFC_COMMISSIONING
-    bool
     default y
 
 config CHIP_OTA_REQUESTOR
-    bool
     default y
 
 # All boards besides nRF7002DK use QSPI NOR external flash
 if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF52840DK_NRF52840
 
 config CHIP_QSPI_NOR
-    bool
     default y
 
 endif # BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF52840DK_NRF52840
@@ -186,35 +152,29 @@ endif # BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF52840DK_NRF52840
 if BOARD_NRF7002DK_NRF5340_CPUAPP
 
 config CHIP_SPI_NOR
-    bool
     default y
 
 endif # BOARD_NRF7002DK_NRF5340_CPUAPP
 
 # Enable extended discovery
 config CHIP_EXTENDED_DISCOVERY
-    bool
     default y
 
 config NVS_LOOKUP_CACHE
-    bool
     default y
 
 config NVS_LOOKUP_CACHE_SIZE
-    int
     default 512
 
 # Enable OpenThread
 
 config NET_L2_OPENTHREAD
-    bool
     default y if !WIFI_NRF700X
 
 if NET_L2_OPENTHREAD
 
 # Increase the default RX stack size
 config IEEE802154_NRF5_RX_STACK_SIZE
-    int
     default 1024
 
 endif
@@ -222,50 +182,39 @@ endif
 if CHIP_WIFI
 
 config NRF_WIFI_LOW_POWER
-    bool
     default n
 
 config MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
-    bool
     default n
 
 config SYSTEM_WORKQUEUE_STACK_SIZE
-    int
     default 1120
 
 # align these numbers to match the OpenThread config
 config NET_IF_UNICAST_IPV6_ADDR_COUNT
-    int
     default 6
 
 config NET_IF_MCAST_IPV6_ADDR_COUNT
-    int
     default 8
 
 config NET_SOCKETS_POSIX_NAMES
-    bool
     default n
 
 config MBEDTLS_SSL_OUT_CONTENT_LEN
-    int
     default 900
 
 # options managed by IP4/IP6 simultaneous support
 # aligned here to match OpenThread config
 config NET_MAX_ROUTERS
-    int
     default 1
 
 config NET_MAX_CONN
-    int
     default 4
 
 config SHELL_STACK_SIZE
-    int
     default 2616
 
 config HEAP_MEM_POOL_SIZE
-    int
     default 200000
 
 endif
@@ -278,183 +227,139 @@ choice OPENTHREAD_SECURITY
 endchoice
 
 config PSA_CRYPTO_DRIVER_CC3XX
-	bool
 	default n
 
 config OBERON_BACKEND
-    bool
     default y
 
 config MBEDTLS_ENABLE_HEAP
-    bool
     default y
 
 config MBEDTLS_HEAP_SIZE
-    int
     default 15360
 
 config MBEDTLS_TLS_LIBRARY
-    bool
     default y
 
 config NRF_SECURITY_ADVANCED
-    bool
     default y
 
 config MBEDTLS_AES_C
-    bool
     default y
 
 config MBEDTLS_ECP_C
-    bool
     default y
 
 config MBEDTLS_ECP_DP_SECP256R1_ENABLED
-    bool
     default y
 
 config MBEDTLS_CTR_DRBG_C
-    bool
     default y
 
 config MBEDTLS_CIPHER_MODE_CTR
-    bool
     default y
 
 config MBEDTLS_ECJPAKE_C
-    bool
     default y
 
 config MBEDTLS_SHA256_C
-    bool
     default y
 
 config MBEDTLS_PK_C
-    bool
     default y
 
 config MBEDTLS_PK_WRITE_C
-    bool
     default y
 
 config MBEDTLS_X509_CREATE_C
-    bool
     default y if !CHIP_CRYPTO_PSA
 
 config MBEDTLS_X509_CSR_WRITE_C
-    bool
     default y if !CHIP_CRYPTO_PSA
 
 # Disable unneeded crypto operations
 
 config MBEDTLS_SHA384_C
-    bool
     default n
 
 config MBEDTLS_SHA512_C
-    bool
     default n
 
 config MBEDTLS_CIPHER_MODE_XTS
-    bool
     default n
 
 config MBEDTLS_CHACHA20_C
-    bool
     default n
 
 config MBEDTLS_POLY1305_C
-    bool
     default n
 
 config MBEDTLS_CHACHAPOLY_C
-    bool
     default n
 
 config MBEDTLS_GCM_C
-    bool
     default n
 
 config MBEDTLS_RSA_C
-    bool
     default n
 
 config PSA_WANT_KEY_TYPE_ARIA
-    bool
     default n
 
 config PSA_WANT_KEY_TYPE_CHACHA20
-    bool
     default n
 
 config PSA_WANT_ALG_GCM
-    bool
     default n
 
 config PSA_WANT_ALG_CHACHA20_POLY1305
-    bool
     default n
 
 config PSA_WANT_ALG_SHA_1
-    bool
     default n
 
 config PSA_WANT_ALG_SHA_224
-    bool
     default n
 
 config PSA_WANT_ALG_SHA_384
-    bool
     default n
 
 config PSA_WANT_ALG_SHA_512
-    bool
     default n
 
 config PSA_WANT_ALG_RIPEMD160
-    bool
     default n
 
 config PSA_WANT_ALG_MD5
-    bool
     default n
 
 config PSA_WANT_ALG_CFB
-    bool
     default n
 
 config PSA_WANT_ALG_OFB
-    bool
     default n
 
 # Disable not used shell modules
 
 config SENSOR_SHELL
-    bool
     default n
 
 config DEVICE_SHELL
-    bool
     default n
 
 config DATE_SHELL
-    bool
     default n
 
 config DEVMEM_SHELL
-    bool
     default n
 
 config MCUBOOT_SHELL
-    bool
     default n
 
 config CLOCK_CONTROL_NRF_SHELL
-    bool
     default n
 
 config FLASH_SHELL
-    bool
     default n
 
 # SoC series related configuration
@@ -463,7 +368,6 @@ if SOC_SERIES_NRF52X
 
 # Increase maximum data length of PDU supported in the Controller
 config BT_CTLR_DATA_LENGTH_MAX
-    int
     default 251
 
 endif # SOC_SERIES_NRF52X
@@ -471,7 +375,6 @@ endif # SOC_SERIES_NRF52X
 if SOC_SERIES_NRF53X
 
 config UPDATEABLE_IMAGE_NUMBER
-    int
     default 2
 
 # Generate random numbers using Xoroshiro algorithm instead of direct calls

--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -49,11 +49,9 @@ config CHIP_QSPI_NOR
 if CHIP_QSPI_NOR
 
 config NORDIC_QSPI_NOR
-	bool
 	default y
 
 config NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE
-	int
 	default 16
 
 endif # CHIP_QSPI_NOR
@@ -71,7 +69,6 @@ config CHIP_SPI_NOR
 if CHIP_SPI_NOR
 
 config SPI_NOR_FLASH_LAYOUT_PAGE_SIZE
-	int
 	default 4096
 
 endif # CHIP_SPI_NOR
@@ -96,41 +93,33 @@ if CHIP_DFU_OVER_BT_SMP
 
 # MCU Manager and SMP configuration
 config MCUMGR_SMP_BT_AUTHEN
-	bool
 	default n
 
 config MCUMGR_BUF_COUNT
-	int
 	default 6
 
 # Increase BT MTU and RX buffer for big size DFU messages
 config BT_L2CAP_TX_MTU
-	int
 	default 498
 
 config BT_BUF_ACL_RX_SIZE
-	int
 	default 502
 
 # Increase MCUMGR_BUF_SIZE, as it must be big enough to fit MAX MTU + overhead and for single-image DFU default is 384 B
 config MCUMGR_BUF_SIZE
-	int
 	default 1024
 
 # Increase system workqueue size, as SMP is processed within it
 config SYSTEM_WORKQUEUE_STACK_SIZE
-	int
 	default 2800
 
 if SOC_SERIES_NRF53X
 
 # Enable custom SMP request to erase settings partition.
 config MCUMGR_GRP_ZEPHYR_BASIC
-	bool
 	default y
 
 config MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE
-	bool
 	default y
 
 endif # SOC_SERIES_NRF53X

--- a/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.defaults
@@ -17,83 +17,63 @@
 # The purpose of this file is to define new default values of settings used when building hci_rpmsg child image for Matter samples.
 
 config LOG
-    bool
     default n
 
 config HEAP_MEM_POOL_SIZE
-    int
     default 8192
 
 config MAIN_STACK_SIZE
-    int
     default 2048
 
 config SYSTEM_WORKQUEUE_STACK_SIZE
-    int
     default 2048
 
 config BT
-    bool
     default y
 
 config BT_HCI_RAW
-    bool
     default y
 
 config BT_MAX_CONN
-    int
     default 1
 
 config BT_PERIPHERAL
-    bool
     default y
 
 config BT_CENTRAL
-    bool
     default n
 
 config BT_BUF_ACL_RX_SIZE
-    int
     default 502
 
 config BT_BUF_ACL_TX_SIZE
-    int
     default 251
 
 config BT_CTLR_DATA_LENGTH_MAX
-    int
     default 251
 
 config BT_CTLR_ASSERT_HANDLER
-    bool
     default y
 
 config BT_HCI_RAW_RESERVE
-    int
     default 1
 
 # Workaround: Unable to allocate command buffer when using K_NO_WAIT since
 # Host number of completed commands does not follow normal flow control.
 config BT_BUF_CMD_TX_COUNT
-    int
     default 10
 
 config ASSERT
-    bool
     default y
 
 config DEBUG_INFO
-    bool
     default y
 
 config EXCEPTION_STACK_TRACE
-    bool
     default y
 
 config IPC_SERVICE
-    bool
     default y
 
 config MBOX
-    bool
     default y

--- a/config/nrfconnect/chip-module/Kconfig.mcuboot.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.mcuboot.defaults
@@ -17,50 +17,39 @@
 # The purpose of this file is to define new default values of settings used when building mcuboot child image for Matter samples.
 
 config MAIN_STACK_SIZE
-    int
     default 10240
 
 config BOOT_SWAP_SAVE_ENCTLV
-    bool
     default n
 
 config BOOT_ENCRYPT_RSA
-    bool
     default n
 
 config BOOT_ENCRYPT_EC256
-    bool
     default n
 
 config BOOT_ENCRYPT_X25519
-    bool
     default n
 
 config BOOT_BOOTSTRAP
-    bool
     default n
 
 config PM
-    bool
     default n
 
 config FLASH
-    bool
     default y
 
 config FPROTECT
-    bool
     default y
 
 # nRF7002DK uses SPI NOR external flash
 if BOARD_NRF7002DK_NRF5340_CPUAPP
 
 config SPI
-    bool
     default y
 
 config SPI_NOR
-    bool
     default y
 
 choice SPI_NOR_SFDP
@@ -68,15 +57,12 @@ choice SPI_NOR_SFDP
 endchoice
 
 config SPI_NOR_FLASH_LAYOUT_PAGE_SIZE
-    int
     default 4096
 
 config MULTITHREADING
-    bool
     default y
 
 config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
-    bool
     default y
 
 endif
@@ -85,68 +71,53 @@ endif
 if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF52840DK_NRF52840
 
 config NORDIC_QSPI_NOR
-    bool
     default y
 
 config NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE
-    int
     default 4096
 
 config NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE
-    int
     default 16
 
 endif
 
 config BOOT_MAX_IMG_SECTORS
-    int
     default 256
 
 config LOG
-    bool
     default n
 
 config CONSOLE_HANDLER
-    bool
     default n
 
 config BOOT_BANNER
-    bool
     default n
 
 config TIMESLICING
-    bool
     default n
 
 config RESET_ON_FATAL_ERROR
-    bool
     default n
 
 config MULTITHREADING
-    bool
     default n
 
 config TICKLESS_KERNEL
-    bool
     default n
 
 config TIMEOUT_64BIT
-    bool
     default n
 
 config NRF_ENABLE_ICACHE
-    bool
     default n
 
 if SOC_SERIES_NRF53X
 
 # The following configurations are required to support simultaneous multi image update
 config PCD_APP
-    bool
     default y
 
 config UPDATEABLE_IMAGE_NUMBER
-    int
     default 2
 
 # Multi-image updates do not support image swapping yet.
@@ -157,24 +128,19 @@ endchoice
 # The network core cannot access external flash directly. The flash simulator must be used to
 # provide a memory region that is used to forward the new firmware to the network core.
 config FLASH_SIMULATOR
-    bool
     default y
 
 config FLASH_SIMULATOR_DOUBLE_WRITES
-    bool
     default y
 
 config FLASH_SIMULATOR_STATS
-    bool
     default n
 
 # Enable custom command to erase settings partition.
 config ENABLE_MGMT_PERUSER
-    bool
     default y
 
 config BOOT_MGMT_CUSTOM_STORAGE_ERASE
-    bool
     default y
 
 endif # SOC_SERIES_NRF53X

--- a/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.defaults
@@ -17,87 +17,66 @@
 # The purpose of this file is to define new default values of settings used when building multiprotocol_rpmsg child image for Matter samples.
 
 config LOG
-    bool
     default n
 
 config HEAP_MEM_POOL_SIZE
-    int 
     default 8192
 
 config MAIN_STACK_SIZE
-    int
     default 2048
 
 config SYSTEM_WORKQUEUE_STACK_SIZE
-    int
     default 2048
 
 config BT
-    bool
     default y
 
 config BT_HCI_RAW
-    bool
     default y
 
 config BT_MAX_CONN
-    int
     default 1
 
 config BT_PERIPHERAL
-    bool
     default y
 
 config BT_CENTRAL
-    bool
     default n
 
 config BT_BUF_ACL_RX_SIZE
-    int
     default 502
 
 config BT_BUF_ACL_TX_SIZE
-    int
     default 251
 
 config BT_CTLR_DATA_LENGTH_MAX
-    int
     default 251
 
 config BT_CTLR_ASSERT_HANDLER
-    bool
     default y
 
 config BT_HCI_RAW_RESERVE
-    int
     default 1
 
 # Workaround: Unable to allocate command buffer when using K_NO_WAIT since
 # Host number of completed commands does not follow normal flow control.
 config BT_BUF_CMD_TX_COUNT
-    int
     default 10
 
 config ASSERT
-    bool
     default y
 
 config DEBUG_INFO
-    bool
     default y
 
 config EXCEPTION_STACK_TRACE
-    bool
     default y
 
 config NRF_802154_SER_RADIO
-    bool
     default y
 
 config NRF_RTC_TIMER_USER_CHAN_COUNT
-    int
     default 2
 
 config NRF_802154_ENCRYPTION
-    bool
     default y


### PR DESCRIPTION
Types should not be used in case of overriding existing kconfig definitions. It is to make sure that compilation will fail due to creating a config without a type in case of name change in the origin kconfig option.
