### PR TITLE
[Silabs] Remove generic base class init from configuration manager

### DIFF
--- a/examples/platform/silabs/efr32/EFR32DeviceDataProvider.cpp
+++ b/examples/platform/silabs/efr32/EFR32DeviceDataProvider.cpp
@@ -321,7 +321,24 @@ exit:
         ChipLogError(DeviceLayer, "Invalid manufacturing date: %s", dateStr);
     }
     return err;
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR EFR32DeviceDataProvider::GetPartNumber(char * buf, size_t bufSize)
+{
+    size_t partNumberLen = 0; // without counting null-terminator
+    return SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_PartNumber, buf, bufSize, partNumberLen);
+}
+
+CHIP_ERROR EFR32DeviceDataProvider::GetProductURL(char * buf, size_t bufSize)
+{
+    size_t productUrlLen = 0; // without counting null-terminator
+    return SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_ProductURL, buf, bufSize, productUrlLen);
+}
+
+CHIP_ERROR EFR32DeviceDataProvider::GetProductLabel(char * buf, size_t bufSize)
+{
+    size_t productLabelLen = 0; // without counting null-terminator
+    return SILABSConfig::ReadConfigValueStr(SILABSConfig::KConfigKey_ProductLabel, buf, bufSize, productLabelLen);
 }
 
 EFR32DeviceDataProvider & EFR32DeviceDataProvider::GetDeviceDataProvider()

--- a/examples/platform/silabs/efr32/EFR32DeviceDataProvider.h
+++ b/examples/platform/silabs/efr32/EFR32DeviceDataProvider.h
@@ -60,6 +60,9 @@ public:
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override;
     CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override;
     CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) override;
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSzie) override;
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
 };
 
 } // namespace EFR32

--- a/src/platform/silabs/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/EFR32/ConfigurationManagerImpl.cpp
@@ -49,10 +49,6 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 
 CHIP_ERROR ConfigurationManagerImpl::Init()
 {
-    // Initialize the generic implementation base class.
-    // err = Internal::GenericConfigurationManagerImpl<SILABSConfig>::Init();
-    // VerifyOrReturnError(err == CHIP_NO_ERROR, err);
-
     // TODO: Initialize the global GroupKeyStore object here (#1626)
 
     IncreaseBootCount();

--- a/src/platform/silabs/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/EFR32/ConfigurationManagerImpl.cpp
@@ -49,11 +49,9 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 
 CHIP_ERROR ConfigurationManagerImpl::Init()
 {
-    CHIP_ERROR err;
-
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<SILABSConfig>::Init();
-    SuccessOrExit(err);
+    // err = Internal::GenericConfigurationManagerImpl<SILABSConfig>::Init();
+    // VerifyOrReturnError(err == CHIP_NO_ERROR, err);
 
     // TODO: Initialize the global GroupKeyStore object here (#1626)
 
@@ -63,10 +61,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     rebootCause = RMU_ResetCauseGet();
     RMU_ResetCauseClear();
 
-    err = CHIP_NO_ERROR;
-
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 bool ConfigurationManagerImpl::CanFactoryReset()

--- a/src/platform/silabs/SilabsConfig.h
+++ b/src/platform/silabs/SilabsConfig.h
@@ -108,6 +108,9 @@ public:
     static constexpr Key kConfigKey_VendorName            = SILABSConfigKey(kMatterFactory_KeyBase, 0x0D);
     static constexpr Key kConfigKey_ProductName           = SILABSConfigKey(kMatterFactory_KeyBase, 0x0E);
     static constexpr Key kConfigKey_HardwareVersionString = SILABSConfigKey(kMatterFactory_KeyBase, 0x0F);
+    static constexpr Key KConfigKey_ProductLabel          = SILABSConfigKey(kMatterFactory_KeyBase, 0x10);
+    static constexpr Key kConfigKey_ProductURL            = SILABSConfigKey(kMatterFactory_KeyBase, 0x11);
+    static constexpr Key kConfigKey_PartNumber            = SILABSConfigKey(kMatterFactory_KeyBase, 0x12);
     static constexpr Key kConfigKey_UniqueId              = SILABSConfigKey(kMatterFactory_KeyBase, 0x1F);
     // Matter Config Keys
     static constexpr Key kConfigKey_ServiceConfig      = SILABSConfigKey(kMatterConfig_KeyBase, 0x01);


### PR DESCRIPTION
#### Description
Platform Configuration Manager was initializing the generic configuration manager which would replace the platform manager

#### Test
Manual tests with different factory data

