### PR TITLE
lock the setuptools version

### DIFF
--- a/integrations/docker/images/chip-build-cirque/Dockerfile
+++ b/integrations/docker/images/chip-build-cirque/Dockerfile
@@ -33,7 +33,7 @@ RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
        sudo socat psmisc tigervnc-standalone-server xorg xauth \
-       python3-pip python3-venv python3-setuptools libdbus-glib-1-dev \
+       python3-pip python3-venv libdbus-glib-1-dev \
        uuid-runtime libgirepository1.0-dev \
     && : # aids diffs
 

--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -105,7 +105,10 @@ function cirquetest_bootstrap() {
     set -ex
 
     cd "$REPO_DIR"/third_party/cirque/repo
+    pip3 uninstall -y setuptools
+    pip3 install setuptools==65.7.0
     pip3 install pycodestyle==2.5.0 wheel
+
     make NO_GRPC=1 install -j
 
     "$REPO_DIR"/integrations/docker/ci-only-images/chip-cirque-device-base/build.sh


### PR DESCRIPTION
It seems upstream setuptools is broken. fix it via pinning the versions.
context is from
https://github.com/pypa/setuptools/issues/3772
