### PR TITLE
Make libwebsockets less chatty by default

### DIFF
--- a/third_party/libwebsockets/lws_config.h
+++ b/third_party/libwebsockets/lws_config.h
@@ -45,6 +45,7 @@
 #define LWS_WITHOUT_DAEMONIZE // "Don't build the daemonization api" - default: ON
 #define LWS_LOGS_TIMESTAMP    // "Timestamp at start of logs" - default: ON
 #define LWS_LOG_TAG_LIFECYCLE // "Log tagged object lifecycle as NOTICE" - default: ON
+#define LWS_WITH_NO_LOGS      // "Disable all logging other than _err and _user from being compiled in" - defaults: OFF
 
 //
 // Implied Options


### PR DESCRIPTION
#### Problem

 `libwebsockets` logs most things by defaults. Make it less chatty by default since this is distracting when running tests.

