### PR TITLE
[Ameba] check rtw_join_status for JOIN_HANDSHAKE_DONE

### DIFF
--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -152,7 +152,10 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
         {
             ChangeWiFiStationState(kWiFiStationState_Connecting_Succeeded);
         }
-        DHCPProcess();
+        if (rtw_join_status & JOIN_HANDSHAKE_DONE)
+        {
+            DHCPProcess();
+        }
         DriveStationState();
     }
     if (event->Type == DeviceEventType::kRtkWiFiStationDisconnectedEvent)


### PR DESCRIPTION
- fix #24441 
- DHCPProcess should not run when handshake fail
- check for JOIN_HANDSHAKE_DONE bit in rtw_join_status before calling DHCPProcess
- require docker update to build pass

