### PR TITLE
Account for manufacturerCode in access.zapt.

### DIFF
--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/access.h
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/access.h
@@ -31,8 +31,8 @@
 #define GENERATED_ACCESS_READ_ATTRIBUTE__CLUSTER { \
     /* Cluster: On/Off, Attribute: StartUpOnOff, Privilege: view */ \
     /* Cluster: Level Control, Attribute: StartUpCurrentLevel, Privilege: view */ \
-    31, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
-    31, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
+    0x0000001F, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
+    0x0000001F, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
     /* Cluster: Access Control, Attribute: SubjectsPerAccessControlEntry, Privilege: view */ \
     /* Cluster: Access Control, Attribute: TargetsPerAccessControlEntry, Privilege: view */ \
     /* Cluster: Access Control, Attribute: AccessControlEntriesPerFabric, Privilege: view */ \
@@ -40,13 +40,13 @@
     /* Cluster: Basic Information, Attribute: Location, Privilege: view */ \
     /* Cluster: Basic Information, Attribute: LocalConfigDisabled, Privilege: view */ \
     /* Cluster: General Commissioning, Attribute: Breadcrumb, Privilege: view */ \
-    49, /* Cluster: Network Commissioning, Attribute: MaxNetworks, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Attribute: Networks, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Attribute: MaxNetworks, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Attribute: Networks, Privilege: administer */ \
     /* Cluster: Network Commissioning, Attribute: InterfaceEnabled, Privilege: view */ \
-    49, /* Cluster: Network Commissioning, Attribute: LastNetworkingStatus, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Attribute: LastNetworkID, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Attribute: LastConnectErrorValue, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Attribute: NOCs, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Attribute: LastNetworkingStatus, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Attribute: LastNetworkID, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Attribute: LastConnectErrorValue, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Attribute: NOCs, Privilege: administer */ \
     /* Cluster: Group Key Management, Attribute: GroupKeyMap, Privilege: view */ \
     /* Cluster: User Label, Attribute: LabelList, Privilege: view */ \
     /* Cluster: Door Lock, Attribute: DoorOpenEvents, Privilege: view */ \
@@ -94,8 +94,8 @@
 #define GENERATED_ACCESS_READ_ATTRIBUTE__ATTRIBUTE { \
     /* Cluster: On/Off, Attribute: StartUpOnOff, Privilege: view */ \
     /* Cluster: Level Control, Attribute: StartUpCurrentLevel, Privilege: view */ \
-    0, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
-    1, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
+    0x00000000, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
+    0x00000001, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
     /* Cluster: Access Control, Attribute: SubjectsPerAccessControlEntry, Privilege: view */ \
     /* Cluster: Access Control, Attribute: TargetsPerAccessControlEntry, Privilege: view */ \
     /* Cluster: Access Control, Attribute: AccessControlEntriesPerFabric, Privilege: view */ \
@@ -103,13 +103,13 @@
     /* Cluster: Basic Information, Attribute: Location, Privilege: view */ \
     /* Cluster: Basic Information, Attribute: LocalConfigDisabled, Privilege: view */ \
     /* Cluster: General Commissioning, Attribute: Breadcrumb, Privilege: view */ \
-    0, /* Cluster: Network Commissioning, Attribute: MaxNetworks, Privilege: administer */ \
-    1, /* Cluster: Network Commissioning, Attribute: Networks, Privilege: administer */ \
+    0x00000000, /* Cluster: Network Commissioning, Attribute: MaxNetworks, Privilege: administer */ \
+    0x00000001, /* Cluster: Network Commissioning, Attribute: Networks, Privilege: administer */ \
     /* Cluster: Network Commissioning, Attribute: InterfaceEnabled, Privilege: view */ \
-    5, /* Cluster: Network Commissioning, Attribute: LastNetworkingStatus, Privilege: administer */ \
-    6, /* Cluster: Network Commissioning, Attribute: LastNetworkID, Privilege: administer */ \
-    7, /* Cluster: Network Commissioning, Attribute: LastConnectErrorValue, Privilege: administer */ \
-    0, /* Cluster: Operational Credentials, Attribute: NOCs, Privilege: administer */ \
+    0x00000005, /* Cluster: Network Commissioning, Attribute: LastNetworkingStatus, Privilege: administer */ \
+    0x00000006, /* Cluster: Network Commissioning, Attribute: LastNetworkID, Privilege: administer */ \
+    0x00000007, /* Cluster: Network Commissioning, Attribute: LastConnectErrorValue, Privilege: administer */ \
+    0x00000000, /* Cluster: Operational Credentials, Attribute: NOCs, Privilege: administer */ \
     /* Cluster: Group Key Management, Attribute: GroupKeyMap, Privilege: view */ \
     /* Cluster: User Label, Attribute: LabelList, Privilege: view */ \
     /* Cluster: Door Lock, Attribute: DoorOpenEvents, Privilege: view */ \
@@ -220,110 +220,110 @@
 
 // Parallel array data (*cluster*, attribute, privilege) for write attribute
 #define GENERATED_ACCESS_WRITE_ATTRIBUTE__CLUSTER { \
-    6, /* Cluster: On/Off, Attribute: StartUpOnOff, Privilege: manage */ \
-    8, /* Cluster: Level Control, Attribute: StartUpCurrentLevel, Privilege: manage */ \
-    31, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
-    31, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
-    40, /* Cluster: Basic Information, Attribute: NodeLabel, Privilege: manage */ \
-    40, /* Cluster: Basic Information, Attribute: Location, Privilege: administer */ \
-    40, /* Cluster: Basic Information, Attribute: LocalConfigDisabled, Privilege: manage */ \
-    48, /* Cluster: General Commissioning, Attribute: Breadcrumb, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Attribute: InterfaceEnabled, Privilege: administer */ \
-    63, /* Cluster: Group Key Management, Attribute: GroupKeyMap, Privilege: manage */ \
-    65, /* Cluster: User Label, Attribute: LabelList, Privilege: manage */ \
-    257, /* Cluster: Door Lock, Attribute: DoorOpenEvents, Privilege: manage */ \
-    257, /* Cluster: Door Lock, Attribute: DoorClosedEvents, Privilege: manage */ \
-    257, /* Cluster: Door Lock, Attribute: OpenPeriod, Privilege: manage */ \
-    257, /* Cluster: Door Lock, Attribute: Language, Privilege: manage */ \
-    257, /* Cluster: Door Lock, Attribute: AutoRelockTime, Privilege: manage */ \
-    257, /* Cluster: Door Lock, Attribute: SoundVolume, Privilege: manage */ \
-    257, /* Cluster: Door Lock, Attribute: OperatingMode, Privilege: manage */ \
-    257, /* Cluster: Door Lock, Attribute: EnableOneTouchLocking, Privilege: manage */ \
-    257, /* Cluster: Door Lock, Attribute: EnableInsideStatusLED, Privilege: manage */ \
-    257, /* Cluster: Door Lock, Attribute: EnablePrivacyModeButton, Privilege: manage */ \
-    257, /* Cluster: Door Lock, Attribute: WrongCodeEntryLimit, Privilege: administer */ \
-    257, /* Cluster: Door Lock, Attribute: UserCodeTemporaryDisableTime, Privilege: administer */ \
-    257, /* Cluster: Door Lock, Attribute: RequirePINforRemoteOperation, Privilege: administer */ \
-    258, /* Cluster: Window Covering, Attribute: Mode, Privilege: manage */ \
-    512, /* Cluster: Pump Configuration and Control, Attribute: LifetimeRunningHours, Privilege: manage */ \
-    512, /* Cluster: Pump Configuration and Control, Attribute: LifetimeEnergyConsumed, Privilege: manage */ \
-    512, /* Cluster: Pump Configuration and Control, Attribute: OperationMode, Privilege: manage */ \
-    512, /* Cluster: Pump Configuration and Control, Attribute: ControlMode, Privilege: manage */ \
-    513, /* Cluster: Thermostat, Attribute: MinHeatSetpointLimit, Privilege: manage */ \
-    513, /* Cluster: Thermostat, Attribute: MaxHeatSetpointLimit, Privilege: manage */ \
-    513, /* Cluster: Thermostat, Attribute: MinCoolSetpointLimit, Privilege: manage */ \
-    513, /* Cluster: Thermostat, Attribute: MaxCoolSetpointLimit, Privilege: manage */ \
-    513, /* Cluster: Thermostat, Attribute: MinSetpointDeadBand, Privilege: manage */ \
-    513, /* Cluster: Thermostat, Attribute: ControlSequenceOfOperation, Privilege: manage */ \
-    513, /* Cluster: Thermostat, Attribute: SystemMode, Privilege: manage */ \
-    516, /* Cluster: Thermostat User Interface Configuration, Attribute: KeypadLockout, Privilege: manage */ \
-    516, /* Cluster: Thermostat User Interface Configuration, Attribute: ScheduleProgrammingVisibility, Privilege: manage */ \
-    768, /* Cluster: Color Control, Attribute: WhitePointX, Privilege: manage */ \
-    768, /* Cluster: Color Control, Attribute: WhitePointY, Privilege: manage */ \
-    768, /* Cluster: Color Control, Attribute: ColorPointRX, Privilege: manage */ \
-    768, /* Cluster: Color Control, Attribute: ColorPointRY, Privilege: manage */ \
-    768, /* Cluster: Color Control, Attribute: ColorPointRIntensity, Privilege: manage */ \
-    768, /* Cluster: Color Control, Attribute: ColorPointGX, Privilege: manage */ \
-    768, /* Cluster: Color Control, Attribute: ColorPointGY, Privilege: manage */ \
-    768, /* Cluster: Color Control, Attribute: ColorPointGIntensity, Privilege: manage */ \
-    768, /* Cluster: Color Control, Attribute: ColorPointBX, Privilege: manage */ \
-    768, /* Cluster: Color Control, Attribute: ColorPointBY, Privilege: manage */ \
-    768, /* Cluster: Color Control, Attribute: ColorPointBIntensity, Privilege: manage */ \
-    768, /* Cluster: Color Control, Attribute: StartUpColorTemperatureMireds, Privilege: manage */ \
+    0x00000006, /* Cluster: On/Off, Attribute: StartUpOnOff, Privilege: manage */ \
+    0x00000008, /* Cluster: Level Control, Attribute: StartUpCurrentLevel, Privilege: manage */ \
+    0x0000001F, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
+    0x0000001F, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
+    0x00000028, /* Cluster: Basic Information, Attribute: NodeLabel, Privilege: manage */ \
+    0x00000028, /* Cluster: Basic Information, Attribute: Location, Privilege: administer */ \
+    0x00000028, /* Cluster: Basic Information, Attribute: LocalConfigDisabled, Privilege: manage */ \
+    0x00000030, /* Cluster: General Commissioning, Attribute: Breadcrumb, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Attribute: InterfaceEnabled, Privilege: administer */ \
+    0x0000003F, /* Cluster: Group Key Management, Attribute: GroupKeyMap, Privilege: manage */ \
+    0x00000041, /* Cluster: User Label, Attribute: LabelList, Privilege: manage */ \
+    0x00000101, /* Cluster: Door Lock, Attribute: DoorOpenEvents, Privilege: manage */ \
+    0x00000101, /* Cluster: Door Lock, Attribute: DoorClosedEvents, Privilege: manage */ \
+    0x00000101, /* Cluster: Door Lock, Attribute: OpenPeriod, Privilege: manage */ \
+    0x00000101, /* Cluster: Door Lock, Attribute: Language, Privilege: manage */ \
+    0x00000101, /* Cluster: Door Lock, Attribute: AutoRelockTime, Privilege: manage */ \
+    0x00000101, /* Cluster: Door Lock, Attribute: SoundVolume, Privilege: manage */ \
+    0x00000101, /* Cluster: Door Lock, Attribute: OperatingMode, Privilege: manage */ \
+    0x00000101, /* Cluster: Door Lock, Attribute: EnableOneTouchLocking, Privilege: manage */ \
+    0x00000101, /* Cluster: Door Lock, Attribute: EnableInsideStatusLED, Privilege: manage */ \
+    0x00000101, /* Cluster: Door Lock, Attribute: EnablePrivacyModeButton, Privilege: manage */ \
+    0x00000101, /* Cluster: Door Lock, Attribute: WrongCodeEntryLimit, Privilege: administer */ \
+    0x00000101, /* Cluster: Door Lock, Attribute: UserCodeTemporaryDisableTime, Privilege: administer */ \
+    0x00000101, /* Cluster: Door Lock, Attribute: RequirePINforRemoteOperation, Privilege: administer */ \
+    0x00000102, /* Cluster: Window Covering, Attribute: Mode, Privilege: manage */ \
+    0x00000200, /* Cluster: Pump Configuration and Control, Attribute: LifetimeRunningHours, Privilege: manage */ \
+    0x00000200, /* Cluster: Pump Configuration and Control, Attribute: LifetimeEnergyConsumed, Privilege: manage */ \
+    0x00000200, /* Cluster: Pump Configuration and Control, Attribute: OperationMode, Privilege: manage */ \
+    0x00000200, /* Cluster: Pump Configuration and Control, Attribute: ControlMode, Privilege: manage */ \
+    0x00000201, /* Cluster: Thermostat, Attribute: MinHeatSetpointLimit, Privilege: manage */ \
+    0x00000201, /* Cluster: Thermostat, Attribute: MaxHeatSetpointLimit, Privilege: manage */ \
+    0x00000201, /* Cluster: Thermostat, Attribute: MinCoolSetpointLimit, Privilege: manage */ \
+    0x00000201, /* Cluster: Thermostat, Attribute: MaxCoolSetpointLimit, Privilege: manage */ \
+    0x00000201, /* Cluster: Thermostat, Attribute: MinSetpointDeadBand, Privilege: manage */ \
+    0x00000201, /* Cluster: Thermostat, Attribute: ControlSequenceOfOperation, Privilege: manage */ \
+    0x00000201, /* Cluster: Thermostat, Attribute: SystemMode, Privilege: manage */ \
+    0x00000204, /* Cluster: Thermostat User Interface Configuration, Attribute: KeypadLockout, Privilege: manage */ \
+    0x00000204, /* Cluster: Thermostat User Interface Configuration, Attribute: ScheduleProgrammingVisibility, Privilege: manage */ \
+    0x00000300, /* Cluster: Color Control, Attribute: WhitePointX, Privilege: manage */ \
+    0x00000300, /* Cluster: Color Control, Attribute: WhitePointY, Privilege: manage */ \
+    0x00000300, /* Cluster: Color Control, Attribute: ColorPointRX, Privilege: manage */ \
+    0x00000300, /* Cluster: Color Control, Attribute: ColorPointRY, Privilege: manage */ \
+    0x00000300, /* Cluster: Color Control, Attribute: ColorPointRIntensity, Privilege: manage */ \
+    0x00000300, /* Cluster: Color Control, Attribute: ColorPointGX, Privilege: manage */ \
+    0x00000300, /* Cluster: Color Control, Attribute: ColorPointGY, Privilege: manage */ \
+    0x00000300, /* Cluster: Color Control, Attribute: ColorPointGIntensity, Privilege: manage */ \
+    0x00000300, /* Cluster: Color Control, Attribute: ColorPointBX, Privilege: manage */ \
+    0x00000300, /* Cluster: Color Control, Attribute: ColorPointBY, Privilege: manage */ \
+    0x00000300, /* Cluster: Color Control, Attribute: ColorPointBIntensity, Privilege: manage */ \
+    0x00000300, /* Cluster: Color Control, Attribute: StartUpColorTemperatureMireds, Privilege: manage */ \
 }
 
 // Parallel array data (cluster, *attribute*, privilege) for write attribute
 #define GENERATED_ACCESS_WRITE_ATTRIBUTE__ATTRIBUTE { \
-    16387, /* Cluster: On/Off, Attribute: StartUpOnOff, Privilege: manage */ \
-    16384, /* Cluster: Level Control, Attribute: StartUpCurrentLevel, Privilege: manage */ \
-    0, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
-    1, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
-    5, /* Cluster: Basic Information, Attribute: NodeLabel, Privilege: manage */ \
-    6, /* Cluster: Basic Information, Attribute: Location, Privilege: administer */ \
-    16, /* Cluster: Basic Information, Attribute: LocalConfigDisabled, Privilege: manage */ \
-    0, /* Cluster: General Commissioning, Attribute: Breadcrumb, Privilege: administer */ \
-    4, /* Cluster: Network Commissioning, Attribute: InterfaceEnabled, Privilege: administer */ \
-    0, /* Cluster: Group Key Management, Attribute: GroupKeyMap, Privilege: manage */ \
-    0, /* Cluster: User Label, Attribute: LabelList, Privilege: manage */ \
-    4, /* Cluster: Door Lock, Attribute: DoorOpenEvents, Privilege: manage */ \
-    5, /* Cluster: Door Lock, Attribute: DoorClosedEvents, Privilege: manage */ \
-    6, /* Cluster: Door Lock, Attribute: OpenPeriod, Privilege: manage */ \
-    33, /* Cluster: Door Lock, Attribute: Language, Privilege: manage */ \
-    35, /* Cluster: Door Lock, Attribute: AutoRelockTime, Privilege: manage */ \
-    36, /* Cluster: Door Lock, Attribute: SoundVolume, Privilege: manage */ \
-    37, /* Cluster: Door Lock, Attribute: OperatingMode, Privilege: manage */ \
-    41, /* Cluster: Door Lock, Attribute: EnableOneTouchLocking, Privilege: manage */ \
-    42, /* Cluster: Door Lock, Attribute: EnableInsideStatusLED, Privilege: manage */ \
-    43, /* Cluster: Door Lock, Attribute: EnablePrivacyModeButton, Privilege: manage */ \
-    48, /* Cluster: Door Lock, Attribute: WrongCodeEntryLimit, Privilege: administer */ \
-    49, /* Cluster: Door Lock, Attribute: UserCodeTemporaryDisableTime, Privilege: administer */ \
-    51, /* Cluster: Door Lock, Attribute: RequirePINforRemoteOperation, Privilege: administer */ \
-    23, /* Cluster: Window Covering, Attribute: Mode, Privilege: manage */ \
-    21, /* Cluster: Pump Configuration and Control, Attribute: LifetimeRunningHours, Privilege: manage */ \
-    23, /* Cluster: Pump Configuration and Control, Attribute: LifetimeEnergyConsumed, Privilege: manage */ \
-    32, /* Cluster: Pump Configuration and Control, Attribute: OperationMode, Privilege: manage */ \
-    33, /* Cluster: Pump Configuration and Control, Attribute: ControlMode, Privilege: manage */ \
-    21, /* Cluster: Thermostat, Attribute: MinHeatSetpointLimit, Privilege: manage */ \
-    22, /* Cluster: Thermostat, Attribute: MaxHeatSetpointLimit, Privilege: manage */ \
-    23, /* Cluster: Thermostat, Attribute: MinCoolSetpointLimit, Privilege: manage */ \
-    24, /* Cluster: Thermostat, Attribute: MaxCoolSetpointLimit, Privilege: manage */ \
-    25, /* Cluster: Thermostat, Attribute: MinSetpointDeadBand, Privilege: manage */ \
-    27, /* Cluster: Thermostat, Attribute: ControlSequenceOfOperation, Privilege: manage */ \
-    28, /* Cluster: Thermostat, Attribute: SystemMode, Privilege: manage */ \
-    1, /* Cluster: Thermostat User Interface Configuration, Attribute: KeypadLockout, Privilege: manage */ \
-    2, /* Cluster: Thermostat User Interface Configuration, Attribute: ScheduleProgrammingVisibility, Privilege: manage */ \
-    48, /* Cluster: Color Control, Attribute: WhitePointX, Privilege: manage */ \
-    49, /* Cluster: Color Control, Attribute: WhitePointY, Privilege: manage */ \
-    50, /* Cluster: Color Control, Attribute: ColorPointRX, Privilege: manage */ \
-    51, /* Cluster: Color Control, Attribute: ColorPointRY, Privilege: manage */ \
-    52, /* Cluster: Color Control, Attribute: ColorPointRIntensity, Privilege: manage */ \
-    54, /* Cluster: Color Control, Attribute: ColorPointGX, Privilege: manage */ \
-    55, /* Cluster: Color Control, Attribute: ColorPointGY, Privilege: manage */ \
-    56, /* Cluster: Color Control, Attribute: ColorPointGIntensity, Privilege: manage */ \
-    58, /* Cluster: Color Control, Attribute: ColorPointBX, Privilege: manage */ \
-    59, /* Cluster: Color Control, Attribute: ColorPointBY, Privilege: manage */ \
-    60, /* Cluster: Color Control, Attribute: ColorPointBIntensity, Privilege: manage */ \
-    16400, /* Cluster: Color Control, Attribute: StartUpColorTemperatureMireds, Privilege: manage */ \
+    0x00004003, /* Cluster: On/Off, Attribute: StartUpOnOff, Privilege: manage */ \
+    0x00004000, /* Cluster: Level Control, Attribute: StartUpCurrentLevel, Privilege: manage */ \
+    0x00000000, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
+    0x00000001, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
+    0x00000005, /* Cluster: Basic Information, Attribute: NodeLabel, Privilege: manage */ \
+    0x00000006, /* Cluster: Basic Information, Attribute: Location, Privilege: administer */ \
+    0x00000010, /* Cluster: Basic Information, Attribute: LocalConfigDisabled, Privilege: manage */ \
+    0x00000000, /* Cluster: General Commissioning, Attribute: Breadcrumb, Privilege: administer */ \
+    0x00000004, /* Cluster: Network Commissioning, Attribute: InterfaceEnabled, Privilege: administer */ \
+    0x00000000, /* Cluster: Group Key Management, Attribute: GroupKeyMap, Privilege: manage */ \
+    0x00000000, /* Cluster: User Label, Attribute: LabelList, Privilege: manage */ \
+    0x00000004, /* Cluster: Door Lock, Attribute: DoorOpenEvents, Privilege: manage */ \
+    0x00000005, /* Cluster: Door Lock, Attribute: DoorClosedEvents, Privilege: manage */ \
+    0x00000006, /* Cluster: Door Lock, Attribute: OpenPeriod, Privilege: manage */ \
+    0x00000021, /* Cluster: Door Lock, Attribute: Language, Privilege: manage */ \
+    0x00000023, /* Cluster: Door Lock, Attribute: AutoRelockTime, Privilege: manage */ \
+    0x00000024, /* Cluster: Door Lock, Attribute: SoundVolume, Privilege: manage */ \
+    0x00000025, /* Cluster: Door Lock, Attribute: OperatingMode, Privilege: manage */ \
+    0x00000029, /* Cluster: Door Lock, Attribute: EnableOneTouchLocking, Privilege: manage */ \
+    0x0000002A, /* Cluster: Door Lock, Attribute: EnableInsideStatusLED, Privilege: manage */ \
+    0x0000002B, /* Cluster: Door Lock, Attribute: EnablePrivacyModeButton, Privilege: manage */ \
+    0x00000030, /* Cluster: Door Lock, Attribute: WrongCodeEntryLimit, Privilege: administer */ \
+    0x00000031, /* Cluster: Door Lock, Attribute: UserCodeTemporaryDisableTime, Privilege: administer */ \
+    0x00000033, /* Cluster: Door Lock, Attribute: RequirePINforRemoteOperation, Privilege: administer */ \
+    0x00000017, /* Cluster: Window Covering, Attribute: Mode, Privilege: manage */ \
+    0x00000015, /* Cluster: Pump Configuration and Control, Attribute: LifetimeRunningHours, Privilege: manage */ \
+    0x00000017, /* Cluster: Pump Configuration and Control, Attribute: LifetimeEnergyConsumed, Privilege: manage */ \
+    0x00000020, /* Cluster: Pump Configuration and Control, Attribute: OperationMode, Privilege: manage */ \
+    0x00000021, /* Cluster: Pump Configuration and Control, Attribute: ControlMode, Privilege: manage */ \
+    0x00000015, /* Cluster: Thermostat, Attribute: MinHeatSetpointLimit, Privilege: manage */ \
+    0x00000016, /* Cluster: Thermostat, Attribute: MaxHeatSetpointLimit, Privilege: manage */ \
+    0x00000017, /* Cluster: Thermostat, Attribute: MinCoolSetpointLimit, Privilege: manage */ \
+    0x00000018, /* Cluster: Thermostat, Attribute: MaxCoolSetpointLimit, Privilege: manage */ \
+    0x00000019, /* Cluster: Thermostat, Attribute: MinSetpointDeadBand, Privilege: manage */ \
+    0x0000001B, /* Cluster: Thermostat, Attribute: ControlSequenceOfOperation, Privilege: manage */ \
+    0x0000001C, /* Cluster: Thermostat, Attribute: SystemMode, Privilege: manage */ \
+    0x00000001, /* Cluster: Thermostat User Interface Configuration, Attribute: KeypadLockout, Privilege: manage */ \
+    0x00000002, /* Cluster: Thermostat User Interface Configuration, Attribute: ScheduleProgrammingVisibility, Privilege: manage */ \
+    0x00000030, /* Cluster: Color Control, Attribute: WhitePointX, Privilege: manage */ \
+    0x00000031, /* Cluster: Color Control, Attribute: WhitePointY, Privilege: manage */ \
+    0x00000032, /* Cluster: Color Control, Attribute: ColorPointRX, Privilege: manage */ \
+    0x00000033, /* Cluster: Color Control, Attribute: ColorPointRY, Privilege: manage */ \
+    0x00000034, /* Cluster: Color Control, Attribute: ColorPointRIntensity, Privilege: manage */ \
+    0x00000036, /* Cluster: Color Control, Attribute: ColorPointGX, Privilege: manage */ \
+    0x00000037, /* Cluster: Color Control, Attribute: ColorPointGY, Privilege: manage */ \
+    0x00000038, /* Cluster: Color Control, Attribute: ColorPointGIntensity, Privilege: manage */ \
+    0x0000003A, /* Cluster: Color Control, Attribute: ColorPointBX, Privilege: manage */ \
+    0x0000003B, /* Cluster: Color Control, Attribute: ColorPointBY, Privilege: manage */ \
+    0x0000003C, /* Cluster: Color Control, Attribute: ColorPointBIntensity, Privilege: manage */ \
+    0x00004010, /* Cluster: Color Control, Attribute: StartUpColorTemperatureMireds, Privilege: manage */ \
 }
 
 // Parallel array data (cluster, attribute, *privilege*) for write attribute
@@ -384,106 +384,106 @@
 
 // Parallel array data (*cluster*, command, privilege) for invoke command
 #define GENERATED_ACCESS_INVOKE_COMMAND__CLUSTER { \
-    3, /* Cluster: Identify, Command: Identify, Privilege: manage */ \
-    3, /* Cluster: Identify, Command: TriggerEffect, Privilege: manage */ \
-    4, /* Cluster: Groups, Command: AddGroup, Privilege: manage */ \
-    4, /* Cluster: Groups, Command: RemoveGroup, Privilege: manage */ \
-    4, /* Cluster: Groups, Command: RemoveAllGroups, Privilege: manage */ \
-    4, /* Cluster: Groups, Command: AddGroupIfIdentifying, Privilege: manage */ \
-    5, /* Cluster: Scenes, Command: AddScene, Privilege: manage */ \
-    5, /* Cluster: Scenes, Command: RemoveScene, Privilege: manage */ \
-    5, /* Cluster: Scenes, Command: RemoveAllScenes, Privilege: manage */ \
-    5, /* Cluster: Scenes, Command: StoreScene, Privilege: manage */ \
-    48, /* Cluster: General Commissioning, Command: ArmFailSafe, Privilege: administer */ \
-    48, /* Cluster: General Commissioning, Command: SetRegulatoryConfig, Privilege: administer */ \
-    48, /* Cluster: General Commissioning, Command: CommissioningComplete, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Command: ScanNetworks, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Command: AddOrUpdateWiFiNetwork, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Command: AddOrUpdateThreadNetwork, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Command: RemoveNetwork, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Command: ConnectNetwork, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Command: ReorderNetwork, Privilege: administer */ \
-    51, /* Cluster: General Diagnostics, Command: TestEventTrigger, Privilege: manage */ \
-    60, /* Cluster: AdministratorCommissioning, Command: OpenCommissioningWindow, Privilege: administer */ \
-    60, /* Cluster: AdministratorCommissioning, Command: OpenBasicCommissioningWindow, Privilege: administer */ \
-    60, /* Cluster: AdministratorCommissioning, Command: RevokeCommissioning, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: AttestationRequest, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: CertificateChainRequest, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: CSRRequest, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: AddNOC, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: UpdateNOC, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: UpdateFabricLabel, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: RemoveFabric, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: AddTrustedRootCertificate, Privilege: administer */ \
-    63, /* Cluster: Group Key Management, Command: KeySetWrite, Privilege: administer */ \
-    63, /* Cluster: Group Key Management, Command: KeySetRead, Privilege: administer */ \
-    63, /* Cluster: Group Key Management, Command: KeySetRemove, Privilege: administer */ \
-    63, /* Cluster: Group Key Management, Command: KeySetReadAllIndices, Privilege: administer */ \
-    257, /* Cluster: Door Lock, Command: SetWeekDaySchedule, Privilege: administer */ \
-    257, /* Cluster: Door Lock, Command: GetWeekDaySchedule, Privilege: administer */ \
-    257, /* Cluster: Door Lock, Command: ClearWeekDaySchedule, Privilege: administer */ \
-    257, /* Cluster: Door Lock, Command: SetYearDaySchedule, Privilege: administer */ \
-    257, /* Cluster: Door Lock, Command: GetYearDaySchedule, Privilege: administer */ \
-    257, /* Cluster: Door Lock, Command: SetUser, Privilege: administer */ \
-    257, /* Cluster: Door Lock, Command: GetUser, Privilege: administer */ \
-    257, /* Cluster: Door Lock, Command: ClearUser, Privilege: administer */ \
-    257, /* Cluster: Door Lock, Command: SetCredential, Privilege: administer */ \
-    257, /* Cluster: Door Lock, Command: GetCredentialStatus, Privilege: administer */ \
-    257, /* Cluster: Door Lock, Command: ClearCredential, Privilege: administer */ \
-    4294048774, /* Cluster: Fault Injection, Command: FailAtFault, Privilege: manage */ \
-    4294048774, /* Cluster: Fault Injection, Command: FailRandomlyAtFault, Privilege: manage */ \
+    0x00000003, /* Cluster: Identify, Command: Identify, Privilege: manage */ \
+    0x00000003, /* Cluster: Identify, Command: TriggerEffect, Privilege: manage */ \
+    0x00000004, /* Cluster: Groups, Command: AddGroup, Privilege: manage */ \
+    0x00000004, /* Cluster: Groups, Command: RemoveGroup, Privilege: manage */ \
+    0x00000004, /* Cluster: Groups, Command: RemoveAllGroups, Privilege: manage */ \
+    0x00000004, /* Cluster: Groups, Command: AddGroupIfIdentifying, Privilege: manage */ \
+    0x00000005, /* Cluster: Scenes, Command: AddScene, Privilege: manage */ \
+    0x00000005, /* Cluster: Scenes, Command: RemoveScene, Privilege: manage */ \
+    0x00000005, /* Cluster: Scenes, Command: RemoveAllScenes, Privilege: manage */ \
+    0x00000005, /* Cluster: Scenes, Command: StoreScene, Privilege: manage */ \
+    0x00000030, /* Cluster: General Commissioning, Command: ArmFailSafe, Privilege: administer */ \
+    0x00000030, /* Cluster: General Commissioning, Command: SetRegulatoryConfig, Privilege: administer */ \
+    0x00000030, /* Cluster: General Commissioning, Command: CommissioningComplete, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Command: ScanNetworks, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Command: AddOrUpdateWiFiNetwork, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Command: AddOrUpdateThreadNetwork, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Command: RemoveNetwork, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Command: ConnectNetwork, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Command: ReorderNetwork, Privilege: administer */ \
+    0x00000033, /* Cluster: General Diagnostics, Command: TestEventTrigger, Privilege: manage */ \
+    0x0000003C, /* Cluster: AdministratorCommissioning, Command: OpenCommissioningWindow, Privilege: administer */ \
+    0x0000003C, /* Cluster: AdministratorCommissioning, Command: OpenBasicCommissioningWindow, Privilege: administer */ \
+    0x0000003C, /* Cluster: AdministratorCommissioning, Command: RevokeCommissioning, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: AttestationRequest, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: CertificateChainRequest, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: CSRRequest, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: AddNOC, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: UpdateNOC, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: UpdateFabricLabel, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: RemoveFabric, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: AddTrustedRootCertificate, Privilege: administer */ \
+    0x0000003F, /* Cluster: Group Key Management, Command: KeySetWrite, Privilege: administer */ \
+    0x0000003F, /* Cluster: Group Key Management, Command: KeySetRead, Privilege: administer */ \
+    0x0000003F, /* Cluster: Group Key Management, Command: KeySetRemove, Privilege: administer */ \
+    0x0000003F, /* Cluster: Group Key Management, Command: KeySetReadAllIndices, Privilege: administer */ \
+    0x00000101, /* Cluster: Door Lock, Command: SetWeekDaySchedule, Privilege: administer */ \
+    0x00000101, /* Cluster: Door Lock, Command: GetWeekDaySchedule, Privilege: administer */ \
+    0x00000101, /* Cluster: Door Lock, Command: ClearWeekDaySchedule, Privilege: administer */ \
+    0x00000101, /* Cluster: Door Lock, Command: SetYearDaySchedule, Privilege: administer */ \
+    0x00000101, /* Cluster: Door Lock, Command: GetYearDaySchedule, Privilege: administer */ \
+    0x00000101, /* Cluster: Door Lock, Command: SetUser, Privilege: administer */ \
+    0x00000101, /* Cluster: Door Lock, Command: GetUser, Privilege: administer */ \
+    0x00000101, /* Cluster: Door Lock, Command: ClearUser, Privilege: administer */ \
+    0x00000101, /* Cluster: Door Lock, Command: SetCredential, Privilege: administer */ \
+    0x00000101, /* Cluster: Door Lock, Command: GetCredentialStatus, Privilege: administer */ \
+    0x00000101, /* Cluster: Door Lock, Command: ClearCredential, Privilege: administer */ \
+    0xFFF1FC06, /* Cluster: Fault Injection, Command: FailAtFault, Privilege: manage */ \
+    0xFFF1FC06, /* Cluster: Fault Injection, Command: FailRandomlyAtFault, Privilege: manage */ \
 }
 
 // Parallel array data (cluster, *command*, privilege) for invoke command
 #define GENERATED_ACCESS_INVOKE_COMMAND__COMMAND { \
-    0, /* Cluster: Identify, Command: Identify, Privilege: manage */ \
-    64, /* Cluster: Identify, Command: TriggerEffect, Privilege: manage */ \
-    0, /* Cluster: Groups, Command: AddGroup, Privilege: manage */ \
-    3, /* Cluster: Groups, Command: RemoveGroup, Privilege: manage */ \
-    4, /* Cluster: Groups, Command: RemoveAllGroups, Privilege: manage */ \
-    5, /* Cluster: Groups, Command: AddGroupIfIdentifying, Privilege: manage */ \
-    0, /* Cluster: Scenes, Command: AddScene, Privilege: manage */ \
-    2, /* Cluster: Scenes, Command: RemoveScene, Privilege: manage */ \
-    3, /* Cluster: Scenes, Command: RemoveAllScenes, Privilege: manage */ \
-    4, /* Cluster: Scenes, Command: StoreScene, Privilege: manage */ \
-    0, /* Cluster: General Commissioning, Command: ArmFailSafe, Privilege: administer */ \
-    2, /* Cluster: General Commissioning, Command: SetRegulatoryConfig, Privilege: administer */ \
-    4, /* Cluster: General Commissioning, Command: CommissioningComplete, Privilege: administer */ \
-    0, /* Cluster: Network Commissioning, Command: ScanNetworks, Privilege: administer */ \
-    2, /* Cluster: Network Commissioning, Command: AddOrUpdateWiFiNetwork, Privilege: administer */ \
-    3, /* Cluster: Network Commissioning, Command: AddOrUpdateThreadNetwork, Privilege: administer */ \
-    4, /* Cluster: Network Commissioning, Command: RemoveNetwork, Privilege: administer */ \
-    6, /* Cluster: Network Commissioning, Command: ConnectNetwork, Privilege: administer */ \
-    8, /* Cluster: Network Commissioning, Command: ReorderNetwork, Privilege: administer */ \
-    0, /* Cluster: General Diagnostics, Command: TestEventTrigger, Privilege: manage */ \
-    0, /* Cluster: AdministratorCommissioning, Command: OpenCommissioningWindow, Privilege: administer */ \
-    1, /* Cluster: AdministratorCommissioning, Command: OpenBasicCommissioningWindow, Privilege: administer */ \
-    2, /* Cluster: AdministratorCommissioning, Command: RevokeCommissioning, Privilege: administer */ \
-    0, /* Cluster: Operational Credentials, Command: AttestationRequest, Privilege: administer */ \
-    2, /* Cluster: Operational Credentials, Command: CertificateChainRequest, Privilege: administer */ \
-    4, /* Cluster: Operational Credentials, Command: CSRRequest, Privilege: administer */ \
-    6, /* Cluster: Operational Credentials, Command: AddNOC, Privilege: administer */ \
-    7, /* Cluster: Operational Credentials, Command: UpdateNOC, Privilege: administer */ \
-    9, /* Cluster: Operational Credentials, Command: UpdateFabricLabel, Privilege: administer */ \
-    10, /* Cluster: Operational Credentials, Command: RemoveFabric, Privilege: administer */ \
-    11, /* Cluster: Operational Credentials, Command: AddTrustedRootCertificate, Privilege: administer */ \
-    0, /* Cluster: Group Key Management, Command: KeySetWrite, Privilege: administer */ \
-    1, /* Cluster: Group Key Management, Command: KeySetRead, Privilege: administer */ \
-    3, /* Cluster: Group Key Management, Command: KeySetRemove, Privilege: administer */ \
-    4, /* Cluster: Group Key Management, Command: KeySetReadAllIndices, Privilege: administer */ \
-    11, /* Cluster: Door Lock, Command: SetWeekDaySchedule, Privilege: administer */ \
-    12, /* Cluster: Door Lock, Command: GetWeekDaySchedule, Privilege: administer */ \
-    13, /* Cluster: Door Lock, Command: ClearWeekDaySchedule, Privilege: administer */ \
-    14, /* Cluster: Door Lock, Command: SetYearDaySchedule, Privilege: administer */ \
-    15, /* Cluster: Door Lock, Command: GetYearDaySchedule, Privilege: administer */ \
-    26, /* Cluster: Door Lock, Command: SetUser, Privilege: administer */ \
-    27, /* Cluster: Door Lock, Command: GetUser, Privilege: administer */ \
-    29, /* Cluster: Door Lock, Command: ClearUser, Privilege: administer */ \
-    34, /* Cluster: Door Lock, Command: SetCredential, Privilege: administer */ \
-    36, /* Cluster: Door Lock, Command: GetCredentialStatus, Privilege: administer */ \
-    38, /* Cluster: Door Lock, Command: ClearCredential, Privilege: administer */ \
-    0, /* Cluster: Fault Injection, Command: FailAtFault, Privilege: manage */ \
-    1, /* Cluster: Fault Injection, Command: FailRandomlyAtFault, Privilege: manage */ \
+    0x00000000, /* Cluster: Identify, Command: Identify, Privilege: manage */ \
+    0x00000040, /* Cluster: Identify, Command: TriggerEffect, Privilege: manage */ \
+    0x00000000, /* Cluster: Groups, Command: AddGroup, Privilege: manage */ \
+    0x00000003, /* Cluster: Groups, Command: RemoveGroup, Privilege: manage */ \
+    0x00000004, /* Cluster: Groups, Command: RemoveAllGroups, Privilege: manage */ \
+    0x00000005, /* Cluster: Groups, Command: AddGroupIfIdentifying, Privilege: manage */ \
+    0x00000000, /* Cluster: Scenes, Command: AddScene, Privilege: manage */ \
+    0x00000002, /* Cluster: Scenes, Command: RemoveScene, Privilege: manage */ \
+    0x00000003, /* Cluster: Scenes, Command: RemoveAllScenes, Privilege: manage */ \
+    0x00000004, /* Cluster: Scenes, Command: StoreScene, Privilege: manage */ \
+    0x00000000, /* Cluster: General Commissioning, Command: ArmFailSafe, Privilege: administer */ \
+    0x00000002, /* Cluster: General Commissioning, Command: SetRegulatoryConfig, Privilege: administer */ \
+    0x00000004, /* Cluster: General Commissioning, Command: CommissioningComplete, Privilege: administer */ \
+    0x00000000, /* Cluster: Network Commissioning, Command: ScanNetworks, Privilege: administer */ \
+    0x00000002, /* Cluster: Network Commissioning, Command: AddOrUpdateWiFiNetwork, Privilege: administer */ \
+    0x00000003, /* Cluster: Network Commissioning, Command: AddOrUpdateThreadNetwork, Privilege: administer */ \
+    0x00000004, /* Cluster: Network Commissioning, Command: RemoveNetwork, Privilege: administer */ \
+    0x00000006, /* Cluster: Network Commissioning, Command: ConnectNetwork, Privilege: administer */ \
+    0x00000008, /* Cluster: Network Commissioning, Command: ReorderNetwork, Privilege: administer */ \
+    0x00000000, /* Cluster: General Diagnostics, Command: TestEventTrigger, Privilege: manage */ \
+    0x00000000, /* Cluster: AdministratorCommissioning, Command: OpenCommissioningWindow, Privilege: administer */ \
+    0x00000001, /* Cluster: AdministratorCommissioning, Command: OpenBasicCommissioningWindow, Privilege: administer */ \
+    0x00000002, /* Cluster: AdministratorCommissioning, Command: RevokeCommissioning, Privilege: administer */ \
+    0x00000000, /* Cluster: Operational Credentials, Command: AttestationRequest, Privilege: administer */ \
+    0x00000002, /* Cluster: Operational Credentials, Command: CertificateChainRequest, Privilege: administer */ \
+    0x00000004, /* Cluster: Operational Credentials, Command: CSRRequest, Privilege: administer */ \
+    0x00000006, /* Cluster: Operational Credentials, Command: AddNOC, Privilege: administer */ \
+    0x00000007, /* Cluster: Operational Credentials, Command: UpdateNOC, Privilege: administer */ \
+    0x00000009, /* Cluster: Operational Credentials, Command: UpdateFabricLabel, Privilege: administer */ \
+    0x0000000A, /* Cluster: Operational Credentials, Command: RemoveFabric, Privilege: administer */ \
+    0x0000000B, /* Cluster: Operational Credentials, Command: AddTrustedRootCertificate, Privilege: administer */ \
+    0x00000000, /* Cluster: Group Key Management, Command: KeySetWrite, Privilege: administer */ \
+    0x00000001, /* Cluster: Group Key Management, Command: KeySetRead, Privilege: administer */ \
+    0x00000003, /* Cluster: Group Key Management, Command: KeySetRemove, Privilege: administer */ \
+    0x00000004, /* Cluster: Group Key Management, Command: KeySetReadAllIndices, Privilege: administer */ \
+    0x0000000B, /* Cluster: Door Lock, Command: SetWeekDaySchedule, Privilege: administer */ \
+    0x0000000C, /* Cluster: Door Lock, Command: GetWeekDaySchedule, Privilege: administer */ \
+    0x0000000D, /* Cluster: Door Lock, Command: ClearWeekDaySchedule, Privilege: administer */ \
+    0x0000000E, /* Cluster: Door Lock, Command: SetYearDaySchedule, Privilege: administer */ \
+    0x0000000F, /* Cluster: Door Lock, Command: GetYearDaySchedule, Privilege: administer */ \
+    0x0000001A, /* Cluster: Door Lock, Command: SetUser, Privilege: administer */ \
+    0x0000001B, /* Cluster: Door Lock, Command: GetUser, Privilege: administer */ \
+    0x0000001D, /* Cluster: Door Lock, Command: ClearUser, Privilege: administer */ \
+    0x00000022, /* Cluster: Door Lock, Command: SetCredential, Privilege: administer */ \
+    0x00000024, /* Cluster: Door Lock, Command: GetCredentialStatus, Privilege: administer */ \
+    0x00000026, /* Cluster: Door Lock, Command: ClearCredential, Privilege: administer */ \
+    0x00000000, /* Cluster: Fault Injection, Command: FailAtFault, Privilege: manage */ \
+    0x00000001, /* Cluster: Fault Injection, Command: FailRandomlyAtFault, Privilege: manage */ \
 }
 
 // Parallel array data (cluster, command, *privilege*) for invoke command
@@ -542,14 +542,14 @@
 
 // Parallel array data (*cluster*, event, privilege) for read event
 #define GENERATED_ACCESS_READ_EVENT__CLUSTER { \
-    31, /* Cluster: Access Control, Event: AccessControlEntryChanged, Privilege: administer */ \
-    31, /* Cluster: Access Control, Event: AccessControlExtensionChanged, Privilege: administer */ \
+    0x0000001F, /* Cluster: Access Control, Event: AccessControlEntryChanged, Privilege: administer */ \
+    0x0000001F, /* Cluster: Access Control, Event: AccessControlExtensionChanged, Privilege: administer */ \
 }
 
 // Parallel array data (cluster, *event*, privilege) for read event
 #define GENERATED_ACCESS_READ_EVENT__EVENT { \
-    0, /* Cluster: Access Control, Event: AccessControlEntryChanged, Privilege: administer */ \
-    1, /* Cluster: Access Control, Event: AccessControlExtensionChanged, Privilege: administer */ \
+    0x00000000, /* Cluster: Access Control, Event: AccessControlEntryChanged, Privilege: administer */ \
+    0x00000001, /* Cluster: Access Control, Event: AccessControlExtensionChanged, Privilege: administer */ \
 }
 
 // Parallel array data (cluster, event, *privilege*) for read event

--- a/scripts/tools/zap/tests/outputs/lighting-app/app-templates/access.h
+++ b/scripts/tools/zap/tests/outputs/lighting-app/app-templates/access.h
@@ -31,8 +31,8 @@
 #define GENERATED_ACCESS_READ_ATTRIBUTE__CLUSTER { \
     /* Cluster: On/Off, Attribute: StartUpOnOff, Privilege: view */ \
     /* Cluster: Level Control, Attribute: StartUpCurrentLevel, Privilege: view */ \
-    31, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
-    31, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
+    0x0000001F, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
+    0x0000001F, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
     /* Cluster: Access Control, Attribute: SubjectsPerAccessControlEntry, Privilege: view */ \
     /* Cluster: Access Control, Attribute: TargetsPerAccessControlEntry, Privilege: view */ \
     /* Cluster: Access Control, Attribute: AccessControlEntriesPerFabric, Privilege: view */ \
@@ -40,13 +40,13 @@
     /* Cluster: Basic Information, Attribute: Location, Privilege: view */ \
     /* Cluster: Basic Information, Attribute: LocalConfigDisabled, Privilege: view */ \
     /* Cluster: General Commissioning, Attribute: Breadcrumb, Privilege: view */ \
-    49, /* Cluster: Network Commissioning, Attribute: MaxNetworks, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Attribute: Networks, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Attribute: MaxNetworks, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Attribute: Networks, Privilege: administer */ \
     /* Cluster: Network Commissioning, Attribute: InterfaceEnabled, Privilege: view */ \
-    49, /* Cluster: Network Commissioning, Attribute: LastNetworkingStatus, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Attribute: LastNetworkID, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Attribute: LastConnectErrorValue, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Attribute: NOCs, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Attribute: LastNetworkingStatus, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Attribute: LastNetworkID, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Attribute: LastConnectErrorValue, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Attribute: NOCs, Privilege: administer */ \
     /* Cluster: Group Key Management, Attribute: GroupKeyMap, Privilege: view */ \
     /* Cluster: User Label, Attribute: LabelList, Privilege: view */ \
     /* Cluster: Color Control, Attribute: StartUpColorTemperatureMireds, Privilege: view */ \
@@ -56,8 +56,8 @@
 #define GENERATED_ACCESS_READ_ATTRIBUTE__ATTRIBUTE { \
     /* Cluster: On/Off, Attribute: StartUpOnOff, Privilege: view */ \
     /* Cluster: Level Control, Attribute: StartUpCurrentLevel, Privilege: view */ \
-    0, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
-    1, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
+    0x00000000, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
+    0x00000001, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
     /* Cluster: Access Control, Attribute: SubjectsPerAccessControlEntry, Privilege: view */ \
     /* Cluster: Access Control, Attribute: TargetsPerAccessControlEntry, Privilege: view */ \
     /* Cluster: Access Control, Attribute: AccessControlEntriesPerFabric, Privilege: view */ \
@@ -65,13 +65,13 @@
     /* Cluster: Basic Information, Attribute: Location, Privilege: view */ \
     /* Cluster: Basic Information, Attribute: LocalConfigDisabled, Privilege: view */ \
     /* Cluster: General Commissioning, Attribute: Breadcrumb, Privilege: view */ \
-    0, /* Cluster: Network Commissioning, Attribute: MaxNetworks, Privilege: administer */ \
-    1, /* Cluster: Network Commissioning, Attribute: Networks, Privilege: administer */ \
+    0x00000000, /* Cluster: Network Commissioning, Attribute: MaxNetworks, Privilege: administer */ \
+    0x00000001, /* Cluster: Network Commissioning, Attribute: Networks, Privilege: administer */ \
     /* Cluster: Network Commissioning, Attribute: InterfaceEnabled, Privilege: view */ \
-    5, /* Cluster: Network Commissioning, Attribute: LastNetworkingStatus, Privilege: administer */ \
-    6, /* Cluster: Network Commissioning, Attribute: LastNetworkID, Privilege: administer */ \
-    7, /* Cluster: Network Commissioning, Attribute: LastConnectErrorValue, Privilege: administer */ \
-    0, /* Cluster: Operational Credentials, Attribute: NOCs, Privilege: administer */ \
+    0x00000005, /* Cluster: Network Commissioning, Attribute: LastNetworkingStatus, Privilege: administer */ \
+    0x00000006, /* Cluster: Network Commissioning, Attribute: LastNetworkID, Privilege: administer */ \
+    0x00000007, /* Cluster: Network Commissioning, Attribute: LastConnectErrorValue, Privilege: administer */ \
+    0x00000000, /* Cluster: Operational Credentials, Attribute: NOCs, Privilege: administer */ \
     /* Cluster: Group Key Management, Attribute: GroupKeyMap, Privilege: view */ \
     /* Cluster: User Label, Attribute: LabelList, Privilege: view */ \
     /* Cluster: Color Control, Attribute: StartUpColorTemperatureMireds, Privilege: view */ \
@@ -106,34 +106,34 @@
 
 // Parallel array data (*cluster*, attribute, privilege) for write attribute
 #define GENERATED_ACCESS_WRITE_ATTRIBUTE__CLUSTER { \
-    6, /* Cluster: On/Off, Attribute: StartUpOnOff, Privilege: manage */ \
-    8, /* Cluster: Level Control, Attribute: StartUpCurrentLevel, Privilege: manage */ \
-    31, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
-    31, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
-    40, /* Cluster: Basic Information, Attribute: NodeLabel, Privilege: manage */ \
-    40, /* Cluster: Basic Information, Attribute: Location, Privilege: administer */ \
-    40, /* Cluster: Basic Information, Attribute: LocalConfigDisabled, Privilege: manage */ \
-    48, /* Cluster: General Commissioning, Attribute: Breadcrumb, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Attribute: InterfaceEnabled, Privilege: administer */ \
-    63, /* Cluster: Group Key Management, Attribute: GroupKeyMap, Privilege: manage */ \
-    65, /* Cluster: User Label, Attribute: LabelList, Privilege: manage */ \
-    768, /* Cluster: Color Control, Attribute: StartUpColorTemperatureMireds, Privilege: manage */ \
+    0x00000006, /* Cluster: On/Off, Attribute: StartUpOnOff, Privilege: manage */ \
+    0x00000008, /* Cluster: Level Control, Attribute: StartUpCurrentLevel, Privilege: manage */ \
+    0x0000001F, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
+    0x0000001F, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
+    0x00000028, /* Cluster: Basic Information, Attribute: NodeLabel, Privilege: manage */ \
+    0x00000028, /* Cluster: Basic Information, Attribute: Location, Privilege: administer */ \
+    0x00000028, /* Cluster: Basic Information, Attribute: LocalConfigDisabled, Privilege: manage */ \
+    0x00000030, /* Cluster: General Commissioning, Attribute: Breadcrumb, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Attribute: InterfaceEnabled, Privilege: administer */ \
+    0x0000003F, /* Cluster: Group Key Management, Attribute: GroupKeyMap, Privilege: manage */ \
+    0x00000041, /* Cluster: User Label, Attribute: LabelList, Privilege: manage */ \
+    0x00000300, /* Cluster: Color Control, Attribute: StartUpColorTemperatureMireds, Privilege: manage */ \
 }
 
 // Parallel array data (cluster, *attribute*, privilege) for write attribute
 #define GENERATED_ACCESS_WRITE_ATTRIBUTE__ATTRIBUTE { \
-    16387, /* Cluster: On/Off, Attribute: StartUpOnOff, Privilege: manage */ \
-    16384, /* Cluster: Level Control, Attribute: StartUpCurrentLevel, Privilege: manage */ \
-    0, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
-    1, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
-    5, /* Cluster: Basic Information, Attribute: NodeLabel, Privilege: manage */ \
-    6, /* Cluster: Basic Information, Attribute: Location, Privilege: administer */ \
-    16, /* Cluster: Basic Information, Attribute: LocalConfigDisabled, Privilege: manage */ \
-    0, /* Cluster: General Commissioning, Attribute: Breadcrumb, Privilege: administer */ \
-    4, /* Cluster: Network Commissioning, Attribute: InterfaceEnabled, Privilege: administer */ \
-    0, /* Cluster: Group Key Management, Attribute: GroupKeyMap, Privilege: manage */ \
-    0, /* Cluster: User Label, Attribute: LabelList, Privilege: manage */ \
-    16400, /* Cluster: Color Control, Attribute: StartUpColorTemperatureMireds, Privilege: manage */ \
+    0x00004003, /* Cluster: On/Off, Attribute: StartUpOnOff, Privilege: manage */ \
+    0x00004000, /* Cluster: Level Control, Attribute: StartUpCurrentLevel, Privilege: manage */ \
+    0x00000000, /* Cluster: Access Control, Attribute: ACL, Privilege: administer */ \
+    0x00000001, /* Cluster: Access Control, Attribute: Extension, Privilege: administer */ \
+    0x00000005, /* Cluster: Basic Information, Attribute: NodeLabel, Privilege: manage */ \
+    0x00000006, /* Cluster: Basic Information, Attribute: Location, Privilege: administer */ \
+    0x00000010, /* Cluster: Basic Information, Attribute: LocalConfigDisabled, Privilege: manage */ \
+    0x00000000, /* Cluster: General Commissioning, Attribute: Breadcrumb, Privilege: administer */ \
+    0x00000004, /* Cluster: Network Commissioning, Attribute: InterfaceEnabled, Privilege: administer */ \
+    0x00000000, /* Cluster: Group Key Management, Attribute: GroupKeyMap, Privilege: manage */ \
+    0x00000000, /* Cluster: User Label, Attribute: LabelList, Privilege: manage */ \
+    0x00004010, /* Cluster: Color Control, Attribute: StartUpColorTemperatureMireds, Privilege: manage */ \
 }
 
 // Parallel array data (cluster, attribute, *privilege*) for write attribute
@@ -156,72 +156,72 @@
 
 // Parallel array data (*cluster*, command, privilege) for invoke command
 #define GENERATED_ACCESS_INVOKE_COMMAND__CLUSTER { \
-    3, /* Cluster: Identify, Command: Identify, Privilege: manage */ \
-    3, /* Cluster: Identify, Command: TriggerEffect, Privilege: manage */ \
-    4, /* Cluster: Groups, Command: AddGroup, Privilege: manage */ \
-    4, /* Cluster: Groups, Command: RemoveGroup, Privilege: manage */ \
-    4, /* Cluster: Groups, Command: RemoveAllGroups, Privilege: manage */ \
-    4, /* Cluster: Groups, Command: AddGroupIfIdentifying, Privilege: manage */ \
-    48, /* Cluster: General Commissioning, Command: ArmFailSafe, Privilege: administer */ \
-    48, /* Cluster: General Commissioning, Command: SetRegulatoryConfig, Privilege: administer */ \
-    48, /* Cluster: General Commissioning, Command: CommissioningComplete, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Command: ScanNetworks, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Command: AddOrUpdateWiFiNetwork, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Command: AddOrUpdateThreadNetwork, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Command: RemoveNetwork, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Command: ConnectNetwork, Privilege: administer */ \
-    49, /* Cluster: Network Commissioning, Command: ReorderNetwork, Privilege: administer */ \
-    51, /* Cluster: General Diagnostics, Command: TestEventTrigger, Privilege: manage */ \
-    60, /* Cluster: AdministratorCommissioning, Command: OpenCommissioningWindow, Privilege: administer */ \
-    60, /* Cluster: AdministratorCommissioning, Command: OpenBasicCommissioningWindow, Privilege: administer */ \
-    60, /* Cluster: AdministratorCommissioning, Command: RevokeCommissioning, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: AttestationRequest, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: CertificateChainRequest, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: CSRRequest, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: AddNOC, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: UpdateNOC, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: UpdateFabricLabel, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: RemoveFabric, Privilege: administer */ \
-    62, /* Cluster: Operational Credentials, Command: AddTrustedRootCertificate, Privilege: administer */ \
-    63, /* Cluster: Group Key Management, Command: KeySetWrite, Privilege: administer */ \
-    63, /* Cluster: Group Key Management, Command: KeySetRead, Privilege: administer */ \
-    63, /* Cluster: Group Key Management, Command: KeySetRemove, Privilege: administer */ \
-    63, /* Cluster: Group Key Management, Command: KeySetReadAllIndices, Privilege: administer */ \
+    0x00000003, /* Cluster: Identify, Command: Identify, Privilege: manage */ \
+    0x00000003, /* Cluster: Identify, Command: TriggerEffect, Privilege: manage */ \
+    0x00000004, /* Cluster: Groups, Command: AddGroup, Privilege: manage */ \
+    0x00000004, /* Cluster: Groups, Command: RemoveGroup, Privilege: manage */ \
+    0x00000004, /* Cluster: Groups, Command: RemoveAllGroups, Privilege: manage */ \
+    0x00000004, /* Cluster: Groups, Command: AddGroupIfIdentifying, Privilege: manage */ \
+    0x00000030, /* Cluster: General Commissioning, Command: ArmFailSafe, Privilege: administer */ \
+    0x00000030, /* Cluster: General Commissioning, Command: SetRegulatoryConfig, Privilege: administer */ \
+    0x00000030, /* Cluster: General Commissioning, Command: CommissioningComplete, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Command: ScanNetworks, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Command: AddOrUpdateWiFiNetwork, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Command: AddOrUpdateThreadNetwork, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Command: RemoveNetwork, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Command: ConnectNetwork, Privilege: administer */ \
+    0x00000031, /* Cluster: Network Commissioning, Command: ReorderNetwork, Privilege: administer */ \
+    0x00000033, /* Cluster: General Diagnostics, Command: TestEventTrigger, Privilege: manage */ \
+    0x0000003C, /* Cluster: AdministratorCommissioning, Command: OpenCommissioningWindow, Privilege: administer */ \
+    0x0000003C, /* Cluster: AdministratorCommissioning, Command: OpenBasicCommissioningWindow, Privilege: administer */ \
+    0x0000003C, /* Cluster: AdministratorCommissioning, Command: RevokeCommissioning, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: AttestationRequest, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: CertificateChainRequest, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: CSRRequest, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: AddNOC, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: UpdateNOC, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: UpdateFabricLabel, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: RemoveFabric, Privilege: administer */ \
+    0x0000003E, /* Cluster: Operational Credentials, Command: AddTrustedRootCertificate, Privilege: administer */ \
+    0x0000003F, /* Cluster: Group Key Management, Command: KeySetWrite, Privilege: administer */ \
+    0x0000003F, /* Cluster: Group Key Management, Command: KeySetRead, Privilege: administer */ \
+    0x0000003F, /* Cluster: Group Key Management, Command: KeySetRemove, Privilege: administer */ \
+    0x0000003F, /* Cluster: Group Key Management, Command: KeySetReadAllIndices, Privilege: administer */ \
 }
 
 // Parallel array data (cluster, *command*, privilege) for invoke command
 #define GENERATED_ACCESS_INVOKE_COMMAND__COMMAND { \
-    0, /* Cluster: Identify, Command: Identify, Privilege: manage */ \
-    64, /* Cluster: Identify, Command: TriggerEffect, Privilege: manage */ \
-    0, /* Cluster: Groups, Command: AddGroup, Privilege: manage */ \
-    3, /* Cluster: Groups, Command: RemoveGroup, Privilege: manage */ \
-    4, /* Cluster: Groups, Command: RemoveAllGroups, Privilege: manage */ \
-    5, /* Cluster: Groups, Command: AddGroupIfIdentifying, Privilege: manage */ \
-    0, /* Cluster: General Commissioning, Command: ArmFailSafe, Privilege: administer */ \
-    2, /* Cluster: General Commissioning, Command: SetRegulatoryConfig, Privilege: administer */ \
-    4, /* Cluster: General Commissioning, Command: CommissioningComplete, Privilege: administer */ \
-    0, /* Cluster: Network Commissioning, Command: ScanNetworks, Privilege: administer */ \
-    2, /* Cluster: Network Commissioning, Command: AddOrUpdateWiFiNetwork, Privilege: administer */ \
-    3, /* Cluster: Network Commissioning, Command: AddOrUpdateThreadNetwork, Privilege: administer */ \
-    4, /* Cluster: Network Commissioning, Command: RemoveNetwork, Privilege: administer */ \
-    6, /* Cluster: Network Commissioning, Command: ConnectNetwork, Privilege: administer */ \
-    8, /* Cluster: Network Commissioning, Command: ReorderNetwork, Privilege: administer */ \
-    0, /* Cluster: General Diagnostics, Command: TestEventTrigger, Privilege: manage */ \
-    0, /* Cluster: AdministratorCommissioning, Command: OpenCommissioningWindow, Privilege: administer */ \
-    1, /* Cluster: AdministratorCommissioning, Command: OpenBasicCommissioningWindow, Privilege: administer */ \
-    2, /* Cluster: AdministratorCommissioning, Command: RevokeCommissioning, Privilege: administer */ \
-    0, /* Cluster: Operational Credentials, Command: AttestationRequest, Privilege: administer */ \
-    2, /* Cluster: Operational Credentials, Command: CertificateChainRequest, Privilege: administer */ \
-    4, /* Cluster: Operational Credentials, Command: CSRRequest, Privilege: administer */ \
-    6, /* Cluster: Operational Credentials, Command: AddNOC, Privilege: administer */ \
-    7, /* Cluster: Operational Credentials, Command: UpdateNOC, Privilege: administer */ \
-    9, /* Cluster: Operational Credentials, Command: UpdateFabricLabel, Privilege: administer */ \
-    10, /* Cluster: Operational Credentials, Command: RemoveFabric, Privilege: administer */ \
-    11, /* Cluster: Operational Credentials, Command: AddTrustedRootCertificate, Privilege: administer */ \
-    0, /* Cluster: Group Key Management, Command: KeySetWrite, Privilege: administer */ \
-    1, /* Cluster: Group Key Management, Command: KeySetRead, Privilege: administer */ \
-    3, /* Cluster: Group Key Management, Command: KeySetRemove, Privilege: administer */ \
-    4, /* Cluster: Group Key Management, Command: KeySetReadAllIndices, Privilege: administer */ \
+    0x00000000, /* Cluster: Identify, Command: Identify, Privilege: manage */ \
+    0x00000040, /* Cluster: Identify, Command: TriggerEffect, Privilege: manage */ \
+    0x00000000, /* Cluster: Groups, Command: AddGroup, Privilege: manage */ \
+    0x00000003, /* Cluster: Groups, Command: RemoveGroup, Privilege: manage */ \
+    0x00000004, /* Cluster: Groups, Command: RemoveAllGroups, Privilege: manage */ \
+    0x00000005, /* Cluster: Groups, Command: AddGroupIfIdentifying, Privilege: manage */ \
+    0x00000000, /* Cluster: General Commissioning, Command: ArmFailSafe, Privilege: administer */ \
+    0x00000002, /* Cluster: General Commissioning, Command: SetRegulatoryConfig, Privilege: administer */ \
+    0x00000004, /* Cluster: General Commissioning, Command: CommissioningComplete, Privilege: administer */ \
+    0x00000000, /* Cluster: Network Commissioning, Command: ScanNetworks, Privilege: administer */ \
+    0x00000002, /* Cluster: Network Commissioning, Command: AddOrUpdateWiFiNetwork, Privilege: administer */ \
+    0x00000003, /* Cluster: Network Commissioning, Command: AddOrUpdateThreadNetwork, Privilege: administer */ \
+    0x00000004, /* Cluster: Network Commissioning, Command: RemoveNetwork, Privilege: administer */ \
+    0x00000006, /* Cluster: Network Commissioning, Command: ConnectNetwork, Privilege: administer */ \
+    0x00000008, /* Cluster: Network Commissioning, Command: ReorderNetwork, Privilege: administer */ \
+    0x00000000, /* Cluster: General Diagnostics, Command: TestEventTrigger, Privilege: manage */ \
+    0x00000000, /* Cluster: AdministratorCommissioning, Command: OpenCommissioningWindow, Privilege: administer */ \
+    0x00000001, /* Cluster: AdministratorCommissioning, Command: OpenBasicCommissioningWindow, Privilege: administer */ \
+    0x00000002, /* Cluster: AdministratorCommissioning, Command: RevokeCommissioning, Privilege: administer */ \
+    0x00000000, /* Cluster: Operational Credentials, Command: AttestationRequest, Privilege: administer */ \
+    0x00000002, /* Cluster: Operational Credentials, Command: CertificateChainRequest, Privilege: administer */ \
+    0x00000004, /* Cluster: Operational Credentials, Command: CSRRequest, Privilege: administer */ \
+    0x00000006, /* Cluster: Operational Credentials, Command: AddNOC, Privilege: administer */ \
+    0x00000007, /* Cluster: Operational Credentials, Command: UpdateNOC, Privilege: administer */ \
+    0x00000009, /* Cluster: Operational Credentials, Command: UpdateFabricLabel, Privilege: administer */ \
+    0x0000000A, /* Cluster: Operational Credentials, Command: RemoveFabric, Privilege: administer */ \
+    0x0000000B, /* Cluster: Operational Credentials, Command: AddTrustedRootCertificate, Privilege: administer */ \
+    0x00000000, /* Cluster: Group Key Management, Command: KeySetWrite, Privilege: administer */ \
+    0x00000001, /* Cluster: Group Key Management, Command: KeySetRead, Privilege: administer */ \
+    0x00000003, /* Cluster: Group Key Management, Command: KeySetRemove, Privilege: administer */ \
+    0x00000004, /* Cluster: Group Key Management, Command: KeySetReadAllIndices, Privilege: administer */ \
 }
 
 // Parallel array data (cluster, command, *privilege*) for invoke command
@@ -263,14 +263,14 @@
 
 // Parallel array data (*cluster*, event, privilege) for read event
 #define GENERATED_ACCESS_READ_EVENT__CLUSTER { \
-    31, /* Cluster: Access Control, Event: AccessControlEntryChanged, Privilege: administer */ \
-    31, /* Cluster: Access Control, Event: AccessControlExtensionChanged, Privilege: administer */ \
+    0x0000001F, /* Cluster: Access Control, Event: AccessControlEntryChanged, Privilege: administer */ \
+    0x0000001F, /* Cluster: Access Control, Event: AccessControlExtensionChanged, Privilege: administer */ \
 }
 
 // Parallel array data (cluster, *event*, privilege) for read event
 #define GENERATED_ACCESS_READ_EVENT__EVENT { \
-    0, /* Cluster: Access Control, Event: AccessControlEntryChanged, Privilege: administer */ \
-    1, /* Cluster: Access Control, Event: AccessControlExtensionChanged, Privilege: administer */ \
+    0x00000000, /* Cluster: Access Control, Event: AccessControlEntryChanged, Privilege: administer */ \
+    0x00000001, /* Cluster: Access Control, Event: AccessControlExtensionChanged, Privilege: administer */ \
 }
 
 // Parallel array data (cluster, event, *privilege*) for read event

--- a/src/app/zap-templates/templates/app/access.zapt
+++ b/src/app/zap-templates/templates/app/access.zapt
@@ -23,11 +23,11 @@
                         {{#if (isStrEqual role "view")}}
     /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "operate")}}
-    {{parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.parent.manufacturerCode parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "manage")}}
-    {{parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.parent.manufacturerCode parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "administer")}}
-    {{parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.parent.manufacturerCode parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
                         {{else}}
     ERROR: access has unrecognized role/privilege [ Cluster: {{parent.parent.name}}, Attribute: {{parent.name}} ]
                         {{/if}}
@@ -56,11 +56,11 @@
                         {{#if (isStrEqual role "view")}}
     /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "operate")}}
-    {{parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.manufacturerCode parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "manage")}}
-    {{parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.manufacturerCode parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "administer")}}
-    {{parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.manufacturerCode parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
                         {{else}}
     ERROR: access has unrecognized role/privilege [ Cluster: {{parent.parent.name}}, Attribute: {{parent.name}} ]
                         {{/if}}
@@ -126,9 +126,9 @@
                         {{else if (isStrEqual role "operate")}}
     /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "manage")}}
-    {{parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.parent.manufacturerCode parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "administer")}}
-    {{parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.parent.manufacturerCode parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
                         {{else}}
     ERROR: access has unrecognized role/privilege [ Cluster: {{parent.parent.name}}, Attribute: {{parent.name}} ]
                         {{/if}}
@@ -159,9 +159,9 @@
                         {{else if (isStrEqual role "operate")}}
     /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "manage")}}
-    {{parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.manufacturerCode parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "administer")}}
-    {{parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.manufacturerCode parent.code}}, /* Cluster: {{parent.parent.name}}, Attribute: {{parent.name}}, Privilege: {{role}} */ \
                         {{else}}
     ERROR: access has unrecognized role/privilege [ Cluster: {{parent.parent.name}}, Attribute: {{parent.name}} ]
                         {{/if}}
@@ -227,9 +227,9 @@
                         {{else if (isStrEqual role "operate")}}
     /* Cluster: {{parent.parent.name}}, Command: {{parent.commandName}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "manage")}}
-    {{parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Command: {{parent.commandName}}, Privilege: {{role}} */ \
+    {{asMEI parent.parent.manufacturerCode parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Command: {{parent.commandName}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "administer")}}
-    {{parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Command: {{parent.commandName}}, Privilege: {{role}} */ \
+    {{asMEI parent.parent.manufacturerCode parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Command: {{parent.commandName}}, Privilege: {{role}} */ \
                         {{else}}
     ERROR: access has unrecognized role/privilege [ Cluster: {{parent.parent.name}}, Command: {{parent.commandName}} ]
                         {{/if}}
@@ -260,9 +260,9 @@
                         {{else if (isStrEqual role "operate")}}
     /* Cluster: {{parent.parent.name}}, Command: {{parent.commandName}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "manage")}}
-    {{parent.code}}, /* Cluster: {{parent.parent.name}}, Command: {{parent.commandName}}, Privilege: {{role}} */ \
+    {{asMEI parent.commandMfgCode parent.code}}, /* Cluster: {{parent.parent.name}}, Command: {{parent.commandName}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "administer")}}
-    {{parent.code}}, /* Cluster: {{parent.parent.name}}, Command: {{parent.commandName}}, Privilege: {{role}} */ \
+    {{asMEI parent.commandMfgCode parent.code}}, /* Cluster: {{parent.parent.name}}, Command: {{parent.commandName}}, Privilege: {{role}} */ \
                         {{else}}
     ERROR: access has unrecognized role/privilege [ Cluster: {{parent.parent.name}}, Command: {{parent.commandName}} ]
                         {{/if}}
@@ -326,11 +326,11 @@
                         {{#if (isStrEqual role "view")}}
     /* Cluster: {{parent.parent.name}}, Event: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "operate")}}
-    {{parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Event: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.parent.manufacturerCode parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Event: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "manage")}}
-    {{parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Event: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.parent.manufacturerCode parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Event: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "administer")}}
-    {{parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Event: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.parent.manufacturerCode parent.parent.code}}, /* Cluster: {{parent.parent.name}}, Event: {{parent.name}}, Privilege: {{role}} */ \
                         {{else}}
     ERROR: access has unrecognized role/privilege [ Cluster: {{parent.parent.name}}, Event: {{parent.name}} ]
                         {{/if}}
@@ -359,11 +359,11 @@
                         {{#if (isStrEqual role "view")}}
     /* Cluster: {{parent.parent.name}}, Event: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "operate")}}
-    {{parent.code}}, /* Cluster: {{parent.parent.name}}, Event: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.manufacturerCode parent.code}}, /* Cluster: {{parent.parent.name}}, Event: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "manage")}}
-    {{parent.code}}, /* Cluster: {{parent.parent.name}}, Event: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.manufacturerCode parent.code}}, /* Cluster: {{parent.parent.name}}, Event: {{parent.name}}, Privilege: {{role}} */ \
                         {{else if (isStrEqual role "administer")}}
-    {{parent.code}}, /* Cluster: {{parent.parent.name}}, Event: {{parent.name}}, Privilege: {{role}} */ \
+    {{asMEI parent.manufacturerCode parent.code}}, /* Cluster: {{parent.parent.name}}, Event: {{parent.name}}, Privilege: {{role}} */ \
                         {{else}}
     ERROR: access has unrecognized role/privilege [ Cluster: {{parent.parent.name}}, Event: {{parent.name}} ]
                         {{/if}}


### PR DESCRIPTION
Unlike all other places that use .code, access.zapt was not accounting for manufacturerCode.

Ideally this would just use the named ids instead of reinventing the id wheel, but for now this at least makes the behavior match.


