### PR TITLE
Copy webapp's YAML file to the coverage output directory

### DIFF
--- a/scripts/build_coverage.sh
+++ b/scripts/build_coverage.sh
@@ -168,3 +168,6 @@ lcov --initial --capture --directory "$OUTPUT_ROOT/obj/src" --exclude="$PWD"/zzz
 lcov --capture --directory "$OUTPUT_ROOT/obj/src" --exclude="$PWD"/zzz_generated/* --exclude="$PWD"/third_party/* --exclude=/usr/include/* --output-file "$COVERAGE_ROOT/lcov_test.info"
 lcov --add-tracefile "$COVERAGE_ROOT/lcov_base.info" --add-tracefile "$COVERAGE_ROOT/lcov_test.info" --output-file "$COVERAGE_ROOT/lcov_final.info"
 genhtml "$COVERAGE_ROOT/lcov_final.info" --output-directory "$COVERAGE_ROOT/html"
+
+# Copy webapp's YAML file to the coverage output directory
+cp "$CHIP_ROOT/integrations/appengine/webapp_config.yaml" "$COVERAGE_ROOT/webapp_config.yaml"


### PR DESCRIPTION
The url path in the webapp config file does not contain the relative path in the source tree, 'gcloud app deploy' command is running under a working directory which contains both the service's YAML files and associated source code.

Copy webapp's YAML file to the coverage output directory, so that we can run the 'gcloud app deploy' command directly under the out/coverage directory without pre-prepare the staging directory.

