### PR TITLE
Increase build time out for "Build Apps"

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -182,7 +182,7 @@ jobs:
                       src/app/zap-templates/zcl/data-model/silabs/zll.xml \
                     "
             - name: Build Apps
-              timeout-minutes: 45
+              timeout-minutes: 60
               run: |
                   scripts/run_in_build_env.sh './scripts/build_python.sh --install_wheel build-env'
                   ./scripts/run_in_build_env.sh \


### PR DESCRIPTION
We seem to hit the 45 minute timeout: 
https://github.com/project-chip/connectedhomeip/actions/runs/3950439833/jobs/6762967834


