### PR TITLE
[ESP32] Add menuconfig options for reboot on OTA image apply

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -171,6 +171,20 @@ menu "CHIP Core"
             help
                 Enable this option to enable OTA Requestor for example
 
+        config OTA_AUTO_REBOOT_ON_APPLY
+            bool "Reboot the device after applying the OTA image"
+            depends on ENABLE_OTA_REQUESTOR
+            default y
+            help
+                Enable this option to reboot the device after applying the new image.
+
+        config OTA_AUTO_REBOOT_DELAY_MS
+            int "OTA reboot delay time (ms)"
+            depends on OTA_AUTO_REBOOT_ON_APPLY
+            default 5000
+            help
+                The delay time for OTA reboot on applying.
+
     endmenu # "System Options"
 
     menu "Security Options"

--- a/src/platform/ESP32/OTAImageProcessorImpl.cpp
+++ b/src/platform/ESP32/OTAImageProcessorImpl.cpp
@@ -245,8 +245,12 @@ void OTAImageProcessorImpl::HandleApply(intptr_t context)
 
     PostOTAStateChangeEvent(DeviceLayer::kOtaApplyComplete);
 
+#if CONFIG_OTA_AUTO_REBOOT_ON_APPLY
     // HandleApply is called after delayed action time seconds are elapsed, so it would be safe to schedule the restart
-    DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(2 * 1000), HandleRestart, nullptr);
+    DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(CONFIG_OTA_AUTO_REBOOT_DELAY_MS), HandleRestart, nullptr);
+#else
+    ESP_LOGI(TAG, "Please reboot the device manually to apply the new image");
+#endif
 }
 
 CHIP_ERROR OTAImageProcessorImpl::SetBlock(ByteSpan & block)


### PR DESCRIPTION
Sometimes the StateTransition event `Applying` might be missed because the reboot time is too short on ESP32 platform.

Add the rebooting options for OTA image apply.

Tested OTA on ESP32C3 the event report can be received after setting a longer reboot time.