### PR TITLE
Allow using MTROperationalCertificateIssuer but letting the Matter framework perform device attestation checks.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -561,7 +561,7 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
         BOOL usePartialDACVerifier = NO;
         if (operationalCertificateIssuer != nil) {
             self->_operationalCredentialsDelegate->SetOperationalCertificateIssuer(operationalCertificateIssuer, queue);
-            usePartialDACVerifier = operationalCertificateIssuer.skipTrustAnchorDeviceAttestationChecks;
+            usePartialDACVerifier = operationalCertificateIssuer.shouldSkipAttestationCertificateValidation;
         }
         if (usePartialDACVerifier) {
             self->_cppCommissioner->SetDeviceAttestationVerifier(self->_partialDACVerifier);
@@ -925,7 +925,7 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
  */
 @interface MTROperationalCertificateChainIssuerShim : NSObject <MTROperationalCertificateIssuer>
 @property (nonatomic, readonly) id<MTRNOCChainIssuer> nocChainIssuer;
-@property (nonatomic, readonly) BOOL skipTrustAnchorDeviceAttestationChecks;
+@property (nonatomic, readonly) BOOL shouldSkipAttestationCertificateValidation;
 - (instancetype)initWithIssuer:(id<MTRNOCChainIssuer>)nocChainIssuer;
 @end
 
@@ -934,7 +934,7 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
 {
     if (self = [super init]) {
         _nocChainIssuer = nocChainIssuer;
-        _skipTrustAnchorDeviceAttestationChecks = YES;
+        _shouldSkipAttestationCertificateValidation = YES;
     }
     return self;
 }

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -561,7 +561,7 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
         BOOL usePartialDACVerifier = NO;
         if (operationalCertificateIssuer != nil) {
             self->_operationalCredentialsDelegate->SetOperationalCertificateIssuer(operationalCertificateIssuer, queue);
-            usePartialDACVerifier = [operationalCertificateIssuer skipTrustAnchorDeviceAttestationChecks];
+            usePartialDACVerifier = operationalCertificateIssuer.skipTrustAnchorDeviceAttestationChecks;
         }
         if (usePartialDACVerifier) {
             self->_cppCommissioner->SetDeviceAttestationVerifier(self->_partialDACVerifier);
@@ -925,6 +925,7 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
  */
 @interface MTROperationalCertificateChainIssuerShim : NSObject <MTROperationalCertificateIssuer>
 @property (nonatomic, readonly) id<MTRNOCChainIssuer> nocChainIssuer;
+@property (nonatomic, readonly) BOOL skipTrustAnchorDeviceAttestationChecks;
 - (instancetype)initWithIssuer:(id<MTRNOCChainIssuer>)nocChainIssuer;
 @end
 
@@ -933,6 +934,7 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
 {
     if (self = [super init]) {
         _nocChainIssuer = nocChainIssuer;
+        _skipTrustAnchorDeviceAttestationChecks = YES;
     }
     return self;
 }
@@ -973,11 +975,6 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
                 *error = nil;
             }
         }];
-}
-
-- (BOOL)skipTrustAnchorDeviceAttestationChecks
-{
-    return YES;
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -558,8 +558,12 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
     }
 
     auto block = ^{
+        BOOL usePartialDACVerifier = NO;
         if (operationalCertificateIssuer != nil) {
             self->_operationalCredentialsDelegate->SetOperationalCertificateIssuer(operationalCertificateIssuer, queue);
+            usePartialDACVerifier = [operationalCertificateIssuer skipTrustAnchorDeviceAttestationChecks];
+        }
+        if (usePartialDACVerifier) {
             self->_cppCommissioner->SetDeviceAttestationVerifier(self->_partialDACVerifier);
         } else {
             // TODO: Once we are not supporting setNocChainIssuer this
@@ -969,6 +973,11 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
                 *error = nil;
             }
         }];
+}
+
+- (BOOL)skipTrustAnchorDeviceAttestationChecks
+{
+    return YES;
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
@@ -193,17 +193,6 @@ NS_ASSUME_NONNULL_BEGIN
  * when commmissioning devices.  Allowed to be nil if this controller either
  * does not issue operational certificates at all or internally generates the
  * certificates to be issued.  In the latter case, nocSigner must not be nil.
- *
- * When this property is non-nill, all device attestation checks that require
- * some sort of trust anchors are delegated to the operationalCertificateIssuer.
- * Specifically, the following device attestation checks are not performed and
- * must be done by the operationalCertificateIssuer:
- *
- * (1) Make sure the PAA is valid and approved by CSA.
- * (2) VID-scoped PAA check: if the PAA is VID scoped, then its VID must match the DAC VID.
- * (3) cert chain check: verify PAI is signed by PAA, and DAC is signed by PAI.
- * (4) PAA subject key id extraction: the PAA subject key must match the PAA key referenced in the PAI.
- * (5) CD signature check: make sure a valid CSA CD key is used to sign the CD.
  */
 @property (nonatomic, strong, nullable) id<MTROperationalCertificateIssuer> operationalCertificateIssuer MTR_NEWLY_AVAILABLE;
 

--- a/src/darwin/Framework/CHIP/MTROperationalCertificateIssuer.h
+++ b/src/darwin/Framework/CHIP/MTROperationalCertificateIssuer.h
@@ -100,7 +100,7 @@ MTR_NEWLY_AVAILABLE
  * This will be read on an arbitrary queue and must not block or call any
  * Matter APIs.
  */
-@property (nonatomic, readonly) BOOL skipTrustAnchorDeviceAttestationChecks;
+@property (nonatomic, readonly) BOOL shouldSkipAttestationCertificateValidation;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTROperationalCertificateIssuer.h
+++ b/src/darwin/Framework/CHIP/MTROperationalCertificateIssuer.h
@@ -66,11 +66,41 @@ MTR_NEWLY_AVAILABLE
  * and resume when the completion is invoked with a non-nil
  * MTROperationalCertificateInfo.  When the completion is invoked with an error,
  * commissioning will fail.
+ *
+ * This will be called on the dispatch queue passed as
+ * operationalCertificateIssuerQueue in the MTRDeviceControllerFactoryParams.
  */
 - (void)issueOperationalCertificateForRequest:(MTROperationalCSRInfo *)csrInfo
                               attestationInfo:(MTRAttestationInfo *)attestationInfo
                                    controller:(MTRDeviceController *)controller
                                    completion:(MTROperationalCertificateIssuedHandler)completion;
+
+/**
+ * A way for MTROperationalCertificateIssuer to control whether it wants the
+ * Matter framework to perform device attestation checks that require trust
+ * anchors.  If this returns NO, then productAttestationAuthorityCertificates
+ * should be passed in via MTRDeviceControllerFactoryParams, as well as any
+ * desired additional certificationDeclarationCertificates.
+ *
+ * If this returns YES, then all device attestation checks that require some
+ * sort of trust anchors are delegated to this MTROperationalCertificateIssuer,
+ * which can use the arguments passed to
+ * issueOperationalCertificateForRequest:attestationInfo:controller:completion:
+ * to perform the checks.
+ *
+ * Specifically, the following device attestation checks are not performed and
+ * must be done by the MTROperationalCertificateIssuer:
+ *
+ * (1) Make sure the PAA is valid and approved by CSA.
+ * (2) VID-scoped PAA check: if the PAA is VID scoped, then its VID must match the DAC VID.
+ * (3) cert chain check: verify PAI is signed by PAA, and DAC is signed by PAI.
+ * (4) PAA subject key id extraction: the PAA subject key must match the PAA key referenced in the PAI.
+ * (5) CD signature check: make sure a valid CSA CD key is used to sign the CD.
+ *
+ * This will be called on an arbitrary queue and must not block or call any
+ * Matter APIs.
+ */
+- (BOOL)skipTrustAnchorDeviceAttestationChecks;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTROperationalCertificateIssuer.h
+++ b/src/darwin/Framework/CHIP/MTROperationalCertificateIssuer.h
@@ -97,10 +97,10 @@ MTR_NEWLY_AVAILABLE
  * (4) PAA subject key id extraction: the PAA subject key must match the PAA key referenced in the PAI.
  * (5) CD signature check: make sure a valid CSA CD key is used to sign the CD.
  *
- * This will be called on an arbitrary queue and must not block or call any
+ * This will be read on an arbitrary queue and must not block or call any
  * Matter APIs.
  */
-- (BOOL)skipTrustAnchorDeviceAttestationChecks;
+@property (nonatomic, readonly) BOOL skipTrustAnchorDeviceAttestationChecks;
 
 @end
 


### PR DESCRIPTION
This gives MTROperationalCertificateIssuer implementations control over whether they want to take over the device attestation checks that require roots of trust or whether they want to allow Matter.framework to perform those checks itself, using the roots of trust it was provided.

Fixes https://github.com/project-chip/connectedhomeip/issues/24310
