### PR TITLE
[scripts] Reduce number of submodules checked out on boostrap

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -30,11 +30,14 @@ _bootstrap_or_activate() {
         _CONFIG_FILE="$PW_CONFIG_FILE"
     fi
 
-    if [ "$_BOOTSTRAP_NAME" = "bootstrap.sh" ] ||
-        [ ! -f "$_CHIP_ROOT/third_party/pigweed/repo/pw_env_setup/util.sh" ]; then
+    if [ ! -f "$_CHIP_ROOT/third_party/pigweed/repo/pw_env_setup/util.sh" ]; then
         # Make sure our submodule remotes are correct for this revision.
         git submodule sync --recursive
         git submodule update --init
+    elif [ "$_BOOTSTRAP_NAME" = "bootstrap.sh" ]; then
+        # In this case, only update already checked out submodules.
+        git submodule sync --recursive
+        git submodule update
     fi
 
     PW_BRANDING_BANNER="$_CHIP_ROOT/scripts/matter_banner.txt"

--- a/scripts/checkout_submodules.py
+++ b/scripts/checkout_submodules.py
@@ -60,15 +60,19 @@ def load_module_info() -> None:
             platforms = module.get('platforms', '').split(',')
             platforms = set(filter(None, platforms))
             assert not (platforms - ALL_PLATFORMS), "Submodule's platform not contained in ALL_PLATFORMS"
+            name = name.replace('submodule "', '').replace('"', '')
             yield Module(name=name, path=module['path'], platforms=platforms)
 
 
 def module_matches_platforms(module: Module, platforms: set) -> bool:
-    # If no platforms have been selected, or the module is not associated with any specific
-    # platforms, treat it as a match.
-    if not platforms or not module.platforms:
+    # If the module is not associated with any specific platform, treat it as a match.
+    if not module.platforms:
         return True
     return bool(platforms & module.platforms)
+
+
+def module_initialized(module: Module) -> bool:
+    return bool(os.listdir(module.path))
 
 
 def make_chip_root_safe_directory() -> None:
@@ -77,11 +81,10 @@ def make_chip_root_safe_directory() -> None:
 
 
 def checkout_modules(modules: list, shallow: bool, force: bool, recursive: bool) -> None:
-    names = [module.name.replace('submodule "', '').replace('"', '') for module in modules]
-    names = ', '.join(names)
+    names = ', '.join([module.name for module in modules])
     logging.info(f'Checking out: {names}')
 
-    cmd = ['git', '-C', CHIP_ROOT, 'submodule', 'update', '--init']
+    cmd = ['git', '-C', CHIP_ROOT, 'submodule', '--quiet', 'update', '--init']
     cmd += ['--depth', '1'] if shallow else []
     cmd += ['--force'] if force else []
     cmd += ['--recursive'] if recursive else []
@@ -91,11 +94,10 @@ def checkout_modules(modules: list, shallow: bool, force: bool, recursive: bool)
 
 
 def deinit_modules(modules: list, force: bool) -> None:
-    names = [module.name.replace('submodule "', '').replace('"', '') for module in modules]
-    names = ', '.join(names)
+    names = ', '.join([module.name for module in modules])
     logging.info(f'Deinitializing: {names}')
 
-    cmd = ['git', '-C', CHIP_ROOT, 'submodule', 'deinit']
+    cmd = ['git', '-C', CHIP_ROOT, 'submodule', '--quiet', 'deinit']
     cmd += ['--force'] if force else []
     cmd += [module.path for module in modules]
 
@@ -118,12 +120,13 @@ def main():
     modules = list(load_module_info())
     selected_platforms = set(args.platform)
     selected_modules = [m for m in modules if module_matches_platforms(m, selected_platforms)]
-    unmatched_modules = [m for m in modules if not module_matches_platforms(m, selected_platforms)]
+    unmatched_modules = [m for m in modules if not module_matches_platforms(
+        m, selected_platforms) and module_initialized(m)]
 
     make_chip_root_safe_directory()
     checkout_modules(selected_modules, args.shallow, args.force, args.recursive)
 
-    if args.deinit_unmatched:
+    if args.deinit_unmatched and unmatched_modules:
         deinit_modules(unmatched_modules, args.force)
 
 


### PR DESCRIPTION
When bootstrap.sh is run on a respository that has pigweed submodule already checked out, only update user-initialized submodules but do not initialize new ones. This is to respect user's choice not to import gigabytes of unnecessary submodules.

When checkout_submodules.py script is called without specifying platforms, by default only checkout common submodules, not associated with any specific platform. By the way, reduce the number of debug logs in the script.