### PR TITLE
Correct the bitmap field names for Ballast Configuration cluster BallastStatus attribute/bitmap

### DIFF
--- a/src/app/zap-templates/zcl/data-model/silabs/ha.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ha.xml
@@ -46,7 +46,7 @@ limitations under the License.
     <attribute side="server" code="0x0009" define="WIND_SUPPORT" type="BITMAP8" writable="false" default="0x00" optional="true">WindSupport</attribute>
     <attribute side="server" code="0x000A" define="WIND_SETTING" type="BITMAP8" writable="true" default="0x00" optional="true">WindSetting</attribute>
   </cluster>
-  <!-- Fan Control Cluster data types -->  
+  <!-- Fan Control Cluster data types -->
   <enum name="FanModeType" type="ENUM8">
     <cluster code="0x0202"/>
     <item name="Off" value="0x00"/>
@@ -65,7 +65,7 @@ limitations under the License.
     <item name="Off/Low/High/Auto" value="0x03"/>
     <item name="Off/On/Auto" value="0x04"/>
     <item name="Off/On" value="0x05"/>
-  </enum>  
+  </enum>
   <bitmap name="FanControlFeature" type="BITMAP32">
     <cluster code="0x0202" />
     <field name="Multi-Speed" mask="0x01" />
@@ -74,21 +74,21 @@ limitations under the License.
     <field name="Wind" mask="0x08" />
   </bitmap>
   <bitmap name="RockSupportMask" type="BITMAP8">
-      <cluster code="0x0202" />
-      <field name="RockLeftRight" mask="0x01" />
-      <field name="RockUpDown" mask="0x02" />
-      <field  name="RockRound" mask="0x04" />
+    <cluster code="0x0202" />
+    <field name="RockLeftRight" mask="0x01" />
+    <field name="RockUpDown" mask="0x02" />
+    <field name="RockRound" mask="0x04" />
   </bitmap>
   <bitmap name="WindSupportMask" type="BITMAP8">
-      <cluster code="0x0202" />
-      <field name="Sleep Wind" mask="0x01" />
-      <field name="Natural Wind" mask="0x02" />
+    <cluster code="0x0202" />
+    <field name="Sleep Wind" mask="0x01" />
+    <field name="Natural Wind" mask="0x02" />
   </bitmap>
   <bitmap name="WindSettingMask" type="BITMAP8">
-      <cluster code="0x0202" />
-      <field name="Sleep Wind" mask="0x01" />
-      <field name="Natural Wind" mask="0x02" />
-  </bitmap>    
+    <cluster code="0x0202" />
+    <field name="Sleep Wind" mask="0x01" />
+    <field name="Natural Wind" mask="0x02" />
+  </bitmap>
   <cluster>
     <name>Thermostat User Interface Configuration</name>
     <domain>HVAC</domain>
@@ -373,7 +373,7 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="4"/>
     <attribute side="server" code="0x0000" define="PHYSICAL_MIN_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="false" default="0x01" optional="false">PhysicalMinLevel</attribute>
     <attribute side="server" code="0x0001" define="PHYSICAL_MAX_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="false" default="0xFE" optional="false">PhysicalMaxLevel</attribute>
-    <attribute side="server" code="0x0002" define="BALLAST_STATUS" type="BITMAP8" min="0x00" max="0x03" writable="false" default="0x00" optional="true">BallastStatus</attribute>
+    <attribute side="server" code="0x0002" define="BALLAST_STATUS" type="BallastStatus" min="0x00" max="0x03" writable="false" default="0x00" optional="true">BallastStatus</attribute>
     <attribute side="server" code="0x0010" define="MIN_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="true" default="0x01" optional="false">MinLevel</attribute>
     <attribute side="server" code="0x0011" define="MAX_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="true" default="0xFE" optional="false">MaxLevel</attribute>
     <attribute side="server" code="0x0014" define="INTRINSIC_BALLAST_FACTOR" type="INT8U" writable="true" isNullable="true" optional="true">IntrinsicBalanceFactor</attribute>
@@ -383,9 +383,18 @@ limitations under the License.
     <attribute side="server" code="0x0031" define="LAMP_MANUFACTURER" type="CHAR_STRING" length="16" writable="true" optional="true">LampManufacturer</attribute>
     <attribute side="server" code="0x0032" define="LAMP_RATED_HOURS" type="INT24U" writable="true" default="0xFFFFFF" isNullable="true" optional="true">LampRatedHours</attribute>
     <attribute side="server" code="0x0033" define="LAMP_BURN_HOURS" type="INT24U" writable="true" default="0x000000" isNullable="true" optional="true">LampBurnHours</attribute>
-    <attribute side="server" code="0x0034" define="LAMP_ALARM_MODE" type="BITMAP8" min="0x00" max="0x01" writable="true" default="0x00" optional="true">LampAlarmMode</attribute>
+    <attribute side="server" code="0x0034" define="LAMP_ALARM_MODE" type="AlarmMode" min="0x00" max="0x01" writable="true" default="0x00" optional="true">LampAlarmMode</attribute>
     <attribute side="server" code="0x0035" define="LAMP_BURN_HOURS_TRIP_POINT" type="INT24U" writable="true" default="0xFFFFFF" isNullable="true" optional="true">LampBurnHoursTripPoint</attribute>
   </cluster>
+  <bitmap name="BallastStatus" type="BITMAP8">
+    <cluster code="0x0301"/>
+    <field name="BallastNonOperational" mask="0x1"/>
+    <field name="LampFailure" mask="0x2"/>
+  </bitmap>
+  <bitmap name="AlarmMode" type="BITMAP8">
+    <cluster code="0x0301"/>
+    <field name="LampBurnHours" mask="0x1"/>
+  </bitmap>
   <cluster>
     <name>Occupancy Sensing</name>
     <domain>Measurement &amp; Sensing</domain>

--- a/src/app/zap-templates/zcl/data-model/silabs/ha.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ha.xml
@@ -386,15 +386,6 @@ limitations under the License.
     <attribute side="server" code="0x0034" define="LAMP_ALARM_MODE" type="AlarmMode" min="0x00" max="0x01" writable="true" default="0x00" optional="true">LampAlarmMode</attribute>
     <attribute side="server" code="0x0035" define="LAMP_BURN_HOURS_TRIP_POINT" type="INT24U" writable="true" default="0xFFFFFF" isNullable="true" optional="true">LampBurnHoursTripPoint</attribute>
   </cluster>
-  <bitmap name="BallastStatus" type="BITMAP8">
-    <cluster code="0x0301"/>
-    <field name="BallastNonOperational" mask="0x1"/>
-    <field name="LampFailure" mask="0x2"/>
-  </bitmap>
-  <bitmap name="AlarmMode" type="BITMAP8">
-    <cluster code="0x0301"/>
-    <field name="LampBurnHours" mask="0x1"/>
-  </bitmap>
   <cluster>
     <name>Occupancy Sensing</name>
     <domain>Measurement &amp; Sensing</domain>

--- a/src/app/zap-templates/zcl/data-model/silabs/ha.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ha.xml
@@ -373,7 +373,7 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="4"/>
     <attribute side="server" code="0x0000" define="PHYSICAL_MIN_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="false" default="0x01" optional="false">PhysicalMinLevel</attribute>
     <attribute side="server" code="0x0001" define="PHYSICAL_MAX_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="false" default="0xFE" optional="false">PhysicalMaxLevel</attribute>
-    <attribute side="server" code="0x0002" define="BALLAST_STATUS" type="BallastStatus" min="0x00" max="0x03" writable="false" default="0x00" optional="true">BallastStatus</attribute>
+    <attribute side="server" code="0x0002" define="BALLAST_STATUS" type="BITMAP8" min="0x00" max="0x03" writable="false" default="0x00" optional="true">BallastStatus</attribute>
     <attribute side="server" code="0x0010" define="MIN_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="true" default="0x01" optional="false">MinLevel</attribute>
     <attribute side="server" code="0x0011" define="MAX_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="true" default="0xFE" optional="false">MaxLevel</attribute>
     <attribute side="server" code="0x0014" define="INTRINSIC_BALLAST_FACTOR" type="INT8U" writable="true" isNullable="true" optional="true">IntrinsicBalanceFactor</attribute>
@@ -383,7 +383,7 @@ limitations under the License.
     <attribute side="server" code="0x0031" define="LAMP_MANUFACTURER" type="CHAR_STRING" length="16" writable="true" optional="true">LampManufacturer</attribute>
     <attribute side="server" code="0x0032" define="LAMP_RATED_HOURS" type="INT24U" writable="true" default="0xFFFFFF" isNullable="true" optional="true">LampRatedHours</attribute>
     <attribute side="server" code="0x0033" define="LAMP_BURN_HOURS" type="INT24U" writable="true" default="0x000000" isNullable="true" optional="true">LampBurnHours</attribute>
-    <attribute side="server" code="0x0034" define="LAMP_ALARM_MODE" type="AlarmMode" min="0x00" max="0x01" writable="true" default="0x00" optional="true">LampAlarmMode</attribute>
+    <attribute side="server" code="0x0034" define="LAMP_ALARM_MODE" type="BITMAP8" min="0x00" max="0x01" writable="true" default="0x00" optional="true">LampAlarmMode</attribute>
     <attribute side="server" code="0x0035" define="LAMP_BURN_HOURS_TRIP_POINT" type="INT24U" writable="true" default="0xFFFFFF" isNullable="true" optional="true">LampBurnHoursTripPoint</attribute>
   </cluster>
   <cluster>

--- a/src/app/zap-templates/zcl/data-model/silabs/types.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/types.xml
@@ -57,8 +57,8 @@ limitations under the License.
     <field name="selfcalibrationFailure" mask="0x4"/>
   </bitmap>
   <bitmap name="BallastStatus" type="BITMAP8">
-    <field name="NonOperational" mask="0x1"/>
-    <field name="LampNotInSocket" mask="0x2"/>
+    <field name="BallastNonOperational" mask="0x1"/>
+    <field name="LampFailure" mask="0x2"/>
   </bitmap>
   <bitmap name="LampAlarmMode" type="BITMAP8">
     <field name="lampBurnHours" mask="0x1"/>


### PR DESCRIPTION
The Ballast Configuration cluster has 2 bitmaps defined in the specification: BallastStatus, AlarmMode.

The Bitmaps are defined in types.xml. Update them to meet the names in the specification. Use them in ha.xml.

Some automated whitespace cleaning is included in the PR.
