### PR TITLE
Fix invalid link to integrations/docker/images/chip-build/Dockerfile

### DIFF
--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -140,7 +140,7 @@ system. You can install it from the zap project
 
 You should install a compatible release version, generally checking against the
 release set in
-[integrations/docker/images/chip-build/Dockerfile](../../../integrations/docker/images/chip-build/Dockerfile).
+[integrations/docker/images/chip-build/Dockerfile](../../integrations/docker/images/chip-build/Dockerfile).
 
 On linux, installation from `zap-linux.zip` is recommended as it pulls fewer
 dependencies than the `.deb` package.


### PR DESCRIPTION

The relative link to *integrations/docker/images/chip-build/Dockerfile* in *docs/guides/BUILDING.md* is incorrect.
* It is *../../../integrations/docker/images/chip-build/Dockerfile* now
* The correct one should be *../../integrations/docker/images/chip-build/Dockerfile*
