### PR TITLE
Added RegulatoryConfig support to AutoCommissioner for Android

### DIFF
--- a/examples/java-matter-controller/args.gni
+++ b/examples/java-matter-controller/args.gni
@@ -23,3 +23,4 @@ chip_system_project_config_include = "<SystemProjectConfig.h>"
 chip_project_config_include_dirs =
     [ "${chip_root}/examples/java-matter-controller/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
+chip_stack_lock_tracking = "none"

--- a/examples/java-matter-controller/java/src/com/matter/controller/Main.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/Main.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2022 Project CHIP Authors
+ *   Copyright (c) 2022-2023 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,6 +105,7 @@ public class Main {
             ControllerParams.newBuilder()
                 .setUdpListenPort(0)
                 .setControllerVendorId(0xFFF1)
+                .setCountryCode("US")
                 .build());
 
     CredentialsIssuer credentialsIssuer = new CredentialsIssuer();

--- a/src/controller/java/src/chip/devicecontroller/ControllerParams.java
+++ b/src/controller/java/src/chip/devicecontroller/ControllerParams.java
@@ -1,5 +1,6 @@
 package chip.devicecontroller;
 
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 /** Parameters representing initialization arguments for {@link ChipDeviceController}. */
@@ -13,6 +14,8 @@ public final class ControllerParams {
   private final boolean attemptNetworkScanWiFi;
   private final boolean attemptNetworkScanThread;
   private final boolean skipCommissioningComplete;
+  private final Optional<String> countryCode;
+  private final Optional<Integer> regulatoryLocationType;
   @Nullable private final KeypairDelegate keypairDelegate;
   @Nullable private final byte[] rootCertificate;
   @Nullable private final byte[] intermediateCertificate;
@@ -32,6 +35,8 @@ public final class ControllerParams {
     this.attemptNetworkScanWiFi = builder.attemptNetworkScanWiFi;
     this.attemptNetworkScanThread = builder.attemptNetworkScanThread;
     this.skipCommissioningComplete = builder.skipCommissioningComplete;
+    this.countryCode = builder.countryCode;
+    this.regulatoryLocationType = builder.regulatoryLocationType;
     this.keypairDelegate = builder.keypairDelegate;
     this.rootCertificate = builder.rootCertificate;
     this.intermediateCertificate = builder.intermediateCertificate;
@@ -71,6 +76,14 @@ public final class ControllerParams {
 
   public boolean getSkipCommissioningComplete() {
     return skipCommissioningComplete;
+  }
+
+  public Optional<String> getCountryCode() {
+    return countryCode;
+  }
+
+  public Optional<Integer> getRegulatoryLocation() {
+    return regulatoryLocationType;
   }
 
   public KeypairDelegate getKeypairDelegate() {
@@ -126,6 +139,8 @@ public final class ControllerParams {
     private boolean attemptNetworkScanWiFi = false;
     private boolean attemptNetworkScanThread = false;
     private boolean skipCommissioningComplete = false;
+    private Optional<String> countryCode = Optional.empty();
+    private Optional<Integer> regulatoryLocationType = Optional.empty();
     @Nullable private KeypairDelegate keypairDelegate = null;
     @Nullable private byte[] rootCertificate = null;
     @Nullable private byte[] intermediateCertificate = null;
@@ -244,6 +259,46 @@ public final class ControllerParams {
      */
     public Builder setSkipCommissioningComplete(boolean skipCommissioningComplete) {
       this.skipCommissioningComplete = skipCommissioningComplete;
+      return this;
+    }
+
+    /**
+     * Sets the Regulatory Location country code passed to ChipDeviceCommissioner's
+     * CommissioningParameters.
+     *
+     * <p>Setting the country code will set the CountryCode when the SetRegulatoryConfig command is
+     * sent by this ChipDeviceCommissioner.
+     *
+     * @param countryCode an ISO 3166-1 alpha-2 code to represent the country, dependent territory,
+     *     or special area of geographic interest
+     * @return
+     */
+    public Builder setCountryCode(final String countryCode) {
+      if (countryCode == null || countryCode.length() != 2) {
+        throw new IllegalArgumentException("countryCode must be 2 characters");
+      }
+      this.countryCode = Optional.of(countryCode);
+      return this;
+    }
+
+    /**
+     * Sets the Regulatory Location capability passed to ChipDeviceCommissioner's
+     * CommissioningParameters.
+     *
+     * <p>Setting the regulatory location type will set the NewRegulatoryConfig when the
+     * SetRegulatoryConfig command is sent by this ChipDeviceCommissioner.
+     *
+     * @param regulatoryLocation an app::Clusters::GeneralCommissioning::RegulatoryLocationType enum
+     *     value
+     * @return
+     */
+    public Builder setRegulatoryLocation(int regulatoryLocation) {
+      if ((regulatoryLocation < 0) || (regulatoryLocation > 2)) {
+        throw new IllegalArgumentException(
+            "regulatoryLocation value must be between RegulatoryLocationType::kIndoor and "
+                + "RegulatoryLocationType::kIndoorOutdoor");
+      }
+      this.regulatoryLocationType = Optional.of(regulatoryLocation);
       return this;
     }
 


### PR DESCRIPTION
> 5. Commissioner SHALL configure regulatory information in the Commissionee if it has at least one instance of Network Commissioning cluster on any endpoint with either the WI (i.e. Wi-Fi) or TH (i.e. Thread) feature flags set in its FeatureMap. Commissioner SHOULD configure UTC time, timezone, and DST offset, if the Commissionee supports the time cluster. The order of configuration of this information is not critical. The UTC time is configured using SetUtcTime command (see Section 11.16.7.1, “SetUtcTime Command”) while timezone and DST offset are set through TimeZone (see Section 11.16.6.6, “TimeZone Attribute”) and DstOffset attribute (see Section 11.16.6.7, “DstOffset Attribute”), respectively. The regulatory information is configured using SetRegulatoryConfig (see Section 11.9.7.4, “SetRegulatoryConfig Command”).

The CommissioningParameters has fields to support CountryCode and DeviceRegulatoryLocation, but the Android commissioner interface does not currently expose a way to set these fields. The interface has been updated to allow the commissioner to set these fields through the ControllerParams.