### PR TITLE
[nrfconnect] Added LOG dependency for CHIP_APP_LOG_LEVEL

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -25,6 +25,7 @@ config CHIP_DEVICE_VENDOR_NAME
 config CHIP_APP_LOG_LEVEL
 	int "Set logging level in application"
 	default LOG_DEFAULT_LEVEL
+	depends on LOG
 	help
 	  Sets the logging level in Matter application. 
 	  This config should be used only within application.


### PR DESCRIPTION
CHIP_APP_LOG_LEVEL tries to set default to LOG_DEFAULT_LEVEL, but if LOG is disabled for release build the assembler will fail to process it.

Added LOG dependency to make sure that LOG_DEFAULT_LEVEL exists before using it.


