### PR TITLE
Fix build error during dry_run linux-x64-all-clusters-coverage

### DIFF
--- a/scripts/build/testdata/dry_run_linux-arm64-chip-tool-ipv6only-clang.txt
+++ b/scripts/build/testdata/dry_run_linux-arm64-chip-tool-ipv6only-clang.txt
@@ -6,6 +6,9 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-ipv6only-clang'
 
+# Setting up Java deps
+third_party/java_deps/set_up_java_deps.sh
+
 # Building linux-arm64-chip-tool-ipv6only-clang
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \

--- a/scripts/build/testdata/dry_run_linux-arm64-ota-requestor-nodeps-ipv6only.txt
+++ b/scripts/build/testdata/dry_run_linux-arm64-ota-requestor-nodeps-ipv6only.txt
@@ -6,6 +6,9 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true chip_crypto="mbedtls" target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor-nodeps-ipv6only'
 
+# Setting up Java deps
+third_party/java_deps/set_up_java_deps.sh
+
 # Building linux-arm64-ota-requestor-nodeps-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \

--- a/scripts/build/testdata/dry_run_linux-x64-all-clusters-coverage.txt
+++ b/scripts/build/testdata/dry_run_linux-x64-all-clusters-coverage.txt
@@ -4,5 +4,8 @@ cd "{root}"
 # Generating linux-x64-all-clusters-coverage
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux --args=use_coverage=true {out}/linux-x64-all-clusters-coverage
 
+# Setting up Java deps
+third_party/java_deps/set_up_java_deps.sh
+
 # Building linux-x64-all-clusters-coverage
 ninja -C {out}/linux-x64-all-clusters-coverage


### PR DESCRIPTION
Hit the following build error during dry-run build 

```
======================================================================
FAIL: test_linux_dry_runs (__main__.TestBuilder)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/yufengw/connectedhomeip/out/coverage/../../scripts/build/test.py", line 130, in test_linux_dry_runs
    self.assertCommandOutput(expected, f'--target {target} --dry-run build'.split(' '))
  File "/home/yufengw/connectedhomeip/out/coverage/../../scripts/build/test.py", line 92, in assertCommandOutput
    self.fail(msg)
AssertionError: DIFFERENCE between expected and generated output in testdata/dry_run_linux-x64-all-clusters-coverage.txt
Expected file can be found in dry_run_linux-x64-all-clusters-coverage.txt.actual

```