### PR TITLE
[nrfconnect] Fix CMake error when two Python versions are installed

### DIFF
--- a/config/nrfconnect/app/check-nrfconnect-version.cmake
+++ b/config/nrfconnect/app/check-nrfconnect-version.cmake
@@ -14,15 +14,23 @@
 #   limitations under the License.
 #
 
-find_package(Python3 REQUIRED)
+# This function is only needed to prevent find_package from polluting the global
+# variable namespace before loading Zephyr CMake module. Without this workaround
+# the build may fail because Zephyr calls find_package(Python3) with different
+# constraints and CMake is not able to handle such a scenario.
+function(check_nrfconnect_version)
+    find_package(Python3 REQUIRED)
 
-# Check nRF Connect SDK version in the CMake configuration phase
-execute_process(
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../../..
-    COMMAND ${Python3_EXECUTABLE} scripts/setup/nrfconnect/update_ncs.py --check --quiet)
+    # Check nRF Connect SDK version in the CMake configuration phase
+    execute_process(
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../../..
+        COMMAND ${Python3_EXECUTABLE} scripts/setup/nrfconnect/update_ncs.py --check --quiet)
 
-# Check nRF Connect SDK version in the build phase
-add_custom_target(check-nrfconnect-version ALL
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../../..
-    COMMAND ${Python3_EXECUTABLE} scripts/setup/nrfconnect/update_ncs.py --check --quiet || (exit 0)
-    USES_TERMINAL)
+    # Check nRF Connect SDK version in the build phase
+    add_custom_target(check-nrfconnect-version ALL
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../../..
+        COMMAND ${Python3_EXECUTABLE} scripts/setup/nrfconnect/update_ncs.py --check --quiet || (exit 0)
+        USES_TERMINAL)
+endfunction()
+
+check_nrfconnect_version()


### PR DESCRIPTION
When pigweed virtual environment is used, and the pigweed's Python is older than python installed in the system, build might fail because find_package(Python3) would select the system Python while find_package(Python3 ...) invoked by Zephyr would use different constraints that select the pigweed Python. It turns out CMake does not like calling find_package() with different constraints in the same scope.