### PR TITLE
Bump cloudbuild docker version after #24518

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -6,7 +6,7 @@ steps:
           - "--init"
           - "--recursive"
       id: Submodules
-    - name: "connectedhomeip/chip-build-vscode:0.6.31"
+    - name: "connectedhomeip/chip-build-vscode:0.6.32"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -21,7 +21,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.31"
+    - name: "connectedhomeip/chip-build-vscode:0.6.32"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -76,7 +76,7 @@ steps:
               --target k32w-shell
               build
               --create-archives /workspace/artifacts/
-    - name: "connectedhomeip/chip-build-vscode:0.6.31"
+    - name: "connectedhomeip/chip-build-vscode:0.6.32"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.6.31"
+    - name: "connectedhomeip/chip-build-vscode:0.6.32"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -26,7 +26,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.31"
+    - name: "connectedhomeip/chip-build-vscode:0.6.32"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 2700s
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.31"
+    - name: "connectedhomeip/chip-build-vscode:0.6.32"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.6.31"
+    - name: "connectedhomeip/chip-build-vscode:0.6.32"
       entrypoint: "bash"
       args:
           - "-c"
@@ -22,7 +22,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.31"
+    - name: "connectedhomeip/chip-build-vscode:0.6.32"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -40,7 +40,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "connectedhomeip/chip-build-vscode:0.6.31"
+    - name: "connectedhomeip/chip-build-vscode:0.6.32"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -61,7 +61,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.31"
+    - name: "connectedhomeip/chip-build-vscode:0.6.32"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -83,7 +83,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.31"
+    - name: "connectedhomeip/chip-build-vscode:0.6.32"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -141,7 +141,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.31"
+    - name: "connectedhomeip/chip-build-vscode:0.6.32"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               git submodule update --init --recursive
       id: Submodules
-    - name: "connectedhomeip/chip-build-vscode:0.6.31"
+    - name: "connectedhomeip/chip-build-vscode:0.6.32"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:


### PR DESCRIPTION
Update dockerfile version to contain the new zap image after #24518 as well.

