### PR TITLE
Fix some typos in src/app/tests/suites/certification/Test_TC_CADMIN_1…

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_11.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_11.yaml
@@ -79,11 +79,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     #Check for DNS-SD advertisement CM is not possible in YAML
@@ -148,11 +148,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     - label: "TH_CR2 starts a commissioning process with DUT_CE"
@@ -188,11 +188,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     - label:
@@ -209,11 +209,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
       response:
           error: FAILURE
@@ -228,9 +228,9 @@ tests:
       response:
           value:
               [
-                  { Label: "", nodeId: nodeId },
-                  { Label: "", nodeId: nodeId3 },
-                  { Label: "", nodeID: nodeId2 },
+                  { Label: "", NodeId: nodeId },
+                  { Label: "", NodeId: nodeId3 },
+                  { Label: "", NodeId: nodeId2 },
               ]
           constraints:
               type: list
@@ -256,8 +256,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 180
-              - name: "discriminator"
-                value: discriminator
 
     #Check for DNS-SD advertisement CM is not possible in YAML
     - label: "Verify that the DNS-SD advertisement shows CM=1"
@@ -294,8 +292,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 180
-              - name: "discriminator"
-                value: discriminator
       response:
           error: FAILURE
           clusterError: 2
@@ -319,9 +315,9 @@ tests:
       response:
           value:
               [
-                  { Label: "", nodeId: nodeId },
-                  { Label: "", nodeId: nodeId3 },
-                  { Label: "", nodeID: nodeId2 },
+                  { Label: "", NodeId: nodeId },
+                  { Label: "", NodeId: nodeId3 },
+                  { Label: "", NodeId: nodeId2 },
               ]
           constraints:
               type: list
@@ -335,8 +331,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 180
-              - name: "discriminator"
-                value: discriminator
 
     - label:
           "Before the expiration of PIXIT.CADMIN.CwDuration seconds that was set
@@ -351,8 +345,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 180
-              - name: "discriminator"
-                value: discriminator
       response:
           error: FAILURE
           clusterError: 2

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_13.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_13.yaml
@@ -83,8 +83,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 180
-              - name: "discriminator"
-                value: discriminator
 
     - label: "TH_CR1 reads WindowStatus attribute from DUT_CE"
       cluster: "AdministratorCommissioning"
@@ -238,8 +236,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 180
-              - name: "discriminator"
-                value: discriminator
 
     - label: "TH_CR2 starts a commissioning process with DUT_CE"
       identity: "beta"
@@ -271,8 +267,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 180
-              - name: "discriminator"
-                value: discriminator
 
     - label: "TH_CR1 opens a 2nd commissioning window on DUT_CE"
       identity: "alpha"
@@ -286,11 +280,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
       response:
           error: FAILURE
@@ -306,9 +300,9 @@ tests:
       response:
           value:
               [
-                  { Label: "", nodeId: nodeId },
-                  { Label: "", nodeId: nodeId2 },
-                  { Label: "", nodeID: nodeId3 },
+                  { Label: "", NodeId: nodeId },
+                  { Label: "", NodeId: nodeId2 },
+                  { Label: "", NodeId: nodeId3 },
               ]
           constraints:
               type: list
@@ -333,11 +327,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     - label: "TH_CR1 reads WindowStatus attribute from DUT_CE"
@@ -388,11 +382,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
       response:
           error: FAILURE
@@ -408,9 +402,9 @@ tests:
       response:
           value:
               [
-                  { Label: "", nodeId: nodeId },
-                  { Label: "", nodeId: nodeId2 },
-                  { Label: "", nodeID: nodeId3 },
+                  { Label: "", NodeId: nodeId },
+                  { Label: "", NodeId: nodeId2 },
+                  { Label: "", NodeId: nodeId3 },
               ]
           constraints:
               type: list
@@ -435,11 +429,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     - label: "TH_CR2 opens a 2nd commissioning window on DUT_CE using ECM"
@@ -454,11 +448,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
       response:
           error: FAILURE

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_15.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_15.yaml
@@ -79,11 +79,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     - label: "TH_CR2 starts a commissioning process with DUT_CE"
@@ -120,11 +120,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     - label: "TH_CR3 Commissions with DUT_CE"
@@ -159,9 +159,9 @@ tests:
       response:
           value:
               [
-                  { Label: "", FabricIndex: 1, nodeId: nodeId },
-                  { Label: "", FabricIndex: 2, nodeId: nodeId2 },
-                  { Label: "", FabricIndex: 3, nodeID: nodeId3 },
+                  { Label: "", FabricIndex: 1, NodeId: nodeId },
+                  { Label: "", FabricIndex: 2, NodeId: nodeId2 },
+                  { Label: "", FabricIndex: 3, NodeId: nodeId3 },
               ]
           constraints:
               type: list
@@ -222,8 +222,8 @@ tests:
       response:
           value:
               [
-                  { Label: "", FabricIndex: 1, nodeId: nodeId },
-                  { Label: "", FabricIndex: 3, nodeID: nodeId3 },
+                  { Label: "", FabricIndex: 1, NodeId: nodeId },
+                  { Label: "", FabricIndex: 3, NodeId: nodeId3 },
               ]
           constraints:
               type: list
@@ -270,11 +270,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     - label: "TH_CR2 starts a commissioning process with DUT_CE"
@@ -309,9 +309,9 @@ tests:
       response:
           value:
               [
-                  { Label: "", FabricIndex: 1, nodeId: nodeId },
-                  { Label: "", FabricIndex: 4, nodeId: nodeId2 },
-                  { Label: "", FabricIndex: 3, nodeID: nodeId3 },
+                  { Label: "", FabricIndex: 1, NodeId: nodeId },
+                  { Label: "", FabricIndex: 4, NodeId: nodeId2 },
+                  { Label: "", FabricIndex: 3, NodeId: nodeId3 },
               ]
           constraints:
               type: list

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_16.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_16.yaml
@@ -75,8 +75,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 180
-              - name: "discriminator"
-                value: discriminator
 
     - label: "TH_CR2 starts a commissioning process with DUT_CE"
       identity: "beta"
@@ -110,8 +108,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 180
-              - name: "discriminator"
-                value: discriminator
 
     - label: "TH_CR3 Commissions with DUT_CE"
       PICS: CADMIN.S
@@ -145,9 +141,9 @@ tests:
       response:
           value:
               [
-                  { Label: "", FabricIndex: 1, nodeId: nodeId },
-                  { Label: "", FabricIndex: 2, nodeId: nodeId2 },
-                  { Label: "", FabricIndex: 3, nodeID: nodeId3 },
+                  { Label: "", FabricIndex: 1, NodeId: nodeId },
+                  { Label: "", FabricIndex: 2, NodeId: nodeId2 },
+                  { Label: "", FabricIndex: 3, NodeId: nodeId3 },
               ]
           constraints:
               type: list
@@ -208,8 +204,8 @@ tests:
       response:
           value:
               [
-                  { Label: "", FabricIndex: 1, nodeId: nodeId },
-                  { Label: "", FabricIndex: 3, nodeID: nodeId3 },
+                  { Label: "", FabricIndex: 1, NodeId: nodeId },
+                  { Label: "", FabricIndex: 3, NodeId: nodeId3 },
               ]
           constraints:
               type: list
@@ -224,8 +220,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 180
-              - name: "discriminator"
-                value: discriminator
 
     - label: "TH_CR2 starts a commissioning process with DUT_CE"
       identity: "beta"
@@ -259,9 +253,9 @@ tests:
       response:
           value:
               [
-                  { Label: "", FabricIndex: 1, nodeId: nodeId },
-                  { Label: "", FabricIndex: 4, nodeId: nodeId2 },
-                  { Label: "", FabricIndex: 3, nodeID: nodeId3 },
+                  { Label: "", FabricIndex: 1, NodeId: nodeId },
+                  { Label: "", FabricIndex: 4, NodeId: nodeId2 },
+                  { Label: "", FabricIndex: 3, NodeId: nodeId3 },
               ]
           constraints:
               type: list

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_21.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_21.yaml
@@ -66,8 +66,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 900
-              - name: "discriminator"
-                value: discriminator
 
     - label: "Wait for commissioning Window to 901 seconds"
       cluster: "DelayCommands"
@@ -95,8 +93,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 901
-              - name: "discriminator"
-                value: discriminator
       response:
           error: INVALID_COMMAND
 

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_22.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_22.yaml
@@ -70,11 +70,11 @@ tests:
                 value: 900
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     - label: "Wait for commissioning Window to 901 seconds"
@@ -105,11 +105,11 @@ tests:
                 value: 901
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
       response:
           error: INVALID_COMMAND

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_23.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_23.yaml
@@ -66,8 +66,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 180
-              - name: "discriminator"
-                value: discriminator
 
     - label: "Wait for commissioning Window to 181 seconds"
       cluster: "DelayCommands"
@@ -95,8 +93,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 179
-              - name: "discriminator"
-                value: discriminator
       response:
           error: INVALID_COMMAND
 

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_24.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_24.yaml
@@ -70,11 +70,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     - label: "Wait for commissioning Window to 181 seconds"
@@ -105,11 +105,11 @@ tests:
                 value: 179
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
       response:
           error: INVALID_COMMAND

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_3.yaml
@@ -73,11 +73,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     #Check for DNS-SD advertisement CM is not possible in YAML
@@ -187,7 +187,7 @@ tests:
       PICS: OPCREDS.S.A0001
       fabricFiltered: false
       response:
-          value: [{ Label: "", nodeId: nodeId }, { Label: "", nodeId: nodeId2 }]
+          value: [{ Label: "", NodeId: nodeId }, { Label: "", NodeId: nodeId2 }]
           constraints:
               type: list
 
@@ -199,7 +199,7 @@ tests:
       PICS: OPCREDS.S.A0001
       fabricFiltered: false
       response:
-          value: [{ Label: "", nodeId: nodeId }, { Label: "", nodeId: nodeId2 }]
+          value: [{ Label: "", NodeId: nodeId }, { Label: "", NodeId: nodeId2 }]
           constraints:
               type: list
 
@@ -263,11 +263,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     - label: "Wait for the commissioning window in step 13 to timeout"
@@ -299,11 +299,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     - label:

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_4.yaml
@@ -69,8 +69,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 180
-              - name: "discriminator"
-                value: discriminator
 
     #Check for DNS-SD advertisement CM is not possible in YAML
     - label: "Verify that the DNS-SD advertisement shows CM=1"
@@ -176,7 +174,7 @@ tests:
       attribute: "Fabrics"
       fabricFiltered: false
       response:
-          value: [{ Label: "", nodeId: nodeId }, { Label: "", nodeId: nodeId2 }]
+          value: [{ Label: "", NodeId: nodeId }, { Label: "", NodeId: nodeId2 }]
           constraints:
               type: list
 
@@ -188,7 +186,7 @@ tests:
       PICS: OPCREDS.S.A0001
       fabricFiltered: false
       response:
-          value: [{ Label: "", nodeId: nodeId }, { Label: "", nodeId: nodeId2 }]
+          value: [{ Label: "", NodeId: nodeId }, { Label: "", NodeId: nodeId2 }]
           constraints:
               type: list
 
@@ -250,8 +248,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 180
-              - name: "discriminator"
-                value: discriminator
 
     - label: "Wait for the commissioning window in step 13 to timeout"
       cluster: "DelayCommands"
@@ -280,8 +276,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 180
-              - name: "discriminator"
-                value: discriminator
 
     - label:
           "TH_CR1 starts a commissioning process with DUT_CE before the timeout

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_5.yaml
@@ -84,11 +84,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     #Check for DNS-SD advertisement CM is not possible in YAML
@@ -146,11 +146,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     - label: "TH_CR1 revokes the commissioning window on DUT_CE"
@@ -210,11 +210,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: IncorrectPakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
       response:
           error: FAILURE
@@ -231,11 +231,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     - label: "TH_CR1 opens another commissioning window on DUT_CE using ECM"
@@ -249,11 +249,11 @@ tests:
                 value: 180
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
       response:
           error: FAILURE

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_9.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_9.yaml
@@ -84,11 +84,11 @@ tests:
                 value: 900
               - name: "PAKEPasscodeVerifier"
                 value: PakeVerifier
-              - name: "discriminator"
+              - name: "Discriminator"
                 value: discriminator
-              - name: "iterations"
+              - name: "Iterations"
                 value: 1000
-              - name: "salt"
+              - name: "Salt"
                 value: "SPAKE2P Key Salt"
 
     #Check for DNS-SD advertisement CM is not possible in YAML


### PR DESCRIPTION
…_*.yaml

#### Problem

When working on running yaml tests with the python parser I have found that `TC_Admin_1_*.yaml` tests contains some typos. While I can fix the parser to be fine with those I prefer to keeps is stricter. Especially since for those specific typos we can see that `NodeId` is written in 3 different ways: `NodeId`, `nodeId`, `nodeID`...