### PR TITLE
[ICD] Initial Impl Active Threshold

### DIFF
--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -120,6 +120,16 @@
 #define CHIP_DEVICE_CONFIG_SED_ACTIVE_INTERVAL 200_ms32
 #endif
 
+/**
+ * CHIP_DEVICE_CONFIG_SED_ACTIVE_THRESHOLD
+ *
+ *  Minimum amount the node SHOULD stay awake after network activity.
+ * Spec section 2.12.5
+ */
+#ifndef CHIP_DEVICE_CONFIG_SED_ACTIVE_THRESHOLD
+#define CHIP_DEVICE_CONFIG_SED_ACTIVE_THRESHOLD System::Clock::Milliseconds32(4000)
+#endif
+
 // -------------------- Device Identification Configuration --------------------
 
 /**

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -224,7 +224,7 @@ public:
      *
      * @param[in]  onOff  true if active mode should be enabled and false otherwise.
      */
-    CHIP_ERROR RequestSEDActiveMode(bool onOff);
+    CHIP_ERROR RequestSEDActiveMode(bool onOff, bool delayIdle = false);
 #endif
 
     // CHIPoBLE service methods
@@ -480,9 +480,9 @@ inline CHIP_ERROR ConnectivityManager::SetSEDIntervalsConfig(const SEDIntervalsC
     return static_cast<ImplClass *>(this)->_SetSEDIntervalsConfig(intervalsConfig);
 }
 
-inline CHIP_ERROR ConnectivityManager::RequestSEDActiveMode(bool onOff)
+inline CHIP_ERROR ConnectivityManager::RequestSEDActiveMode(bool onOff, bool delayIdle)
 {
-    return static_cast<ImplClass *>(this)->_RequestSEDActiveMode(onOff);
+    return static_cast<ImplClass *>(this)->_RequestSEDActiveMode(onOff, delayIdle);
 }
 #endif
 

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -182,7 +182,7 @@ private:
      *
      * @param[in]  onOff  true if active mode should be enabled and false otherwise.
      */
-    CHIP_ERROR RequestSEDActiveMode(bool onOff);
+    CHIP_ERROR RequestSEDActiveMode(bool onOff, bool delayIdle = false);
 #endif
 
     bool HaveMeshConnectivity();
@@ -402,9 +402,9 @@ inline CHIP_ERROR ThreadStackManager::SetSEDIntervalsConfig(const ConnectivityMa
     return static_cast<ImplClass *>(this)->_SetSEDIntervalsConfig(intervalsConfig);
 }
 
-inline CHIP_ERROR ThreadStackManager::RequestSEDActiveMode(bool onOff)
+inline CHIP_ERROR ThreadStackManager::RequestSEDActiveMode(bool onOff, bool delayIdle)
 {
-    return static_cast<ImplClass *>(this)->_RequestSEDActiveMode(onOff);
+    return static_cast<ImplClass *>(this)->_RequestSEDActiveMode(onOff, delayIdle);
 }
 #endif
 

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h
@@ -52,7 +52,7 @@ protected:
     CHIP_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);
     CHIP_ERROR _GetSEDIntervalsConfig(ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
     CHIP_ERROR _SetSEDIntervalsConfig(const ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
-    CHIP_ERROR _RequestSEDActiveMode(bool onOff);
+    CHIP_ERROR _RequestSEDActiveMode(bool onOff, bool delayIdle = false);
     bool _IsThreadAttached(void);
     bool _IsThreadProvisioned(void);
     void _ErasePersistentInfo(void);
@@ -130,7 +130,7 @@ inline CHIP_ERROR GenericConnectivityManagerImpl_NoThread<ImplClass>::_SetSEDInt
 }
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_NoThread<ImplClass>::_RequestSEDActiveMode(bool onOff)
+inline CHIP_ERROR GenericConnectivityManagerImpl_NoThread<ImplClass>::_RequestSEDActiveMode(bool onOff, bool delayIdle)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
@@ -66,7 +66,7 @@ protected:
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
     CHIP_ERROR _GetSEDIntervalsConfig(ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
     CHIP_ERROR _SetSEDIntervalsConfig(const ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
-    CHIP_ERROR _RequestSEDActiveMode(bool onOff);
+    CHIP_ERROR _RequestSEDActiveMode(bool onOff, bool delayIdle = false);
 #endif
     bool _IsThreadAttached();
     bool _IsThreadProvisioned();
@@ -157,9 +157,9 @@ inline CHIP_ERROR GenericConnectivityManagerImpl_Thread<ImplClass>::_SetSEDInter
 }
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_Thread<ImplClass>::_RequestSEDActiveMode(bool onOff)
+inline CHIP_ERROR GenericConnectivityManagerImpl_Thread<ImplClass>::_RequestSEDActiveMode(bool onOff, bool delayIdle)
 {
-    return ThreadStackMgrImpl().RequestSEDActiveMode(onOff);
+    return ThreadStackMgrImpl().RequestSEDActiveMode(onOff, delayIdle);
 }
 #endif
 

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -125,7 +125,7 @@ void ExchangeContext::UpdateSEDIntervalMode(bool activeMode)
     if (activeMode != IsRequestingActiveMode())
     {
         SetRequestingActiveMode(activeMode);
-        DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(activeMode);
+        DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(activeMode, true);
     }
 }
 #endif

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -496,9 +496,10 @@ CHIP_ERROR ThreadStackManagerImpl::_SetSEDIntervalsConfig(const ConnectivityMana
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ThreadStackManagerImpl::_RequestSEDActiveMode(bool onOff)
+CHIP_ERROR ThreadStackManagerImpl::_RequestSEDActiveMode(bool onOff, bool delayIdle)
 {
     (void) onOff;
+    (void) delayIdle;
 
     ChipLogError(DeviceLayer, "SED intervals config is not supported on linux");
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -89,7 +89,7 @@ public:
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
     CHIP_ERROR _GetSEDIntervalsConfig(ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
     CHIP_ERROR _SetSEDIntervalsConfig(const ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
-    CHIP_ERROR _RequestSEDActiveMode(bool onOff);
+    CHIP_ERROR _RequestSEDActiveMode(bool onOff, bool delayIdle = false);
 #endif
 
     bool _HaveMeshConnectivity();

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1902,14 +1902,14 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_RequestSEDActiv
             return err;
         }
 
-        ChipLogError(DeviceLayer, "Failed to postponed Idle Mode with error %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Failed to postponed Idle Mode with error %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return SEDChangeMode();
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::SEDChangeMode(void)
+CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::SEDChangeMode()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     ConnectivityManager::SEDIntervalMode mode;
@@ -1926,10 +1926,9 @@ template <class ImplClass>
 void GenericThreadStackManagerImpl_OpenThread<ImplClass>::RequestSEDModeChange(chip::System::Layer * apSystemLayer,
                                                                                void * apAppState)
 {
-
     if (apAppState != nullptr)
     {
-        ((GenericThreadStackManagerImpl_OpenThread *) apAppState)->SEDChangeMode();
+        static_cast<GenericThreadStackManagerImpl_OpenThread *>(apAppState)->SEDChangeMode();
     }
 }
 #endif

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1836,9 +1836,10 @@ GenericThreadStackManagerImpl_OpenThread<ImplClass>::SetSEDIntervalMode(Connecti
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
-    mIntervalsMode = intervalType;
 
     Impl()->LockThreadStack();
+
+    mIntervalsMode = intervalType;
 
 // For Thread devices, the intervals are defined as:
 // * poll period for SED devices that poll the parent for data
@@ -1879,10 +1880,9 @@ GenericThreadStackManagerImpl_OpenThread<ImplClass>::SetSEDIntervalMode(Connecti
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_RequestSEDActiveMode(bool onOff)
+CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_RequestSEDActiveMode(bool onOff, bool delayIdle)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    ConnectivityManager::SEDIntervalMode mode;
 
     if (onOff)
     {
@@ -1894,12 +1894,43 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_RequestSEDActiv
             mActiveModeConsumers--;
     }
 
+    if (!onOff && delayIdle && CHIP_DEVICE_CONFIG_SED_ACTIVE_THRESHOLD.count() != 0)
+    {
+        err = DeviceLayer::SystemLayer().StartTimer(CHIP_DEVICE_CONFIG_SED_ACTIVE_THRESHOLD, RequestSEDModeChange, this);
+        if (CHIP_NO_ERROR == err)
+        {
+            return err;
+        }
+
+        ChipLogError(DeviceLayer, "Failed to postponed Idle Mode with error %s", ErrorStr(err));
+    }
+
+    return SEDChangeMode();
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::SEDChangeMode(void)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    ConnectivityManager::SEDIntervalMode mode;
+
     mode = mActiveModeConsumers > 0 ? ConnectivityManager::SEDIntervalMode::Active : ConnectivityManager::SEDIntervalMode::Idle;
 
     if (mIntervalsMode != mode)
         err = SetSEDIntervalMode(mode);
 
     return err;
+}
+
+template <class ImplClass>
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::RequestSEDModeChange(chip::System::Layer * apSystemLayer,
+                                                                               void * apAppState)
+{
+
+    if (apAppState != nullptr)
+    {
+        ((GenericThreadStackManagerImpl_OpenThread *) apAppState)->SEDChangeMode();
+    }
 }
 #endif
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -103,7 +103,9 @@ protected:
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
     CHIP_ERROR _GetSEDIntervalsConfig(ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
     CHIP_ERROR _SetSEDIntervalsConfig(const ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
-    CHIP_ERROR _RequestSEDActiveMode(bool onOff);
+    CHIP_ERROR _RequestSEDActiveMode(bool onOff, bool delayIdle);
+    CHIP_ERROR SEDChangeMode(void);
+    static void RequestSEDModeChange(chip::System::Layer * apSystemLayer, void * apAppState);
 #endif
 
     bool _HaveMeshConnectivity(void);


### PR DESCRIPTION
Partial fix of https://github.com/project-chip/connectedhomeip/issues/24260

Implement sections 2.12.5 which is in direct contradiction with section 11.24.5.3 of the same spec (Global constant vs cluster attribute).

Main differences are that current implementation is based on a hard coded threshold value and respect the SHOULD instead of the SHALL. Meaning that in the rare corner case where no timer are available to postponed the Idle mode, a device COULD go to Idle mode immediately which is in accordance with section 2.12.5.

Tested on Silabs EFR32 platform