### PR TITLE
Propagate the target_arch for darwin-framework-tool to the framework build

### DIFF
--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -62,14 +62,14 @@ action("build-darwin-framework") {
     "Matter Framework",
     "--log_path",
     rebase_path("${root_build_dir}/darwin_framework_build.log", root_build_dir),
+    "--target_arch",
+    mac_target_arch,
   ]
 
   if (sdk != "macosx") {
     args += [
       "--target_sdk",
       sdk,
-      "--target_arch",
-      mac_target_arch,
     ]
   }
 

--- a/scripts/build/build_darwin_framework.py
+++ b/scripts/build/build_darwin_framework.py
@@ -52,7 +52,7 @@ def build_darwin_framework(args):
         args.project_path,
         '-derivedDataPath',
         abs_path,
-        "PLATFORM_PREFERRED_ARCH={}".format(args.target_arch),
+        "ARCHS={}".format(args.target_arch),
         # For now disable unguarded-availability-new warnings because we
         # internally use APIs that we are annotating as only available on
         # new enough versions.  Maybe we should change out deployment


### PR DESCRIPTION
We no longer use PLATFORM_PREFERRED_ARCH in chip_xcode_build_connector.sh; we should be using ARCHS.  And we should always set --target_arch when calling build_darwin_framework.py, so we handle someone setting a non-default one on the command line when building darwin-framework-tool.
