### PR TITLE
[chip-tool] Add DataModelLogger::LogJson command and makes it goes ov…

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -110,6 +110,7 @@ static_library("chip-tool-utils") {
     "${chip_root}/src/controller/data_model",
     "${chip_root}/src/credentials:file_attestation_trust_store",
     "${chip_root}/src/lib",
+    "${chip_root}/src/lib/support/jsontlv",
     "${chip_root}/src/platform",
     "${chip_root}/third_party/inipp",
     "${chip_root}/third_party/jsoncpp",

--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -74,6 +74,8 @@ public:
         CHIP_ERROR error = status.ToChipError();
         if (CHIP_NO_ERROR != error)
         {
+            ReturnOnFailure(DataModelLogger::LogErrorAsJSON(path, status));
+
             ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
             mError = error;
             return;
@@ -81,6 +83,8 @@ public:
 
         if (data != nullptr)
         {
+            ReturnOnFailure(DataModelLogger::LogCommandAsJSON(path, data));
+
             error = DataModelLogger::LogCommand(path, data);
             if (CHIP_NO_ERROR != error)
             {
@@ -93,6 +97,8 @@ public:
 
     virtual void OnError(const chip::app::CommandSender * client, CHIP_ERROR error) override
     {
+        ReturnOnFailure(DataModelLogger::LogErrorAsJSON(error));
+
         ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(error));
         mError = error;
     }

--- a/examples/chip-tool/commands/clusters/DataModelLogger.h
+++ b/examples/chip-tool/commands/clusters/DataModelLogger.h
@@ -24,8 +24,25 @@
 #include <app/ConcreteAttributePath.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventHeader.h>
+#include <app/MessageDef/StatusIB.h>
 #include <app/data-model/DecodableList.h>
 #include <lib/support/BytesToHex.h>
+#include <lib/support/jsontlv/TlvJson.h>
+
+constexpr const char * kClusterIdKey      = "clusterId";
+constexpr const char * kEndpointIdKey     = "endpointId";
+constexpr const char * kAttributeIdKey    = "attributeId";
+constexpr const char * kEventIdKey        = "eventId";
+constexpr const char * kCommandIdKey      = "commandId";
+constexpr const char * kErrorIdKey        = "error";
+constexpr const char * kClusterErrorIdKey = "clusterError";
+
+class DataModelLoggerJSONDelegate
+{
+public:
+    CHIP_ERROR virtual LogJSON(const char *) = 0;
+    virtual ~DataModelLoggerJSONDelegate(){};
+};
 
 class DataModelLogger
 {
@@ -34,7 +51,119 @@ public:
     static CHIP_ERROR LogCommand(const chip::app::ConcreteCommandPath & path, chip::TLV::TLVReader * data);
     static CHIP_ERROR LogEvent(const chip::app::EventHeader & header, chip::TLV::TLVReader * data);
 
+    static CHIP_ERROR LogAttributeAsJSON(const chip::app::ConcreteDataAttributePath & path, chip::TLV::TLVReader * data)
+    {
+        VerifyOrReturnError(mJSONDelegate != nullptr, CHIP_NO_ERROR);
+
+        Json::Value value;
+        value[kClusterIdKey]   = path.mClusterId;
+        value[kEndpointIdKey]  = path.mEndpointId;
+        value[kAttributeIdKey] = path.mAttributeId;
+
+        chip::TLV::TLVReader reader;
+        reader.Init(*data);
+        ReturnErrorOnFailure(chip::TlvToJson(reader, value));
+
+        auto valueStr = chip::JsonToString(value);
+        return mJSONDelegate->LogJSON(valueStr.c_str());
+    }
+
+    static CHIP_ERROR LogErrorAsJSON(const chip::app::ConcreteDataAttributePath & path, const chip::app::StatusIB & status)
+    {
+        VerifyOrReturnError(mJSONDelegate != nullptr, CHIP_NO_ERROR);
+
+        Json::Value value;
+        value[kClusterIdKey]   = path.mClusterId;
+        value[kEndpointIdKey]  = path.mEndpointId;
+        value[kAttributeIdKey] = path.mAttributeId;
+
+        return LogError(value, status);
+    }
+
+    static CHIP_ERROR LogCommandAsJSON(const chip::app::ConcreteCommandPath & path, chip::TLV::TLVReader * data)
+    {
+        VerifyOrReturnError(mJSONDelegate != nullptr, CHIP_NO_ERROR);
+
+        Json::Value value;
+        value[kClusterIdKey]  = path.mClusterId;
+        value[kEndpointIdKey] = path.mEndpointId;
+        value[kCommandIdKey]  = path.mCommandId;
+
+        chip::TLV::TLVReader reader;
+        reader.Init(*data);
+        ReturnErrorOnFailure(chip::TlvToJson(reader, value));
+
+        auto valueStr = chip::JsonToString(value);
+        return mJSONDelegate->LogJSON(valueStr.c_str());
+    }
+
+    static CHIP_ERROR LogErrorAsJSON(const chip::app::ConcreteCommandPath & path, const chip::app::StatusIB & status)
+    {
+        VerifyOrReturnError(mJSONDelegate != nullptr, CHIP_NO_ERROR);
+
+        Json::Value value;
+        value[kClusterIdKey]  = path.mClusterId;
+        value[kEndpointIdKey] = path.mEndpointId;
+        value[kCommandIdKey]  = path.mCommandId;
+
+        return LogError(value, status);
+    }
+
+    static CHIP_ERROR LogEventAsJSON(const chip::app::EventHeader & header, chip::TLV::TLVReader * data)
+    {
+        VerifyOrReturnError(mJSONDelegate != nullptr, CHIP_NO_ERROR);
+
+        Json::Value value;
+        value[kClusterIdKey]  = header.mPath.mClusterId;
+        value[kEndpointIdKey] = header.mPath.mEndpointId;
+        value[kEventIdKey]    = header.mPath.mEventId;
+
+        chip::TLV::TLVReader reader;
+        reader.Init(*data);
+        ReturnErrorOnFailure(chip::TlvToJson(reader, value));
+
+        auto valueStr = chip::JsonToString(value);
+        return mJSONDelegate->LogJSON(valueStr.c_str());
+    }
+
+    static CHIP_ERROR LogErrorAsJSON(const chip::app::EventHeader & header, const chip::app::StatusIB & status)
+    {
+        VerifyOrReturnError(mJSONDelegate != nullptr, CHIP_NO_ERROR);
+
+        Json::Value value;
+        value[kClusterIdKey]  = header.mPath.mClusterId;
+        value[kEndpointIdKey] = header.mPath.mEndpointId;
+        value[kEventIdKey]    = header.mPath.mEventId;
+
+        return LogError(value, status);
+    }
+
+    static CHIP_ERROR LogErrorAsJSON(const CHIP_ERROR & error)
+    {
+        Json::Value value;
+        chip::app::StatusIB status;
+        status.InitFromChipError(error);
+        return LogError(value, status);
+    }
+
+    static void SetJSONDelegate(DataModelLoggerJSONDelegate * delegate) { mJSONDelegate = delegate; }
+
 private:
+    static CHIP_ERROR LogError(Json::Value & value, const chip::app::StatusIB & status)
+    {
+        if (status.mClusterStatus.HasValue())
+        {
+            auto statusValue          = status.mClusterStatus.Value();
+            value[kClusterErrorIdKey] = statusValue;
+        }
+
+        auto statusName    = chip::Protocols::InteractionModel::StatusName(status.mStatus);
+        value[kErrorIdKey] = statusName;
+
+        auto valueStr = chip::JsonToString(value);
+        return mJSONDelegate->LogJSON(valueStr.c_str());
+    }
+
     static CHIP_ERROR LogValue(const char * label, size_t indent, bool value)
     {
         DataModelLogger::LogString(label, indent, value ? "TRUE" : "FALSE");
@@ -194,4 +323,5 @@ private:
     }
 
     static size_t ComputePrefixSize(const std::string label, size_t indent) { return ComputePrefix(label, indent).size(); }
+    static DataModelLoggerJSONDelegate * mJSONDelegate;
 };

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -37,6 +37,8 @@ public:
         CHIP_ERROR error = status.ToChipError();
         if (CHIP_NO_ERROR != error)
         {
+            ReturnOnFailure(DataModelLogger::LogErrorAsJSON(path, status));
+
             ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
             mError = error;
             return;
@@ -48,6 +50,8 @@ public:
             mError = CHIP_ERROR_INTERNAL;
             return;
         }
+
+        ReturnOnFailure(DataModelLogger::LogAttributeAsJSON(path, data));
 
         error = DataModelLogger::LogAttribute(path, data);
         if (CHIP_NO_ERROR != error)
@@ -66,6 +70,8 @@ public:
             CHIP_ERROR error = status->ToChipError();
             if (CHIP_NO_ERROR != error)
             {
+                ReturnOnFailure(DataModelLogger::LogErrorAsJSON(eventHeader, *status));
+
                 ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
                 mError = error;
                 return;

--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -109,6 +109,8 @@ public:
         CHIP_ERROR error = status.ToChipError();
         if (CHIP_NO_ERROR != error)
         {
+            ReturnOnFailure(DataModelLogger::LogErrorAsJSON(path, status));
+
             ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
             mError = error;
         }
@@ -116,6 +118,8 @@ public:
 
     void OnError(const chip::app::WriteClient * client, CHIP_ERROR error) override
     {
+        ReturnOnFailure(DataModelLogger::LogErrorAsJSON(error));
+
         ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(error));
         mError = error;
     }

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.h
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "../clusters/DataModelLogger.h"
 #include "../common/CHIPCommand.h"
 #include "../common/Commands.h"
 
@@ -35,7 +36,7 @@ public:
     /////////// CHIPCommand Interface /////////
     chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(0); }
 
-    bool ParseCommand(char * command);
+    bool ParseCommand(char * command, int * status);
 
 private:
     Commands * mHandler = nullptr;
@@ -52,7 +53,7 @@ public:
     CHIP_ERROR RunCommand() override;
 };
 
-class InteractiveServerCommand : public InteractiveCommand, public WebSocketServerDelegate
+class InteractiveServerCommand : public InteractiveCommand, public WebSocketServerDelegate, public DataModelLoggerJSONDelegate
 {
 public:
     InteractiveServerCommand(Commands * commandsHandler, CredentialIssuerCommands * credsIssuerConfig) :
@@ -66,6 +67,9 @@ public:
 
     /////////// WebSocketServerDelegate Interface /////////
     bool OnWebSocketMessageReceived(char * msg) override;
+
+    /////////// DataModelLoggerJSONDelegate interface /////////
+    CHIP_ERROR LogJSON(const char * json) override;
 
 private:
     WebSocketServer mWebSocketServer;

--- a/examples/chip-tool/commands/interactive/WebSocketServer.h
+++ b/examples/chip-tool/commands/interactive/WebSocketServer.h
@@ -28,4 +28,5 @@ class WebSocketServer
 {
 public:
     CHIP_ERROR Run(chip::Optional<uint16_t> port, WebSocketServerDelegate * delegate);
+    CHIP_ERROR Send(const char * msg);
 };

--- a/examples/chip-tool/templates/logging/DataModelLogger-src.zapt
+++ b/examples/chip-tool/templates/logging/DataModelLogger-src.zapt
@@ -4,6 +4,8 @@
 
 using namespace chip::app::Clusters;
 
+DataModelLoggerJSONDelegate * DataModelLogger::mJSONDelegate = nullptr;
+
 {{#structs_with_clusters groupByStructName=1}}
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const chip::app::Clusters::{{#unless (is_number_greater_than structClusterCount 1)}}{{as_camel_cased clusterName false}}{{else}}detail{{/unless}}::Structs::{{name}}::DecodableType & value)
 {

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -85,6 +85,7 @@ chip_data_model("tv-casting-common") {
 
   deps = [
     "${chip_root}/src/app/tests/suites/commands/interaction_model",
+    "${chip_root}/src/lib/support/jsontlv",
     "${chip_root}/third_party/inipp",
     "${chip_root}/third_party/jsoncpp",
   ]

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -21,6 +21,8 @@
 
 using namespace chip::app::Clusters;
 
+DataModelLoggerJSONDelegate * DataModelLogger::mJSONDelegate = nullptr;
+
 CHIP_ERROR
 DataModelLogger::LogValue(const char * label, size_t indent,
                           const chip::app::Clusters::AccessControl::Structs::AccessControlEntryStruct::DecodableType & value)


### PR DESCRIPTION
…er websockets in interactive server mode

#### Problem

This PR sends some data back from `chip-tool` to a web socket client.
It both sends the command results as well as any logs dumped by the stack using the `ChipLog*` helpers.

I expect the `DataModelLogger::Log*` changes to be temporary and changed in a different way in the future. The fundamental reason why I would like to changed that is because this not going to work with `darwin-framework-tool` as if and I will have to duplicates some code. But in the meantime, it allows moving forward the python runner...