### PR TITLE
Darwin: Add vendorID and productID properties to MTRDeviceAttestationDeviceInfo

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,1 @@
+../../../Darwin.xcworkspace/xcshareddata/IDETemplateMacros.plist

--- a/src/darwin/Darwin.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/src/darwin/Darwin.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string>
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */</string>
+</dict>
+</plist>

--- a/src/darwin/Framework/CHIP/MTRConversion.h
+++ b/src/darwin/Framework/CHIP/MTRConversion.h
@@ -1,6 +1,5 @@
 /**
- *
- *    Copyright (c) 2022 Project CHIP Authors
+ *    Copyright (c) 2023 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,16 +14,22 @@
  *    limitations under the License.
  */
 
-#import "MTRDeviceAttestationDelegate.h"
+#import "NSDataSpanConversion.h"
+#import "NSStringSpanConversion.h"
+
+#import <Foundation/Foundation.h>
+
+#include <lib/core/Optional.h>
+#include <type_traits>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MTRDeviceAttestationDeviceInfo ()
-
-- (instancetype)initWithDACCertificate:(MTRCertificateDERBytes)dacCertificate
-                     dacPAICertificate:(MTRCertificateDERBytes)dacPAICertificate
-                certificateDeclaration:(NSData *)certificateDeclaration;
-
-@end
+template <typename T>
+inline std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value || std::is_enum<T>::value,
+    NSNumber * _Nullable>
+AsNumber(chip::Optional<T> optional)
+{
+    return (optional.HasValue()) ? @(optional.Value()) : nil;
+}
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.h
@@ -16,17 +16,31 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <Matter/MTRCertificates.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class MTRDeviceController;
 
 @interface MTRDeviceAttestationDeviceInfo : NSObject
+
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-@property (nonatomic, readonly) NSData * dacCertificate;
-@property (nonatomic, readonly) NSData * dacPAICertificate;
+
+/**
+ * The vendor ID for the device from the Device Attestation Certificate. May be nil only if attestation was unsucessful.
+ */
+@property (nonatomic, readonly, nullable) NSNumber * vendorID;
+
+/**
+ * The product ID for the device from the Device Attestation Certificate. May be nil only if attestation was unsucessful.
+ */
+@property (nonatomic, readonly, nullable) NSNumber * productID;
+
+@property (nonatomic, readonly) MTRCertificateDERBytes dacCertificate;
+@property (nonatomic, readonly) MTRCertificateDERBytes dacPAICertificate;
 @property (nonatomic, readonly, nullable) NSData * certificateDeclaration;
+
 @end
 
 /**

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.mm
@@ -15,19 +15,32 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-#import <MTRDeviceAttestationDelegate_Internal.h>
+#import "MTRDeviceAttestationDelegate_Internal.h"
+
+#import "MTRConversion.h"
+
+#include <crypto/CHIPCryptoPAL.h>
+
+using namespace chip::Crypto;
 
 @implementation MTRDeviceAttestationDeviceInfo
-- (instancetype)initWithDACCertificate:(NSData *)dacCertificate
-                     dacPAICertificate:(NSData *)dacPAICertificate
+
+- (instancetype)initWithDACCertificate:(MTRCertificateDERBytes)dacCertificate
+                     dacPAICertificate:(MTRCertificateDERBytes)dacPAICertificate
                 certificateDeclaration:(NSData *)certificateDeclaration
 {
     if (self = [super init]) {
         _dacCertificate = [dacCertificate copy];
         _dacPAICertificate = [dacPAICertificate copy];
         _certificateDeclaration = [certificateDeclaration copy];
+
+        struct AttestationCertVidPid dacVidPid;
+        if (ExtractVIDPIDFromX509Cert(AsByteSpan(_dacCertificate), dacVidPid) == CHIP_NO_ERROR) {
+            _vendorID = AsNumber(dacVidPid.mVendorId);
+            _productID = AsNumber(dacVidPid.mProductId);
+        }
     }
     return self;
 }
+
 @end

--- a/src/darwin/Framework/CHIP/NSDataSpanConversion.h
+++ b/src/darwin/Framework/CHIP/NSDataSpanConversion.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#import "Foundation/Foundation.h"
+#import <Foundation/Foundation.h>
 
 #include <lib/support/Span.h>
 

--- a/src/darwin/Framework/CHIP/NSStringSpanConversion.h
+++ b/src/darwin/Framework/CHIP/NSStringSpanConversion.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#import "Foundation/Foundation.h"
+#import <Foundation/Foundation.h>
 
 #include <lib/support/Span.h>
 

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		3DECCB702934AECD00585AEC /* MTRLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DECCB6F2934AC1C00585AEC /* MTRLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3DECCB722934AFE200585AEC /* MTRLogging.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3DECCB712934AFE200585AEC /* MTRLogging.mm */; };
 		3DECCB742934C21B00585AEC /* MTRDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DECCB732934C21B00585AEC /* MTRDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3DFCB32C29678C9500332B35 /* MTRConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DFCB32B29678C9500332B35 /* MTRConversion.h */; };
 		51029DF6293AA6100087AFB0 /* MTROperationalCertificateIssuer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51029DF5293AA6100087AFB0 /* MTROperationalCertificateIssuer.mm */; };
 		511913FB28C100EF009235E9 /* MTRBaseSubscriptionCallback.mm in Sources */ = {isa = PBXBuildFile; fileRef = 511913F928C100EF009235E9 /* MTRBaseSubscriptionCallback.mm */; };
 		511913FC28C100EF009235E9 /* MTRBaseSubscriptionCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 511913FA28C100EF009235E9 /* MTRBaseSubscriptionCallback.h */; };
@@ -236,6 +237,7 @@
 		3DECCB6F2934AC1C00585AEC /* MTRLogging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRLogging.h; sourceTree = "<group>"; };
 		3DECCB712934AFE200585AEC /* MTRLogging.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRLogging.mm; sourceTree = "<group>"; };
 		3DECCB732934C21B00585AEC /* MTRDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRDefines.h; sourceTree = "<group>"; };
+		3DFCB32B29678C9500332B35 /* MTRConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRConversion.h; sourceTree = "<group>"; };
 		51029DF5293AA6100087AFB0 /* MTROperationalCertificateIssuer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTROperationalCertificateIssuer.mm; sourceTree = "<group>"; };
 		511913F928C100EF009235E9 /* MTRBaseSubscriptionCallback.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRBaseSubscriptionCallback.mm; sourceTree = "<group>"; };
 		511913FA28C100EF009235E9 /* MTRBaseSubscriptionCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRBaseSubscriptionCallback.h; sourceTree = "<group>"; };
@@ -507,6 +509,7 @@
 				99AECC7F2798A57E00B6355B /* MTRCommissioningParameters.mm */,
 				51E030FE27EA20D20083DC9C /* MTRControllerAccessControl.h */,
 				51E030FF27EA20D20083DC9C /* MTRControllerAccessControl.mm */,
+				3DFCB32B29678C9500332B35 /* MTRConversion.h */,
 				3CF134A6289D8AD90017A19E /* MTRCSRInfo.h */,
 				3CF134A8289D8D800017A19E /* MTRCSRInfo.mm */,
 				3DECCB732934C21B00585AEC /* MTRDefines.h */,
@@ -667,6 +670,7 @@
 				27A53C1727FBC6920053F131 /* MTRAttestationTrustStoreBridge.h in Headers */,
 				5A830D6C27CFCF590053B85D /* MTRDeviceControllerOverXPC_Internal.h in Headers */,
 				88EBF8D027FABDD500686BC1 /* MTRDeviceAttestationDelegateBridge.h in Headers */,
+				3DFCB32C29678C9500332B35 /* MTRConversion.h in Headers */,
 				5A60370827EA1FF60020DB79 /* MTRClusterStateCacheContainer+XPC.h in Headers */,
 				5ACDDD7E27CD3F3A00EFD68A /* MTRClusterStateCacheContainer_Internal.h in Headers */,
 				5136661328067D550025EDAE /* MTRDeviceController_Internal.h in Headers */,

--- a/src/darwin/Framework/Matter.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/src/darwin/Framework/Matter.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,1 @@
+../../../Darwin.xcworkspace/xcshareddata/IDETemplateMacros.plist


### PR DESCRIPTION
Fixes #23338

Also add Xcode header templates for new files (due to an Xcode bug an extra `//` ends up at the top of the file that needs to be manually removed.)
