### PR TITLE
[chip-tool] InitArguments is off by one for global commands

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -331,19 +331,6 @@ bool Command::InitArgument(size_t argIndex, char * argValue)
         return true;
     }
 
-    case ArgumentType::Attribute: {
-        if (arg.isOptional() || arg.isNullable())
-        {
-            isValidArgument = false;
-        }
-        else
-        {
-            char * value    = reinterpret_cast<char *>(arg.value);
-            isValidArgument = (strcmp(argValue, value) == 0);
-        }
-        break;
-    }
-
     case ArgumentType::String: {
         isValidArgument = HandleNullableOptional<char *>(arg, argValue, [&](auto * value) {
             *value = argValue;
@@ -603,16 +590,14 @@ bool Command::InitArgument(size_t argIndex, char * argValue)
     return isValidArgument;
 }
 
-size_t Command::AddArgument(const char * name, const char * value, const char * desc, uint8_t flags)
+void Command::AddArgument(const char * name, const char * value, const char * desc)
 {
-    Argument arg;
-    arg.type  = ArgumentType::Attribute;
+    ReadOnlyGlobalCommandArgument arg;
     arg.name  = name;
-    arg.value = const_cast<void *>(reinterpret_cast<const void *>(value));
-    arg.flags = flags;
+    arg.value = value;
     arg.desc  = desc;
 
-    return AddArgumentToList(std::move(arg));
+    mReadOnlyGlobalCommandArgument.SetValue(arg);
 }
 
 size_t Command::AddArgument(const char * name, char ** value, const char * desc, uint8_t flags)
@@ -832,16 +817,26 @@ const char * Command::GetArgumentDescription(size_t index) const
     return nullptr;
 }
 
+const char * Command::GetReadOnlyGlobalCommandArgument() const
+{
+    if (GetAttribute())
+    {
+        return GetAttribute();
+    }
+
+    if (GetEvent())
+    {
+        return GetEvent();
+    }
+
+    return nullptr;
+}
+
 const char * Command::GetAttribute() const
 {
-    size_t argsCount = mArgs.size();
-    for (size_t i = 0; i < argsCount; i++)
+    if (mReadOnlyGlobalCommandArgument.HasValue())
     {
-        Argument arg = mArgs.at(i);
-        if (arg.type == ArgumentType::Attribute)
-        {
-            return reinterpret_cast<const char *>(arg.value);
-        }
+        return mReadOnlyGlobalCommandArgument.Value().value;
     }
 
     return nullptr;
@@ -849,14 +844,9 @@ const char * Command::GetAttribute() const
 
 const char * Command::GetEvent() const
 {
-    size_t argsCount = mArgs.size();
-    for (size_t i = 0; i < argsCount; i++)
+    if (mReadOnlyGlobalCommandArgument.HasValue())
     {
-        Argument arg = mArgs.at(i);
-        if (arg.type == ArgumentType::Attribute)
-        {
-            return reinterpret_cast<const char *>(arg.value);
-        }
+        return mReadOnlyGlobalCommandArgument.Value().value;
     }
 
     return nullptr;
@@ -940,11 +930,6 @@ void Command::ResetArguments()
             }
             case ArgumentType::VectorCustom: {
                 // No optional VectorCustom arguments so far.
-                VerifyOrDie(false);
-                break;
-            }
-            case ArgumentType::Attribute: {
-                // No optional Attribute arguments so far.
                 VerifyOrDie(false);
                 break;
             }

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -65,7 +65,6 @@ enum ArgumentType
     String,
     CharString,
     OctetString,
-    Attribute,
     Address,
     Complex,
     Custom,
@@ -95,6 +94,13 @@ struct Argument
     bool isNullable() const { return flags & kNullable; }
 };
 
+struct ReadOnlyGlobalCommandArgument
+{
+    const char * name;
+    const char * value;
+    const char * desc;
+};
+
 class Command
 {
 public:
@@ -109,6 +115,7 @@ public:
 
     const char * GetName(void) const { return mName; }
     const char * GetHelpText() const { return mHelpText; }
+    const char * GetReadOnlyGlobalCommandArgument(void) const;
     const char * GetAttribute(void) const;
     const char * GetEvent(void) const;
     const char * GetArgumentName(size_t index) const;
@@ -117,7 +124,7 @@ public:
     size_t GetArgumentsCount(void) const { return mArgs.size(); }
 
     bool InitArguments(int argc, char ** argv);
-    size_t AddArgument(const char * name, const char * value, const char * desc = "", uint8_t flags = 0);
+    void AddArgument(const char * name, const char * value, const char * desc = "");
     /**
      * @brief
      *   Add a char string command argument
@@ -274,5 +281,7 @@ private:
     const char * mName     = nullptr;
     const char * mHelpText = nullptr;
     bool mIsInteractive    = false;
+
+    chip::Optional<ReadOnlyGlobalCommandArgument> mReadOnlyGlobalCommandArgument;
     std::vector<Argument> mArgs;
 };

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -93,7 +93,8 @@ CHIP_ERROR Commands::RunCommand(int argc, char ** argv, bool interactive)
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    if (!IsGlobalCommand(argv[2]))
+    bool isGlobalCommand = IsGlobalCommand(argv[2]);
+    if (!isGlobalCommand)
     {
         command = GetCommand(cluster->second, argv[2]);
         if (command == nullptr)
@@ -138,7 +139,8 @@ CHIP_ERROR Commands::RunCommand(int argc, char ** argv, bool interactive)
         }
     }
 
-    if (!command->InitArguments(argc - 3, &argv[3]))
+    int argumentsPosition = isGlobalCommand ? 4 : 3;
+    if (!command->InitArguments(argc - argumentsPosition, &argv[argumentsPosition]))
     {
         ShowCommand(argv[0], argv[1], command);
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -320,6 +322,12 @@ void Commands::ShowCommand(std::string executable, std::string clusterName, Comm
     std::string arguments;
     std::string description;
     arguments += command->GetName();
+
+    if (command->GetReadOnlyGlobalCommandArgument())
+    {
+        arguments += ' ';
+        arguments += command->GetReadOnlyGlobalCommandArgument();
+    }
 
     size_t argumentsCount = command->GetArgumentsCount();
     for (size_t i = 0; i < argumentsCount; i++)


### PR DESCRIPTION
#### Problem

The argument parsing code for `chip-tool` overrides the `attr-name`/`event-name` argument of global command (`read`, `write`,  `subscribe`,  `read-event`, `subscribe-event`) which is already setup during the command definition.

