### PR TITLE
Add shared-reviewers-signify

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -144,6 +144,14 @@ groups:
             teams: [reviewers-samsung]
         reviews:
             request: 10
+    shared-reviewers-signify:
+        type: optional
+        conditions:
+            - files.include('*')
+        reviewers:
+            teams: [reviewers-signify]
+        reviews:
+            request: 10
     shared-reviewers-silabs:
         type: optional
         conditions:

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -167,7 +167,7 @@ groups:
         reviewers:
             teams: [reviewers-tcl]
         reviews:
-            request: 1
+            request: 10
 
     ############################################################
     #  Base Required Reviewers


### PR DESCRIPTION
This allows more companies to review as part of our PR review pool. We have members of signify team having reviewed quite a few PRs, lets make it count towards the consensus check.
