### PR TITLE
[matter_yamltests] Add PICS checker

### DIFF
--- a/scripts/py_matter_yamltests/BUILD.gn
+++ b/scripts/py_matter_yamltests/BUILD.gn
@@ -31,11 +31,15 @@ pw_python_package("matter_yamltests") {
     "matter_yamltests/definitions.py",
     "matter_yamltests/fixes.py",
     "matter_yamltests/parser.py",
+    "matter_yamltests/pics_checker.py",
   ]
 
   python_deps = [ "${chip_root}/scripts/py_matter_idl:matter_idl" ]
 
-  tests = [ "test_spec_definitions.py" ]
+  tests = [
+    "test_spec_definitions.py",
+    "test_pics_checker.py",
+  ]
 
   # TODO: at a future time consider enabling all (* or missing) here to get
   #       pylint checking these files

--- a/scripts/py_matter_yamltests/matter_yamltests/pics_checker.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pics_checker.py
@@ -1,0 +1,185 @@
+#
+#    Copyright (c) 2023 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the 'License');
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an 'AS IS' BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import unicodedata
+
+_COMMENT_CHARACTER = '#'
+_VALUE_SEPARATOR = '='
+_VALUE_DISABLED = '0'
+_VALUE_ENABLED = '1'
+_CONTROL_CHARACTER_IDENTIFIER = 'C'
+
+
+class InvalidPICSConfigurationError(Exception):
+    "Raised when the configured pics entry can not be parsed."
+    pass
+
+
+class InvalidPICSConfigurationValueError(Exception):
+    "Raised when the configured pics value is not an authorized value."
+    pass
+
+
+class InvalidPICSParsingError(Exception):
+    "Raised when a parsing error occured."
+    pass
+
+
+class PICSChecker():
+    """Class to compute a PICS expression"""
+    __pics: None
+    __expression_index: 0
+
+    def __init__(self, pics_file: str):
+        if pics_file is not None:
+            self.__pics = self.__parse(pics_file)
+
+    def check(self, pics) -> bool:
+        if pics is None:
+            return True
+
+        self.__expression_index = 0
+        tokens = self.__tokenize(pics)
+        return self.__evaluate_expression(tokens, self.__pics)
+
+    def __parse(self, pics_file: str):
+        pics = {}
+        with open(pics_file) as f:
+            line = f.readline()
+            while line:
+                preprocessed_line = self.__preprocess_input(line)
+                if preprocessed_line:
+                    items = preprocessed_line.split(_VALUE_SEPARATOR)
+                    # There should always be one key and one value, nothing else.
+                    if len(items) != 2:
+                        raise InvalidPICSConfigurationError(
+                            f'Invalid expression: {line}')
+
+                    key, value = items
+                    if value != _VALUE_DISABLED and value != _VALUE_ENABLED:
+                        raise InvalidPICSConfigurationValueError(
+                            f'Invalid expression: {line}')
+
+                    pics[key] = value == _VALUE_ENABLED
+
+                line = f.readline()
+        return pics
+
+    def __evaluate_expression(self, tokens: list[str], pics: dict):
+        leftExpr = self.__evaluate_sub_expression(tokens, pics)
+        if self.__expression_index >= len(tokens):
+            return leftExpr
+
+        token = tokens[self.__expression_index]
+
+        if token == ')':
+            return leftExpr
+
+        token = tokens[self.__expression_index]
+
+        if token == '&&':
+            self.__expression_index += 1
+            rightExpr = self.__evaluate_sub_expression(tokens, pics)
+            return leftExpr and rightExpr
+
+        if token == '||':
+            self.__expression_index += 1
+            rightExpr = self.__evaluate_sub_expression(tokens, pics)
+            return leftExpr or rightExpr
+
+        raise InvalidPICSParsingError(f'Unknown token: {token}')
+
+    def __evaluate_sub_expression(self, tokens: list[str], pics: dict):
+        token = tokens[self.__expression_index]
+        if token == '(':
+            self.__expression_index += 1
+            expr = self.__evaluate_expression(tokens, pics)
+            if tokens[self.__expression_index] != ')':
+                raise KeyError('Missing ")"')
+
+            self.__expression_index += 1
+            return expr
+
+        if token == '!':
+            self.__expression_index += 1
+            expr = self.__evaluate_expression(tokens, pics)
+            return not expr
+
+        token = self.__normalize(token)
+        self.__expression_index += 1
+
+        if pics.get(token) == None:
+            # By default, let's consider that if a PICS item is not defined, it is |false|.
+            # It allows to create a file that only contains enabled features.
+            return False
+
+        return pics.get(token)
+
+    def __tokenize(self, expression: str):
+        token = ''
+        tokens = []
+
+        for c in expression:
+            if c == ' ' or c == '\t' or c == '\n':
+                pass
+            elif c == '(' or c == ')' or c == '!':
+                if token:
+                    tokens.append(token)
+                    token = ''
+                tokens.append(c)
+            elif c == '&' or c == '|':
+                if token and token[-1] == c:
+                    token = token[:-1]
+                    if token:
+                        tokens.append(token)
+                        token = ''
+                    tokens.append(c + c)
+                else:
+                    token += c
+            else:
+                token += c
+
+        if token:
+            tokens.append(token)
+            token = ''
+
+        return tokens
+
+    def __preprocess_input(self, value: str):
+        value = self.__remove_comments(value)
+        value = self.__remove_control_characters(value)
+        value = self.__remove_whitespaces(value)
+        value = self.__make_lowercase(value)
+        return value
+
+    def __remove_comments(self, value: str) -> str:
+        return value if not value else value.split(_COMMENT_CHARACTER, 1)[0]
+
+    def __remove_control_characters(self, value: str) -> str:
+        return ''.join(c for c in value if unicodedata.category(c)[0] != _CONTROL_CHARACTER_IDENTIFIER)
+
+    def __remove_whitespaces(self, value: str) -> str:
+        return value.replace(' ', '')
+
+    def __make_lowercase(self, value: str) -> str:
+        return value.lower()
+
+    def __normalize(self, token: str):
+        # Convert to all-lowercase so people who mess up cases don't have things
+        # break on them in subtle ways.
+        token = self.__make_lowercase(token)
+
+        # TODO strip off "(Additional Context)" bits from the end of the code.
+        return token

--- a/scripts/py_matter_yamltests/test_pics_checker.py
+++ b/scripts/py_matter_yamltests/test_pics_checker.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env -S python3 -B
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the 'License');
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an 'AS IS' BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import io
+import unittest
+from unittest.mock import mock_open, patch
+
+from matter_yamltests.pics_checker import InvalidPICSConfigurationError, InvalidPICSConfigurationValueError, PICSChecker
+
+empty_config = ''
+
+simple_config = '''
+A.A=0
+A.B=1
+A.C=0
+'''
+
+simple_config_with_whitespaces_and_control_characters = '''
+ A.A=0 \n
+\tA.B = 1
+'''
+
+simple_config_with_comments = '''
+# This is a comment
+A.A=0
+# This is an other comment
+A.B=1
+A.C=1 # This is a comment
+'''
+
+simple_config_with_invalid_entry_1 = '''
+A.A=FOO
+'''
+
+simple_config_with_invalid_entry_2 = '''
+A.B=2
+'''
+
+simple_config_with_invalid_entry_3 = '''
+A.C=
+'''
+
+simple_config_with_invalid_entry_4 = '''
+A.E==
+'''
+
+simple_config_with_invalid_entry_5 = '''
+A.D
+'''
+
+simple_config_with_invalid_entry_6 = '''
+A.D=1=
+'''
+
+
+class TestPICSChecker(unittest.TestCase):
+    @patch('builtins.open', mock_open(read_data=empty_config))
+    def test_empty_config(self):
+        pics_checker = PICSChecker('')
+        self.assertIsInstance(pics_checker, PICSChecker)
+
+    @patch('builtins.open', mock_open(read_data=simple_config))
+    def test_simple_config(self):
+        pics_checker = PICSChecker('')
+
+        self.assertFalse(pics_checker.check('A.A'))
+        self.assertFalse(pics_checker.check('A.DoesNotExist'))
+
+        self.assertTrue(pics_checker.check('A.B'))
+        self.assertTrue(pics_checker.check('A.b'))
+        self.assertTrue(pics_checker.check('a.b'))
+        self.assertTrue(pics_checker.check(' A.B'))
+        self.assertTrue(pics_checker.check('A.B '))
+
+    @patch('builtins.open', mock_open(read_data=simple_config))
+    def test_logic_negation(self):
+        pics_checker = PICSChecker('')
+        self.assertFalse(pics_checker.check('A.C'))
+        self.assertTrue(pics_checker.check('!A.C'))
+        self.assertFalse(pics_checker.check('!!A.C'))
+        self.assertTrue(pics_checker.check('!!!A.C'))
+
+    @patch('builtins.open', mock_open(read_data=simple_config))
+    def test_logical_and(self):
+        pics_checker = PICSChecker('')
+        self.assertFalse(pics_checker.check('A.C && A.B'))
+        self.assertFalse(pics_checker.check('A.C && A.B'))
+        self.assertTrue(pics_checker.check('!A.A && A.B'))
+
+    @patch('builtins.open', mock_open(read_data=simple_config))
+    def test_logical_or(self):
+        pics_checker = PICSChecker('')
+        self.assertFalse(pics_checker.check('A.A || A.C'))
+        self.assertTrue(pics_checker.check('A.B || A.C'))
+        self.assertTrue(pics_checker.check('!A.A || A.C'))
+        self.assertTrue(pics_checker.check('A.A || A.B || A.C'))
+
+    @patch('builtins.open', mock_open(read_data=simple_config))
+    def test_logical_parenthesis(self):
+        pics_checker = PICSChecker('')
+        self.assertFalse(pics_checker.check('(A.A)'))
+        self.assertTrue(pics_checker.check('(A.B)'))
+        self.assertTrue(pics_checker.check('!(A.A)'))
+        self.assertTrue(pics_checker.check('(!(A.A))'))
+        self.assertFalse(pics_checker.check('(A.A && A.B)'))
+        self.assertFalse(pics_checker.check('((A.A) && (A.B))'))
+        self.assertTrue(pics_checker.check('(!A.A && A.B)'))
+        self.assertTrue(pics_checker.check('(!(A.A) && (A.B))'))
+        self.assertTrue(pics_checker.check('(A.A || A.B)'))
+        self.assertFalse(pics_checker.check('A.C && (A.A || A.B)'))
+        self.assertTrue(pics_checker.check('A.B || (A.A || A.C)'))
+        self.assertTrue(pics_checker.check('!A.C && (A.A || A.B)'))
+        self.assertTrue(pics_checker.check('!A.C || (A.A && A.B)'))
+
+    @patch('builtins.open', mock_open(read_data=simple_config_with_whitespaces_and_control_characters))
+    def test_simple_config_with_whitespaces_and_control_characters(self):
+        pics_checker = PICSChecker('')
+        self.assertFalse(pics_checker.check('A.A'))
+        self.assertTrue(pics_checker.check('A.B'))
+
+    @patch('builtins.open', mock_open(read_data=simple_config_with_comments))
+    def test_simple_config_with_comments(self):
+        pics_checker = PICSChecker('')
+        self.assertFalse(pics_checker.check('A.A'))
+        self.assertTrue(pics_checker.check('A.B'))
+        self.assertTrue(pics_checker.check('A.C'))
+
+    def test_simple_config_with_invalid_entry(self):
+        with patch("builtins.open", mock_open(read_data=simple_config_with_invalid_entry_1)) as mock_file:
+            self.assertRaises(
+                InvalidPICSConfigurationValueError, PICSChecker, mock_file)
+
+        with patch("builtins.open", mock_open(read_data=simple_config_with_invalid_entry_2)) as mock_file:
+            self.assertRaises(
+                InvalidPICSConfigurationValueError, PICSChecker, mock_file)
+
+        with patch("builtins.open", mock_open(read_data=simple_config_with_invalid_entry_3)) as mock_file:
+            self.assertRaises(
+                InvalidPICSConfigurationValueError, PICSChecker, mock_file)
+
+        with patch("builtins.open", mock_open(read_data=simple_config_with_invalid_entry_4)) as mock_file:
+            self.assertRaises(InvalidPICSConfigurationError,
+                              PICSChecker, mock_file)
+
+        with patch("builtins.open", mock_open(read_data=simple_config_with_invalid_entry_5)) as mock_file:
+            self.assertRaises(InvalidPICSConfigurationError,
+                              PICSChecker, mock_file)
+
+        with patch("builtins.open", mock_open(read_data=simple_config_with_invalid_entry_6)) as mock_file:
+            self.assertRaises(InvalidPICSConfigurationError,
+                              PICSChecker, mock_file)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### Problem

`matter_yamltests` does not supports `PICS` code. This PR adds a `PICSChecker` class (with tests) that set the `is_pics_enabled` attribute on every test step.

The test is still part of the list in order to allow different showing to the user which tests are runned/disabled when PICS code are updated.
