### PR TITLE
tv-casting-app: Fixes for #24399 and #24400

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
@@ -27,7 +27,11 @@ public class MainActivity extends AppCompatActivity
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
 
-    initJni();
+    boolean ret = initJni();
+    if (!ret) {
+      Log.e(TAG, "Failed to initialize Matter TV casting library");
+      return;
+    }
 
     Fragment fragment = CommissionerDiscoveryFragment.newInstance(tvCastingApp);
     getSupportFragmentManager()
@@ -71,7 +75,7 @@ public class MainActivity extends AppCompatActivity
    * AndroidChipPlatform to prepare platform, then start ChipAppServer, then call init on
    * TvCastingApp
    */
-  private void initJni() {
+  private boolean initJni() {
     tvCastingApp = new TvCastingApp();
 
     Context applicationContext = this.getApplicationContext();
@@ -84,7 +88,7 @@ public class MainActivity extends AppCompatActivity
     appParameters.setDacProvider(new DACProviderStub());
     appParameters.setSetupPasscode(GlobalCastingConstants.SetupPasscode);
     appParameters.setDiscriminator(GlobalCastingConstants.Discriminator);
-    tvCastingApp.initApp(applicationContext, appParameters);
+    return tvCastingApp.initApp(applicationContext, appParameters);
   }
 
   private void showFragment(Fragment fragment, boolean showOnBack) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -65,21 +65,40 @@ public class TvCastingApp {
             new ChipMdnsCallbackImpl(),
             new DiagnosticDataProviderImpl(applicationContext));
 
-    chipPlatform.updateCommissionableDataProviderData(
-        appParameters.getSpake2pVerifierBase64(),
-        appParameters.getSpake2pSaltBase64(),
-        appParameters.getSpake2pIterationCount(),
-        appParameters.getSetupPasscode(),
-        appParameters.getDiscriminator());
+    boolean ret =
+        chipPlatform.updateCommissionableDataProviderData(
+            appParameters.getSpake2pVerifierBase64(),
+            appParameters.getSpake2pSaltBase64(),
+            appParameters.getSpake2pIterationCount(),
+            appParameters.getSetupPasscode(),
+            appParameters.getDiscriminator());
+    if (!ret) {
+      Log.e(
+          TAG,
+          "TvCastingApp.initApp failed to updateCommissionableDataProviderData on chipPlatform");
+      return ret;
+    }
+
+    ret = preInitJni(appParameters);
+    if (!ret) {
+      Log.e(TAG, "TvCastingApp.initApp failed in preInitJni");
+      return ret;
+    }
 
     chipAppServer = new ChipAppServer();
-    chipAppServer.startApp();
+    ret = chipAppServer.startApp();
+    if (!ret) {
+      Log.e(TAG, "TvCastingApp.initApp failed in start chipAppServer");
+      return ret;
+    }
 
     setDACProvider(appParameters.getDacProvider());
     return initJni(appParameters);
   }
 
   private native void setDACProvider(DACProvider provider);
+
+  private native boolean preInitJni(AppParameters appParameters);
 
   private native boolean initJni(AppParameters appParameters);
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -52,6 +52,37 @@ void JNI_OnUnload(JavaVM * jvm, void * reserved)
     return AndroidAppServerJNI_OnUnload(jvm, reserved);
 }
 
+JNI_METHOD(jboolean, preInitJni)(JNIEnv *, jobject, jobject jAppParameters)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "JNI_METHOD preInitJni called");
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (jAppParameters == nullptr)
+    {
+        err = CastingServer::GetInstance()->PreInit();
+    }
+    else
+    {
+        AppParams appParams;
+        err = convertJAppParametersToCppAppParams(jAppParameters, appParams);
+        VerifyOrExit(err == CHIP_NO_ERROR,
+                     ChipLogError(AppServer, "Conversion of AppParameters from jobject to Cpp type failed: %" CHIP_ERROR_FORMAT,
+                                  err.Format()));
+        err = CastingServer::GetInstance()->PreInit(&appParams);
+    }
+    VerifyOrExit(
+        err == CHIP_NO_ERROR,
+        ChipLogError(AppServer, "Call to CastingServer::GetInstance()->PreInit() failed: %" CHIP_ERROR_FORMAT, err.Format()));
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
 JNI_METHOD(jboolean, initJni)(JNIEnv *, jobject, jobject jAppParameters)
 {
     chip::DeviceLayer::StackLock lock;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -75,12 +75,7 @@ JNI_METHOD(jboolean, preInitJni)(JNIEnv *, jobject, jobject jAppParameters)
         err == CHIP_NO_ERROR,
         ChipLogError(AppServer, "Call to CastingServer::GetInstance()->PreInit() failed: %" CHIP_ERROR_FORMAT, err.Format()));
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, initJni)(JNIEnv *, jobject, jobject jAppParameters)
@@ -105,12 +100,7 @@ JNI_METHOD(jboolean, initJni)(JNIEnv *, jobject, jobject jAppParameters)
     VerifyOrExit(err == CHIP_NO_ERROR,
                  ChipLogError(AppServer, "Call to CastingServer::GetInstance()->Init() failed: %" CHIP_ERROR_FORMAT, err.Format()));
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(void, setDACProvider)(JNIEnv *, jobject, jobject provider)
@@ -154,12 +144,7 @@ JNI_METHOD(jboolean, openBasicCommissioningWindow)
                  ChipLogError(AppServer, "CastingServer::OpenBasicCommissioningWindow failed: %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jobject, readCachedVideoPlayers)(JNIEnv * env, jobject)
@@ -227,12 +212,7 @@ JNI_METHOD(jboolean, verifyOrEstablishConnection)
                  ChipLogError(AppServer, "CastingServer::OpenBasicCommissioningWindow failed: %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(void, shutdownAllSubscriptions)(JNIEnv * env, jobject)
@@ -352,12 +332,7 @@ JNI_METHOD(jboolean, contentLauncherLaunchURL)
     env->ReleaseStringUTFChars(contentDisplayStr, nativeContentDisplayStr);
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 CHIP_ERROR CreateParameter(JNIEnv * env, jobject jParameter,
@@ -458,12 +433,7 @@ JNI_METHOD(jboolean, contentLauncher_1launchContent)
     env->ReleaseStringUTFChars(jData, nativeData);
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, contentLauncher_1subscribeToSupportedStreamingProtocols)
@@ -515,12 +485,7 @@ JNI_METHOD(jboolean, contentLauncher_1subscribeToSupportedStreamingProtocols)
                               err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, levelControl_1step)
@@ -549,12 +514,7 @@ JNI_METHOD(jboolean, levelControl_1step)
                  ChipLogError(AppServer, "CastingServer.LevelControl_Step failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, levelControl_1moveToLevel)
@@ -583,12 +543,7 @@ JNI_METHOD(jboolean, levelControl_1moveToLevel)
                  ChipLogError(AppServer, "CastingServer.LevelControl_MoveToLevel failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, levelControl_1subscribeToCurrentLevel)
@@ -634,12 +589,7 @@ JNI_METHOD(jboolean, levelControl_1subscribeToCurrentLevel)
         ChipLogError(AppServer, "CastingServer.LevelControl_SubscribeToCurrentLevel failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, levelControl_1subscribeToMinLevel)
@@ -683,12 +633,7 @@ JNI_METHOD(jboolean, levelControl_1subscribeToMinLevel)
         ChipLogError(AppServer, "CastingServer.LevelControl_SubscribeToMinLevel failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, levelControl_1subscribeToMaxLevel)
@@ -732,12 +677,7 @@ JNI_METHOD(jboolean, levelControl_1subscribeToMaxLevel)
         ChipLogError(AppServer, "CastingServer.LevelControl_SubscribeToMaxLevel failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, onOff_1on)
@@ -762,12 +702,7 @@ JNI_METHOD(jboolean, onOff_1on)
     VerifyOrExit(CHIP_NO_ERROR == err, ChipLogError(AppServer, "CastingServer.OnOff_On failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, onOff_1off)
@@ -792,12 +727,7 @@ JNI_METHOD(jboolean, onOff_1off)
     VerifyOrExit(CHIP_NO_ERROR == err, ChipLogError(AppServer, "CastingServer.OnOff_Off failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, onOff_1toggle)
@@ -823,12 +753,7 @@ JNI_METHOD(jboolean, onOff_1toggle)
                  ChipLogError(AppServer, "CastingServer.OnOff_Toggle failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, mediaPlayback_1play)
@@ -854,12 +779,7 @@ JNI_METHOD(jboolean, mediaPlayback_1play)
                  ChipLogError(AppServer, "CastingServer.MediaPlayback_Play failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, mediaPlayback_1pause)
@@ -885,12 +805,7 @@ JNI_METHOD(jboolean, mediaPlayback_1pause)
                  ChipLogError(AppServer, "CastingServer.MediaPlayback_Pause failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, mediaPlayback_1stopPlayback)
@@ -917,12 +832,7 @@ JNI_METHOD(jboolean, mediaPlayback_1stopPlayback)
                  ChipLogError(AppServer, "CastingServer.MediaPlayback_StopPlayback failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, mediaPlayback_1next)
@@ -948,12 +858,7 @@ JNI_METHOD(jboolean, mediaPlayback_1next)
                  ChipLogError(AppServer, "CastingServer.MediaPlayback_Next failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, mediaPlayback_1seek)
@@ -980,12 +885,7 @@ JNI_METHOD(jboolean, mediaPlayback_1seek)
                  ChipLogError(AppServer, "CastingServer.MediaPlayback_Seek failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, mediaPlayback_1skipForward)
@@ -1012,12 +912,7 @@ JNI_METHOD(jboolean, mediaPlayback_1skipForward)
                  ChipLogError(AppServer, "CastingServer.MediaPlayback_SkipForward failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, mediaPlayback_1skipBackward)
@@ -1044,12 +939,7 @@ JNI_METHOD(jboolean, mediaPlayback_1skipBackward)
                  ChipLogError(AppServer, "CastingServer.MediaPlayback_SkipBackward failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, mediaPlayback_1subscribeToCurrentState)
@@ -1095,12 +985,7 @@ JNI_METHOD(jboolean, mediaPlayback_1subscribeToCurrentState)
         ChipLogError(AppServer, "CastingServer.MediaPlayback_SubscribeToCurrentState failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, mediaPlayback_1subscribeToDuration)
@@ -1145,12 +1030,7 @@ JNI_METHOD(jboolean, mediaPlayback_1subscribeToDuration)
         ChipLogError(AppServer, "CastingServer.mediaPlayback_subscribeToDuration failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, mediaPlayback_1subscribeToSampledPosition)
@@ -1197,12 +1077,7 @@ JNI_METHOD(jboolean, mediaPlayback_1subscribeToSampledPosition)
         ChipLogError(AppServer, "CastingServer.mediaPlayback_subscribeToSampledPosition failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, mediaPlayback_1subscribeToPlaybackSpeed)
@@ -1248,12 +1123,7 @@ JNI_METHOD(jboolean, mediaPlayback_1subscribeToPlaybackSpeed)
         ChipLogError(AppServer, "CastingServer.mediaPlayback_subscribeToPlaybackSpeed failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, mediaPlayback_1subscribeToSeekRangeEnd)
@@ -1299,12 +1169,7 @@ JNI_METHOD(jboolean, mediaPlayback_1subscribeToSeekRangeEnd)
         ChipLogError(AppServer, "CastingServer.mediaPlayback_subscribeToSeekRangeEnd failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, mediaPlayback_1subscribeToSeekRangeStart)
@@ -1351,12 +1216,7 @@ JNI_METHOD(jboolean, mediaPlayback_1subscribeToSeekRangeStart)
         ChipLogError(AppServer, "CastingServer.mediaPlayback_subscribeToSeekRangeStart failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, applicationLauncher_1launchApp)
@@ -1391,12 +1251,7 @@ JNI_METHOD(jboolean, applicationLauncher_1launchApp)
 
     env->ReleaseStringUTFChars(applicationId, nativeApplicationId);
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, applicationLauncher_1stopApp)
@@ -1429,12 +1284,7 @@ JNI_METHOD(jboolean, applicationLauncher_1stopApp)
 
     env->ReleaseStringUTFChars(applicationId, nativeApplicationId);
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, applicationLauncher_1hideApp)
@@ -1467,12 +1317,7 @@ JNI_METHOD(jboolean, applicationLauncher_1hideApp)
 
     env->ReleaseStringUTFChars(applicationId, nativeApplicationId);
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, targetNavigator_1navigateTarget)
@@ -1506,12 +1351,7 @@ JNI_METHOD(jboolean, targetNavigator_1navigateTarget)
         env->ReleaseStringUTFChars(data, nativeData);
     }
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, targetNavigator_1subscribeToCurrentTarget)
@@ -1558,12 +1398,7 @@ JNI_METHOD(jboolean, targetNavigator_1subscribeToCurrentTarget)
         ChipLogError(AppServer, "CastingServer.targetNavigator_subscribeToCurrentTarget failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, targetNavigator_1subscribeToTargetList)
@@ -1609,12 +1444,7 @@ JNI_METHOD(jboolean, targetNavigator_1subscribeToTargetList)
         ChipLogError(AppServer, "CastingServer.targetNavigator_subscribeToTargetList failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, keypadInput_1sendKey)
@@ -1641,12 +1471,7 @@ JNI_METHOD(jboolean, keypadInput_1sendKey)
                  ChipLogError(AppServer, "CastingServer.KeypadInput_SendKey failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 // APPLICATION BASIC
@@ -1693,12 +1518,7 @@ JNI_METHOD(jboolean, applicationBasic_1subscribeToVendorName)
         ChipLogError(AppServer, "CastingServer.applicationBasic_subscribeToVendorName failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, applicationBasic_1subscribeToVendorID)
@@ -1744,12 +1564,7 @@ JNI_METHOD(jboolean, applicationBasic_1subscribeToVendorID)
         ChipLogError(AppServer, "CastingServer.applicationBasic_subscribeToVendorID failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, applicationBasic_1subscribeToApplicationName)
@@ -1796,12 +1611,7 @@ JNI_METHOD(jboolean, applicationBasic_1subscribeToApplicationName)
                               err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, applicationBasic_1subscribeToProductID)
@@ -1847,12 +1657,7 @@ JNI_METHOD(jboolean, applicationBasic_1subscribeToProductID)
         ChipLogError(AppServer, "CastingServer.applicationBasic_subscribeToProductID failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, applicationBasic_1subscribeToApplicationVersion)
@@ -1902,12 +1707,7 @@ JNI_METHOD(jboolean, applicationBasic_1subscribeToApplicationVersion)
                               err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, applicationBasic_1readVendorName)
@@ -1944,12 +1744,7 @@ JNI_METHOD(jboolean, applicationBasic_1readVendorName)
         ChipLogError(AppServer, "CastingServer.applicationBasic_1readVendorName failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, applicationBasic_1readVendorID)
@@ -1983,12 +1778,7 @@ JNI_METHOD(jboolean, applicationBasic_1readVendorID)
                  ChipLogError(AppServer, "CastingServer.applicationBasic_ReadVendorID failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, applicationBasic_1readApplicationName)
@@ -2026,12 +1816,7 @@ JNI_METHOD(jboolean, applicationBasic_1readApplicationName)
         ChipLogError(AppServer, "CastingServer.applicationBasic_ReadApplicationName failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, applicationBasic_1readProductID)
@@ -2065,12 +1850,7 @@ JNI_METHOD(jboolean, applicationBasic_1readProductID)
                  ChipLogError(AppServer, "CastingServer.applicationBasic_ReadProductID failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }
 
 JNI_METHOD(jboolean, applicationBasic_1readApplicationVersion)
@@ -2108,10 +1888,5 @@ JNI_METHOD(jboolean, applicationBasic_1readApplicationVersion)
         ChipLogError(AppServer, "CastingServer.applicationBasic_ReadApplicationVersion failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    return true;
+    return (err == CHIP_NO_ERROR);
 }

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
@@ -33,9 +33,9 @@
 
 + (CastingServerBridge * _Nullable)getSharedInstance;
 
-- (void)initApp:(AppParameters * _Nullable)appParameters
-             clientQueue:(dispatch_queue_t _Nonnull)clientQueue
-    initAppStatusHandler:(nullable void (^)(bool))initAppStatusHandler;
+- (MatterError * _Nonnull)initializeApp:(AppParameters * _Nullable)appParameters
+                            clientQueue:(dispatch_queue_t _Nonnull)clientQueue
+                   initAppStatusHandler:(nullable void (^)(bool))initAppStatusHandler;
 
 /*!
  @brief Browse for on-network commissioner TVs

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -527,6 +527,16 @@
             return;
         }
 
+        err = CastingServer::GetInstance()->InitBindingHandlers();
+        if (err != CHIP_NO_ERROR) {
+            ChipLogError(AppServer, "Binding init failed: %s", ErrorStr(err));
+            dispatch_async(clientQueue, ^{
+                startMatterServerCompletionCallback(
+                    [[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
+            });
+            return;
+        }
+
         // Now reconnect to the VideoPlayer the casting app was previously connected to (if any)
         if (self->_previouslyConnectedVideoPlayer != nil) {
             ChipLogProgress(

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -108,9 +108,9 @@
     return self;
 }
 
-- (void)initApp:(AppParameters * _Nullable)appParameters
-             clientQueue:(dispatch_queue_t _Nonnull)clientQueue
-    initAppStatusHandler:(nullable void (^)(bool))initAppStatusHandler
+- (MatterError *)initializeApp:(AppParameters * _Nullable)appParameters
+                   clientQueue:(dispatch_queue_t _Nonnull)clientQueue
+          initAppStatusHandler:(nullable void (^)(bool))initAppStatusHandler
 {
     ChipLogProgress(AppServer, "CastingServerBridge().initApp() called");
 
@@ -128,7 +128,7 @@
         err = [ConversionUtils convertToCppAppParamsInfoFrom:_appParameters outAppParams:cppAppParams];
         if (err != CHIP_NO_ERROR) {
             ChipLogError(AppServer, "AppParameters conversion failed: %s", ErrorStr(err));
-            return;
+            return [[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]];
         }
 
         // set fields in commissionableDataProvider
@@ -156,7 +156,7 @@
             setupDiscriminator);
         if (err != CHIP_NO_ERROR) {
             ChipLogError(AppServer, "Failed to initialize CommissionableDataProvider: %s", ErrorStr(err));
-            return;
+            return [[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]];
         }
 
         if (_appParameters.deviceAttestationCredentials != nil) {
@@ -219,13 +219,24 @@
     err = _serverInitParams->InitializeStaticResourcesBeforeServerInit();
     if (err != CHIP_NO_ERROR) {
         ChipLogError(AppServer, "InitializeStaticResourcesBeforeServerInit failed: %s", ErrorStr(err));
-        return;
+        return [[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]];
+    }
+
+    AppParams appParam;
+    if (appParameters == nil) {
+        err = CastingServer::GetInstance()->PreInit();
+    } else if ((err = [ConversionUtils convertToCppAppParamsInfoFrom:appParameters outAppParams:appParam]) == CHIP_NO_ERROR) {
+        err = CastingServer::GetInstance()->PreInit(&appParam);
+    }
+    if (err != CHIP_NO_ERROR) {
+        ChipLogError(AppServer, "CastingServer PreInit failed: %s", ErrorStr(err));
+        return [[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]];
     }
 
     err = chip::Server::GetInstance().Init(*_serverInitParams);
     if (err != CHIP_NO_ERROR) {
         ChipLogError(AppServer, "chip::Server init failed: %s", ErrorStr(err));
-        return;
+        return [[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]];
     }
 
     _chipWorkQueue = chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue();
@@ -251,6 +262,9 @@
             initAppStatusHandler(initAppStatus);
         });
     });
+
+    return [[MatterError alloc] initWithCode:CHIP_NO_ERROR.AsInteger()
+                                     message:[NSString stringWithUTF8String:CHIP_NO_ERROR.AsString()]];
 }
 
 - (void)discoverCommissioners:(dispatch_queue_t _Nonnull)clientQueue
@@ -527,6 +541,7 @@
             return;
         }
 
+        // Initialize binding handlers
         err = CastingServer::GetInstance()->InitBindingHandlers();
         if (err != CHIP_NO_ERROR) {
             ChipLogError(AppServer, "Binding init failed: %s", ErrorStr(err));

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/TvCastingApp.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/TvCastingApp.swift
@@ -46,9 +46,10 @@ struct TvCastingApp: App {
                         
                         appParameters.onboardingPayload = onboardingParameters
                         
-                        castingServerBridge.initApp(appParameters, clientQueue: DispatchQueue.main, initAppStatusHandler: { (result: Bool) -> () in
-                            self.Log.info("initApp result \(result)")
+                        let err = castingServerBridge.initializeApp(appParameters, clientQueue: DispatchQueue.main, initAppStatusHandler: { (result: Bool) -> () in
+                            self.Log.info("initializeApp result \(result)")
                         })
+                        self.Log.info("initializeApp return value \(err)")
                     }
                 })
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -134,6 +134,8 @@ int main(int argc, char * argv[])
         SetDeviceAttestationVerifier(GetDefaultDACVerifier(testingRootStore));
     }
 
+    SuccessOrExit(err = CastingServer::GetInstance()->PreInit());
+
     // Enter commissioning mode, open commissioning window
     static chip::CommonCaseDeviceServerInitParams initParams;
     VerifyOrDie(CHIP_NO_ERROR == initParams.InitializeStaticResourcesBeforeServerInit());

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -54,6 +54,7 @@ public:
     static CastingServer * GetInstance();
 
     CHIP_ERROR Init(AppParams * AppParams = nullptr);
+    CHIP_ERROR InitBindingHandlers();
 
     CHIP_ERROR DiscoverCommissioners();
     const chip::Dnssd::DiscoveredNodeData *
@@ -418,7 +419,6 @@ private:
     static CastingServer * castingServer_;
     CastingServer();
 
-    CHIP_ERROR InitBindingHandlers();
     static void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     void ReadServerClusters(chip::EndpointId endpointId);
 

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -53,6 +53,7 @@ public:
     void operator=(const CastingServer &) = delete;
     static CastingServer * GetInstance();
 
+    CHIP_ERROR PreInit(AppParams * AppParams = nullptr);
     CHIP_ERROR Init(AppParams * AppParams = nullptr);
     CHIP_ERROR InitBindingHandlers();
 
@@ -418,6 +419,8 @@ public:
 private:
     static CastingServer * castingServer_;
     CastingServer();
+
+    CHIP_ERROR SetRotatingDeviceIdUniqueId(chip::Optional<chip::ByteSpan> rotatingDeviceIdUniqueId);
 
     static void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     void ReadServerClusters(chip::EndpointId endpointId);

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -289,16 +289,17 @@ CHIP_ERROR CastingServer::VerifyOrEstablishConnection(TargetVideoPlayerInfo & ta
     mOnConnectionFailureClientCallback = onConnectionFailure;
     mOnNewOrUpdatedEndpoint            = onNewOrUpdatedEndpoint;
 
+    chip::OperationalDeviceProxy * prevDeviceProxy =
+        CastingServer::GetInstance()->mActiveTargetVideoPlayerInfo.GetOperationalDeviceProxy();
+    if (prevDeviceProxy != nullptr)
+    {
+        ChipLogProgress(AppServer, "CastingServer::VerifyOrEstablishConnection Disconnecting previous deviceProxy");
+        prevDeviceProxy->Disconnect();
+    }
+
     return targetVideoPlayerInfo.FindOrEstablishCASESession(
         [](TargetVideoPlayerInfo * videoPlayer) {
             ChipLogProgress(AppServer, "CastingServer::OnConnectionSuccess lambda called");
-            chip::OperationalDeviceProxy * prevDeviceProxy =
-                CastingServer::GetInstance()->mActiveTargetVideoPlayerInfo.GetOperationalDeviceProxy();
-            if (prevDeviceProxy != nullptr)
-            {
-                ChipLogProgress(AppServer, "CastingServer::OnConnectionSuccess lambda Disconnecting deviceProxy");
-                prevDeviceProxy->Disconnect();
-            }
             CastingServer::GetInstance()->mActiveTargetVideoPlayerInfo = *videoPlayer;
             CastingServer::GetInstance()->mOnConnectionSuccessClientCallback(videoPlayer);
         },

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -36,35 +36,21 @@ CastingServer * CastingServer::GetInstance()
     return castingServer_;
 }
 
+CHIP_ERROR CastingServer::PreInit(AppParams * appParams)
+{
+#if CHIP_ENABLE_ROTATING_DEVICE_ID
+    return SetRotatingDeviceIdUniqueId(appParams != nullptr ? appParams->GetRotatingDeviceIdUniqueId() : chip::NullOptional);
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif // CHIP_ENABLE_ROTATING_DEVICE_ID
+}
+
 CHIP_ERROR CastingServer::Init(AppParams * AppParams)
 {
     if (mInited)
     {
         return CHIP_NO_ERROR;
     }
-
-#if CHIP_ENABLE_ROTATING_DEVICE_ID
-    // if this class's client provided a RotatingDeviceIdUniqueId, use that
-    if (AppParams != nullptr && AppParams->GetRotatingDeviceIdUniqueId().HasValue())
-    {
-        ByteSpan rotatingDeviceIdUniqueId(AppParams->GetRotatingDeviceIdUniqueId().Value());
-        chip::DeviceLayer::ConfigurationMgr().SetRotatingDeviceIdUniqueId(rotatingDeviceIdUniqueId);
-    }
-#ifdef CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID
-    else
-    {
-        // otherwise, generate and set a random uniqueId for generating rotatingId
-        uint8_t rotatingDeviceIdUniqueId[chip::DeviceLayer::ConfigurationManager::kRotatingDeviceIDUniqueIDLength];
-        for (size_t i = 0; i < sizeof(rotatingDeviceIdUniqueId); i++)
-        {
-            rotatingDeviceIdUniqueId[i] = chip::Crypto::GetRandU8();
-        }
-
-        // ByteSpan rotatingDeviceIdUniqueIdSpan(rotatingDeviceIdUniqueId);
-        chip::DeviceLayer::ConfigurationMgr().SetRotatingDeviceIdUniqueId(ByteSpan(rotatingDeviceIdUniqueId));
-    }
-#endif // CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID
-#endif // CHIP_ENABLE_ROTATING_DEVICE_ID
 
     // Initialize binding handlers
     ReturnErrorOnFailure(InitBindingHandlers());
@@ -73,6 +59,33 @@ CHIP_ERROR CastingServer::Init(AppParams * AppParams)
     ReturnErrorOnFailure(DeviceLayer::PlatformMgrImpl().AddEventHandler(DeviceEventCallback, 0));
 
     mInited = true;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR CastingServer::SetRotatingDeviceIdUniqueId(chip::Optional<chip::ByteSpan> rotatingDeviceIdUniqueIdOptional)
+{
+#if CHIP_ENABLE_ROTATING_DEVICE_ID
+    // if this class's client provided a RotatingDeviceIdUniqueId, use that
+    if (rotatingDeviceIdUniqueIdOptional.HasValue())
+    {
+        ChipLogProgress(AppServer, "Setting rotatingDeviceIdUniqueId received from client app");
+        return chip::DeviceLayer::ConfigurationMgr().SetRotatingDeviceIdUniqueId(rotatingDeviceIdUniqueIdOptional.Value());
+    }
+#ifdef CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID
+    else
+    {
+        // otherwise, generate and set a random uniqueId for generating rotatingId
+        ChipLogProgress(AppServer, "Setting random rotatingDeviceIdUniqueId");
+        uint8_t rotatingDeviceIdUniqueId[chip::DeviceLayer::ConfigurationManager::kRotatingDeviceIDUniqueIDLength];
+        for (size_t i = 0; i < sizeof(rotatingDeviceIdUniqueId); i++)
+        {
+            rotatingDeviceIdUniqueId[i] = chip::Crypto::GetRandU8();
+        }
+
+        return chip::DeviceLayer::ConfigurationMgr().SetRotatingDeviceIdUniqueId(ByteSpan(rotatingDeviceIdUniqueId));
+    }
+#endif // CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID
+#endif // CHIP_ENABLE_ROTATING_DEVICE_ID
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/24399 and https://github.com/project-chip/connectedhomeip/issues/24400

#### Change Summary
1. Fix for https://github.com/project-chip/connectedhomeip/issues/24399 - Re-initialized binding handlers in the startMatterServer API to make sure the SDK is set up to make the callback on calls to FindOrEstablishSession the first time.
2. Fix for https://github.com/project-chip/connectedhomeip/issues/24400 - Moved calls to SetRotatingDeviceIdUniqueId to a point before the Matter server is initialized, to ensure we always are using the client's passed in RotatingDeviceIdUniqueId and never a default one.

#### Testing
Tested using the Android/iOS tv-casting-apps running against the Linux tv-app