### PR TITLE
[chip-tool] Add support for unordered commands/attributes arguments formatted a…

### DIFF
--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -32,7 +32,7 @@ public:
 
     void Register(const char * clusterName, commands_list commandsList);
     int Run(int argc, char ** argv);
-    int RunInteractive(int argc, char ** argv);
+    int RunInteractive(const char * command);
 
 private:
     CHIP_ERROR RunCommand(int argc, char ** argv, bool interactive = false);
@@ -49,6 +49,10 @@ private:
     void ShowClusterAttributes(std::string executable, std::string clusterName, std::string commandName, CommandsVector & commands);
     void ShowClusterEvents(std::string executable, std::string clusterName, std::string commandName, CommandsVector & commands);
     void ShowCommand(std::string executable, std::string clusterName, Command * command);
+
+    bool DecodeArgumentsFromInteractiveMode(const char * command, std::vector<std::string> & args);
+    bool DecodeArgumentsFromBase64EncodedJson(const char * encodedData, std::vector<std::string> & args);
+    bool DecodeArgumentsFromStringStream(const char * command, std::vector<std::string> & args);
 
     std::map<std::string, CommandsVector> mClusters;
 #ifdef CONFIG_USE_LOCAL_STORAGE

--- a/examples/chip-tool/commands/common/CustomStringPrefix.h
+++ b/examples/chip-tool/commands/common/CustomStringPrefix.h
@@ -18,11 +18,27 @@
 
 #pragma once
 
+static constexpr char kJsonStringPrefix[] = "json:";
+constexpr size_t kJsonStringPrefixLen     = ArraySize(kJsonStringPrefix) - 1; // Don't count the null
+
+static constexpr char kBase64StringPrefix[] = "base64:";
+constexpr size_t kBase64StringPrefixLen     = ArraySize(kBase64StringPrefix) - 1; // Don't count the null
+
 static constexpr char kHexStringPrefix[] = "hex:";
 constexpr size_t kHexStringPrefixLen     = ArraySize(kHexStringPrefix) - 1; // Don't count the null
 
 static constexpr char kStrStringPrefix[] = "str:";
 constexpr size_t kStrStringPrefixLen     = ArraySize(kStrStringPrefix) - 1; // Don't count the null
+
+inline bool IsJsonString(const char * str)
+{
+    return strncmp(str, kJsonStringPrefix, kJsonStringPrefixLen) == 0;
+}
+
+inline bool IsBase64String(const char * str)
+{
+    return strncmp(str, kBase64StringPrefix, kBase64StringPrefixLen) == 0;
+}
 
 inline bool IsHexString(const char * str)
 {

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -21,12 +21,8 @@
 #include <platform/logging/LogV.h>
 
 #include <editline.h>
-#include <iomanip>
-#include <sstream>
 
-char kInteractiveModeName[]                            = "";
 constexpr const char * kInteractiveModePrompt          = ">>> ";
-constexpr uint8_t kInteractiveModeArgumentsMaxLength   = 32;
 constexpr const char * kInteractiveModeHistoryFilePath = "/tmp/chip_tool_history";
 constexpr const char * kInteractiveModeStopCommand     = "quit()";
 
@@ -114,31 +110,7 @@ bool InteractiveCommand::ParseCommand(char * command)
         return false;
     }
 
-    char * args[kInteractiveModeArgumentsMaxLength];
-    args[0]       = kInteractiveModeName;
-    int argsCount = 1;
-    std::string arg;
-
-    std::stringstream ss(command);
-    while (ss >> std::quoted(arg, '\''))
-    {
-        if (argsCount == kInteractiveModeArgumentsMaxLength)
-        {
-            ChipLogError(chipTool, "Too many arguments. Ignoring.");
-            return true;
-        }
-
-        char * carg = new char[arg.size() + 1];
-        strcpy(carg, arg.c_str());
-        args[argsCount++] = carg;
-    }
-
     ClearLine();
-    mHandler->RunInteractive(argsCount, args);
-
-    // Do not delete arg[0]
-    while (--argsCount)
-        delete[] args[argsCount];
-
+    mHandler->RunInteractive(command);
     return true;
 }

--- a/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
+++ b/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
@@ -21,12 +21,8 @@
 #include <platform/logging/LogV.h>
 
 #include <editline.h>
-#include <iomanip>
-#include <sstream>
 
-char kInteractiveModeName[] = "";
 constexpr const char * kInteractiveModePrompt = ">>> ";
-constexpr uint8_t kInteractiveModeArgumentsMaxLength = 32;
 constexpr const char * kInteractiveModeHistoryFilePath = "/tmp/darwin_framework_tool_history";
 constexpr const char * kInteractiveModeStopCommand = "quit()";
 
@@ -144,29 +140,7 @@ bool InteractiveStartCommand::ParseCommand(char * command)
         return NO;
     }
 
-    char * args[kInteractiveModeArgumentsMaxLength];
-    args[0] = kInteractiveModeName;
-    int argsCount = 1;
-    std::string arg;
-
-    std::stringstream ss(command);
-    while (ss >> std::quoted(arg, '\'')) {
-        if (argsCount == kInteractiveModeArgumentsMaxLength) {
-            ChipLogError(chipTool, "Too many arguments. Ignoring.");
-            return YES;
-        }
-
-        char * carg = new char[arg.size() + 1];
-        strcpy(carg, arg.c_str());
-        args[argsCount++] = carg;
-    }
-
     ClearLine();
-    mHandler->RunInteractive(argsCount, args);
-
-    // Do not delete arg[0]
-    while (--argsCount)
-        delete[] args[argsCount];
-
+    mHandler->RunInteractive(command);
     return YES;
 }


### PR DESCRIPTION
…s json

#### Problem

`chip-tool` now supports simple commands over web socket (e.g `onoff toggle 0x12344321 1`) but for commands that are more complex, the client does not necessarily know the arguments ordering.
Additional some arguments can not be passed over the wire as simple strings since they may contains control characters and notable `\0`.

This PR adds some supports to `chip-tool` to handle unordered commands over web sockets.
I have also updated the code such that `examples/chip-tool/commands/common/Commands.cpp` is now responsible for parsing "all" interactive commands - which avoid duplicating some code between `chip-tool` and `darwin-framework-tool`.
