### PR TITLE
tv-casting-app: On kBindingsChangedViaCluster, connect to VideoPlayer if already commissioned with it

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -415,8 +415,8 @@ private:
     void ReadServerClusters(chip::EndpointId endpointId);
 
     PersistenceManager mPersistenceManager;
-    bool mInited       = false;
-    bool udcInProgress = false;
+    bool mInited        = false;
+    bool mUdcInProgress = false;
     TargetVideoPlayerInfo mActiveTargetVideoPlayerInfo;
     TargetVideoPlayerInfo mCachedTargetVideoPlayerInfo[kMaxCachedVideoPlayers];
     uint16_t mTargetVideoPlayerVendorId                                   = 0;

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -415,7 +415,8 @@ private:
     void ReadServerClusters(chip::EndpointId endpointId);
 
     PersistenceManager mPersistenceManager;
-    bool mInited = false;
+    bool mInited       = false;
+    bool udcInProgress = false;
     TargetVideoPlayerInfo mActiveTargetVideoPlayerInfo;
     TargetVideoPlayerInfo mCachedTargetVideoPlayerInfo[kMaxCachedVideoPlayers];
     uint16_t mTargetVideoPlayerVendorId                                   = 0;

--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -43,6 +43,7 @@ public:
     size_t GetNumIPs() const { return mNumIPs; }
     const chip::Inet::IPAddress * GetIpAddresses() const { return mIpAddress; }
     bool IsSameAs(const chip::Dnssd::DiscoveredNodeData * discoveredNodeData);
+    bool IsSameAs(const char * deviceName, size_t numIPs, const chip::Inet::IPAddress * ipAddresses);
 
     chip::OperationalDeviceProxy * GetOperationalDeviceProxy()
     {

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -345,7 +345,9 @@ void CastingServer::DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * eve
                     CastingServer::GetInstance()->ReadCachedTargetVideoPlayerInfos();
                 if (connectableVideoPlayerList == nullptr || !connectableVideoPlayerList[0].IsInitialized())
                 {
-                    ChipLogProgress(AppServer, "No cached video players found");
+                    ChipLogError(AppServer, "CastingServer::DeviceEventCallback No cached video players found");
+                    CastingServer::GetInstance()->mCommissioningCompleteCallback(CHIP_ERROR_INCORRECT_STATE);
+                    return;
                 }
 
                 for (size_t i = 0; i < kMaxCachedVideoPlayers && connectableVideoPlayerList[i].IsInitialized(); i++)
@@ -360,6 +362,14 @@ void CastingServer::DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * eve
                         targetFabricIndex    = connectableVideoPlayerList[i].GetFabricIndex();
                         runPostCommissioning = true;
                     }
+                }
+
+                if (targetPeerNodeId == 0 && runPostCommissioning == false)
+                {
+                    ChipLogError(AppServer,
+                                 "CastingServer::DeviceEventCallback did NOT find the video player to initialize/connect to");
+                    CastingServer::GetInstance()->mCommissioningCompleteCallback(CHIP_ERROR_INCORRECT_STATE);
+                    return;
                 }
             }
         }

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -130,6 +130,7 @@ CHIP_ERROR CastingServer::SendUserDirectedCommissioningRequest(chip::Transport::
 
 CHIP_ERROR CastingServer::SendUserDirectedCommissioningRequest(Dnssd::DiscoveredNodeData * selectedCommissioner)
 {
+    udcInProgress = true;
     // Send User Directed commissioning request
     ReturnErrorOnFailure(SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress::UDP(
         selectedCommissioner->resolutionData.ipAddress[0], selectedCommissioner->resolutionData.port,
@@ -320,23 +321,81 @@ CastingServer::ContentLauncherLaunchURL(TargetEndpointInfo * endpoint, const cha
 
 void CastingServer::DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
 {
+    bool runPostCommissioning           = false;
+    chip::NodeId targetPeerNodeId       = 0;
+    chip::FabricIndex targetFabricIndex = 0;
     if (event->Type == DeviceLayer::DeviceEventType::kBindingsChangedViaCluster)
     {
+        ChipLogProgress(AppServer, "CastingServer::DeviceEventCallback kBindingsChangedViaCluster received");
         if (CastingServer::GetInstance()->GetActiveTargetVideoPlayer()->IsInitialized())
         {
+            ChipLogProgress(AppServer,
+                            "CastingServer::DeviceEventCallback already connected to video player, reading server clusters");
             CastingServer::GetInstance()->ReadServerClustersForNode(
                 CastingServer::GetInstance()->GetActiveTargetVideoPlayer()->GetNodeId());
+        }
+        else if (CastingServer::GetInstance()->udcInProgress)
+        {
+            ChipLogProgress(AppServer,
+                            "CastingServer::DeviceEventCallback UDC is in progress while handling kBindingsChangedViaCluster");
+            CastingServer::GetInstance()->udcInProgress = false;
+            if (CastingServer::GetInstance()->mTargetVideoPlayerNumIPs > 0)
+            {
+                TargetVideoPlayerInfo * connectableVideoPlayerList =
+                    CastingServer::GetInstance()->ReadCachedTargetVideoPlayerInfos();
+                if (connectableVideoPlayerList == nullptr || !connectableVideoPlayerList[0].IsInitialized())
+                {
+                    ChipLogProgress(AppServer, "No cached video players found");
+                }
+
+                for (size_t i = 0; i < kMaxCachedVideoPlayers && connectableVideoPlayerList[i].IsInitialized(); i++)
+                {
+                    if (connectableVideoPlayerList[i].IsSameAs(CastingServer::GetInstance()->mTargetVideoPlayerDeviceName,
+                                                               CastingServer::GetInstance()->mTargetVideoPlayerNumIPs,
+                                                               CastingServer::GetInstance()->mTargetVideoPlayerIpAddress))
+                    {
+                        ChipLogProgress(AppServer,
+                                        "CastingServer::DeviceEventCallback found the video player to initialize/connect to");
+                        targetPeerNodeId     = connectableVideoPlayerList[i].GetNodeId();
+                        targetFabricIndex    = connectableVideoPlayerList[i].GetFabricIndex();
+                        runPostCommissioning = true;
+                    }
+                }
+            }
         }
     }
     else if (event->Type == DeviceLayer::DeviceEventType::kCommissioningComplete)
     {
+        ChipLogProgress(AppServer, "CastingServer::DeviceEventCallback kCommissioningComplete received");
+        CastingServer::GetInstance()->udcInProgress = false;
+        targetPeerNodeId                            = event->CommissioningComplete.nodeId;
+        targetFabricIndex                           = event->CommissioningComplete.fabricIndex;
+        runPostCommissioning                        = true;
+    }
+
+    if (runPostCommissioning)
+    {
+        ChipLogProgress(AppServer,
+                        "CastingServer::DeviceEventCallback will connect with nodeId=0x" ChipLogFormatX64 " fabricIndex=%d",
+                        ChipLogValueX64(targetPeerNodeId), targetFabricIndex);
         CHIP_ERROR err = CastingServer::GetInstance()->GetActiveTargetVideoPlayer()->Initialize(
-            event->CommissioningComplete.nodeId, event->CommissioningComplete.fabricIndex,
-            CastingServer::GetInstance()->mOnConnectionSuccessClientCallback,
+            targetPeerNodeId, targetFabricIndex, CastingServer::GetInstance()->mOnConnectionSuccessClientCallback,
             CastingServer::GetInstance()->mOnConnectionFailureClientCallback,
             CastingServer::GetInstance()->mTargetVideoPlayerVendorId, CastingServer::GetInstance()->mTargetVideoPlayerProductId,
             CastingServer::GetInstance()->mTargetVideoPlayerDeviceType, CastingServer::GetInstance()->mTargetVideoPlayerDeviceName,
             CastingServer::GetInstance()->mTargetVideoPlayerNumIPs, CastingServer::GetInstance()->mTargetVideoPlayerIpAddress);
+
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(AppServer, "Failed to initialize target video player");
+        }
+
+        err = CastingServer::GetInstance()->mPersistenceManager.AddVideoPlayer(
+            &CastingServer::GetInstance()->mActiveTargetVideoPlayerInfo);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(AppServer, "AddVideoPlayer(ToCache) error: %" CHIP_ERROR_FORMAT, err.Format());
+        }
 
         CastingServer::GetInstance()->mCommissioningCompleteCallback(err);
     }

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -130,7 +130,7 @@ CHIP_ERROR CastingServer::SendUserDirectedCommissioningRequest(chip::Transport::
 
 CHIP_ERROR CastingServer::SendUserDirectedCommissioningRequest(Dnssd::DiscoveredNodeData * selectedCommissioner)
 {
-    udcInProgress = true;
+    mUdcInProgress = true;
     // Send User Directed commissioning request
     ReturnErrorOnFailure(SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress::UDP(
         selectedCommissioner->resolutionData.ipAddress[0], selectedCommissioner->resolutionData.port,
@@ -334,11 +334,11 @@ void CastingServer::DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * eve
             CastingServer::GetInstance()->ReadServerClustersForNode(
                 CastingServer::GetInstance()->GetActiveTargetVideoPlayer()->GetNodeId());
         }
-        else if (CastingServer::GetInstance()->udcInProgress)
+        else if (CastingServer::GetInstance()->mUdcInProgress)
         {
             ChipLogProgress(AppServer,
                             "CastingServer::DeviceEventCallback UDC is in progress while handling kBindingsChangedViaCluster");
-            CastingServer::GetInstance()->udcInProgress = false;
+            CastingServer::GetInstance()->mUdcInProgress = false;
             if (CastingServer::GetInstance()->mTargetVideoPlayerNumIPs > 0)
             {
                 TargetVideoPlayerInfo * connectableVideoPlayerList =
@@ -377,10 +377,10 @@ void CastingServer::DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * eve
     else if (event->Type == DeviceLayer::DeviceEventType::kCommissioningComplete)
     {
         ChipLogProgress(AppServer, "CastingServer::DeviceEventCallback kCommissioningComplete received");
-        CastingServer::GetInstance()->udcInProgress = false;
-        targetPeerNodeId                            = event->CommissioningComplete.nodeId;
-        targetFabricIndex                           = event->CommissioningComplete.fabricIndex;
-        runPostCommissioning                        = true;
+        CastingServer::GetInstance()->mUdcInProgress = false;
+        targetPeerNodeId                             = event->CommissioningComplete.nodeId;
+        targetFabricIndex                            = event->CommissioningComplete.fabricIndex;
+        runPostCommissioning                         = true;
     }
 
     if (runPostCommissioning)

--- a/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
@@ -126,16 +126,10 @@ void TargetVideoPlayerInfo::PrintInfo()
     }
 }
 
-bool TargetVideoPlayerInfo::IsSameAs(const chip::Dnssd::DiscoveredNodeData * discoveredNodeData)
+bool TargetVideoPlayerInfo::IsSameAs(const char * deviceName, size_t numIPs, const chip::Inet::IPAddress * ipAddresses)
 {
-    // return false because 'this' VideoPlayer is not null
-    if (discoveredNodeData == nullptr)
-    {
-        return false;
-    }
-
     // return false because deviceNames are different
-    if (strcmp(mDeviceName, discoveredNodeData->commissionData.deviceName) != 0)
+    if (strcmp(mDeviceName, deviceName) != 0)
     {
         return false;
     }
@@ -146,10 +140,9 @@ bool TargetVideoPlayerInfo::IsSameAs(const chip::Dnssd::DiscoveredNodeData * dis
         bool matchFound = false;
         for (size_t i = 0; i < mNumIPs && i < chip::Dnssd::CommonResolutionData::kMaxIPAddresses; i++)
         {
-            for (size_t j = 0;
-                 j < discoveredNodeData->resolutionData.numIPs && j < chip::Dnssd::CommonResolutionData::kMaxIPAddresses; j++)
+            for (size_t j = 0; j < numIPs && j < chip::Dnssd::CommonResolutionData::kMaxIPAddresses; j++)
             {
-                if (mIpAddress[i] == discoveredNodeData->resolutionData.ipAddress[j])
+                if (mIpAddress[i] == ipAddresses[j])
                 {
                     matchFound = true;
                     break;
@@ -168,4 +161,16 @@ bool TargetVideoPlayerInfo::IsSameAs(const chip::Dnssd::DiscoveredNodeData * dis
     }
 
     return true;
+}
+
+bool TargetVideoPlayerInfo::IsSameAs(const chip::Dnssd::DiscoveredNodeData * discoveredNodeData)
+{
+    // return false because 'this' VideoPlayer is not null
+    if (discoveredNodeData == nullptr)
+    {
+        return false;
+    }
+
+    return IsSameAs(discoveredNodeData->commissionData.deviceName, discoveredNodeData->resolutionData.numIPs,
+                    discoveredNodeData->resolutionData.ipAddress);
 }


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/24267

### Change summary
1. Added a flag udcInProgress to CastingServer to track if UDC is in progress
2. On kBindingsChangedViaCluster, if we find UDC is in progress, we select the video player (find its nodeId and fabricIndex) from the cache which matches the one we were trying to commission with now (based on IP addresses and device names)
3. Then we connect to the video player found above and call the commissioningCompleteCallback.

### Testing
Tested with the Android tv-casting-app and the Linux tv-app as per the instructions in https://github.com/project-chip/connectedhomeip/issues/24267