### PR TITLE
Make AutoCommissioner::SetCommissioningParameters safer.

### DIFF
--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -425,6 +425,26 @@ public:
         return *this;
     }
 
+    // Clear all members that depend on some sort of external buffer.  Can be
+    // used to make sure that we are not holding any dangling pointers.
+    void ClearExternalBufferDependentValues()
+    {
+        mCSRNonce.ClearValue();
+        mAttestationNonce.ClearValue();
+        mWiFiCreds.ClearValue();
+        mCountryCode.ClearValue();
+        mThreadOperationalDataset.ClearValue();
+        mNOCChainGenerationParameters.ClearValue();
+        mRootCert.ClearValue();
+        mNoc.ClearValue();
+        mIcac.ClearValue();
+        mIpk.ClearValue();
+        mAttestationElements.ClearValue();
+        mAttestationSignature.ClearValue();
+        mPAI.ClearValue();
+        mDAC.ClearValue();
+    }
+
 private:
     // Items that can be set by the commissioner
     Optional<uint16_t> mFailsafeTimerSeconds;


### PR DESCRIPTION
Right now, we copy all members of the incoming CommissioningParameters (which might include pointers to buffers that we don't own), then copy some of those external buffers into our own buffers.  Then we also hand-copy some scalar values we have already copied.

Changes in this PR:

* Stop copying scalar values that operator= already handled.
* Clear out all buffer references from our copy of CommissioningParameters before we start copying things into our buffers, so we don't end up with dangling pointers.
* Add the missing early return when an incoming country code value is too long (used to end up with a dangling pointer).
