### PR TITLE
Add docbuild workflow for PRs

### DIFF
--- a/.github/workflows/docbuild.yaml
+++ b/.github/workflows/docbuild.yaml
@@ -1,6 +1,14 @@
 name: Documentation Build
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - master
+    paths:
+    - '.github/workflows/docbuild.yaml'
+    - '**.md'
+    - 'docs/**'
   push:
     branches:
       - master
@@ -9,7 +17,7 @@ permissions:
   contents: write
 
 jobs:
-  build-and-deploy:
+  build-and-publish:
     runs-on: ubuntu-latest
 
     steps:
@@ -39,7 +47,7 @@ jobs:
           make html
           touch _build/html/.nojekyll
       - name: Deploy to gh-pages
-        if: github.repository == 'project-chip/connectedhomeip'
+        if: github.repository == 'project-chip/connectedhomeip' && github.event_name == 'push' && github.ref_name == 'master'
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.DOXYGEN_DEPLOY_KEY }}

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -W -c . -d _build/doctrees
+SPHINXOPTS    ?= -W --keep-going -c . -d _build/doctrees
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = _build/src
 BUILDDIR      = _build

--- a/examples/light-switch-app/silabs/SiWx917/README.md
+++ b/examples/light-switch-app/silabs/SiWx917/README.md
@@ -32,8 +32,6 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
 > release with added tools and documentation.
 > [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
 
-<a name="intro"></a>
-
 ## Introduction
 
 The EFR32 light switch example provides a baseline demonstration of a on-off
@@ -52,8 +50,6 @@ Rendez-vous procedure.
 The light switch example is intended to serve both as a means to explore the
 workings of Matter as well as a template for creating real products based on the
 Silicon Labs platform.
-
-<a name="building"></a>
 
 ## Building
 
@@ -181,14 +177,12 @@ Silicon Labs platform.
           $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
           $ ninja -C out/debug
 
-    [Running Pigweed RPC console](#running-pigweed-rpc-console)
+    [Running Pigweed RPC console](#running-rpc-console)
 
 For more build options, help is provided when running the build script without
 arguments
 
     ./scripts/examples/gn_efr32_example.sh
-
-<a name="flashing"></a>
 
 ## Flashing the Application
 
@@ -198,8 +192,6 @@ arguments
           $ python3 out/debug/chip-efr32-light-switch-example.flash.py
 
 -   Or with the Ozone debugger, just load the .out file.
-
-<a name="view-logging"></a>
 
 ## Viewing Logging Output
 
@@ -248,8 +240,6 @@ combination with JLinkRTTClient as follows:
 -   In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
-
-<a name="running-complete-example"></a>
 
 ## Running the Complete Example
 
@@ -385,8 +375,6 @@ combination with JLinkRTTClient as follows:
 #Add Ipv6 route on PC(Linux) \$ sudo ip route add <Thread global ipv6 prefix>/64
 via 2002::2
 
-<a name="running-pigweed-rpc-console"></a>
-
 ## Running RPC console
 
 -   As part of building the example with RPCs enabled the chip_rpc python
@@ -432,7 +420,7 @@ tracking code inside the `trackAlloc` and `trackFree` function
 
 For the description of Software Update process with EFR32 example applications
 see
-[EFR32 OTA Software Update](../../../docs/guides/silabs_efr32_software_update.md)
+[EFR32 OTA Software Update](../../../../docs/guides/silabs_efr32_software_update.md)
 
 ## Building options
 

--- a/examples/lock-app/silabs/SiWx917/README.md
+++ b/examples/lock-app/silabs/SiWx917/README.md
@@ -27,8 +27,6 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
 > release with added tools and documentation.
 > [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
 
-<a name="intro"></a>
-
 ## Introduction
 
 The EFR32 lock example provides a baseline demonstration of a door lock control
@@ -47,8 +45,6 @@ Rendez-vous procedure.
 The lighting example is intended to serve both as a means to explore the
 workings of Matter as well as a template for creating real products based on the
 Silicon Labs platform.
-
-<a name="building"></a>
 
 ## Building
 
@@ -189,16 +185,12 @@ Mac OS X
           $ ninja -C out/debug
           ```
 
-    [Running Pigweed RPC console](#running-pigweed-rpc-console)
-
 For more build options, help is provided when running the build script without
 arguments
 
          ```
          ./scripts/examples/gn_efr32_example.sh
          ```
-
-<a name="flashing"></a>
 
 ## Flashing the Application
 
@@ -210,8 +202,6 @@ arguments
           ```
 
 -   Or with the Ozone debugger, just load the .out file.
-
-<a name="view-logging"></a>
 
 ## Viewing Logging Output
 
@@ -270,8 +260,6 @@ combination with JLinkRTTClient as follows:
           ```
           $ JLinkRTTClient
           ```
-
-<a name="running-complete-example"></a>
 
 ## Running the Complete Example
 
@@ -413,7 +401,7 @@ tracking code inside the `trackAlloc` and `trackFree` function
 
 For the description of Software Update process with EFR32 example applications
 see
-[EFR32 OTA Software Update](../../../docs/guides/silabs_efr32_software_update.md)
+[EFR32 OTA Software Update](../../../../docs/guides/silabs_efr32_software_update.md)
 
 ## Building options
 

--- a/examples/window-app/silabs/SiWx917/README.md
+++ b/examples/window-app/silabs/SiWx917/README.md
@@ -26,8 +26,6 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
 > release with added tools and documentation.
 > [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
 
-<a name="intro"></a>
-
 ## Introduction
 
 The EFR32 window-covering example provides a baseline demonstration of a Window
@@ -47,8 +45,6 @@ representation of the window covering state.
 The window-covering example is intended to serve both as a means to explore the
 workings of Matter as well as a template for creating real products based on the
 Silicon Labs platform.
-
-<a name="building"></a>
 
 ## Building
 
@@ -145,14 +141,10 @@ Silicon Labs platform.
           $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
           $ ninja -C out/debug
 
-    [Running Pigweed RPC console](#running-pigweed-rpc-console)
-
 For more build options, help is provided when running the build script without
 arguments
 
          ./scripts/examples/gn_efr32_example.sh
-
-<a name="flashing"></a>
 
 ## Flashing the Application
 
@@ -162,8 +154,6 @@ arguments
           $ python3 out/debug/chip-efr32-window-example.flash.py
 
 -   Or with the Ozone debugger, just load the .out file.
-
-<a name="view-logging"></a>
 
 ## Viewing Logging Output
 
@@ -212,8 +202,6 @@ combination with JLinkRTTClient as follows:
 -   In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
-
-<a name="running-complete-example"></a>
 
 ## Running the Complete Example
 
@@ -344,13 +332,11 @@ combination with JLinkRTTClient as follows:
           # Add Ipv6 route on PC (Linux)
           $ sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2
 
-<a name="running-pigweed-rpc-console"></a>
-
 ## OTA Software Update
 
 For the description of Software Update process with EFR32 example applications
 see
-[EFR32 OTA Software Update](../../../docs/guides/silabs_efr32_software_update.md)
+[EFR32 OTA Software Update](../../../../docs/guides/silabs_efr32_software_update.md)
 
 ## Building options
 


### PR DESCRIPTION
Fixed some reference issues in markdown files that caused the Sphinx build to fail.

Also reorganized the docbuild workflow so that it runs on every PR related to the docs or .md-files so that future changes that break the docs can be identified before merging. The deploy step now only runs when pushing to the master branch.