### PR TITLE
Update ZAP to tip.

### DIFF
--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -183,7 +183,7 @@ RUN set -x \
 #       for a uniform update, a separate update script exists:
 #
 #       scripts/tools/zap/version_update.py
-ENV ZAP_VERSION=v2023.01.18-nightly
+ENV ZAP_VERSION=v2023.01.19-nightly
 RUN set -x \
     && mkdir -p /opt/zap-${ZAP_VERSION} \
     && cd /opt/zap-${ZAP_VERSION} \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.33 Version bump reason: [Ameba] Fix dhcpprocess issue and update wifi api
+0.6.34 Version bump reason: Updating ZAP to v2023.01.19-nightly


### PR DESCRIPTION
Fixes bug in determining response commands when two clusters have the same response command name.


