### PR TITLE
Fix dynamic bridge metadata init order after #24336

### DIFF
--- a/examples/dynamic-bridge-app/linux/include/data-model/Attribute.h
+++ b/examples/dynamic-bridge-app/linux/include/data-model/Attribute.h
@@ -35,7 +35,7 @@ struct Attribute : public AttributeInterface
 {
     Attribute(chip::CharSpan name, chip::AttributeId id, EmberAfAttributeMask mask, EmberAfAttributeType type, size_t size,
               Type value = Type()) :
-        mMetadata(EmberAfAttributeMetadata{ id, type, (uint16_t) size, mask, ZAP_EMPTY_DEFAULT() }),
+        mMetadata(EmberAfAttributeMetadata{ ZAP_EMPTY_DEFAULT(), id, (uint16_t) size, type, mask }),
         mData(value), mName(name)
     {}
 


### PR DESCRIPTION
Clang detected invalid initialization ordering in bridge app. Fixing it.
