### PR TITLE
Fix some typos in src/app/tests/suites/TestLevelControlWithOnOffDepen…

### DIFF
--- a/src/app/tests/suites/TestLevelControlWithOnOffDependency.yaml
+++ b/src/app/tests/suites/TestLevelControlWithOnOffDependency.yaml
@@ -32,13 +32,13 @@ tests:
       command: "MoveToLevel"
       arguments:
           values:
-              - name: "level"
+              - name: "Level"
                 value: 1
-              - name: "transitionTime"
+              - name: "TransitionTime"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 1
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 1
 
     - label: "Wait 100 ms"
@@ -155,13 +155,13 @@ tests:
       command: "MoveToLevel"
       arguments:
           values:
-              - name: "level"
+              - name: "Level"
                 value: 127
-              - name: "transitionTime"
+              - name: "TransitionTime"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 1
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 1
 
     - label: "Wait 100 ms"


### PR DESCRIPTION
#### Problem

When working on running yaml tests with the python parser I have found that `TestLevelControlWithOnOffDependency.yaml` tests contains some typos. While I can fix the parser to be fine with those I prefer to keeps is stricter. 
