### PR TITLE
iOS TvCasting app: Adding async completion callback to startMatterServer API

### DIFF
--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
@@ -185,9 +185,15 @@
 - (void)disconnect:(dispatch_queue_t _Nonnull)clientQueue requestSentHandler:(nullable void (^)())requestSentHandler;
 
 /**
- @brief Start the Matter server and reconnect to a previously connected Video Player (if any)
+ @brief Start the Matter server and reconnect to a previously connected Video Player (if any). This API is async
+
+ @param clientQueue Queue to invoke callbacks on
+
+ @param startMatterServerCompletionCallback Called after the Matter server has started and connected (or failed to connect) to a
+ previously connected video player (if any) are complete
  */
-- (void)startMatterServer;
+- (void)startMatterServer:(dispatch_queue_t _Nonnull)clientQueue
+    startMatterServerCompletionCallback:(nullable void (^)(MatterError * _Nonnull))startMatterServerCompletionCallback;
 
 /**
  @brief Stop the Matter server

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/TvCastingApp.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/TvCastingApp.swift
@@ -64,7 +64,11 @@ struct TvCastingApp: App {
                     {
                         if let castingServerBridge = CastingServerBridge.getSharedInstance()
                         {
-                            castingServerBridge.startMatterServer()
+                            castingServerBridge.startMatterServer(DispatchQueue.main, startMatterServerCompletionCallback: { (error: MatterError) -> () in
+                                DispatchQueue.main.async {
+                                    self.Log.info("TvCastingApp.startMatterServerCompletionCallback called with \(error)")
+                                }
+                            })
                         }
                     }
                     firstAppActivation = false


### PR DESCRIPTION
Related to https://github.com/project-chip/connectedhomeip/issues/24048

### Change summary
The startMatterServer API did not have a callback to tell the client application when it was fully done/complete. This change adds that callback.

### Testing
Tested with the iOS tv-casting-app and the Linux tv-app to check that the callback is made after the startMatterServer API is done initing the server and reconnecting to the video players previously connected to (if any)
