### PR TITLE
[crypto] Replace AesCcm128Key with sensitive data buffer

### DIFF
--- a/examples/platform/linux/testing/CustomCSRResponseOperationalKeyStore.cpp
+++ b/examples/platform/linux/testing/CustomCSRResponseOperationalKeyStore.cpp
@@ -63,8 +63,8 @@ CHIP_ERROR CustomCSRResponseOperationalKeyStore::ReuseOpKeypair(FabricIndex fabr
 
     // Scope 1: Load up the keypair data from storage
     {
-        // Use a CapacityBoundBuffer to get RAII secret data clearing on scope exit.
-        Crypto::CapacityBoundBuffer<OpKeyTLVMaxSize()> buf;
+        // Use a SensitiveDataBuffer to get RAII secret data clearing on scope exit.
+        Crypto::SensitiveDataBuffer<OpKeyTLVMaxSize()> buf;
 
         // Load up the operational key structure from storage
         uint16_t size = static_cast<uint16_t>(buf.Capacity());

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -450,7 +450,7 @@ Optional<System::Clock::Timeout> AutoCommissioner::GetCommandTimeout(DeviceProxy
     return MakeOptional(timeout);
 }
 
-CHIP_ERROR AutoCommissioner::NOCChainGenerated(ByteSpan noc, ByteSpan icac, ByteSpan rcac, AesCcm128KeySpan ipk,
+CHIP_ERROR AutoCommissioner::NOCChainGenerated(ByteSpan noc, ByteSpan icac, ByteSpan rcac, IdentityProtectionKeySpan ipk,
                                                NodeId adminSubject)
 {
     // Reuse ICA Cert buffer for temporary store Root Cert.

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -63,7 +63,7 @@ private:
     ByteSpan GetDAC() const { return ByteSpan(mDAC, mDACLen); }
     ByteSpan GetPAI() const { return ByteSpan(mPAI, mPAILen); }
 
-    CHIP_ERROR NOCChainGenerated(ByteSpan noc, ByteSpan icac, ByteSpan rcac, AesCcm128KeySpan ipk, NodeId adminSubject);
+    CHIP_ERROR NOCChainGenerated(ByteSpan noc, ByteSpan icac, ByteSpan rcac, IdentityProtectionKeySpan ipk, NodeId adminSubject);
     /**
      * The device argument to GetCommandTimeout is the device whose session will
      * be used for sending the relevant command.

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1244,7 +1244,7 @@ void DeviceCommissioner::OnOperationalCertificateSigningRequest(
 }
 
 void DeviceCommissioner::OnDeviceNOCChainGeneration(void * context, CHIP_ERROR status, const ByteSpan & noc, const ByteSpan & icac,
-                                                    const ByteSpan & rcac, Optional<AesCcm128KeySpan> ipk,
+                                                    const ByteSpan & rcac, Optional<IdentityProtectionKeySpan> ipk,
                                                     Optional<NodeId> adminSubject)
 {
     MATTER_TRACE_EVENT_SCOPE("OnDeviceNOCChainGeneration", "DeviceCommissioner");
@@ -1271,7 +1271,7 @@ void DeviceCommissioner::OnDeviceNOCChainGeneration(void * context, CHIP_ERROR s
 
     // TODO - Verify that the generated root cert matches with commissioner's root cert
     CommissioningDelegate::CommissioningReport report;
-    report.Set<NocChain>(NocChain(noc, icac, rcac, ipk.HasValue() ? ipk.Value() : AesCcm128KeySpan(placeHolderIpk),
+    report.Set<NocChain>(NocChain(noc, icac, rcac, ipk.HasValue() ? ipk.Value() : IdentityProtectionKeySpan(placeHolderIpk),
                                   adminSubject.HasValue() ? adminSubject.Value() : commissioner->GetNodeId()));
     commissioner->CommissioningStageComplete(status, report);
 }
@@ -1325,8 +1325,9 @@ CHIP_ERROR DeviceCommissioner::ProcessCSR(DeviceProxy * proxy, const ByteSpan & 
 }
 
 CHIP_ERROR DeviceCommissioner::SendOperationalCertificate(DeviceProxy * device, const ByteSpan & nocCertBuf,
-                                                          const Optional<ByteSpan> & icaCertBuf, const AesCcm128KeySpan ipk,
-                                                          const NodeId adminSubject, Optional<System::Clock::Timeout> timeout)
+                                                          const Optional<ByteSpan> & icaCertBuf,
+                                                          const IdentityProtectionKeySpan ipk, const NodeId adminSubject,
+                                                          Optional<System::Clock::Timeout> timeout)
 {
     MATTER_TRACE_EVENT_SCOPE("SendOperationalCertificate", "DeviceCommissioner");
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -732,7 +732,8 @@ private:
        The function does not hold a reference to the device object.
      */
     CHIP_ERROR SendOperationalCertificate(DeviceProxy * device, const ByteSpan & nocCertBuf, const Optional<ByteSpan> & icaCertBuf,
-                                          AesCcm128KeySpan ipk, NodeId adminSubject, Optional<System::Clock::Timeout> timeout);
+                                          IdentityProtectionKeySpan ipk, NodeId adminSubject,
+                                          Optional<System::Clock::Timeout> timeout);
     /* This function sends the trusted root certificate to the device.
        The function does not hold a reference to the device object.
      */
@@ -792,7 +793,8 @@ private:
                                                            Credentials::AttestationVerificationResult result);
 
     static void OnDeviceNOCChainGeneration(void * context, CHIP_ERROR status, const ByteSpan & noc, const ByteSpan & icac,
-                                           const ByteSpan & rcac, Optional<AesCcm128KeySpan> ipk, Optional<NodeId> adminSubject);
+                                           const ByteSpan & rcac, Optional<IdentityProtectionKeySpan> ipk,
+                                           Optional<NodeId> adminSubject);
     static void OnArmFailSafe(void * context,
                               const chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType & data);
     static void OnSetRegulatoryConfigResponse(

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -177,9 +177,9 @@ public:
     // Epoch key for the identity protection key for the node being commissioned. In the AutoCommissioner, this is set by by the
     // kGenerateNOCChain stage through the OperationalCredentialsDelegate.
     // This value must be set before calling PerformCommissioningStep for the kSendNOC step.
-    const Optional<AesCcm128KeySpan> GetIpk() const
+    const Optional<IdentityProtectionKeySpan> GetIpk() const
     {
-        return mIpk.HasValue() ? Optional<AesCcm128KeySpan>(mIpk.Value().Span()) : Optional<AesCcm128KeySpan>();
+        return mIpk.HasValue() ? Optional<IdentityProtectionKeySpan>(mIpk.Value().Span()) : Optional<IdentityProtectionKeySpan>();
     }
 
     // Admin subject id used for the case access control entry created if the AddNOC command succeeds. In the AutoCommissioner, this
@@ -321,9 +321,9 @@ public:
         mIcac.SetValue(icac);
         return *this;
     }
-    CommissioningParameters & SetIpk(const AesCcm128KeySpan ipk)
+    CommissioningParameters & SetIpk(const IdentityProtectionKeySpan ipk)
     {
-        mIpk.SetValue(AesCcm128Key(ipk));
+        mIpk.SetValue(IdentityProtectionKey(ipk));
         return *this;
     }
     CommissioningParameters & SetAdminSubject(const NodeId adminSubject)
@@ -439,7 +439,7 @@ private:
     Optional<ByteSpan> mRootCert;
     Optional<ByteSpan> mNoc;
     Optional<ByteSpan> mIcac;
-    Optional<AesCcm128Key> mIpk;
+    Optional<IdentityProtectionKey> mIpk;
     Optional<NodeId> mAdminSubject;
     // Items that come from the device in commissioning steps
     Optional<ByteSpan> mAttestationElements;
@@ -484,13 +484,13 @@ struct CSRResponse
 
 struct NocChain
 {
-    NocChain(ByteSpan newNoc, ByteSpan newIcac, ByteSpan newRcac, AesCcm128KeySpan newIpk, NodeId newAdminSubject) :
+    NocChain(ByteSpan newNoc, ByteSpan newIcac, ByteSpan newRcac, IdentityProtectionKeySpan newIpk, NodeId newAdminSubject) :
         noc(newNoc), icac(newIcac), rcac(newRcac), ipk(newIpk), adminSubject(newAdminSubject)
     {}
     ByteSpan noc;
     ByteSpan icac;
     ByteSpan rcac;
-    AesCcm128KeySpan ipk;
+    IdentityProtectionKeySpan ipk;
     NodeId adminSubject;
 };
 

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -386,7 +386,7 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChain(const ByteSpan 
     // Prepare IPK to be sent back. A more fully-fledged operational credentials delegate
     // would obtain a suitable key per fabric.
     uint8_t ipkValue[CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES];
-    Crypto::AesCcm128KeySpan ipkSpan(ipkValue);
+    Crypto::IdentityProtectionKeySpan ipkSpan(ipkValue);
 
     ReturnErrorCodeIf(defaultIpkSpan.size() != sizeof(ipkValue), CHIP_ERROR_INTERNAL);
     memcpy(&ipkValue[0], defaultIpkSpan.data(), defaultIpkSpan.size());

--- a/src/controller/OperationalCredentialsDelegate.h
+++ b/src/controller/OperationalCredentialsDelegate.h
@@ -30,7 +30,8 @@ namespace chip {
 namespace Controller {
 
 typedef void (*OnNOCChainGeneration)(void * context, CHIP_ERROR status, const ByteSpan & noc, const ByteSpan & icac,
-                                     const ByteSpan & rcac, Optional<Crypto::AesCcm128KeySpan> ipk, Optional<NodeId> adminSubject);
+                                     const ByteSpan & rcac, Optional<Crypto::IdentityProtectionKeySpan> ipk,
+                                     Optional<NodeId> adminSubject);
 
 constexpr uint32_t kMaxCHIPDERCertLength = 600;
 constexpr size_t kCSRNonceLength         = 32;

--- a/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
@@ -297,7 +297,8 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::CallbackGenerateNOCChain(const B
 }
 
 CHIP_ERROR AndroidOperationalCredentialsIssuer::NOCChainGenerated(CHIP_ERROR status, const ByteSpan & noc, const ByteSpan & icac,
-                                                                  const ByteSpan & rcac, Optional<Crypto::AesCcm128KeySpan> ipk,
+                                                                  const ByteSpan & rcac,
+                                                                  Optional<Crypto::IdentityProtectionKeySpan> ipk,
                                                                   Optional<NodeId> adminSubject)
 {
     ReturnErrorCodeIf(mOnNOCCompletionCallback == nullptr, CHIP_ERROR_INCORRECT_STATE);
@@ -384,7 +385,7 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::LocalGenerateNOCChain(const Byte
     // Prepare IPK to be sent back. A more fully-fledged operational credentials delegate
     // would obtain a suitable key per fabric.
     uint8_t ipkValue[CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES];
-    Crypto::AesCcm128KeySpan ipkSpan(ipkValue);
+    Crypto::IdentityProtectionKeySpan ipkSpan(ipkValue);
 
     ReturnErrorCodeIf(defaultIpkSpan.size() != sizeof(ipkValue), CHIP_ERROR_INTERNAL);
 

--- a/src/controller/java/AndroidOperationalCredentialsIssuer.h
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.h
@@ -53,7 +53,7 @@ public:
                                 Callback::Callback<OnNOCChainGeneration> * onCompletion) override;
 
     CHIP_ERROR NOCChainGenerated(CHIP_ERROR status, const ByteSpan & noc, const ByteSpan & icac, const ByteSpan & rcac,
-                                 Optional<Crypto::AesCcm128KeySpan> ipk, Optional<NodeId> adminSubject);
+                                 Optional<Crypto::IdentityProtectionKeySpan> ipk, Optional<NodeId> adminSubject);
 
     void SetUseJavaCallbackForNOCRequest(bool useJavaCallbackForNOCRequest)
     {

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -205,9 +205,9 @@ JNI_METHOD(jint, onNOCChainGeneration)
     // use ipk and adminSubject from CommissioningParameters if not set in ControllerParams
     CommissioningParameters commissioningParams = wrapper->GetCommissioningParameters();
 
-    Optional<Crypto::AesCcm128KeySpan> ipkOptional;
+    Optional<Crypto::IdentityProtectionKeySpan> ipkOptional;
     uint8_t ipkValue[CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES];
-    Crypto::AesCcm128KeySpan ipkTempSpan(ipkValue);
+    Crypto::IdentityProtectionKeySpan ipkTempSpan(ipkValue);
 
     jbyteArray ipk = (jbyteArray) env->CallObjectMethod(controllerParams, getIpk);
     if (ipk != nullptr)

--- a/src/controller/python/ChipDeviceController-IssueNocChain.cpp
+++ b/src/controller/python/ChipDeviceController-IssueNocChain.cpp
@@ -50,7 +50,7 @@ PyChipError pychip_DeviceController_IssueNOCChain(chip::Controller::DeviceCommis
 }
 
 void pychip_DeviceController_IssueNOCChainCallback(void * context, CHIP_ERROR status, const ByteSpan & noc, const ByteSpan & icac,
-                                                   const ByteSpan & rcac, Optional<Crypto::AesCcm128KeySpan> ipk,
+                                                   const ByteSpan & rcac, Optional<Crypto::IdentityProtectionKeySpan> ipk,
                                                    Optional<NodeId> adminSubject)
 {
     if (pychip_DeviceController_IssueNOCChainCallbackPythonCallbackFunct == nullptr)
@@ -65,8 +65,8 @@ void pychip_DeviceController_IssueNOCChainCallback(void * context, CHIP_ERROR st
     MutableByteSpan chipIcacSpan;
     MutableByteSpan chipRcacSpan;
 
-    Crypto::AesCcm128KeySpan ipkData;
-    ipkData = ipk.ValueOr(Crypto::AesCcm128KeySpan());
+    Crypto::IdentityProtectionKeySpan ipkData;
+    ipkData = ipk.ValueOr(Crypto::IdentityProtectionKeySpan());
 
     CHIP_ERROR err = status;
     if (err != CHIP_NO_ERROR)

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -296,7 +296,7 @@ CHIP_ERROR ChipCertificateSet::VerifySignature(const ChipCertificateData * cert,
 
     VerifyOrReturnError((cert != nullptr) && (caCert != nullptr), CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorOnFailure(signature.SetLength(cert->mSignature.size()));
-    memcpy(signature, cert->mSignature.data(), cert->mSignature.size());
+    memcpy(signature.Bytes(), cert->mSignature.data(), cert->mSignature.size());
 
     memcpy(caPublicKey, caCert->mPublicKey.data(), caCert->mPublicKey.size());
 

--- a/src/credentials/CertificationDeclaration.cpp
+++ b/src/credentials/CertificationDeclaration.cpp
@@ -475,7 +475,7 @@ CHIP_ERROR EncodeSignerInfo(const ByteSpan & signerKeyId, const P256ECDSASignatu
 
             uint8_t asn1SignatureBuf[kMax_ECDSA_Signature_Length_Der];
             MutableByteSpan asn1Signature(asn1SignatureBuf);
-            ReturnErrorOnFailure(EcdsaRawSignatureToAsn1(kP256_FE_Length, ByteSpan(signature, signature.Length()), asn1Signature));
+            ReturnErrorOnFailure(EcdsaRawSignatureToAsn1(kP256_FE_Length, signature.Span(), asn1Signature));
 
             // signature OCTET STRING
             ReturnErrorOnFailure(writer.PutOctetString(asn1Signature.data(), static_cast<uint16_t>(asn1Signature.size())));
@@ -539,7 +539,7 @@ CHIP_ERROR DecodeSignerInfo(ASN1Reader & reader, ByteSpan & signerKeyId, P256ECD
             // signature OCTET STRING
             ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_OctetString);
 
-            MutableByteSpan signatureSpan(signature, signature.Capacity());
+            MutableByteSpan signatureSpan(signature.Bytes(), signature.Capacity());
             ReturnErrorOnFailure(
                 EcdsaAsn1SignatureToRaw(kP256_FE_Length, ByteSpan(reader.GetValue(), reader.GetValueLen()), signatureSpan));
             ReturnErrorOnFailure(signature.SetLength(signatureSpan.size()));

--- a/src/credentials/tests/TestCertificationDeclaration.cpp
+++ b/src/credentials/tests/TestCertificationDeclaration.cpp
@@ -363,7 +363,7 @@ static void TestCD_CMSSignAndVerify(nlTestSuite * inSuite, void * inContext)
     // Test with known key
     P256Keypair keypair2;
     P256SerializedKeypair serializedKeypair;
-    memcpy(serializedKeypair, sTestCMS_SignerSerializedKeypair, sizeof(sTestCMS_SignerSerializedKeypair));
+    memcpy(serializedKeypair.Bytes(), sTestCMS_SignerSerializedKeypair, sizeof(sTestCMS_SignerSerializedKeypair));
     serializedKeypair.SetLength(sizeof(sTestCMS_SignerSerializedKeypair));
     cdContentIn   = ByteSpan(sTestCMS_CDContent02);
     signedMessage = MutableByteSpan(signedMessageBuf);

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -89,8 +89,8 @@ static CHIP_ERROR LoadTestFabric_Node01_01(nlTestSuite * inSuite, FabricTable & 
     static Crypto::P256Keypair opKey_Node01_01;
 
     FabricIndex fabricIndex;
-    memcpy((uint8_t *) (opKeysSerialized), TestCerts::sTestCert_Node01_01_PublicKey, TestCerts::sTestCert_Node01_01_PublicKey_Len);
-    memcpy((uint8_t *) (opKeysSerialized) + TestCerts::sTestCert_Node01_01_PublicKey_Len, TestCerts::sTestCert_Node01_01_PrivateKey,
+    memcpy(opKeysSerialized.Bytes(), TestCerts::sTestCert_Node01_01_PublicKey, TestCerts::sTestCert_Node01_01_PublicKey_Len);
+    memcpy(opKeysSerialized.Bytes() + TestCerts::sTestCert_Node01_01_PublicKey_Len, TestCerts::sTestCert_Node01_01_PrivateKey,
            TestCerts::sTestCert_Node01_01_PrivateKey_Len);
 
     ByteSpan rcacSpan(TestCerts::sTestCert_Root01_Chip, TestCerts::sTestCert_Root01_Chip_Len);
@@ -119,8 +119,8 @@ static CHIP_ERROR LoadTestFabric_Node01_02(nlTestSuite * inSuite, FabricTable & 
     FabricIndex fabricIndex;
     static Crypto::P256Keypair opKey_Node01_02;
 
-    memcpy((uint8_t *) (opKeysSerialized), TestCerts::sTestCert_Node01_02_PublicKey, TestCerts::sTestCert_Node01_02_PublicKey_Len);
-    memcpy((uint8_t *) (opKeysSerialized) + TestCerts::sTestCert_Node01_02_PublicKey_Len, TestCerts::sTestCert_Node01_02_PrivateKey,
+    memcpy(opKeysSerialized.Bytes(), TestCerts::sTestCert_Node01_02_PublicKey, TestCerts::sTestCert_Node01_02_PublicKey_Len);
+    memcpy(opKeysSerialized.Bytes() + TestCerts::sTestCert_Node01_02_PublicKey_Len, TestCerts::sTestCert_Node01_02_PrivateKey,
            TestCerts::sTestCert_Node01_02_PrivateKey_Len);
 
     ByteSpan rcacSpan(TestCerts::sTestCert_Root01_Chip, TestCerts::sTestCert_Root01_Chip_Len);
@@ -151,8 +151,8 @@ static CHIP_ERROR LoadTestFabric_Node02_01(nlTestSuite * inSuite, FabricTable & 
     FabricIndex fabricIndex;
     static Crypto::P256Keypair opKey_Node02_01;
 
-    memcpy((uint8_t *) (opKeysSerialized), TestCerts::sTestCert_Node02_01_PublicKey, TestCerts::sTestCert_Node02_01_PublicKey_Len);
-    memcpy((uint8_t *) (opKeysSerialized) + TestCerts::sTestCert_Node02_01_PublicKey_Len, TestCerts::sTestCert_Node02_01_PrivateKey,
+    memcpy(opKeysSerialized.Bytes(), TestCerts::sTestCert_Node02_01_PublicKey, TestCerts::sTestCert_Node02_01_PublicKey_Len);
+    memcpy(opKeysSerialized.Bytes() + TestCerts::sTestCert_Node02_01_PublicKey_Len, TestCerts::sTestCert_Node02_01_PrivateKey,
            TestCerts::sTestCert_Node02_01_PrivateKey_Len);
 
     ByteSpan rcacSpan(TestCerts::sTestCert_Root02_Chip, TestCerts::sTestCert_Root02_Chip_Len);

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -228,68 +228,120 @@ public:
                                                      const Sig & signature) const                                              = 0;
 };
 
-template <size_t Cap>
-class CapacityBoundBuffer
+template <size_t kCapacity>
+class SensitiveDataBuffer
 {
 public:
-    ~CapacityBoundBuffer()
+    ~SensitiveDataBuffer()
     {
         // Sanitize after use
-        ClearSecretData(&bytes[0], Cap);
+        ClearSecretData(mBytes);
     }
 
-    CapacityBoundBuffer & operator=(const CapacityBoundBuffer & other)
+    SensitiveDataBuffer & operator=(const SensitiveDataBuffer & other)
     {
         // Guard self assignment
         if (this == &other)
             return *this;
 
-        ClearSecretData(&bytes[0], Cap);
+        ClearSecretData(mBytes);
         SetLength(other.Length());
-        ::memcpy(Bytes(), other.Bytes(), other.Length());
+        ::memcpy(Bytes(), other.ConstBytes(), other.Length());
         return *this;
     }
 
-    /** @brief Set current length of the buffer that's being used
-     * @return Returns error if new length is > capacity
-     **/
-    CHIP_ERROR SetLength(size_t len)
+    /**
+     * @brief Set current length of the buffer
+     * @return Error if new length is exceeds capacity of the buffer
+     */
+    CHIP_ERROR SetLength(size_t length)
     {
-        VerifyOrReturnError(len <= sizeof(bytes), CHIP_ERROR_INVALID_ARGUMENT);
-        length = len;
+        VerifyOrReturnError(length <= kCapacity, CHIP_ERROR_INVALID_ARGUMENT);
+        mLength = length;
         return CHIP_NO_ERROR;
     }
 
-    /** @brief Returns current length of the buffer that's being used
-     * @return Returns 0 if SetLength() was never called
-     **/
-    size_t Length() const { return length; }
+    /**
+     * @brief Returns current length of the buffer
+     */
+    size_t Length() const { return mLength; }
 
-    /** @brief Returns max capacity of the buffer
-     **/
-    static constexpr size_t Capacity() { return sizeof(bytes); }
+    /**
+     * @brief Returns non-const pointer to start of the underlying buffer
+     */
+    uint8_t * Bytes() { return &mBytes[0]; }
 
-    /** @brief Returns pointer to start of underlying buffer
-     **/
-    uint8_t * Bytes() { return &bytes[0]; }
+    /**
+     * @brief Returns const pointer to start of the underlying buffer
+     */
+    const uint8_t * ConstBytes() const { return &mBytes[0]; }
 
-    /** @brief Returns const pointer to start of underlying buffer
-     **/
-    const uint8_t * ConstBytes() const { return &bytes[0]; }
+    /**
+     * @brief Constructs span from the underlying buffer
+     */
+    ByteSpan Span() const { return ByteSpan(ConstBytes(), Length()); }
 
-    /** @brief Returns buffer pointer
-     **/
-    operator uint8_t *() { return bytes; }
-    operator const uint8_t *() const { return bytes; }
+    /**
+     * @brief Returns capacity of the buffer
+     */
+    static constexpr size_t Capacity() { return kCapacity; }
 
 private:
-    uint8_t bytes[Cap];
-    size_t length = 0;
+    uint8_t mBytes[kCapacity];
+    size_t mLength = 0;
 };
 
-typedef CapacityBoundBuffer<kMax_ECDSA_Signature_Length> P256ECDSASignature;
+template <size_t kCapacity>
+class SensitiveDataFixedBuffer
+{
+public:
+    SensitiveDataFixedBuffer() = default;
 
-typedef CapacityBoundBuffer<kMax_ECDH_Secret_Length> P256ECDHDerivedSecret;
+    constexpr explicit SensitiveDataFixedBuffer(const uint8_t (&rawValue)[kCapacity])
+    {
+        memcpy(&mBytes[0], &rawValue[0], kCapacity);
+    }
+
+    constexpr explicit SensitiveDataFixedBuffer(const FixedByteSpan<kCapacity> & value)
+    {
+        memcpy(&mBytes[0], value.data(), kCapacity);
+    }
+
+    ~SensitiveDataFixedBuffer()
+    {
+        // Sanitize after use
+        ClearSecretData(mBytes);
+    }
+
+    /**
+     * @brief Returns fixed length of the buffer
+     */
+    constexpr size_t Length() const { return kCapacity; }
+
+    /**
+     * @brief Returns non-const pointer to start of the underlying buffer
+     */
+    uint8_t * Bytes() { return &mBytes[0]; }
+
+    /**
+     * @brief Returns const pointer to start of the underlying buffer
+     */
+    const uint8_t * ConstBytes() const { return &mBytes[0]; }
+
+    /**
+     * @brief Constructs fixed span from the underlying buffer
+     */
+    FixedByteSpan<kCapacity> Span() const { return FixedByteSpan<kCapacity>(mBytes); }
+
+private:
+    uint8_t mBytes[kCapacity];
+};
+
+using P256ECDSASignature    = SensitiveDataBuffer<kMax_ECDSA_Signature_Length>;
+using P256ECDHDerivedSecret = SensitiveDataBuffer<kMax_ECDH_Secret_Length>;
+
+using IdentityProtectionKey     = SensitiveDataFixedBuffer<CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES>;
+using IdentityProtectionKeySpan = FixedByteSpan<Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES>;
 
 class P256PublicKey : public ECPKey<P256ECDSASignature>
 {
@@ -382,7 +434,7 @@ struct alignas(size_t) P256KeypairContext
     uint8_t mBytes[kMAX_P256Keypair_Context_Size];
 };
 
-typedef CapacityBoundBuffer<kP256_PublicKey_Length + kP256_PrivateKey_Length> P256SerializedKeypair;
+using P256SerializedKeypair = SensitiveDataBuffer<kP256_PublicKey_Length + kP256_PrivateKey_Length>;
 
 class P256KeypairBase : public ECPKeypair<P256PublicKey, P256ECDHDerivedSecret, P256ECDSASignature>
 {
@@ -475,47 +527,6 @@ protected:
     P256PublicKey mPublicKey;
     mutable P256KeypairContext mKeypair;
     bool mInitialized = false;
-};
-
-/**
- *  @brief  A data structure for holding an AES CCM128 symmetric key, without the ownership of it.
- */
-using AesCcm128KeySpan = FixedByteSpan<Crypto::kAES_CCM128_Key_Length>;
-
-class AesCcm128Key
-{
-public:
-    AesCcm128Key() {}
-
-    ~AesCcm128Key()
-    {
-        // Sanitize after use
-        ClearSecretData(&bytes[0], Length());
-    }
-
-    template <size_t N>
-    constexpr AesCcm128Key(const uint8_t (&raw_value)[N])
-    {
-        static_assert(N == kAES_CCM128_Key_Length, "Can only array-initialize from proper bounds");
-        memcpy(&bytes[0], &raw_value[0], N);
-    }
-
-    template <size_t N>
-    constexpr AesCcm128Key(const FixedByteSpan<N> & value)
-    {
-        static_assert(N == kAES_CCM128_Key_Length, "Can only initialize from proper sized byte span");
-        memcpy(&bytes[0], value.data(), N);
-    }
-
-    size_t Length() const { return sizeof(bytes); }
-    operator uint8_t *() { return bytes; }
-    operator const uint8_t *() const { return bytes; }
-    const uint8_t * ConstBytes() const { return &bytes[0]; }
-    AesCcm128KeySpan Span() const { return AesCcm128KeySpan(bytes); }
-    uint8_t * Bytes() { return &bytes[0]; }
-
-private:
-    uint8_t bytes[kAES_CCM128_Key_Length];
 };
 
 /**
@@ -1414,8 +1425,6 @@ CHIP_ERROR GenerateCompressedFabricId(const Crypto::P256PublicKey & root_public_
  */
 CHIP_ERROR GenerateCompressedFabricId(const Crypto::P256PublicKey & rootPublicKey, uint64_t fabricId,
                                       uint64_t & compressedFabricId);
-
-typedef CapacityBoundBuffer<kMax_x509_Certificate_Length> X509DerCertificate;
 
 enum class CertificateChainValidationResult
 {

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -941,7 +941,7 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     out_buf_length = (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length();
-    result         = EVP_PKEY_derive(context, Uint8::to_uchar(out_secret), &out_buf_length);
+    result         = EVP_PKEY_derive(context, out_secret.Bytes(), &out_buf_length);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
     SuccessOrExit(out_secret.SetLength(out_buf_length));
 
@@ -1077,7 +1077,7 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
 
     {
         size_t len = output.Length() == 0 ? output.Capacity() : output.Length();
-        Encoding::BufferWriter bbuf(output, len);
+        Encoding::BufferWriter bbuf(output.Bytes(), len);
         bbuf.Put(mPublicKey, mPublicKey.Length());
         bbuf.Put(privkey, sizeof(privkey));
         VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
@@ -1108,10 +1108,10 @@ CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
     int result       = 0;
     int nid          = NID_undef;
 
-    const uint8_t * privkey = Uint8::to_const_uchar(input) + mPublicKey.Length();
+    const uint8_t * privkey = input.ConstBytes() + mPublicKey.Length();
 
     VerifyOrExit(input.Length() == mPublicKey.Length() + kP256_PrivateKey_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
-    bbuf.Put(input, mPublicKey.Length());
+    bbuf.Put(input.ConstBytes(), mPublicKey.Length());
     VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
 
     nid = _nidForCurve(curve);

--- a/src/crypto/PersistentStorageOperationalKeystore.cpp
+++ b/src/crypto/PersistentStorageOperationalKeystore.cpp
@@ -57,8 +57,8 @@ CHIP_ERROR StoreOperationalKey(FabricIndex fabricIndex, PersistentStorageDelegat
     VerifyOrReturnError(IsValidFabricIndex(fabricIndex) && (storage != nullptr) && (keypair != nullptr),
                         CHIP_ERROR_INVALID_ARGUMENT);
 
-    // Use a CapacityBoundBuffer to get RAII secret data clearing on scope exit.
-    Crypto::CapacityBoundBuffer<OpKeyTLVMaxSize()> buf;
+    // Use a SensitiveDataBuffer to get RAII secret data clearing on scope exit.
+    Crypto::SensitiveDataBuffer<OpKeyTLVMaxSize()> buf;
     TLV::TLVWriter writer;
 
     writer.Init(buf.Bytes(), buf.Capacity());
@@ -80,7 +80,7 @@ CHIP_ERROR StoreOperationalKey(FabricIndex fabricIndex, PersistentStorageDelegat
 
     const auto opKeyLength = writer.GetLengthWritten();
     VerifyOrReturnError(CanCastTo<uint16_t>(opKeyLength), CHIP_ERROR_BUFFER_TOO_SMALL);
-    ReturnErrorOnFailure(storage->SyncSetKeyValue(DefaultStorageKeyAllocator::FabricOpKey(fabricIndex).KeyName(), buf,
+    ReturnErrorOnFailure(storage->SyncSetKeyValue(DefaultStorageKeyAllocator::FabricOpKey(fabricIndex).KeyName(), buf.ConstBytes(),
                                                   static_cast<uint16_t>(opKeyLength)));
 
     return CHIP_NO_ERROR;
@@ -107,8 +107,8 @@ CHIP_ERROR SignWithStoredOpKey(FabricIndex fabricIndex, PersistentStorageDelegat
 
     // Scope 1: Load up the keypair data from storage
     {
-        // Use a CapacityBoundBuffer to get RAII secret data clearing on scope exit.
-        Crypto::CapacityBoundBuffer<OpKeyTLVMaxSize()> buf;
+        // Use a SensitiveDataBuffer to get RAII secret data clearing on scope exit.
+        Crypto::SensitiveDataBuffer<OpKeyTLVMaxSize()> buf;
 
         // Load up the operational key structure from storage
         uint16_t size = static_cast<uint16_t>(buf.Capacity());
@@ -177,8 +177,8 @@ bool PersistentStorageOperationalKeystore::HasOpKeypairForFabric(FabricIndex fab
     //               properly enforcing CHIP_ERROR_BUFFER_TOO_SMALL behavior needed by
     //               PersistentStorageDelegate. Very unfortunate, needs fixing ASAP.
 
-    // Use a CapacityBoundBuffer to get RAII secret data clearing on scope exit.
-    Crypto::CapacityBoundBuffer<OpKeyTLVMaxSize()> buf;
+    // Use a SensitiveDataBuffer to get RAII secret data clearing on scope exit.
+    Crypto::SensitiveDataBuffer<OpKeyTLVMaxSize()> buf;
 
     uint16_t keySize = static_cast<uint16_t>(buf.Capacity());
     CHIP_ERROR err =

--- a/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_P256.cpp
+++ b/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_P256.cpp
@@ -208,7 +208,7 @@ exit:
 CHIP_ERROR P256KeypairHSM::Serialize(P256SerializedKeypair & output) const
 {
     const size_t len = output.Length() == 0 ? output.Capacity() : output.Length();
-    Encoding::BufferWriter bbuf(output, len);
+    Encoding::BufferWriter bbuf(output.Bytes(), len);
     uint8_t privkey[kP256_PrivateKey_Length] = {
         0,
     };
@@ -249,7 +249,7 @@ CHIP_ERROR P256KeypairHSM::Deserialize(P256SerializedKeypair & input)
     VerifyOrReturnError(bbuf.Fit(), CHIP_ERROR_NO_MEMORY);
     {
         /* When HSM is used for ECC key generation, key info in stored in private key buffer */
-        const uint8_t * privkey = Uint8::to_const_uchar(input) + public_key.Length();
+        const uint8_t * privkey = input.ConstBytes() + public_key.Length();
         keyid                   = Encoding::LittleEndian::Get32(privkey);
         public_key.SetPublicKeyId(keyid);
     }
@@ -274,7 +274,7 @@ CHIP_ERROR P256KeypairHSM::ECDH_derive_secret(const P256PublicKey & remote_publi
     VerifyOrReturnError(gex_sss_chip_ctx.ks.session != nullptr, CHIP_ERROR_INTERNAL);
 
     const smStatus_t smstatus = Se05x_API_ECGenSharedSecret(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, keyid,
-                                                            rem_pubKey, rem_pubKeyLen, Uint8::to_uchar(out_secret), &secret_length);
+                                                            rem_pubKey, rem_pubKeyLen, out_secret.Bytes(), &secret_length);
     VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 
     return out_secret.SetLength(secret_length);

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -460,38 +460,76 @@ static void TestAES_CCM_128DecryptInvalidNonceLen(nlTestSuite * inSuite, void * 
     NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
 }
 
-static void TestAES_CCM_128Containers(nlTestSuite * inSuite, void * inContext)
+static void TestSensitiveDataBuffer(nlTestSuite * inSuite, void * inContext)
 {
     HeapChecker heapChecker(inSuite);
-    uint8_t testVector[kAES_CCM128_Key_Length];
-    AesCcm128Key deepCopy;
-    AesCcm128KeySpan shallowCopy;
-    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    constexpr size_t kCapacity         = 32;
+    constexpr size_t kLength           = 16;
+    using Buffer                       = SensitiveDataBuffer<kCapacity>;
+    const uint8_t kAllZeros[kCapacity] = { 0 };
+    uint8_t testVector[kCapacity];
 
     // Give us some data.
+    CHIP_ERROR err = DRBG_get_bytes(testVector, sizeof(testVector));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Test initial value
+    Buffer buffer;
+    NL_TEST_ASSERT(inSuite, buffer.ConstBytes() == (const uint8_t *) buffer.Bytes());
+    NL_TEST_ASSERT(inSuite, buffer.Length() == 0);
+
+    // Put data in the buffer and test all accessors
+    memcpy(buffer.Bytes(), testVector, kCapacity);
+    buffer.SetLength(kLength);
+
+    NL_TEST_ASSERT(inSuite, buffer.ConstBytes() == (const uint8_t *) buffer.Bytes());
+    NL_TEST_ASSERT(inSuite, buffer.ConstBytes() == buffer.Span().data());
+    NL_TEST_ASSERT(inSuite, buffer.Length() == kLength);
+    NL_TEST_ASSERT(inSuite, buffer.Length() == buffer.Span().size());
+
+    // Test sanitization of entire buffer (even though length < capacity)
+    const void * bufferStorage = buffer.ConstBytes();
+    buffer.~Buffer();
+    NL_TEST_ASSERT(inSuite, memcmp(bufferStorage, kAllZeros, kCapacity) == 0);
+    NL_TEST_ASSERT(inSuite, memcmp(bufferStorage, testVector, kCapacity));
+}
+
+static void TestSensitiveDataFixedBuffer(nlTestSuite * inSuite, void * inContext)
+{
+    HeapChecker heapChecker(inSuite);
+
+    constexpr size_t kCapacity         = 32;
+    using Buffer                       = SensitiveDataFixedBuffer<kCapacity>;
+    using BufferSpan                   = FixedByteSpan<kCapacity>;
+    const uint8_t kAllZeros[kCapacity] = { 0 };
+    uint8_t testVector[kCapacity];
+
+    // Give us some data.
+    CHIP_ERROR err = DRBG_get_bytes(testVector, sizeof(testVector));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Test construction from array and all accessors
+    Buffer buffer(testVector);
+    NL_TEST_ASSERT(inSuite, buffer.ConstBytes() == (const uint8_t *) buffer.Bytes());
+    NL_TEST_ASSERT(inSuite, buffer.ConstBytes() == buffer.Span().data());
+    NL_TEST_ASSERT(inSuite, memcmp(buffer.ConstBytes(), testVector, kCapacity) == 0);
+
+    // Test sanitization
+    const void * bufferStorage = buffer.ConstBytes();
+    buffer.~Buffer();
+    NL_TEST_ASSERT(inSuite, memcmp(bufferStorage, kAllZeros, kCapacity) == 0);
+    NL_TEST_ASSERT(inSuite, memcmp(bufferStorage, testVector, kCapacity));
+
+    // Give us different data
     err = DRBG_get_bytes(testVector, sizeof(testVector));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    // Test deep copy from array.
-    deepCopy = AesCcm128Key(testVector);
-    NL_TEST_ASSERT(inSuite, memcmp(deepCopy, testVector, sizeof(testVector)) == 0);
-
-    // Test sanitization.
-    deepCopy.~AesCcm128Key();
-    new (&deepCopy) AesCcm128Key();
-    NL_TEST_ASSERT(inSuite, memcmp(deepCopy, testVector, sizeof(testVector)));
-
-    // Give us different data.
-    err = DRBG_get_bytes(testVector, sizeof(testVector));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    // Test deep copy from KeySpan.
-    shallowCopy = AesCcm128KeySpan(testVector);
-    deepCopy    = AesCcm128Key(shallowCopy);
-    NL_TEST_ASSERT(inSuite, memcmp(deepCopy, testVector, sizeof(testVector)) == 0);
-
-    // Test Span getter.
-    NL_TEST_ASSERT(inSuite, memcmp(testVector, deepCopy.Span().data(), deepCopy.Span().size()) == 0);
+    // Test construction from span and all accessors
+    new (&buffer) Buffer(BufferSpan(testVector));
+    NL_TEST_ASSERT(inSuite, buffer.ConstBytes() == (const uint8_t *) buffer.Bytes());
+    NL_TEST_ASSERT(inSuite, buffer.ConstBytes() == buffer.Span().data());
+    NL_TEST_ASSERT(inSuite, memcmp(buffer.ConstBytes(), testVector, kCapacity) == 0);
 }
 
 static void TestAsn1Conversions(nlTestSuite * inSuite, void * inContext)
@@ -919,7 +957,7 @@ static void TestECDSA_ValidationFailIncorrectMsgSignature(nlTestSuite * inSuite,
     P256ECDSASignature signature;
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(reinterpret_cast<const uint8_t *>(msg), msg_length, signature);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
-    signature[0] = static_cast<uint8_t>(~signature[0]); // Flipping bits should invalidate the signature.
+    signature.Bytes()[0] = static_cast<uint8_t>(~signature.ConstBytes()[0]); // Flipping bits should invalidate the signature.
 
     CHIP_ERROR validation_error =
         keypair.Pubkey().ECDSA_validate_msg_signature(reinterpret_cast<const uint8_t *>(msg), msg_length, signature);
@@ -942,7 +980,7 @@ static void TestECDSA_ValidationFailIncorrectHashSignature(nlTestSuite * inSuite
     P256ECDSASignature signature;
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(msg, msg_length, signature);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
-    signature[0] = static_cast<uint8_t>(~signature[0]); // Flipping bits should invalidate the signature.
+    signature.Bytes()[0] = static_cast<uint8_t>(~signature.ConstBytes()[0]); // Flipping bits should invalidate the signature.
 
     CHIP_ERROR validation_error = keypair.Pubkey().ECDSA_validate_hash_signature(hash, sizeof(hash), signature);
     NL_TEST_ASSERT(inSuite, validation_error == CHIP_ERROR_INVALID_SIGNATURE);
@@ -1029,14 +1067,14 @@ static void TestECDH_EstablishSecret(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, keypair2.Initialize(ECPKeyTarget::ECDH) == CHIP_NO_ERROR);
 
     P256ECDHDerivedSecret out_secret1;
-    out_secret1[0] = 0;
+    out_secret1.Bytes()[0] = 0;
 
     P256ECDHDerivedSecret out_secret2;
-    out_secret2[0] = 1;
+    out_secret2.Bytes()[0] = 1;
 
     CHIP_ERROR error = CHIP_NO_ERROR;
     NL_TEST_ASSERT(inSuite,
-                   memcmp(Uint8::to_uchar(out_secret1), Uint8::to_uchar(out_secret2), out_secret1.Capacity()) !=
+                   memcmp(out_secret1.ConstBytes(), out_secret2.ConstBytes(), out_secret1.Capacity()) !=
                        0); // Validate that buffers are indeed different.
 
     error = keypair2.ECDH_derive_secret(keypair1.Pubkey(), out_secret1);
@@ -1048,7 +1086,7 @@ static void TestECDH_EstablishSecret(nlTestSuite * inSuite, void * inContext)
     bool signature_lengths_match = out_secret1.Length() == out_secret2.Length();
     NL_TEST_ASSERT(inSuite, signature_lengths_match);
 
-    bool signatures_match = (memcmp(Uint8::to_uchar(out_secret1), Uint8::to_uchar(out_secret2), out_secret1.Length()) == 0);
+    bool signatures_match = (memcmp(out_secret1.ConstBytes(), out_secret2.ConstBytes(), out_secret1.Length()) == 0);
     NL_TEST_ASSERT(inSuite, signatures_match);
 }
 
@@ -2498,7 +2536,6 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test encrypting AES-CCM-128 using invalid tag", TestAES_CCM_128EncryptInvalidTagLen),
     NL_TEST_DEF("Test decrypting AES-CCM-128 invalid key", TestAES_CCM_128DecryptInvalidKey),
     NL_TEST_DEF("Test decrypting AES-CCM-128 invalid nonce", TestAES_CCM_128DecryptInvalidNonceLen),
-    NL_TEST_DEF("Test decrypting AES-CCM-128 Containers", TestAES_CCM_128Containers),
     NL_TEST_DEF("Test encrypt/decrypt AES-CTR-128 test vectors", TestAES_CTR_128CryptTestVectors),
     NL_TEST_DEF("Test ASN.1 signature conversion routines", TestAsn1Conversions),
     NL_TEST_DEF("Test Integer to ASN.1 DER conversion", TestRawIntegerToDerValidCases),
@@ -2547,6 +2584,8 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test Group Operation Key Derivation", TestGroup_OperationalKeyDerivation),
     NL_TEST_DEF("Test Group Session ID Derivation", TestGroup_SessionIdDerivation),
     NL_TEST_DEF("Test Group Privacy Key Derivation", TestGroup_PrivacyKeyDerivation),
+    NL_TEST_DEF("Test sensitive data buffer", TestSensitiveDataBuffer),
+    NL_TEST_DEF("Test sensitive data fixed buffer", TestSensitiveDataFixedBuffer),
     NL_TEST_SENTINEL()
 };
 

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
@@ -79,7 +79,7 @@ public:
     CHIP_ERROR GenerateNOC(chip::NodeId nodeId, chip::FabricId fabricId, const chip::CATValues & cats,
         const chip::Crypto::P256PublicKey & pubkey, chip::MutableByteSpan & noc);
 
-    const chip::Crypto::AesCcm128KeySpan GetIPK() { return mIPK.Span(); }
+    const chip::Crypto::IdentityProtectionKeySpan GetIPK() { return mIPK.Span(); }
 
     // Get the root/intermediate X.509 DER certs as a ByteSpan.
     chip::ByteSpan RootCertSpan() const;
@@ -133,7 +133,7 @@ private:
 
     ChipP256KeypairPtr mIssuerKey;
 
-    chip::Crypto::AesCcm128Key mIPK;
+    chip::Crypto::IdentityProtectionKey mIPK;
 
     static const uint32_t kCertificateValiditySecs = 365 * 24 * 60 * 60;
 

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
@@ -249,7 +249,7 @@ void MTROperationalCredentialsDelegate::ExternalNOCChainGenerated(
                 return;
             }
 
-            AesCcm128KeySpan ipk = commissioningParameters.Value().GetIpk().ValueOr(GetIPK());
+            IdentityProtectionKeySpan ipk = commissioningParameters.Value().GetIpk().ValueOr(GetIPK());
 
             Optional<NodeId> adminSubject;
             if (info.adminSubject != nil) {

--- a/src/platform/android/CHIPP256KeypairBridge.cpp
+++ b/src/platform/android/CHIPP256KeypairBridge.cpp
@@ -138,7 +138,7 @@ CHIP_ERROR CHIPP256KeypairBridge::ECDSA_sign_msg(const uint8_t * msg, size_t msg
     }
 
     JniByteArray jniSignature(env, static_cast<jbyteArray>(signedResult));
-    MutableByteSpan signatureSpan(out_signature, out_signature.Capacity());
+    MutableByteSpan signatureSpan(out_signature.Bytes(), out_signature.Capacity());
     ReturnErrorOnFailure(EcdsaAsn1SignatureToRaw(CHIP_CRYPTO_GROUP_SIZE_BYTES, jniSignature.byteSpan(), signatureSpan));
     ReturnErrorOnFailure(out_signature.SetLength(signatureSpan.size()));
 

--- a/src/platform/silabs/EFR32/Efr32PsaOpaqueKeypair.cpp
+++ b/src/platform/silabs/EFR32/Efr32PsaOpaqueKeypair.cpp
@@ -433,7 +433,7 @@ CHIP_ERROR EFR32OpaqueP256Keypair::ECDH_derive_secret(const P256PublicKey & remo
     CHIP_ERROR error     = CHIP_NO_ERROR;
     size_t output_length = 0;
 
-    error = Derive(Uint8::to_const_uchar(remote_public_key), remote_public_key.Length(), Uint8::to_uchar(out_secret),
+    error = Derive(Uint8::to_const_uchar(remote_public_key), remote_public_key.Length(), out_secret.Bytes(),
                    (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length(), &output_length);
 
     SuccessOrExit(error);

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -226,8 +226,8 @@ CHIP_ERROR InitCredentialSets()
         P256SerializedKeypair opKeysSerialized;
 
         // TODO: Rename gCommissioner* to gInitiator*
-        memcpy((uint8_t *) (opKeysSerialized), sTestCert_Node01_02_PublicKey, sTestCert_Node01_02_PublicKey_Len);
-        memcpy((uint8_t *) (opKeysSerialized) + sTestCert_Node01_02_PublicKey_Len, sTestCert_Node01_02_PrivateKey,
+        memcpy(opKeysSerialized.Bytes(), sTestCert_Node01_02_PublicKey, sTestCert_Node01_02_PublicKey_Len);
+        memcpy(opKeysSerialized.Bytes() + sTestCert_Node01_02_PublicKey_Len, sTestCert_Node01_02_PrivateKey,
                sTestCert_Node01_02_PrivateKey_Len);
 
         ReturnErrorOnFailure(opKeysSerialized.SetLength(sTestCert_Node01_02_PublicKey_Len + sTestCert_Node01_02_PrivateKey_Len));
@@ -254,8 +254,8 @@ CHIP_ERROR InitCredentialSets()
         P256SerializedKeypair opKeysSerialized;
 
         auto deviceOpKey = Platform::MakeUnique<Crypto::P256Keypair>();
-        memcpy((uint8_t *) (opKeysSerialized), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
-        memcpy((uint8_t *) (opKeysSerialized) + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
+        memcpy(opKeysSerialized.Bytes(), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
+        memcpy(opKeysSerialized.Bytes() + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
                sTestCert_Node01_01_PrivateKey_Len);
 
         ReturnErrorOnFailure(opKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));

--- a/src/protocols/secure_channel/tests/TestDefaultSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/tests/TestDefaultSessionResumptionStorage.cpp
@@ -92,7 +92,8 @@ void TestSave(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT(inSuite,
                        sessionStorage.FindByScopedNodeId(vector.node, outResumptionId, outSharedSecret, outCats) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, memcmp(vector.resumptionId.data(), outResumptionId.data(), vector.resumptionId.size()) == 0);
-        NL_TEST_ASSERT(inSuite, memcmp(vector.sharedSecret.ConstBytes(), outSharedSecret, vector.sharedSecret.Length()) == 0);
+        NL_TEST_ASSERT(inSuite,
+                       memcmp(vector.sharedSecret.ConstBytes(), outSharedSecret.ConstBytes(), vector.sharedSecret.Length()) == 0);
         NL_TEST_ASSERT(inSuite, vector.cats.values[0] == outCats.values[0]);
         NL_TEST_ASSERT(inSuite, vector.cats.values[1] == outCats.values[1]);
         NL_TEST_ASSERT(inSuite, vector.cats.values[2] == outCats.values[2]);
@@ -101,7 +102,8 @@ void TestSave(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT(inSuite,
                        sessionStorage.FindByResumptionId(vector.resumptionId, outNode, outSharedSecret, outCats) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, vector.node == outNode);
-        NL_TEST_ASSERT(inSuite, memcmp(vector.sharedSecret.Bytes(), outSharedSecret, vector.sharedSecret.Length()) == 0);
+        NL_TEST_ASSERT(inSuite,
+                       memcmp(vector.sharedSecret.Bytes(), outSharedSecret.ConstBytes(), vector.sharedSecret.Length()) == 0);
         NL_TEST_ASSERT(inSuite, vector.cats.values[0] == outCats.values[0]);
         NL_TEST_ASSERT(inSuite, vector.cats.values[1] == outCats.values[1]);
         NL_TEST_ASSERT(inSuite, vector.cats.values[2] == outCats.values[2]);
@@ -173,7 +175,9 @@ void TestInPlaceSave(nlTestSuite * inSuite, void * inContext)
                            CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite,
                        memcmp(vectors[i].resumptionId.data(), outResumptionId.data(), vectors[i].resumptionId.size()) == 0);
-        NL_TEST_ASSERT(inSuite, memcmp(vectors[i].sharedSecret.Bytes(), outSharedSecret, vectors[i].sharedSecret.Length()) == 0);
+        NL_TEST_ASSERT(
+            inSuite,
+            memcmp(vectors[i].sharedSecret.ConstBytes(), outSharedSecret.ConstBytes(), vectors[i].sharedSecret.Length()) == 0);
         NL_TEST_ASSERT(inSuite, vectors[i].cats.values[0] == outCats.values[0]);
         NL_TEST_ASSERT(inSuite, vectors[i].cats.values[1] == outCats.values[1]);
         NL_TEST_ASSERT(inSuite, vectors[i].cats.values[2] == outCats.values[2]);
@@ -183,7 +187,9 @@ void TestInPlaceSave(nlTestSuite * inSuite, void * inContext)
                        sessionStorage.FindByResumptionId(vectors[i].resumptionId, outNode, outSharedSecret, outCats) ==
                            CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, vectors[i].node == outNode);
-        NL_TEST_ASSERT(inSuite, memcmp(vectors[i].sharedSecret.Bytes(), outSharedSecret, vectors[i].sharedSecret.Length()) == 0);
+        NL_TEST_ASSERT(
+            inSuite,
+            memcmp(vectors[i].sharedSecret.ConstBytes(), outSharedSecret.ConstBytes(), vectors[i].sharedSecret.Length()) == 0);
         NL_TEST_ASSERT(inSuite, vectors[i].cats.values[0] == outCats.values[0]);
         NL_TEST_ASSERT(inSuite, vectors[i].cats.values[1] == outCats.values[1]);
         NL_TEST_ASSERT(inSuite, vectors[i].cats.values[2] == outCats.values[2]);
@@ -211,7 +217,9 @@ void TestInPlaceSave(nlTestSuite * inSuite, void * inContext)
                            CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite,
                        memcmp(vectors[i].resumptionId.data(), outResumptionId.data(), vectors[i].resumptionId.size()) == 0);
-        NL_TEST_ASSERT(inSuite, memcmp(vectors[i].sharedSecret.Bytes(), outSharedSecret, vectors[i].sharedSecret.Length()) == 0);
+        NL_TEST_ASSERT(
+            inSuite,
+            memcmp(vectors[i].sharedSecret.ConstBytes(), outSharedSecret.ConstBytes(), vectors[i].sharedSecret.Length()) == 0);
         NL_TEST_ASSERT(inSuite, vectors[i].cats.values[0] == outCats.values[0]);
         NL_TEST_ASSERT(inSuite, vectors[i].cats.values[1] == outCats.values[1]);
         NL_TEST_ASSERT(inSuite, vectors[i].cats.values[2] == outCats.values[2]);
@@ -221,7 +229,9 @@ void TestInPlaceSave(nlTestSuite * inSuite, void * inContext)
                        sessionStorage.FindByResumptionId(vectors[i].resumptionId, outNode, outSharedSecret, outCats) ==
                            CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, vectors[i].node == outNode);
-        NL_TEST_ASSERT(inSuite, memcmp(vectors[i].sharedSecret.Bytes(), outSharedSecret, vectors[i].sharedSecret.Length()) == 0);
+        NL_TEST_ASSERT(
+            inSuite,
+            memcmp(vectors[i].sharedSecret.ConstBytes(), outSharedSecret.ConstBytes(), vectors[i].sharedSecret.Length()) == 0);
         NL_TEST_ASSERT(inSuite, vectors[i].cats.values[0] == outCats.values[0]);
         NL_TEST_ASSERT(inSuite, vectors[i].cats.values[1] == outCats.values[1]);
         NL_TEST_ASSERT(inSuite, vectors[i].cats.values[2] == outCats.values[2]);

--- a/src/tools/chip-cert/Cmd_GenCD.cpp
+++ b/src/tools/chip-cert/Cmd_GenCD.cpp
@@ -995,7 +995,7 @@ CHIP_ERROR EncodeSignerInfo_Ignor_Error(const ByteSpan & signerKeyId, const P256
 
             uint8_t asn1SignatureBuf[kMax_ECDSA_Signature_Length_Der];
             MutableByteSpan asn1Signature(asn1SignatureBuf);
-            ReturnErrorOnFailure(EcdsaRawSignatureToAsn1(kP256_FE_Length, ByteSpan(signature, signature.Length()), asn1Signature));
+            ReturnErrorOnFailure(EcdsaRawSignatureToAsn1(kP256_FE_Length, signature.Span(), asn1Signature));
 
             if (!cdConfig.IsCMSSignatureCorrect())
             {

--- a/src/transport/CryptoContext.cpp
+++ b/src/transport/CryptoContext.cpp
@@ -129,7 +129,7 @@ CHIP_ERROR CryptoContext::InitFromKeyPair(const Crypto::P256Keypair & local_keyp
     P256ECDHDerivedSecret secret;
     ReturnErrorOnFailure(local_keypair.ECDH_derive_secret(remote_public_key, secret));
 
-    return InitFromSecret(ByteSpan(secret, secret.Length()), salt, infoType, role);
+    return InitFromSecret(secret.Span(), salt, infoType, role);
 }
 
 CHIP_ERROR CryptoContext::BuildNonce(NonceView nonce, uint8_t securityFlags, uint32_t messageCounter, NodeId nodeId)


### PR DESCRIPTION
`AesCcm128Key`, despite its name, is currently only used for Identity Protection Key. Additionally, it has very similar interface to `CapacityBoundBuffer`.

Rename `CapacityBoundBuffer` to `SensitiveDataBuffer` to better describe its purpose and add `SensitiveDataFixedBuffer` for fixed-size contents. Align interfaces of these two and implicit cast operators for better type safety.

Finally, replace `AesCcm128Key` with new `IdentityProtectionKey` type alias defined as `SensitiveDataFixedBuffer<
CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES>`. Removing `AesCcm128Key` was requested when reviewing https://github.com/project-chip/connectedhomeip/pull/23792 which adds another AES key handle type.
