### PR TITLE
Fix various typos in various tests

### DIFF
--- a/src/app/tests/suites/OTA_SuccessfulTransfer.yaml
+++ b/src/app/tests/suites/OTA_SuccessfulTransfer.yaml
@@ -147,13 +147,13 @@ tests:
       command: "AnnounceOTAProvider"
       arguments:
           values:
-              - name: "providerNodeId"
+              - name: "ProviderNodeID"
                 value: providerNodeId
-              - name: "vendorId"
+              - name: "VendorID"
                 value: 0
-              - name: "announcementReason"
+              - name: "AnnouncementReason"
                 value: 0
-              - name: "endpoint"
+              - name: "Endpoint"
                 value: endpoint
 
     - label: "Wait for transfer complete message"

--- a/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
+++ b/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
@@ -192,13 +192,13 @@ tests:
                   {
                       FabricIndex: 1,
                       GroupId: 0x0101,
-                      endpoints: [1],
+                      Endpoints: [1],
                       GroupName: "Group #1",
                   },
                   {
                       FabricIndex: 1,
                       GroupId: 0x0102,
-                      endpoints: [1],
+                      Endpoints: [1],
                       GroupName: "Group #2",
                   },
               ]
@@ -264,7 +264,7 @@ tests:
                   {
                       FabricIndex: 1,
                       GroupId: 0x0102,
-                      endpoints: [1],
+                      Endpoints: [1],
                       GroupName: "Group #2",
                   },
               ]

--- a/src/app/tests/suites/TestGroupsCluster.yaml
+++ b/src/app/tests/suites/TestGroupsCluster.yaml
@@ -66,7 +66,7 @@ tests:
           values:
               - name: "Status"
                 value: 0x7e
-              - name: "GroupId"
+              - name: "GroupID"
                 value: 0x0101
 
     - label: "Add KeySet"

--- a/src/app/tests/suites/certification/Test_TC_ALOGIN_12_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ALOGIN_12_1.yaml
@@ -47,7 +47,7 @@ tests:
       command: "LaunchApp"
       arguments:
           values:
-              - name: "Data"
+              - name: "data"
                 value: "Hello World"
               - name: "application"
                 value:

--- a/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_7.yaml
@@ -42,7 +42,7 @@ tests:
       command: "LaunchApp"
       arguments:
           values:
-              - name: "Data"
+              - name: "data"
                 value: "Hello World"
               - name: "application"
                 value:

--- a/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_1.yaml
@@ -47,7 +47,7 @@ tests:
       command: "SelectOutput"
       arguments:
           values:
-              - name: "Index"
+              - name: "index"
                 value: Index
 
     - label: "Reads the CurrentOutput attribute"

--- a/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_2.yaml
@@ -48,7 +48,7 @@ tests:
       command: "RenameOutput"
       arguments:
           values:
-              - name: "Index"
+              - name: "index"
                 value: Index
               - name: "name"
                 value: "CertTest"

--- a/src/app/tests/suites/certification/Test_TC_CC_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_3_1.yaml
@@ -51,7 +51,7 @@ tests:
       command: "MoveToHue"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 60
               - name: "Direction"
                 value: 0
@@ -77,7 +77,7 @@ tests:
       command: "MoveToHue"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 120
               - name: "Direction"
                 value: 0
@@ -163,7 +163,7 @@ tests:
       command: "MoveToHue"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 60
               - name: "Direction"
                 value: 0
@@ -189,7 +189,7 @@ tests:
       command: "MoveToHue"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 135
               - name: "Direction"
                 value: 1
@@ -285,7 +285,7 @@ tests:
       command: "MoveToHue"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 60
               - name: "Direction"
                 value: 0
@@ -311,7 +311,7 @@ tests:
       command: "MoveToHue"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 120
               - name: "Direction"
                 value: 2
@@ -397,7 +397,7 @@ tests:
       command: "MoveToHue"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 120
               - name: "Direction"
                 value: 0
@@ -423,7 +423,7 @@ tests:
       command: "MoveToHue"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 60
               - name: "Direction"
                 value: 3

--- a/src/app/tests/suites/certification/Test_TC_CC_3_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_3_2.yaml
@@ -50,7 +50,7 @@ tests:
       command: "MoveToHue"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 200
               - name: "Direction"
                 value: 0
@@ -176,7 +176,7 @@ tests:
       command: "MoveToHue"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 60
               - name: "Direction"
                 value: 0

--- a/src/app/tests/suites/certification/Test_TC_CC_3_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_3_3.yaml
@@ -50,7 +50,7 @@ tests:
       command: "MoveToHue"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 200
               - name: "Direction"
                 value: 0
@@ -145,7 +145,7 @@ tests:
       command: "MoveToHue"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 50
               - name: "Direction"
                 value: 0

--- a/src/app/tests/suites/certification/Test_TC_CC_4_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_4_4.yaml
@@ -51,7 +51,7 @@ tests:
       command: "MoveToHueAndSaturation"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 200
               - name: "Saturation"
                 value: 50
@@ -95,7 +95,7 @@ tests:
       command: "MoveToHueAndSaturation"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 160
               - name: "Saturation"
                 value: 80

--- a/src/app/tests/suites/certification/Test_TC_CC_5_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_5_1.yaml
@@ -50,9 +50,9 @@ tests:
       command: "MoveToColor"
       arguments:
           values:
-              - name: "colorX"
+              - name: "ColorX"
                 value: 32768
-              - name: "colorY"
+              - name: "ColorY"
                 value: 19660
               - name: "TransitionTime"
                 value: 0
@@ -94,9 +94,9 @@ tests:
       command: "MoveToColor"
       arguments:
           values:
-              - name: "colorX"
+              - name: "ColorX"
                 value: 13107
-              - name: "colorY"
+              - name: "ColorY"
                 value: 13107
               - name: "TransitionTime"
                 value: 200
@@ -210,9 +210,9 @@ tests:
       command: "MoveToColor"
       arguments:
           values:
-              - name: "colorX"
+              - name: "ColorX"
                 value: 32768
-              - name: "colorY"
+              - name: "ColorY"
                 value: 19660
               - name: "TransitionTime"
                 value: 0
@@ -259,9 +259,9 @@ tests:
       command: "MoveToColor"
       arguments:
           values:
-              - name: "colorX"
+              - name: "ColorX"
                 value: 13107
-              - name: "colorY"
+              - name: "ColorY"
                 value: 13107
               - name: "TransitionTime"
                 value: 0
@@ -299,9 +299,9 @@ tests:
       command: "MoveToColor"
       arguments:
           values:
-              - name: "colorX"
+              - name: "ColorX"
                 value: 13107
-              - name: "colorY"
+              - name: "ColorY"
                 value: 32768
               - name: "TransitionTime"
                 value: 0
@@ -339,9 +339,9 @@ tests:
       command: "MoveToColor"
       arguments:
           values:
-              - name: "colorX"
+              - name: "ColorX"
                 value: 26214
-              - name: "colorY"
+              - name: "ColorY"
                 value: 32768
               - name: "TransitionTime"
                 value: 0
@@ -402,9 +402,9 @@ tests:
       command: "MoveToColor"
       arguments:
           values:
-              - name: "colorX"
+              - name: "ColorX"
                 value: 32768
-              - name: "colorY"
+              - name: "ColorY"
                 value: 19660
               - name: "TransitionTime"
                 value: 0
@@ -451,9 +451,9 @@ tests:
       command: "MoveToColor"
       arguments:
           values:
-              - name: "colorX"
+              - name: "ColorX"
                 value: 13107
-              - name: "colorY"
+              - name: "ColorY"
                 value: 13107
               - name: "TransitionTime"
                 value: 0
@@ -495,9 +495,9 @@ tests:
       command: "MoveToColor"
       arguments:
           values:
-              - name: "colorX"
+              - name: "ColorX"
                 value: 13107
-              - name: "colorY"
+              - name: "ColorY"
                 value: 32768
               - name: "TransitionTime"
                 value: 0
@@ -535,9 +535,9 @@ tests:
       command: "MoveToColor"
       arguments:
           values:
-              - name: "colorX"
+              - name: "ColorX"
                 value: 26214
-              - name: "colorY"
+              - name: "ColorY"
                 value: 32768
               - name: "TransitionTime"
                 value: 0

--- a/src/app/tests/suites/certification/Test_TC_CC_5_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_5_2.yaml
@@ -50,9 +50,9 @@ tests:
       command: "MoveToColor"
       arguments:
           values:
-              - name: "colorX"
+              - name: "ColorX"
                 value: 33000
-              - name: "colorY"
+              - name: "ColorY"
                 value: 26000
               - name: "TransitionTime"
                 value: 0
@@ -74,9 +74,9 @@ tests:
       PICS: CC.S.F03 && CC.S.C08.Rsp
       arguments:
           values:
-              - name: "rateX"
+              - name: "RateX"
                 value: -100
-              - name: "rateY"
+              - name: "RateY"
                 value: 100
               - name: "OptionsMask"
                 value: 0

--- a/src/app/tests/suites/certification/Test_TC_CC_5_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_5_3.yaml
@@ -50,9 +50,9 @@ tests:
       command: "MoveToColor"
       arguments:
           values:
-              - name: "colorX"
+              - name: "ColorX"
                 value: 33000
-              - name: "colorY"
+              - name: "ColorY"
                 value: 20000
               - name: "TransitionTime"
                 value: 0
@@ -76,9 +76,9 @@ tests:
       PICS: CC.S.F03 && CC.S.C09.Rsp
       arguments:
           values:
-              - name: "stepX"
+              - name: "StepX"
                 value: -20000
-              - name: "stepY"
+              - name: "StepY"
                 value: -6000
               - name: "TransitionTime"
                 value: 200

--- a/src/app/tests/suites/certification/Test_TC_CC_8_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_8_1.yaml
@@ -50,7 +50,7 @@ tests:
       command: "MoveToHue"
       arguments:
           values:
-              - name: "hue"
+              - name: "Hue"
                 value: 200
               - name: "Direction"
                 value: 0

--- a/src/app/tests/suites/certification/Test_TC_CC_9_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_9_1.yaml
@@ -51,15 +51,15 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C40.Rsp
       arguments:
           values:
-              - name: "enhancedHue"
+              - name: "EnhancedHue"
                 value: 16384
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "transitionTime"
+              - name: "TransitionTime"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Wait for 1000ms"
@@ -77,19 +77,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 1
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT"
@@ -107,19 +107,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 2
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopDirection attribute from DUT"
@@ -136,19 +136,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 4
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 30
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopTime attribute from DUT"
@@ -165,19 +165,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 8
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 160
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopStartEnhancedHue attribute from DUT"
@@ -195,19 +195,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 1
-              - name: "action"
+              - name: "Action"
                 value: 1
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT"
@@ -276,19 +276,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 1
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT"
@@ -322,19 +322,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 2
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 1
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopDirection attribute from DUT"
@@ -352,19 +352,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 1
-              - name: "action"
+              - name: "Action"
                 value: 1
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT"
@@ -433,19 +433,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 1
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT"
@@ -478,15 +478,15 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C40.Rsp
       arguments:
           values:
-              - name: "enhancedHue"
+              - name: "EnhancedHue"
                 value: 16384
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "transitionTime"
+              - name: "TransitionTime"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Wait 1000ms"
@@ -512,19 +512,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 2
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopDirection attribute from DUT"
@@ -542,19 +542,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 1
-              - name: "action"
+              - name: "Action"
                 value: 2
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT"
@@ -623,19 +623,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 1
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT"
@@ -669,19 +669,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 2
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 1
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopDirection attribute from DUT"
@@ -699,19 +699,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 1
-              - name: "action"
+              - name: "Action"
                 value: 2
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT"
@@ -780,19 +780,19 @@ tests:
       PICS: CC.S.F02 && CC.S.F01 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 1
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT"

--- a/src/app/tests/suites/certification/Test_TC_CC_9_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_9_2.yaml
@@ -52,15 +52,15 @@ tests:
       PICS: CC.S.F01 && CC.S.F02 && CC.S.C40.Rsp
       arguments:
           values:
-              - name: "enhancedHue"
+              - name: "EnhancedHue"
                 value: 16384
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "transitionTime"
+              - name: "TransitionTime"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Wait for 1000ms"
@@ -80,19 +80,19 @@ tests:
       PICS: CC.S.F01 && CC.S.F02 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 15
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 30
-              - name: "startHue"
+              - name: "StartHue"
                 value: 160
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT"
@@ -131,19 +131,19 @@ tests:
       PICS: CC.S.F01 && CC.S.F02 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 1
-              - name: "action"
+              - name: "Action"
                 value: 1
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT."
@@ -213,19 +213,19 @@ tests:
       PICS: CC.S.F01 && CC.S.F02 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 2
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 1
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopDirection attribute from DUT."
@@ -287,19 +287,19 @@ tests:
       PICS: CC.S.F01 && CC.S.F02 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 1
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT"

--- a/src/app/tests/suites/certification/Test_TC_CC_9_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_9_3.yaml
@@ -51,15 +51,15 @@ tests:
       PICS: CC.S.F01 && CC.S.F02 && CC.S.C40.Rsp
       arguments:
           values:
-              - name: "enhancedHue"
+              - name: "EnhancedHue"
                 value: 16384
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "transitionTime"
+              - name: "TransitionTime"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Wait for 1000ms"
@@ -79,19 +79,19 @@ tests:
       PICS: CC.S.F01 && CC.S.F02 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 15
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 30
-              - name: "startHue"
+              - name: "StartHue"
                 value: 160
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT"
@@ -130,19 +130,19 @@ tests:
       PICS: CC.S.F01 && CC.S.F02 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 1
-              - name: "action"
+              - name: "Action"
                 value: 1
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT."
@@ -211,19 +211,19 @@ tests:
       PICS: CC.S.F01 && CC.S.F02 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 4
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 60
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopTime attribute from DUT."
@@ -276,19 +276,19 @@ tests:
       PICS: CC.S.F01 && CC.S.F02 && CC.S.C44.Rsp
       arguments:
           values:
-              - name: "updateFlags"
+              - name: "UpdateFlags"
                 value: 1
-              - name: "action"
+              - name: "Action"
                 value: 0
-              - name: "direction"
+              - name: "Direction"
                 value: 0
-              - name: "time"
+              - name: "Time"
                 value: 0
-              - name: "startHue"
+              - name: "StartHue"
                 value: 0
-              - name: "optionsMask"
+              - name: "OptionsMask"
                 value: 0
-              - name: "optionsOverride"
+              - name: "OptionsOverride"
                 value: 0
 
     - label: "Read ColorLoopActive attribute from DUT"

--- a/src/app/tests/suites/certification/Test_TC_CHANNEL_5_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CHANNEL_5_3.yaml
@@ -66,7 +66,7 @@ tests:
       command: "SkipChannel"
       arguments:
           values:
-              - name: "Count"
+              - name: "count"
                 value: 1
 
     - label: "Verify that the channel has changed on the device"

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_2.yaml
@@ -227,9 +227,10 @@ tests:
       PICS: DRLK.S.A0030
       command: "readAttribute"
       attribute: "WrongCodeEntryLimit"
-      constraints:
-          minValue: 1
-          maxValue: 255
+      response:
+          constraints:
+              minValue: 1
+              maxValue: 255
 
     #currently for loop is not implemented in yaml framework so converted this step as user prompt
     - label:
@@ -370,9 +371,10 @@ tests:
       PICS: DRLK.S.A0031
       command: "readAttribute"
       attribute: "UserCodeTemporaryDisableTime"
-      constraints:
-          minValue: 1
-          maxValue: 255
+      response:
+          constraints:
+              minValue: 1
+              maxValue: 255
 
     - label:
           "TH writes UserCodeTemporaryDisableTime attribute value as between 1

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_3.yaml
@@ -166,7 +166,7 @@ tests:
       timedInteractionTimeoutMs: 1000
       arguments:
           values:
-              - name: "PINCode"
+              - name: "pinCode"
                 value: "123456"
 
     - label:
@@ -202,7 +202,7 @@ tests:
       timedInteractionTimeoutMs: 1000
       arguments:
           values:
-              - name: "PINCode"
+              - name: "pinCode"
                 value: "123456"
 
     - label: "TH sends the unlock Door command to the DUT with invalid PINCode"
@@ -211,7 +211,7 @@ tests:
       timedInteractionTimeoutMs: 1000
       arguments:
           values:
-              - name: "PINCode"
+              - name: "pinCode"
                 value: "1234568"
       response:
           error: FAILURE
@@ -269,7 +269,7 @@ tests:
       timedInteractionTimeoutMs: 1000
       arguments:
           values:
-              - name: "PINCode"
+              - name: "pinCode"
                 value: "1234568"
       response:
           error: FAILURE
@@ -280,7 +280,7 @@ tests:
       timedInteractionTimeoutMs: 1000
       arguments:
           values:
-              - name: "PINCode"
+              - name: "pinCode"
                 value: "1234568"
       response:
           error: FAILURE
@@ -291,7 +291,7 @@ tests:
       timedInteractionTimeoutMs: 1000
       arguments:
           values:
-              - name: "PINCode"
+              - name: "pinCode"
                 value: "1234568"
       response:
           error: FAILURE
@@ -302,7 +302,7 @@ tests:
       timedInteractionTimeoutMs: 1000
       arguments:
           values:
-              - name: "PINCode"
+              - name: "pinCode"
                 value: "1234568"
       response:
           error: FAILURE
@@ -322,7 +322,7 @@ tests:
       timedInteractionTimeoutMs: 1000
       arguments:
           values:
-              - name: "PINCode"
+              - name: "pinCode"
                 value: "123456"
       response:
           error: FAILURE

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_4.yaml
@@ -149,9 +149,9 @@ tests:
       timedInteractionTimeoutMs: 1000
       arguments:
           values:
-              - name: "Timeout"
+              - name: "timeout"
                 value: 60
-              - name: "PINCode"
+              - name: "pinCode"
                 value: "123456"
 
     - label: "Wait 60s"

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_7.yaml
@@ -108,13 +108,13 @@ tests:
       command: "SetYearDaySchedule"
       arguments:
           values:
-              - name: "YearDayIndex"
+              - name: "yearDayIndex"
                 value: 1
               - name: "userIndex"
                 value: 1
-              - name: "LocalStartTime"
+              - name: "localStartTime"
                 value: 960
-              - name: "LocalEndTime"
+              - name: "localEndTime"
                 value: 1980
 
     #issue #18591
@@ -123,21 +123,21 @@ tests:
       command: "GetYearDaySchedule"
       arguments:
           values:
-              - name: "YearDayIndex"
+              - name: "yearDayIndex"
                 value: 1
               - name: "userIndex"
                 value: 1
       response:
           values:
-              - name: "YearDayIndex"
+              - name: "yearDayIndex"
                 value: 1
               - name: "userIndex"
                 value: 1
               - name: "status"
                 value: 0x0
-              - name: "LocalStartTime"
+              - name: "localStartTime"
                 value: 960
-              - name: "LocalEndTime"
+              - name: "localEndTime"
                 value: 1980
                 constraints:
                     minValue: 961
@@ -147,13 +147,13 @@ tests:
       command: "SetYearDaySchedule"
       arguments:
           values:
-              - name: "YearDayIndex"
+              - name: "yearDayIndex"
                 value: 0
               - name: "userIndex"
                 value: 15
-              - name: "LocalStartTime"
+              - name: "localStartTime"
                 value: 1020
-              - name: "LocalEndTime"
+              - name: "localEndTime"
                 value: 2040
       response:
           error: INVALID_COMMAND
@@ -163,22 +163,22 @@ tests:
       command: "GetYearDaySchedule"
       arguments:
           values:
-              - name: "YearDayIndex"
+              - name: "yearDayIndex"
                 value: 0
               - name: "userIndex"
                 value: 15
       response:
           values:
-              - name: "YearDayIndex"
+              - name: "yearDayIndex"
                 value: 0
               - name: "userIndex"
                 value: 15
               - name: "status"
                 value: 0x85
-              - name: "LocalStartTime"
+              - name: "localStartTime"
                 constraints:
                     hasValue: false
-              - name: "LocalEndTime"
+              - name: "localEndTime"
                 constraints:
                     hasValue: false
 
@@ -207,22 +207,22 @@ tests:
       command: "GetYearDaySchedule"
       arguments:
           values:
-              - name: "YearDayIndex"
+              - name: "yearDayIndex"
                 value: NumberOfYearDaySchedulesSupportedPerUser
               - name: "userIndex"
                 value: 5
       response:
           values:
-              - name: "YearDayIndex"
+              - name: "yearDayIndex"
                 value: NumberOfYearDaySchedulesSupportedPerUser
               - name: "userIndex"
                 value: 5
               - name: "status"
                 value: 0x8B
-              - name: "LocalStartTime"
+              - name: "localStartTime"
                 constraints:
                     hasValue: false
-              - name: "LocalEndTime"
+              - name: "localEndTime"
                 constraints:
                     hasValue: false
 
@@ -241,22 +241,22 @@ tests:
       command: "GetYearDaySchedule"
       arguments:
           values:
-              - name: "YearDayIndex"
+              - name: "yearDayIndex"
                 value: 1
               - name: "userIndex"
                 value: 1
       response:
           values:
-              - name: "YearDayIndex"
+              - name: "yearDayIndex"
                 value: 1
               - name: "userIndex"
                 value: 1
               - name: "status"
                 value: 0x8B
-              - name: "LocalStartTime"
+              - name: "localStartTime"
                 constraints:
                     hasValue: false
-              - name: "LocalEndTime"
+              - name: "localEndTime"
                 constraints:
                     hasValue: false
 
@@ -265,13 +265,13 @@ tests:
       command: "SetYearDaySchedule"
       arguments:
           values:
-              - name: "YearDayIndex"
+              - name: "yearDayIndex"
                 value: 1
               - name: "userIndex"
                 value: 1
-              - name: "LocalStartTime"
+              - name: "localStartTime"
                 value: 1080
-              - name: "LocalEndTime"
+              - name: "localEndTime"
                 value: 2100
 
     - label: "TH sends Get Year Day Schedule Command to DUT"
@@ -279,21 +279,21 @@ tests:
       command: "GetYearDaySchedule"
       arguments:
           values:
-              - name: "YearDayIndex"
+              - name: "yearDayIndex"
                 value: 1
               - name: "userIndex"
                 value: 1
       response:
           values:
-              - name: "YearDayIndex"
+              - name: "yearDayIndex"
                 value: 1
               - name: "userIndex"
                 value: 1
               - name: "status"
                 value: 0x00
-              - name: "LocalStartTime"
+              - name: "localStartTime"
                 value: 1080
-              - name: "LocalEndTime"
+              - name: "localEndTime"
                 value: 2100
                 constraints:
                     minValue: 1081

--- a/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_2.yaml
@@ -139,7 +139,7 @@ tests:
       command: "SkipForward"
       arguments:
           values:
-              - name: "DeltaPositionMilliseconds"
+              - name: "deltaPositionMilliseconds"
                 value: 10000
       response:
           values:
@@ -170,7 +170,7 @@ tests:
       command: "SkipBackward"
       arguments:
           values:
-              - name: "DeltaPositionMilliseconds"
+              - name: "deltaPositionMilliseconds"
                 value: 10000
       response:
           values:

--- a/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_3.yaml
@@ -49,7 +49,7 @@ tests:
       command: "Seek"
       arguments:
           values:
-              - name: "Position"
+              - name: "position"
                 value: 10000
       response:
           values:

--- a/src/app/tests/suites/certification/Test_TC_TGTNAV_8_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TGTNAV_8_1.yaml
@@ -58,7 +58,7 @@ tests:
       command: "NavigateTarget"
       arguments:
           values:
-              - name: "Target"
+              - name: "target"
                 value: targetvalue
 
     - label: "Reads the CurrentTarget attribute"

--- a/src/app/tests/suites/certification/Test_TC_WNCV_4_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_4_1.yaml
@@ -74,8 +74,6 @@ tests:
           values:
               - name: "liftPercent100thsValue"
                 value: 2500
-              - name: "liftPercentageValue"
-                value: 25
 
     ### Depends on a sleep/wait command how to do this with a real device for CI keep at 100ms
     - label: "2b: DUT updates its attributes"
@@ -143,8 +141,6 @@ tests:
           values:
               - name: "liftPercent100thsValue"
                 value: 7520
-              - name: "liftPercentageValue"
-                value: 75
 
     ### Depends on a sleep/wait command how to do this with a real device for CI keep at 100ms
     - label: "4b: DUT updates its attributes"

--- a/src/app/tests/suites/certification/Test_TC_WNCV_4_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_4_2.yaml
@@ -74,8 +74,6 @@ tests:
           values:
               - name: "tiltPercent100thsValue"
                 value: 3000
-              - name: "tiltPercentageValue"
-                value: 30
 
     ### Depends on a sleep/wait command how to do this with a real device for CI keep at 100ms
     - label: "2b: DUT updates its attributes"
@@ -143,8 +141,6 @@ tests:
           values:
               - name: "tiltPercent100thsValue"
                 value: 6005
-              - name: "tiltPercentageValue"
-                value: 60
 
     ### Depends on a sleep/wait command how to do this with a real device for CI keep at 100ms
     - label: "4b: DUT updates its attributes"

--- a/src/app/tests/suites/certification/Test_TC_WNCV_4_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_4_3.yaml
@@ -74,10 +74,8 @@ tests:
       PICS: WNCV.S.F00 && WNCV.S.F02 || WNCV.S.F00 && WNCV.S.C05.Rsp
       arguments:
           values:
-              - name: "LiftPercent100thsValue"
+              - name: "liftPercent100thsValue"
                 value: 0x3000
-              - name: "LiftPercentageValue"
-                value: 0x3F
       response:
           error: CONSTRAINT_ERROR
 
@@ -88,10 +86,8 @@ tests:
       PICS: WNCV.S.F00 && WNCV.S.F02 || WNCV.S.F00 && WNCV.S.C05.Rsp
       arguments:
           values:
-              - name: "LiftPercent100thsValue"
+              - name: "liftPercent100thsValue"
                 value: 10001
-              - name: "LiftPercentageValue"
-                value: 100
       response:
           error: CONSTRAINT_ERROR
 
@@ -102,9 +98,7 @@ tests:
       PICS: WNCV.S.F00 && WNCV.S.F02 || WNCV.S.F00 && WNCV.S.C05.Rsp
       arguments:
           values:
-              - name: "LiftPercent100thsValue"
+              - name: "liftPercent100thsValue"
                 value: 0xFFFF
-              - name: "LiftPercentageValue"
-                value: 0xFF
       response:
           error: CONSTRAINT_ERROR

--- a/src/app/tests/suites/certification/Test_TC_WNCV_4_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_4_4.yaml
@@ -74,10 +74,8 @@ tests:
       PICS: WNCV.S.F01 && WNCV.S.F04 || WNCV.S.F01 && WNCV.S.C08.Rsp
       arguments:
           values:
-              - name: "TiltPercent100thsValue"
+              - name: "tiltPercent100thsValue"
                 value: 0x3000
-              - name: "TiltPercentageValue"
-                value: 0x3F
       response:
           error: CONSTRAINT_ERROR
 
@@ -88,10 +86,8 @@ tests:
       PICS: WNCV.S.F01 && WNCV.S.F04 || WNCV.S.F01 && WNCV.S.C08.Rsp
       arguments:
           values:
-              - name: "TiltPercent100thsValue"
+              - name: "tiltPercent100thsValue"
                 value: 10001
-              - name: "TiltPercentageValue"
-                value: 100
       response:
           error: CONSTRAINT_ERROR
 
@@ -102,9 +98,7 @@ tests:
       PICS: WNCV.S.F01 && WNCV.S.F04 || WNCV.S.F01 && WNCV.S.C08.Rsp
       arguments:
           values:
-              - name: "TiltPercent100thsValue"
+              - name: "tiltPercent100thsValue"
                 value: 0xFFFF
-              - name: "TiltPercentageValue"
-                value: 0xFF
       response:
           error: CONSTRAINT_ERROR

--- a/src/app/tests/suites/certification/Test_TC_WNCV_4_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_4_5.yaml
@@ -48,10 +48,8 @@ tests:
       PICS: WNCV.S.F00 && WNCV.S.F02 && WNCV.S.C05.Rsp
       arguments:
           values:
-              - name: "LiftPercent100thsValue"
+              - name: "liftPercent100thsValue"
                 value: 9000
-              - name: "LiftPercentageValue"
-                value: 90
 
     #
     # TODO: For some reason, the window-covering server impl arms a 5s timer before it actually
@@ -86,10 +84,8 @@ tests:
       PICS: WNCV.S.F01 && WNCV.S.F04 && WNCV.S.C08.Rsp
       arguments:
           values:
-              - name: "TiltPercent100thsValue"
+              - name: "tiltPercent100thsValue"
                 value: 9000
-              - name: "TiltPercentageValue"
-                value: 90
 
     #
     # TODO: For some reason, the window-covering server impl arms a 5s timer before it actually


### PR DESCRIPTION
#### Problem

Using the `matter_yamltests` framework I found various typos in various tests.
Some are just uppercase/lowercase confusion but some others are non-existing arguments or `constraints` put at the wrong place.

