### PR TITLE
[matter_yamltests] Update the parser to fix some parsing issues with …

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/constraints.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/constraints.py
@@ -30,7 +30,7 @@ class ConstraintValidationError(Exception):
 
 
 class BaseConstraint(ABC):
-    '''Constrain Interface'''
+    '''Constraint Interface'''
 
     def __init__(self, types: list, is_null_allowed: bool = False):
         '''An empty type list provided that indicates any type is accepted'''
@@ -58,7 +58,8 @@ class _ConstraintHasValue(BaseConstraint):
         self._has_value = has_value
 
     def check_response(self, value) -> bool:
-        raise ConstraintValidationError('HasValue constraint currently not implemented')
+        raise ConstraintValidationError(
+            'HasValue constraint currently not implemented')
 
 
 class _ConstraintType(BaseConstraint):
@@ -355,3 +356,29 @@ def get_constraints(constraints: dict) -> list[BaseConstraint]:
             raise ConstraintParseError(f'Unknown constraint type:{constraint}')
 
     return _constraints
+
+
+def is_typed_constraint(constraint: str):
+    constraints = {
+        'hasValue': False,
+        'type': False,
+        'minLength': False,
+        'maxLength': False,
+        'isHexString': False,
+        'startsWith': True,
+        'endsWith': True,
+        'isUpperCase': False,
+        'isLowerCase': False,
+        'minValue': True,
+        'maxValue': True,
+        'contains': True,
+        'excludes': True,
+        'hasMasksSet': False,
+        'hasMasksClear': False,
+        'notValue': True,
+    }
+
+    is_typed = constraints.get(constraint)
+    if is_typed is None:
+        raise ConstraintParseError(f'Unknown constraint type:{constraint}')
+    return is_typed

--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -19,7 +19,7 @@ from enum import Enum
 import yaml
 
 from . import fixes
-from .constraints import get_constraints
+from .constraints import get_constraints, is_typed_constraint
 
 _TESTS_SECTION = [
     'name',
@@ -163,8 +163,7 @@ def _check_valid_keys(section, valid_keys_dict):
     if section:
         for key in section:
             if key not in valid_keys_dict:
-                print(f'Unknown key: {key}')
-                raise KeyError
+                raise KeyError(f'Unknown key: {key}')
 
 
 def _value_or_none(data, key):
@@ -172,7 +171,7 @@ def _value_or_none(data, key):
 
 
 def _value_or_config(data, key, config):
-    return data[key] if key in data else config[key]
+    return data[key] if key in data else config.get(key)
 
 
 class _TestStepWithPlaceholders:
@@ -303,7 +302,18 @@ class _TestStepWithPlaceholders:
 
         for value in list(container['values']):
             for key, item_value in list(value.items()):
-                mapping = mapping_type if self.is_attribute else mapping_type[value['name']]
+                if self.is_attribute:
+                    mapping = mapping_type
+                else:
+                    target_key = value['name']
+                    if mapping_type.get(target_key) is None:
+                        for candidate_key in mapping_type:
+                            if candidate_key.lower() == target_key.lower():
+                                raise KeyError(
+                                    f'"{self.label}": Unknown key: "{target_key}". Did you mean "{candidate_key}" ?')
+                        raise KeyError(
+                            f'"{self.label}": Unknown key: "{target_key}". Candidates are: "{[ key for key in mapping_type]}".')
+                    mapping = mapping_type[target_key]
 
                 if key == 'value':
                     value[key] = self._update_value_with_definition(
@@ -312,8 +322,11 @@ class _TestStepWithPlaceholders:
                     self._parsing_config_variable_storage[item_value] = None
                 elif key == 'constraints':
                     for constraint, constraint_value in item_value.items():
-                        value[key][constraint] = self._update_value_with_definition(
-                            constraint_value, mapping_type)
+                        # Only apply update_value_with_definition to constraints that have a value that depends on
+                        # the the value type for the target field.
+                        if is_typed_constraint(constraint):
+                            value[key][constraint] = self._update_value_with_definition(
+                                constraint_value, mapping_type)
                 else:
                     # This key, value pair does not rely on cluster specifications.
                     pass


### PR DESCRIPTION
…the current yaml tests

#### Problem

This PR fix different issues with the `matter_yamltests` package not properly parsing various tests.
Some are because the keywords has been missing in the list of allowed keywords, some constraints handled as `uint64` while the constraint value itself is unrelated to the type from the cluster definition and an other because `nodeId` is mandatory because of the current code while some tests does not use it (e.g `OTA_SuccessfulTransfer.yaml`)

