### PR TITLE
[Tizen] Do not log binary buffer with `%s`

### DIFF
--- a/src/platform/Tizen/AppPreference.cpp
+++ b/src/platform/Tizen/AppPreference.cpp
@@ -30,6 +30,7 @@
 #include <lib/support/Base64.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
+#include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 namespace chip {
@@ -85,7 +86,9 @@ CHIP_ERROR GetData(const char * key, void * data, size_t dataSize, size_t * getD
     }
     ::memcpy(data, decodedData.Get() + offset, copySize);
 
-    ChipLogProgress(DeviceLayer, "Get data [%s:%.*s]", key, static_cast<int>(copySize), static_cast<char *>(data));
+    ChipLogDetail(DeviceLayer, "Get data [%s]: %u", key, static_cast<unsigned int>(copySize));
+    ChipLogByteSpan(DeviceLayer, ByteSpan(reinterpret_cast<uint8_t *>(data), copySize));
+
     return CHIP_NO_ERROR;
 }
 
@@ -111,7 +114,9 @@ CHIP_ERROR SaveData(const char * key, const void * data, size_t dataSize)
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    ChipLogProgress(DeviceLayer, "Save data [%s:%.*s]", key, static_cast<int>(dataSize), static_cast<const char *>(data));
+    ChipLogDetail(DeviceLayer, "Save data [%s]: %u", key, static_cast<unsigned int>(dataSize));
+    ChipLogByteSpan(DeviceLayer, ByteSpan(reinterpret_cast<const uint8_t *>(data), dataSize));
+
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
### Problem

Printing binary buffer with `%s` might lead to Tizen logger corruption, so no more logs will be readable after such accident, e.g.:

```
INFO    I/CHIP    (  819): FP: Metadata for Fabric 0x1 persisted to storage.
INFO    I/CHIP    (  819): DL: Save data [f/1/o:$]
INFO    I/CHIP    (  819): DL: Save data [f/1/n:0$7$&Ç"ü'&Ç%M:7$$$0     A0ø├.▓ÿ¨Zõd=éWÚEù±¯­¾▀àÿµ▒╩╦MÚÝ*súÏR`»W¤p´6Þ»Q!╬r╦3î·¦+*Î7
INFO    I/CHIP    (  819): 5($60!¹)(=V■"-KÅ(Yö W▮╗×Í°┌1IÑ⎽î§␌ðA└▮1³¯▮
                                                                     @⎼¦┘!$È5Î╬ı↑E┴
INFO    I/CHIP    (  819): V┘ûØ4>ıûá←$¦├¨Ù
                                          ²öÇØ¢┘ºÁ◆▓<┼I%¼↑ÑU┼ÃÝ░WìK
INFO    I/CHIP    (  819): DL: S▒┴␊ ␍▒├▒ [°/1/␋:▮$7$&Ç"ü'&Ç%M:7$$▮      A^¢Û^▄çX╠Ë©I£┌E╣à␊(┌BÐø%Ì#6┴7]
INFO    I/CHIP    (  819): DL: S▒┴␊ ␍▒├▒ [°/1/⎼:▮$7$&Ç"ü'&Ç%M:7$$▮      AÆ*º[5[Ì*␍Îð┐LÈ■SþJÎ°ï¤↓≠L1┐≥¨#NW¨EüB
```

### Changes

- print binary data with `ChipLogByteSpan`

### Testing

Tested locally. After this patch Tizen logger no longer gets corrupted.