### PR TITLE
[tlv] Rename CHIPCircularTLVBuffer to TLVCircularBuffer.

### DIFF
--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -691,7 +691,7 @@ CHIP_ERROR EventManagement::FabricRemovedCB(const TLV::TLVReader & aReader, size
             VerifyOrReturnError(event.Get(fabricIndex) == CHIP_NO_ERROR, CHIP_NO_ERROR);
             if (fabricIndex == *invalidFabricIndex)
             {
-                CHIPCircularTLVBuffer * readBuffer = static_cast<CHIPCircularTLVBuffer *>(event.GetBackingStore());
+                TLVCircularBuffer * readBuffer = static_cast<TLVCircularBuffer *>(event.GetBackingStore());
                 // fabricIndex is encoded as an integer; the dataPtr will point to a location immediately after its encoding
                 // shift the dataPtr to point to the encoding of the fabric index, accounting for wraparound in backing storage
                 // we cannot get the actual encoding size from current container beginning to the fabric index because of several
@@ -796,7 +796,7 @@ CHIP_ERROR EventManagement::FetchEventParameters(const TLVReader & aReader, size
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR EventManagement::EvictEvent(CHIPCircularTLVBuffer & apBuffer, void * apAppData, TLVReader & aReader)
+CHIP_ERROR EventManagement::EvictEvent(TLVCircularBuffer & apBuffer, void * apAppData, TLVReader & aReader)
 {
     // pull out the delta time, pull out the priority
     ReturnErrorOnFailure(aReader.Next());
@@ -847,7 +847,7 @@ void EventManagement::SetScheduledEventInfo(EventNumber & aEventNumber, uint32_t
 void CircularEventBuffer::Init(uint8_t * apBuffer, uint32_t aBufferLength, CircularEventBuffer * apPrev,
                                CircularEventBuffer * apNext, PriorityLevel aPriorityLevel)
 {
-    CHIPCircularTLVBuffer::Init(apBuffer, aBufferLength);
+    TLVCircularBuffer::Init(apBuffer, aBufferLength);
     mpPrev    = apPrev;
     mpNext    = apNext;
     mPriority = aPriorityLevel;

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -33,7 +33,7 @@
 #include <app/MessageDef/StatusIB.h>
 #include <app/ObjectList.h>
 #include <app/util/basic-types.h>
-#include <lib/core/CHIPCircularTLVBuffer.h>
+#include <lib/core/TLVCircularBuffer.h>
 #include <lib/support/CHIPCounter.h>
 #include <messaging/ExchangeMgr.h>
 
@@ -49,17 +49,17 @@ constexpr uint16_t kRequiredEventField =
 
 /**
  * @brief
- *   Internal event buffer, built around the TLV::CHIPCircularTLVBuffer
+ *   Internal event buffer, built around the TLV::TLVCircularBuffer
  */
 
-class CircularEventBuffer : public TLV::CHIPCircularTLVBuffer
+class CircularEventBuffer : public TLV::TLVCircularBuffer
 {
 public:
     /**
      * @brief
      *   A constructor for the CircularEventBuffer (internal API).
      */
-    CircularEventBuffer() : CHIPCircularTLVBuffer(nullptr, 0){};
+    CircularEventBuffer() : TLVCircularBuffer(nullptr, 0){};
 
     /**
      * @brief
@@ -119,10 +119,10 @@ class CircularEventReader;
  *   if nothing left there update its CircularEventBuffer until the buffer with data has been found,
  *   the tlv reader will have a pointer to this impl.
  */
-class CircularEventBufferWrapper : public TLV::CHIPCircularTLVBuffer
+class CircularEventBufferWrapper : public TLV::TLVCircularBuffer
 {
 public:
-    CircularEventBufferWrapper() : CHIPCircularTLVBuffer(nullptr, 0), mpCurrent(nullptr){};
+    CircularEventBufferWrapper() : TLVCircularBuffer(nullptr, 0), mpCurrent(nullptr){};
     CircularEventBuffer * mpCurrent;
 
 private:
@@ -149,7 +149,7 @@ enum class EventManagementStates
 
 struct LogStorageResources
 {
-    // TODO: Update CHIPCircularTLVBuffer with size_t for buffer size, then use ByteSpan
+    // TODO: Update TLVCircularBuffer with size_t for buffer size, then use ByteSpan
     uint8_t * mpBuffer =
         nullptr; // Buffer to be used as a storage at the particular priority level and shared with more important events.
                  // Must not be nullptr.  Must be large enough to accommodate the largest event emitted by the system.
@@ -466,8 +466,8 @@ private:
      * @brief checking if the tail's event can be moved to higher priority, if not, dropped, if yes, note how much space it
      * requires, and return.
      */
-    static CHIP_ERROR EvictEvent(chip::TLV::CHIPCircularTLVBuffer & aBuffer, void * apAppData, TLV::TLVReader & aReader);
-    static CHIP_ERROR AlwaysFail(chip::TLV::CHIPCircularTLVBuffer & aBuffer, void * apAppData, TLV::TLVReader & aReader)
+    static CHIP_ERROR EvictEvent(chip::TLV::TLVCircularBuffer & aBuffer, void * apAppData, TLV::TLVReader & aReader);
+    static CHIP_ERROR AlwaysFail(chip::TLV::TLVCircularBuffer & aBuffer, void * apAppData, TLV::TLVReader & aReader)
     {
         return CHIP_ERROR_NO_MEMORY;
     };

--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -93,8 +93,6 @@ static_library("core") {
     # instead.
     "${chip_root}/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h",
     "CHIPCallback.h",
-    "CHIPCircularTLVBuffer.cpp",
-    "CHIPCircularTLVBuffer.h",
     "CHIPCore.h",
     "CHIPEncoding.h",
     "CHIPError.cpp",
@@ -110,6 +108,8 @@ static_library("core") {
     "PasscodeId.h",
     "PeerId.h",
     "TLV.h",
+    "TLVCircularBuffer.cpp",
+    "TLVCircularBuffer.h",
     "TLVDebug.cpp",
     "TLVReader.cpp",
     "TLVTags.h",

--- a/src/lib/core/TLVCircularBuffer.cpp
+++ b/src/lib/core/TLVCircularBuffer.cpp
@@ -30,7 +30,7 @@
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
 #endif
-#include <lib/core/CHIPCircularTLVBuffer.h>
+#include <lib/core/TLVCircularBuffer.h>
 
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPEncoding.h>
@@ -47,7 +47,7 @@ using namespace chip::Encoding;
 
 /**
  * @brief
- *   CHIPCircularTLVBuffer constructor
+ *   TLVCircularBuffer constructor
  *
  * @param[in] inBuffer       A pointer to the backing store for the queue
  *
@@ -56,7 +56,7 @@ using namespace chip::Encoding;
  * @param[in] inHead         Initial point for the head.  The @a inHead pointer is must fall within the backing store for the
  * circular buffer, i.e. within @a inBuffer and &(@a inBuffer[@a inBufferLength])
  */
-CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t * inBuffer, uint32_t inBufferLength, uint8_t * inHead)
+TLVCircularBuffer::TLVCircularBuffer(uint8_t * inBuffer, uint32_t inBufferLength, uint8_t * inHead)
 {
     mQueue       = inBuffer;
     mQueueSize   = inBufferLength;
@@ -74,26 +74,26 @@ CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t * inBuffer, uint32_t inBuff
 
 /**
  * @brief
- *   CHIPCircularTLVBuffer constructor
+ *   TLVCircularBuffer constructor
  *
  * @param[in] inBuffer       A pointer to the backing store for the queue
  *
  * @param[in] inBufferLength Length, in bytes, of the backing store
  */
-CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t * inBuffer, uint32_t inBufferLength)
+TLVCircularBuffer::TLVCircularBuffer(uint8_t * inBuffer, uint32_t inBufferLength)
 {
     Init(inBuffer, inBufferLength);
 }
 
 /**
  * @brief
- *   CHIPCircularTLVBuffer Init function
+ *   TLVCircularBuffer Init function
  *
  * @param[in] inBuffer       A pointer to the backing store for the queue
  *
  * @param[in] inBufferLength Length, in bytes, of the backing store
  */
-void CHIPCircularTLVBuffer::Init(uint8_t * inBuffer, uint32_t inBufferLength)
+void TLVCircularBuffer::Init(uint8_t * inBuffer, uint32_t inBufferLength)
 {
     mQueue       = inBuffer;
     mQueueSize   = inBufferLength;
@@ -111,7 +111,7 @@ void CHIPCircularTLVBuffer::Init(uint8_t * inBuffer, uint32_t inBufferLength)
 
 /**
  * @brief
- *   Evicts the oldest top-level TLV element in the CHIPCircularTLVBuffer
+ *   Evicts the oldest top-level TLV element in the TLVCircularBuffer
  *
  * This function removes the oldest top level TLV element in the
  * buffer.  The function will call the callback registered at
@@ -119,7 +119,7 @@ void CHIPCircularTLVBuffer::Init(uint8_t * inBuffer, uint32_t inBufferLength)
  * If the callback returns anything but #CHIP_NO_ERROR, the element
  * is not removed.  Similarly, if any other error occurs -- no
  * elements within the buffer, etc -- the underlying
- * #CHIPCircularTLVBuffer remains unchanged.
+ * #TLVCircularBuffer remains unchanged.
  *
  *  @retval #CHIP_NO_ERROR On success.
  *
@@ -127,7 +127,7 @@ void CHIPCircularTLVBuffer::Init(uint8_t * inBuffer, uint32_t inBufferLength)
  *                         or by the TLVReader.
  *
  */
-CHIP_ERROR CHIPCircularTLVBuffer::EvictHead()
+CHIP_ERROR TLVCircularBuffer::EvictHead()
 {
     CircularTLVReader reader;
     uint8_t * newHead;
@@ -169,7 +169,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::EvictHead()
  * @brief
  *  Implements TLVBackingStore::OnInit(TLVWriter) for circular buffers.
  */
-CHIP_ERROR CHIPCircularTLVBuffer::OnInit(TLVWriter & writer, uint8_t *& bufStart, uint32_t & bufLen)
+CHIP_ERROR TLVCircularBuffer::OnInit(TLVWriter & writer, uint8_t *& bufStart, uint32_t & bufLen)
 {
     return GetNewBuffer(writer, bufStart, bufLen);
 }
@@ -192,7 +192,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::OnInit(TLVWriter & writer, uint8_t *& bufStart
  *                         top-level TLV element.
  */
 
-CHIP_ERROR CHIPCircularTLVBuffer::GetNewBuffer(TLVWriter & ioWriter, uint8_t *& outBufStart, uint32_t & outBufLen)
+CHIP_ERROR TLVCircularBuffer::GetNewBuffer(TLVWriter & ioWriter, uint8_t *& outBufStart, uint32_t & outBufLen)
 {
     uint8_t * tail = QueueTail();
 
@@ -219,7 +219,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::GetNewBuffer(TLVWriter & ioWriter, uint8_t *& 
 
 /**
  * @brief
- *   FinalizeBuffer adjust the `CHIPCircularTLVBuffer` state on
+ *   FinalizeBuffer adjust the `TLVCircularBuffer` state on
  *   completion of output from the TLVWriter.  This function affects
  *   the position of the queue tail.
  *
@@ -234,7 +234,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::GetNewBuffer(TLVWriter & ioWriter, uint8_t *& 
  * @retval #CHIP_NO_ERROR Unconditionally.
  */
 
-CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBuffer(TLVWriter & ioWriter, uint8_t * inBufStart, uint32_t inBufLen)
+CHIP_ERROR TLVCircularBuffer::FinalizeBuffer(TLVWriter & ioWriter, uint8_t * inBufStart, uint32_t inBufLen)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t * tail = inBufStart + inBufLen;
@@ -256,7 +256,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBuffer(TLVWriter & ioWriter, uint8_t *
  * @brief
  *  Implements TLVBackingStore::OnInit(TVLReader) for circular buffers.
  */
-CHIP_ERROR CHIPCircularTLVBuffer::OnInit(TLVReader & reader, const uint8_t *& bufStart, uint32_t & bufLen)
+CHIP_ERROR TLVCircularBuffer::OnInit(TLVReader & reader, const uint8_t *& bufStart, uint32_t & bufLen)
 {
     return GetNextBuffer(reader, bufStart, bufLen);
 }
@@ -265,7 +265,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::OnInit(TLVReader & reader, const uint8_t *& bu
  * @brief
  *   Get additional space for the TLVReader.
  *
- *  The storage provided by the CHIPCircularTLVBuffer may be
+ *  The storage provided by the TLVCircularBuffer may be
  *  wraparound within the buffer.  This function provides us with an
  *  ability to match the buffering of the circular buffer to the
  *  TLVReader constraints.  The reader will read at most `mQueueSize`
@@ -282,7 +282,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::OnInit(TLVReader & reader, const uint8_t *& bu
  *
  * @retval #CHIP_NO_ERROR      Succeeds unconditionally.
  */
-CHIP_ERROR CHIPCircularTLVBuffer::GetNextBuffer(TLVReader & ioReader, const uint8_t *& outBufStart, uint32_t & outBufLen)
+CHIP_ERROR TLVCircularBuffer::GetNextBuffer(TLVReader & ioReader, const uint8_t *& outBufStart, uint32_t & outBufLen)
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
     uint8_t * tail              = QueueTail();

--- a/src/lib/core/TLVCircularBuffer.h
+++ b/src/lib/core/TLVCircularBuffer.h
@@ -42,23 +42,23 @@ namespace chip {
 namespace TLV {
 
 /**
- * @class CHIPCircularTLVBuffer
+ * @class TLVCircularBuffer
  *
  * @brief
- *    CHIPCircularTLVBuffer provides circular storage for the
+ *    TLVCircularBuffer provides circular storage for the
  *    chip::TLV::TLVWriter and chip::TLVTLVReader.  chip::TLV::TLVWriter is able to write an
- *    unbounded number of TLV entries to the CHIPCircularTLVBuffer
+ *    unbounded number of TLV entries to the TLVCircularBuffer
  *    as long as each individual TLV entry fits entirely within the
  *    provided storage.  The chip::TLV::TLVReader will read at most the size of
  *    the buffer, but will accommodate the wraparound within the
  *    buffer.
  *
  */
-class DLL_EXPORT CHIPCircularTLVBuffer : public chip::TLV::TLVBackingStore
+class DLL_EXPORT TLVCircularBuffer : public chip::TLV::TLVBackingStore
 {
 public:
-    CHIPCircularTLVBuffer(uint8_t * inBuffer, uint32_t inBufferLength);
-    CHIPCircularTLVBuffer(uint8_t * inBuffer, uint32_t inBufferLength, uint8_t * inHead);
+    TLVCircularBuffer(uint8_t * inBuffer, uint32_t inBufferLength);
+    TLVCircularBuffer(uint8_t * inBuffer, uint32_t inBufferLength, uint8_t * inHead);
 
     void Init(uint8_t * inBuffer, uint32_t inBufferLength);
     inline uint8_t * QueueHead() const { return mQueueHead; }
@@ -78,10 +78,10 @@ public:
     CHIP_ERROR FinalizeBuffer(TLVWriter & ioWriter, uint8_t * inBufStart, uint32_t inBufLen) override;
 
     /**
-     *  @typedef CHIP_ERROR (*ProcessEvictedElementFunct)(CHIPCircularTLVBuffer &inBuffer, void * inAppData, TLVReader &inReader)
+     *  @typedef CHIP_ERROR (*ProcessEvictedElementFunct)(TLVCircularBuffer &inBuffer, void * inAppData, TLVReader &inReader)
      *
      *  A function that is called to process a TLV element prior to it
-     *  being evicted from the chip::TLV::CHIPCircularTLVBuffer
+     *  being evicted from the chip::TLV::TLVCircularBuffer
      *
      *  Functions of this type are used to process a TLV element about
      *  to be evicted from the buffer.  The function will be given a
@@ -89,14 +89,14 @@ public:
      *  well as void * context where the user may have provided
      *  additional environment for the callback.  If the function
      *  processed the element successfully, it must return
-     *  #CHIP_NO_ERROR ; this signifies to the CHIPCircularTLVBuffer
+     *  #CHIP_NO_ERROR ; this signifies to the TLVCircularBuffer
      *  that the element may be safely evicted.  Any other return
      *  value is treated as an error and will prevent the
-     *  #CHIPCircularTLVBuffer from evicting the element under
+     *  #TLVCircularBuffer from evicting the element under
      *  consideration.
      *
      *  Note: This callback may be used to force
-     *  CHIPCircularTLVBuffer to not evict the element.  This may be
+     *  TLVCircularBuffer to not evict the element.  This may be
      *  useful in a number of circumstances, when it is desired to
      *  have an underlying circular buffer, but not to override any
      *  elements within it.
@@ -119,7 +119,7 @@ public:
      *                       triggered this element eviction will
      *                       fail.
      */
-    typedef CHIP_ERROR (*ProcessEvictedElementFunct)(CHIPCircularTLVBuffer & inBuffer, void * inAppData, TLVReader & inReader);
+    typedef CHIP_ERROR (*ProcessEvictedElementFunct)(TLVCircularBuffer & inBuffer, void * inAppData, TLVReader & inReader);
 
     uint32_t mImplicitProfileId;
     void * mAppData; /**< An optional, user supplied context to be used with the callback processing the evicted element. */
@@ -140,17 +140,17 @@ class DLL_EXPORT CircularTLVReader : public TLVReader
 public:
     /**
      * @brief
-     *   Initializes a TLVReader object to read from a single CHIPCircularTLVBuffer
+     *   Initializes a TLVReader object to read from a single TLVCircularBuffer
      *
      * Parsing begins at the start of the buffer (obtained by the
      * buffer->Start() position) and continues until the end of the buffer
      * Parsing may wraparound within the buffer (on any element).  At most
      * buffer->GetQueueSize() bytes are read out.
      *
-     * @param[in]    buf   A pointer to a fully initialized CHIPCircularTLVBuffer
+     * @param[in]    buf   A pointer to a fully initialized TLVCircularBuffer
      *
      */
-    void Init(CHIPCircularTLVBuffer & buf) { TLVReader::Init(buf, buf.DataLength()); }
+    void Init(TLVCircularBuffer & buf) { TLVReader::Init(buf, buf.DataLength()); }
 };
 
 class DLL_EXPORT CircularTLVWriter : public TLVWriter
@@ -158,7 +158,7 @@ class DLL_EXPORT CircularTLVWriter : public TLVWriter
 public:
     /**
      * @brief
-     *   Initializes a TLVWriter object to write from a single CHIPCircularTLVBuffer
+     *   Initializes a TLVWriter object to write from a single TLVCircularBuffer
      *
      * Writing begins at the last byte of the buffer.  The number of bytes
      * to be written is not constrained by the underlying circular buffer:
@@ -168,10 +168,10 @@ public:
      * 7 byte buffer will work indefinitely, but writing an 8-byte TLV
      * structure will result in an error.
      *
-     * @param[in]    buf   A pointer to a fully initialized CHIPCircularTLVBuffer
+     * @param[in]    buf   A pointer to a fully initialized TLVCircularBuffer
      *
      */
-    void Init(CHIPCircularTLVBuffer & buf) { TLVWriter::Init(buf, UINT32_MAX); }
+    void Init(TLVCircularBuffer & buf) { TLVWriter::Init(buf, UINT32_MAX); }
 };
 
 } // namespace TLV

--- a/src/lib/core/tests/TestTLV.cpp
+++ b/src/lib/core/tests/TestTLV.cpp
@@ -26,9 +26,9 @@
 #include <nlbyteorder.h>
 #include <nlunit-test.h>
 
-#include <lib/core/CHIPCircularTLVBuffer.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>
+#include <lib/core/TLVCircularBuffer.h>
 #include <lib/core/TLVData.h>
 #include <lib/core/TLVDebug.h>
 #include <lib/core/TLVUtilities.h>
@@ -2278,7 +2278,7 @@ void CheckPacketBuffer(nlTestSuite * inSuite, void * inContext)
     ReadEncoding1(inSuite, reader);
 }
 
-CHIP_ERROR CountEvictedMembers(CHIPCircularTLVBuffer & inBuffer, void * inAppData, TLVReader & inReader)
+CHIP_ERROR CountEvictedMembers(TLVCircularBuffer & inBuffer, void * inAppData, TLVReader & inReader)
 {
     TestTLVContext * context = static_cast<TestTLVContext *>(inAppData);
     CHIP_ERROR err;
@@ -2307,7 +2307,7 @@ void CheckCircularTLVBufferSimple(nlTestSuite * inSuite, void * inContext)
     CircularTLVWriter writer;
     CircularTLVReader reader;
     TestTLVContext * context = static_cast<TestTLVContext *>(inContext);
-    CHIPCircularTLVBuffer buffer(backingStore, 30);
+    TLVCircularBuffer buffer(backingStore, 30);
     writer.Init(buffer);
     writer.ImplicitProfileId = TestProfile_2;
 
@@ -2357,7 +2357,7 @@ void CheckCircularTLVBufferStartMidway(nlTestSuite * inSuite, void * inContext)
     CircularTLVWriter writer;
     CircularTLVReader reader;
     TestTLVContext * context = static_cast<TestTLVContext *>(inContext);
-    CHIPCircularTLVBuffer buffer(backingStore, 30, &(backingStore[15]));
+    TLVCircularBuffer buffer(backingStore, 30, &(backingStore[15]));
     writer.Init(buffer);
     writer.ImplicitProfileId = TestProfile_2;
 
@@ -2408,7 +2408,7 @@ void CheckCircularTLVBufferEvictStraddlingEvent(nlTestSuite * inSuite, void * in
     uint8_t backingStore[30];
     CircularTLVWriter writer;
     CircularTLVReader reader;
-    CHIPCircularTLVBuffer buffer(backingStore, 30);
+    TLVCircularBuffer buffer(backingStore, 30);
     writer.Init(buffer);
     writer.ImplicitProfileId = TestProfile_2;
 
@@ -2470,8 +2470,8 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
     CircularTLVReader reader;
     TLVWriter writer1;
 
-    CHIPCircularTLVBuffer buffer(backingStore, sizeof(backingStore));
-    CHIPCircularTLVBuffer buffer1(backingStore1, sizeof(backingStore1));
+    TLVCircularBuffer buffer(backingStore, sizeof(backingStore));
+    TLVCircularBuffer buffer1(backingStore1, sizeof(backingStore1));
     writer.Init(buffer);
     writer.ImplicitProfileId = TestProfile_2;
 
@@ -2703,7 +2703,7 @@ void CheckTLVPutStringFCircular(nlTestSuite * inSuite, void * inContext)
     uint8_t backingStore[bufsize];
     CircularTLVWriter writer;
     CircularTLVReader reader;
-    CHIPCircularTLVBuffer buffer(backingStore, bufsize);
+    TLVCircularBuffer buffer(backingStore, bufsize);
     size_t num     = 1;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -2797,7 +2797,7 @@ void CheckTLVSkipCircular(nlTestSuite * inSuite, void * inContext)
     // Any pair of reader and writer would work here, either PacketBuffer based or CircularTLV based.
     CircularTLVWriter writer;
     CircularTLVReader reader;
-    CHIPCircularTLVBuffer buffer(backingStore, bufsize);
+    TLVCircularBuffer buffer(backingStore, bufsize);
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     writer.Init(buffer);


### PR DESCRIPTION
Extends cleanup of TLV module by renaming `CHIPCircularTLVBuffer` to `TLVCircularBuffer`.

