### PR TITLE
Fix cast for error: CHIP_ERROR is not an integer without explicit cast

### DIFF
--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -113,7 +113,8 @@ void GetConnectedDeviceCallback::OnDeviceConnectionFailureFn(void * context, con
     JniClass controllerExceptionJniCls(controllerExceptionCls);
 
     jmethodID exceptionConstructor = env->GetMethodID(controllerExceptionCls, "<init>", "(ILjava/lang/String;)V");
-    jobject exception = env->NewObject(controllerExceptionCls, exceptionConstructor, error, env->NewStringUTF(ErrorStr(error)));
+    jobject exception =
+        env->NewObject(controllerExceptionCls, exceptionConstructor, error.AsInteger(), env->NewStringUTF(ErrorStr(error)));
 
     DeviceLayer::StackUnlock unlock;
     env->CallVoidMethod(javaCallback, failureMethod, peerId.GetNodeId(), exception);


### PR DESCRIPTION
JNI layer finds a method expecting an integer, but passes in a CHIP_ERROR struct.

Original problem found and fixed by @gmarcosb, I am creating a stand-alone patch for this to be checked in faster.
