### PR TITLE
Fix dynamic bridge compilation

### DIFF
--- a/examples/dynamic-bridge-app/linux/BUILD.gn
+++ b/examples/dynamic-bridge-app/linux/BUILD.gn
@@ -115,6 +115,8 @@ executable("dynamic-chip-bridge-app") {
   }
 
   output_dir = root_out_dir
+
+  configs += ["${chip_root}/src:includes"]
 }
 
 group("linux") {

--- a/examples/dynamic-bridge-app/linux/include/ActionCluster.h
+++ b/examples/dynamic-bridge-app/linux/include/ActionCluster.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <app-common/app-common/zap-generated/cluster-enums.h>
+#include <app-common/zap-generated/cluster-enums.h>
 #include <lib/support/Span.h>
 
 #include <stdbool.h>

--- a/examples/dynamic-bridge-app/linux/include/Device.h
+++ b/examples/dynamic-bridge-app/linux/include/Device.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <app-common/app-common/zap-generated/cluster-enums.h>
+#include <app-common/zap-generated/cluster-enums.h>
 #include <lib/support/Span.h>
 
 #include <stdbool.h>


### PR DESCRIPTION
Dynamic bridge compilation fails with:

```
...
Step #5 - "Linux": 2023-01-18 19:15:59 INFO    ../../examples/dynamic-bridge-app/linux/include/ActionCluster.h:21:10: fatal error: 'app-common/app-common/zap-generated/cluster-enums.h' file not found
Step #5 - "Linux": 2023-01-18 19:15:59 INFO    #include <app-common/app-common/zap-generated/cluster-enums.h>
```

this is because include paths are not properly referenced in this app. Fixed include paths and added dependency to gn.

