### PR TITLE
Update ZAP to tip.

### DIFF
--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -178,7 +178,7 @@ RUN set -x \
 
 # Install a known ZAP release
 # Only keep the cli version, since `zap` is 143MB and not usable (UI)
-ENV ZAP_VERSION=v2022.12.20-nightly
+ENV ZAP_VERSION=v2023.01.05-nightly
 RUN set -x \
     && mkdir -p /opt/zap-${ZAP_VERSION} \
     && cd /opt/zap-${ZAP_VERSION} \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.27 Version bump reason: [Telink] Update Telink Docker image (Zephyr update)
+0.6.28 Version bump reason: Updating ZAP to v2023.01.05-nightly


### PR DESCRIPTION
Moves list of weakly typed enums out of the ZAP helper code.


