### PR TITLE
Make efr32 cloudbuild lock build with mtd openthread

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -70,8 +70,8 @@ steps:
               ./scripts/build/build_examples.py --enable-flashbundle
               --target efr32-brd4161a-light
               --target efr32-brd4161a-light-rpc
-              --target efr32-brd4161a-lock
-              --target efr32-brd4161a-lock-rpc
+              --target efr32-brd4161a-lock-openthread_mtd
+              --target efr32-brd4161a-lock-rpc-openthread_mtd
               --target efr32-brd4161a-unit-test
               build
               --create-archives /workspace/artifacts/


### PR DESCRIPTION
without MTD, we run out of space and build fails.

This should unblock builds.