### PR TITLE
[chip-tool] Add delay wait-for-commissionee command

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -60,6 +60,7 @@ static_library("chip-tool-utils") {
     "commands/common/CredentialIssuerCommands.h",
     "commands/common/HexConversion.h",
     "commands/delay/SleepCommand.cpp",
+    "commands/delay/WaitForCommissioneeCommand.cpp",
     "commands/discover/DiscoverCommand.cpp",
     "commands/discover/DiscoverCommissionablesCommand.cpp",
     "commands/discover/DiscoverCommissionersCommand.cpp",

--- a/examples/chip-tool/commands/delay/Commands.h
+++ b/examples/chip-tool/commands/delay/Commands.h
@@ -20,12 +20,14 @@
 
 #include "commands/common/Commands.h"
 #include "commands/delay/SleepCommand.h"
+#include "commands/delay/WaitForCommissioneeCommand.h"
 
 void registerCommandsDelay(Commands & commands, CredentialIssuerCommands * credsIssuerConfig)
 {
     const char * clusterName      = "Delay";
     commands_list clusterCommands = {
-        make_unique<SleepCommand>(credsIssuerConfig), //
+        make_unique<SleepCommand>(credsIssuerConfig),               //
+        make_unique<WaitForCommissioneeCommand>(credsIssuerConfig), //
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/delay/WaitForCommissioneeCommand.cpp
+++ b/examples/chip-tool/commands/delay/WaitForCommissioneeCommand.cpp
@@ -1,0 +1,51 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "WaitForCommissioneeCommand.h"
+
+using namespace chip;
+
+CHIP_ERROR WaitForCommissioneeCommand::RunCommand()
+{
+    chip::FabricIndex fabricIndex = CurrentCommissioner().GetFabricIndex();
+    ReturnErrorCodeIf(fabricIndex == chip::kUndefinedFabricIndex, CHIP_ERROR_INCORRECT_STATE);
+
+    if (mExpireExistingSession.ValueOr(true))
+    {
+        CurrentCommissioner().SessionMgr()->ExpireAllSessions(chip::ScopedNodeId(mNodeId, fabricIndex));
+    }
+
+    return CurrentCommissioner().GetConnectedDevice(mNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+}
+
+void WaitForCommissioneeCommand::OnDeviceConnectedFn(void * context, Messaging::ExchangeManager & exchangeMgr,
+                                                     SessionHandle & sessionHandle)
+{
+    auto * command = reinterpret_cast<WaitForCommissioneeCommand *>(context);
+    VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectedFn: context is null"));
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
+}
+
+void WaitForCommissioneeCommand::OnDeviceConnectionFailureFn(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR err)
+{
+    LogErrorOnFailure(err);
+
+    auto * command = reinterpret_cast<WaitForCommissioneeCommand *>(context);
+    VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectionFailureFn: context is null"));
+    command->SetCommandExitStatus(err);
+}

--- a/examples/chip-tool/commands/delay/WaitForCommissioneeCommand.h
+++ b/examples/chip-tool/commands/delay/WaitForCommissioneeCommand.h
@@ -1,0 +1,56 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../common/CHIPCommand.h"
+#include <app/OperationalSessionSetup.h>
+#include <lib/core/CHIPCallback.h>
+
+class WaitForCommissioneeCommand : public CHIPCommand
+{
+public:
+    WaitForCommissioneeCommand(CredentialIssuerCommands * credIssuerCommands) :
+        CHIPCommand("wait-for-commissionee", credIssuerCommands), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
+        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
+    {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
+        AddArgument("expire-existing-session", 0, 1, &mExpireExistingSession);
+        AddArgument("timeout", 0, UINT64_MAX, &mTimeoutSecs,
+                    "Time, in seconds, before this command is considered to have timed out.");
+    }
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+    chip::System::Clock::Timeout GetWaitDuration() const override
+    {
+        return chip::System::Clock::Seconds16(mTimeoutSecs.ValueOr(10));
+    }
+
+private:
+    chip::NodeId mNodeId;
+    chip::Optional<uint16_t> mTimeoutSecs;
+    chip::Optional<bool> mExpireExistingSession;
+
+    static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
+                                    chip::SessionHandle & sessionHandle);
+    static void OnDeviceConnectionFailureFn(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error);
+
+    chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
+    chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
+};


### PR DESCRIPTION
#### Problem

The test runner usually starts with `WaitForCommissionee`. This command set up a case session between and in the case of  the test runner updates some internal states to know the target of following  steps.

It is not strictly needed in `chip-tool` but I found it useful to time how long does it takes to recover the device and it makes the integration between the python runner and `chip-tool` simpler.
It is also a good alternative to the current `pairing close-session` command when the other side has been shutted down (which happens frequently when doing local tests)