### PR TITLE
Fix java discovery test failure

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -463,8 +463,6 @@ jobs:
                       build \
                    "
             - name: Run Discover Tests
-              # temporarily disable the failing test, would re-enable it later
-              if: false
               timeout-minutes: 10
               run: |
                   scripts/run_in_build_env.sh \

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/discover/DiscoverCommissionablesCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/discover/DiscoverCommissionablesCommand.java
@@ -58,7 +58,8 @@ public final class DiscoverCommissionablesCommand extends MatterCommand {
   }
 
   private final void logDevice(DiscoveredDevice device) {
-    System.out.format("\tDiscriminator: %ld", device.discriminator);
-    System.out.format("\tIP Address : %s", device.ipAddress);
+    System.out.println("Discovered node:");
+    System.out.format("\tDiscriminator: %d", device.discriminator);
+    System.out.format("\tIP Address : %s%n", device.ipAddress);
   }
 }


### PR DESCRIPTION
Fix:#24411

Fix exception failure during Java discovery test and re-enable Java discovery test in CI

```
[2023-01-12 18:43:41.952142][JAVA ][STDOUT][45937:45940] CHIP:CTL: Setting up group data for Fabric Index 1 with Compressed Fabric ID:
[2023-01-12 18:43:41.952212][JAVA ][STDOUT][45937:45940] CHIP:SPT: 0x7c, 0x00, 0x09, 0x1c, 0xc1, 0x05, 0xd0, 0xdb,
[2023-01-12 18:43:41.959577][JAVA ][STDOUT][45937:45954] CHIP:CTL: IO thread starting
[2023-01-12 18:43:49.001990][JAVA ][STDOUT]Run command failed with exception: Conversion = 'l'
```

