### PR TITLE
Align naming in Account Login cluster XML with the spec.

### DIFF
--- a/src/app/tests/suites/TV_AccountLoginCluster.yaml
+++ b/src/app/tests/suites/TV_AccountLoginCluster.yaml
@@ -33,20 +33,20 @@ tests:
       timedInteractionTimeoutMs: 10000
       arguments:
           values:
-              - name: "tempAccountIdentifier"
+              - name: "TempAccountIdentifier"
                 value: "asdf"
       response:
           values:
-              - name: "setupPIN"
+              - name: "SetupPIN"
                 value: "tempPin123"
     - label: "Login Command"
       command: "login"
       timedInteractionTimeoutMs: 10000
       arguments:
           values:
-              - name: "tempAccountIdentifier"
+              - name: "TempAccountIdentifier"
                 value: "asdf"
-              - name: "setupPIN"
+              - name: "SetupPIN"
                 value: "tempPin123"
 
     - label: "Logout Command"

--- a/src/app/tests/suites/certification/Test_TC_ALOGIN_12_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ALOGIN_12_1.yaml
@@ -72,7 +72,7 @@ tests:
                 value: TempAccountIdentifier
       response:
           values:
-              - name: "setupPIN"
+              - name: "SetupPIN"
                 saveAs: setupPIN
 
     - label:
@@ -83,9 +83,9 @@ tests:
       timedInteractionTimeoutMs: 10000
       arguments:
           values:
-              - name: "tempAccountIdentifier"
+              - name: "TempAccountIdentifier"
                 value: TempAccountIdentifier
-              - name: "setupPIN"
+              - name: "SetupPIN"
                 value: setupPIN
 
     - label:

--- a/src/app/zap-templates/zcl/data-model/chip/account-login-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/account-login-cluster.xml
@@ -27,13 +27,13 @@ limitations under the License.
 
     <command source="client" code="0x00" name="GetSetupPIN" response="GetSetupPINResponse" mustUseTimedInvoke="true" optional="false">
       <description>Upon receipt, the Content App checks if the account associated with the client Temp Account Identifier Rotating ID is the same acount that is active on the given Content App. If the accounts are the same, then the Content App includes the Setup PIN in the GetSetupPIN Response.</description>
-      <arg name="tempAccountIdentifier" minLength="16" length="100" type="CHAR_STRING"/>
+      <arg name="TempAccountIdentifier" minLength="16" length="100" type="CHAR_STRING"/>
     </command>
 
     <command source="client" code="0x02" name="Login" mustUseTimedInvoke="true" optional="false">
       <description>Upon receipt, the Content App checks if the account associated with the client’s Temp Account Identifier (Rotating ID) has a current active Setup PIN with the given value. If the Setup PIN is valid for the user account associated with the Temp Account Identifier, then the Content App MAY make that user account active.</description>
-      <arg name="tempAccountIdentifier" minLength="16" length="100" type="CHAR_STRING"/>
-      <arg name="setupPIN" minLength="11" type="CHAR_STRING"/>
+      <arg name="TempAccountIdentifier" minLength="16" length="100" type="CHAR_STRING"/>
+      <arg name="SetupPIN" minLength="11" type="CHAR_STRING"/>
     </command>
 
     <command source="client" code="0x03" name="Logout" mustUseTimedInvoke="true" optional="false">
@@ -42,7 +42,7 @@ limitations under the License.
 
     <command source="server" code="0x01" name="GetSetupPINResponse" optional="false" disableDefaultResponse="true">
       <description>This message is sent in response to the GetSetupPIN Request, and contains the Setup PIN code, or null when the accounts identified in the request does not match the active account of the running Content App.</description>
-      <arg name="setupPIN" type="CHAR_STRING"/>
+      <arg name="SetupPIN" type="CHAR_STRING"/>
     </command>
 
   </cluster>

--- a/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
@@ -3718,10 +3718,10 @@ void CHIPAccountLoginClusterGetSetupPINResponseCallback::CallbackFn(
     err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error invoking Java callback: %s", ErrorStr(err)));
 
-    jobject setupPIN;
-    setupPIN = env->NewStringUTF(std::string(dataResponse.setupPIN.data(), dataResponse.setupPIN.size()).c_str());
+    jobject SetupPIN;
+    SetupPIN = env->NewStringUTF(std::string(dataResponse.setupPIN.data(), dataResponse.setupPIN.size()).c_str());
 
-    env->CallVoidMethod(javaCallbackRef, javaMethod, setupPIN);
+    env->CallVoidMethod(javaCallbackRef, javaMethod, SetupPIN);
 }
 CHIPUnitTestingClusterTestSpecificResponseCallback::CHIPUnitTestingClusterTestSpecificResponseCallback(jobject javaCallback) :
     Callback::Callback<CHIPUnitTestingClusterTestSpecificResponseCallbackType>(CallbackFn, this)

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
@@ -6544,10 +6544,10 @@ public class ClusterInfoMapping {
     }
 
     @Override
-    public void onSuccess(String setupPIN) {
+    public void onSuccess(String SetupPIN) {
       Map<CommandResponseInfo, Object> responseValues = new LinkedHashMap<>();
-      CommandResponseInfo setupPINResponseValue = new CommandResponseInfo("setupPIN", "String");
-      responseValues.put(setupPINResponseValue, setupPIN);
+      CommandResponseInfo SetupPINResponseValue = new CommandResponseInfo("SetupPIN", "String");
+      responseValues.put(SetupPINResponseValue, SetupPIN);
       callback.onSuccess(responseValues);
     }
 

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -8765,7 +8765,7 @@ bool emberAfAccountLoginClusterGetSetupPINCallback(
  * @brief Account Login Cluster GetSetupPINResponse Command callback (from server)
  */
 bool emberAfAccountLoginClusterGetSetupPINResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                           chip::CharSpan setupPIN);
+                                                           chip::CharSpan SetupPIN);
 /**
  * @brief Account Login Cluster Login Command callback (from client)
  */


### PR DESCRIPTION
REVIEW NOTE: Only the first commit contains manual changes. The rest is code-generated.
