### PR TITLE
Stop holding a reference into a temporary.

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -100,7 +100,7 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
 
     if (params.GetCountryCode().HasValue())
     {
-        auto & code = params.GetCountryCode().Value();
+        auto code = params.GetCountryCode().Value();
         MutableCharSpan copiedCode(mCountryCode);
         if (CopyCharSpanToMutableCharSpan(code, copiedCode) == CHIP_NO_ERROR)
         {


### PR DESCRIPTION
This was drive-by fixed on tip by
https://github.com/project-chip/connectedhomeip/pull/23827 but we should fix on 1.0 too.

Fixes #24367

