### PR TITLE
Fix indent in chip.configuration python module

### DIFF
--- a/src/controller/python/chip/configuration/__init__.py
+++ b/src/controller/python/chip/configuration/__init__.py
@@ -61,11 +61,11 @@ def SetCommissionerCAT(cat: int):
 
 
 def GetCommissionerCAT() -> int:
- """Returns the current local (controllers/commissioning) device CAT. If none has been set,
-    a default is set and used."""
-  global _local_cat
+    """Returns the current local (controllers/commissioning) device CAT. If none has been set,
+       a default is set and used."""
+    global _local_cat
 
-   if _local_cat is None:
+    if _local_cat is None:
         SetCommissionerCAT(DEFAULT_COMMISSIONER_CAT)
 
     return _local_cat


### PR DESCRIPTION
The GetCommissionerCAT function body has wrong indent, which breaks the import of the package.

```
❯ python __init__.py
  File "/tmp/connectedhomeip/src/controller/python/chip/configuration/__init__.py", line 66
    global _local_cat
IndentationError: unexpected indent
```