### PR TITLE
Fix reference to out-of-scope temporary in SetUpCodePairer.

### DIFF
--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -491,7 +491,8 @@ void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error)
     if (CHIP_ERROR_TIMEOUT == error && mCurrentPASEParameters.HasValue())
     {
         const auto & params = mCurrentPASEParameters.Value();
-        auto & ip           = params.GetPeerAddress().GetIPAddress();
+        const auto & peer   = params.GetPeerAddress();
+        const auto & ip     = peer.GetIPAddress();
         auto err            = Dnssd::Resolver::Instance().ReconfirmRecord(params.mHostName, ip, params.mInterfaceId);
         if (CHIP_NO_ERROR != err && CHIP_ERROR_NOT_IMPLEMENTED != err)
         {


### PR DESCRIPTION
The old code used to get a reference to a member of a temporary, but nothing kept the temporary alive (it was not assigned to a named reference or anything), so it went out of scope and got destroyed.  And then we were referencing garbage.

Explicitly keep references to all the things we are using, so they don't go away on us.


