### PR TITLE
Fix syntax of test in chip_xcode_build_connector.sh.

### DIFF
--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -63,10 +63,11 @@ target_defines=[${target_defines:1}]
 declare target_arch=
 declare target_cpu=
 declare target_cflags=
+declare current_arch="$(uname -m)"
 
 read -r -a archs <<<"$ARCHS"
 for arch in "${archs[@]}"; do
-    if [ -z "$target_arch"] ]; then
+    if [ -z "$target_arch" ] || [ "$arch" = "$current_arch" ]; then
         target_arch="$arch"
         case "$arch" in
             x86_64) target_cpu="x64" ;;


### PR DESCRIPTION
There was a stray ']' that was being treated as part of the string, so we never set target_arch or target_cpu.

Fixing that ended up with us setting target_arch/cpu to arm64 if it came before
x84_64 in ARCHS, which breaks CI.  So make sure we use the host arch as the
target_arch if it's in ARCHS at all.
