### PR TITLE
Allow building with host toolchain when building arm64e on an arm64 host

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -69,7 +69,9 @@ if (_chip_defaults.custom_toolchain != "") {
   }
 
   _default_toolchain = "${_build_overrides.build_root}/toolchain/linux:linux_${target_cpu}_${_target_compiler}"
-} else if (target_os == host_os && target_cpu == host_cpu) {
+} else if (target_os == host_os &&
+           (target_cpu == host_cpu ||
+            (target_cpu == "arm64e" && host_cpu == "arm64"))) {
   _default_toolchain = host_toolchain
 } else if (target_os == "freertos") {
   if (_chip_defaults.is_clang) {


### PR DESCRIPTION
The host toolchain should be fine in this case.
