### PR TITLE
[Third Party] Add libwebsockets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -290,3 +290,7 @@
 	url = https://github.com/bouffalolab/bl_iot_sdk_tiny.git
         branch = main
         platforms = bouffalolab
+[submodule "third_party/libwebsockets/repo"]
+	path = third_party/libwebsockets/repo
+	url = https://github.com/warmcat/libwebsockets
+  platforms = linux,darwin

--- a/third_party/libwebsockets/BUILD.gn
+++ b/third_party/libwebsockets/BUILD.gn
@@ -1,0 +1,109 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+config("libwebsockets_config") {
+  include_dirs = [
+    ".",
+    "repo/include",
+  ]
+
+  cflags = [
+    "-Wno-shadow",
+    "-Wno-unreachable-code",
+    "-Wno-format-nonliteral",
+  ]
+
+  defines = []
+}
+
+source_set("libwebsockets") {
+  include_dirs = [
+    "repo/lib/plat/windows",
+    "repo/lib/plat/freertos",
+    "repo/lib/plat/unix",
+    "repo/lib/secure-streams",
+    "repo/lib/event-libs",
+    "repo/lib/roles",
+    "repo/lib/roles/http",
+    "repo/lib/roles/h1",
+    "repo/lib/roles/h2",
+    "repo/lib/roles/ws",
+    "repo/lib/system/metrics",
+    "repo/lib/system/smd",
+    "repo/lib/system/async-dns",
+    "repo/lib/core",
+    "repo/lib/core-net",
+  ]
+
+  sources = [
+    "repo/lib/core-net/adopt.c",
+    "repo/lib/core-net/close.c",
+    "repo/lib/core-net/dummy-callback.c",
+    "repo/lib/core-net/network.c",
+    "repo/lib/core-net/output.c",
+    "repo/lib/core-net/pollfd.c",
+    "repo/lib/core-net/service.c",
+    "repo/lib/core-net/sorted-usec-list.c",
+    "repo/lib/core-net/vhost.c",
+    "repo/lib/core-net/wsi-timeout.c",
+    "repo/lib/core-net/wsi.c",
+    "repo/lib/core/alloc.c",
+    "repo/lib/core/buflist.c",
+    "repo/lib/core/context.c",
+    "repo/lib/core/libwebsockets.c",
+    "repo/lib/core/logs.c",
+    "repo/lib/core/lws_dll2.c",
+    "repo/lib/event-libs/poll/poll.c",
+    "repo/lib/misc/base64-decode.c",
+    "repo/lib/misc/sha-1.c",
+    "repo/lib/roles/h1/ops-h1.c",
+    "repo/lib/roles/http/date.c",
+    "repo/lib/roles/http/header.c",
+    "repo/lib/roles/http/parsers.c",
+    "repo/lib/roles/http/server/server.c",
+    "repo/lib/roles/listen/ops-listen.c",
+    "repo/lib/roles/pipe/ops-pipe.c",
+    "repo/lib/roles/raw-skt/ops-raw-skt.c",
+    "repo/lib/roles/ws/ops-ws.c",
+    "repo/lib/roles/ws/server-ws.c",
+    "repo/lib/system/system.c",
+  ]
+
+  if (current_os == "freertos") {
+    sources += [
+      "repo/lib/plat/freertos/freertos-fds.c",
+      "repo/lib/plat/freertos/freertos-init.c",
+      "repo/lib/plat/freertos/freertos-misc.c",
+      "repo/lib/plat/freertos/freertos-pipe.c",
+      "repo/lib/plat/freertos/freertos-service.c",
+      "repo/lib/plat/freertos/freertos-sockets.c",
+    ]
+
+    cflags = [ "-DLWS_PLAT_FREERTOS" ]
+  } else {
+    sources += [
+      "repo/lib/plat/unix/unix-caps.c",
+      "repo/lib/plat/unix/unix-fds.c",
+      "repo/lib/plat/unix/unix-init.c",
+      "repo/lib/plat/unix/unix-misc.c",
+      "repo/lib/plat/unix/unix-pipe.c",
+      "repo/lib/plat/unix/unix-service.c",
+      "repo/lib/plat/unix/unix-sockets.c",
+    ]
+
+    cflags = [ "-DLWS_PLAT_UNIX" ]
+  }
+
+  public_configs = [ ":libwebsockets_config" ]
+}

--- a/third_party/libwebsockets/lws_config.h
+++ b/third_party/libwebsockets/lws_config.h
@@ -1,0 +1,65 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#define LWS_LIBRARY_VERSION "4.3.99"
+
+//
+// Major individual features
+//
+#define LWS_WITH_NETWORK // "Compile with network-related code"  - default: ON
+#define LWS_ROLE_H1      // "Compile with support for http/1 (needed for ws)"  - default: ON
+#define LWS_ROLE_WS      // "Compile with support for websockets"  - default: ON
+#define LWS_WITH_IPV6    // "Compile with support for ipv6" - default: OFF
+#define LWS_UNIX_SOCK    // "Compile with support for UNIX domain socket if OS supports it"  - default: ON
+
+//
+// Client / Server / Test Apps build control
+//
+#define LWS_WITHOUT_CLIENT // "Don't build the client part of the library" default - OFF
+
+//
+// Extensions (permessage-deflate)
+//
+#define LWS_WITHOUT_EXTENSIONS // "Don't compile with extensions" - default: ON
+
+//
+// Helpers + misc
+//
+#define LWS_WITHOUT_DAEMONIZE // "Don't build the daemonization api" - default: ON
+#define LWS_LOGS_TIMESTAMP    // "Timestamp at start of logs" - default: ON
+#define LWS_LOG_TAG_LIFECYCLE // "Log tagged object lifecycle as NOTICE" - default: ON
+
+//
+// Implied Options
+//
+#define LWS_WITH_POLL
+#define LWS_MAX_SMP 1
+
+#ifdef LWS_WITHOUT_DAEMONIZE
+#define LWS_NO_DAEMONIZE
+#endif
+
+#ifdef LWS_WITH_HTTP2
+#define LWS_ROLE_H2
+#endif
+
+#ifndef LWS_WITHOUT_SERVER
+#define LWS_WITH_SERVER
+#endif

--- a/third_party/libwebsockets/lws_config_private.h
+++ b/third_party/libwebsockets/lws_config_private.h
@@ -1,0 +1,19 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once


### PR DESCRIPTION
In order to connect `chip-tool` and `darwin-framework-tool` to the new test runner in python I would need to use `libwebsockets`. This PR adds as a submodule with a default `lws_config.h` file that enables the server bits.

Alternatively, and if preferred, I have a version with `websocketspp` but in the end `libwebsockets` looks more flexible and it does not use exceptions contrary to `websocketspp`

