### PR TITLE
Update android const correctness/overrides after #24355

### DIFF
--- a/examples/tv-app/android/java/TVApp-JNI.cpp
+++ b/examples/tv-app/android/java/TVApp-JNI.cpp
@@ -201,7 +201,7 @@ MyPincodeService gMyPincodeService;
 class MyPostCommissioningListener : public PostCommissioningListener
 {
     void CommissioningCompleted(uint16_t vendorId, uint16_t productId, NodeId nodeId, Messaging::ExchangeManager & exchangeMgr,
-                                SessionHandle & sessionHandle) override
+                                const SessionHandle & sessionHandle) override
     {
         // read current binding list
         chip::Controller::BindingCluster cluster(exchangeMgr, sessionHandle, kTargetBindingClusterEndpointId);
@@ -296,7 +296,7 @@ class MyPostCommissioningListener : public PostCommissioningListener
     }
 
     void cacheContext(uint16_t vendorId, uint16_t productId, NodeId nodeId, Messaging::ExchangeManager & exchangeMgr,
-                      SessionHandle & sessionHandle)
+                      const SessionHandle & sessionHandle)
     {
         mVendorId    = vendorId;
         mProductId   = productId;


### PR DESCRIPTION
Android fails to build (e.g. 
https://github.com/project-chip/connectedhomeip/actions/runs/3928357745/jobs/6715909168)

This is due #24355 making a session handle const. Updated tv app code to make the override const and updated on dependent call as well.
