### PR TITLE
[ESP32] Fix compilation errors with bridge app

### DIFF
--- a/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
+++ b/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
@@ -17,6 +17,7 @@
  */
 #include "CommonDeviceCallbacks.h"
 
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #if CONFIG_BT_ENABLED
 #include "esp_bt.h"
 #if CONFIG_BT_NIMBLE_ENABLED
@@ -26,6 +27,7 @@
 #include "nimble/nimble_port.h"
 #endif // CONFIG_BT_NIMBLE_ENABLED
 #endif // CONFIG_BT_ENABLED
+#endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
 #include "esp_err.h"
 #include "esp_heap_caps.h"
@@ -78,7 +80,7 @@ void CommonDeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, i
 
     case DeviceEventType::kCommissioningComplete: {
         ESP_LOGI(TAG, "Commissioning complete");
-#if CONFIG_BT_NIMBLE_ENABLED && CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE && CONFIG_BT_NIMBLE_ENABLED && CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING
 
         if (ble_hs_is_enabled())
         {


### PR DESCRIPTION
- Fixes #24203 
- Currently we have all the nimble related code under CHIPoBLE config option 
- Same thing should be followed for examples/platform/esp32/common/CommonDeviceCallbacks.cpp 

### Testing:
 - Compilation works after disabling CHIPoBLE config option and without disabling CHIPoBLE config option too
 - Tested commissioning and cluster control using chip-tool

