### PR TITLE
doc: orphan examples/nxp/doc/manufacturing_flow.md

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 # Configuration file for the Sphinx documentation builder.
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 # -- Paths -------------------------------------------------------------------
 
@@ -29,7 +29,6 @@ exclude_patterns = [
     "examples/ota-requestor-app/efr32/README.md",
     "**/android/App/app/libs*",
     "examples/providers/README.md",
-    "examples/platform/nxp/doc/manufacturing_flow.md",
     "examples/thermostat/nxp/linux-se05x/README.md",
 ]
 
@@ -72,7 +71,5 @@ external_content_link_prefixes = [
     "CONTRIBUTING",
     "scripts/",
     "examples/android/",
-    "examples/platform/",
-    "platform",
 ]
 external_content_link_extensions = [".md", ".png", ".jpg", ".svg"]

--- a/examples/persistent-storage/qpg/APPLICATION.md
+++ b/examples/persistent-storage/qpg/APPLICATION.md
@@ -25,7 +25,7 @@ This application does not have any LED output.
 
 ## Logging Output
 
--   See [View Logging Output](../../platform/qpg/README.md#view-logging-output)
+-   See [View Logging Output](../../platform/qpg/README.md)
 -   At startup you will see:
 
 ```

--- a/examples/platform/nxp/doc/manufacturing_flow.md
+++ b/examples/platform/nxp/doc/manufacturing_flow.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 ## Manufacturing data
 
 By default, the example application is configured to use generic test
@@ -110,5 +114,3 @@ possible for a final stage application to generate its own manufacturing data:
         out_dut1.bin/out2_dut2.bin contains the corresponding DACs/PAIs generated using generate_nxp_chip_factory_bin.py script. The discriminator is 14014 and the passcode is 1000.
 
         These demo certificates are working with the CDs installed in CHIPProjectConfig.h.
-
-    <a name="flashdebug"></a>


### PR DESCRIPTION
Orphan a markdown file previously ignored by sphinx. This allows the examples/platform folder to be picked up by Sphinx so that links to its content do not have to be made into external links.

This previously made some images not render in the documentation.
Additionally fixed a broken section link in the platform folder.

Signed-off-by: Gaute Svanes Lunde <gaute.lunde@nordicsemi.no>

