### PR TITLE
Add a way for Darwin invokes to specify a server-side processing timeout.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseClusterUtils.h
+++ b/src/darwin/Framework/CHIP/MTRBaseClusterUtils.h
@@ -25,6 +25,7 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/TLV.h>
 #include <lib/support/CHIPMem.h>
+#include <system/SystemClock.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -378,11 +379,18 @@ protected:
     bool mCalledCallback = false;
 };
 
+/**
+ * timedInvokeTimeoutMs, if provided, is how long the server will wait for us to
+ * send the invoke after we sent the Timed Request message.
+ *
+ * invokeTimeout, if provided, will have possible MRP latency added to it and
+ * the result is how long we will wait for the server to respond.
+ */
 template <typename BridgeType, typename RequestDataType>
 CHIP_ERROR MTRStartInvokeInteraction(BridgeType * _Nonnull bridge, const RequestDataType & requestData,
     chip::Messaging::ExchangeManager & exchangeManager, const chip::SessionHandle & session,
     typename BridgeType::SuccessCallbackType successCb, MTRErrorCallback failureCb, chip::EndpointId endpoint,
-    chip::Optional<uint16_t> timedInvokeTimeoutMs)
+    chip::Optional<uint16_t> timedInvokeTimeoutMs, chip::Optional<chip::System::Clock::Timeout> invokeTimeout)
 {
     auto callback = chip::Platform::MakeUnique<MTRInvokeCallback<BridgeType, typename RequestDataType::ResponseType>>(
         bridge, successCb, failureCb);
@@ -395,7 +403,11 @@ CHIP_ERROR MTRStartInvokeInteraction(BridgeType * _Nonnull bridge, const Request
     chip::app::CommandPathParams commandPath(endpoint, 0, RequestDataType::GetClusterId(), RequestDataType::GetCommandId(),
         chip::app::CommandPathFlags::kEndpointIdValid);
     ReturnErrorOnFailure(commandSender->AddRequestData(commandPath, requestData, timedInvokeTimeoutMs));
-    ReturnErrorOnFailure(commandSender->SendCommandRequest(session));
+
+    if (invokeTimeout.HasValue()) {
+        invokeTimeout.SetValue(session->ComputeRoundTripTimeout(invokeTimeout.Value()));
+    }
+    ReturnErrorOnFailure(commandSender->SendCommandRequest(session, invokeTimeout));
 
     callback->AdoptCommandSender(std::move(commandSender));
     callback.release();

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -22,6 +22,7 @@
 #import "MTRCluster.h"
 #import "MTRClusterStateCacheContainer_Internal.h"
 #import "MTRCluster_Internal.h"
+#import "MTRDevice_Internal.h"
 #import "MTRError_Internal.h"
 #import "MTREventTLVValueDecoder_Internal.h"
 #import "MTRLogging_Internal.h"
@@ -1132,7 +1133,11 @@ exit:
 
             ReturnErrorOnFailure(commandSender->AddRequestData(commandPath, MTRDataValueDictionaryDecodableType(commandFields),
                 (timeoutMs == nil) ? NullOptional : Optional<uint16_t>([timeoutMs unsignedShortValue])));
-            ReturnErrorOnFailure(commandSender->SendCommandRequest(session));
+
+            // We don't have a way to communicate a non-default invoke timeout
+            // here for now.
+            // TODO: https://github.com/project-chip/connectedhomeip/issues/24563
+            ReturnErrorOnFailure(commandSender->SendCommandRequest(session, NullOptional));
 
             decoder.release();
             commandSender.release();

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
@@ -9,6 +9,7 @@
 #import "MTRCluster_Internal.h"
 #import "MTRClusterStateCacheContainer_Internal.h"
 #import "MTRCommandPayloadsObjc.h"
+#import "MTRDevice_Internal.h"
 #import "MTRStructsObjc.h"
 
 #include <lib/support/CHIPListUtils.h>
@@ -20,6 +21,9 @@ using chip::Callback::Cancelable;
 using namespace chip::app::Clusters;
 using chip::Messaging::ExchangeManager;
 using chip::SessionHandle;
+using chip::Optional;
+using chip::System::Clock::Timeout;
+using chip::System::Clock::Seconds16;
 
 // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks): Linter is unable to locate the delete on these objects.
 {{#chip_client_clusters includeAll=true}}
@@ -80,12 +84,20 @@ MTR{{cluster}}Cluster{{command}}Params
       {{/if}}
       ^(ExchangeManager & exchangeManager, const SessionHandle & session, {{>callbackName}}CallbackType successCb, MTRErrorCallback failureCb, MTRCallbackBridgeBase * bridge) {
         auto * typedBridge = static_cast<MTR{{>callbackName}}CallbackBridge *>(bridge);
-        chip::Optional<uint16_t> timedInvokeTimeoutMs;
+        Optional<uint16_t> timedInvokeTimeoutMs;
+        Optional<Timeout> invokeTimeout;
         ListFreer listFreer;
         {{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Type request;
         if (params != nil) {
           if (params.timedInvokeTimeoutMs != nil) {
+            params.timedInvokeTimeoutMs = MTRClampedNumber(params.timedInvokeTimeoutMs, @(1), @(UINT16_MAX));
             timedInvokeTimeoutMs.SetValue(params.timedInvokeTimeoutMs.unsignedShortValue);
+          }
+          if (params.serverSideProcessingTimeout != nil) {
+            // Clamp to a number of seconds that will not overflow 32-bit
+            // int when converted to ms.
+            auto * serverSideProcessingTimeout = MTRClampedNumber(params.serverSideProcessingTimeout, @(0), @(UINT16_MAX));
+            invokeTimeout.SetValue(Seconds16(serverSideProcessingTimeout.unsignedShortValue));
           }
         }
         {{#if mustUseTimedInvoke}}
@@ -107,7 +119,7 @@ MTR{{cluster}}Cluster{{command}}Params
           {{/last}}
         {{/chip_cluster_command_arguments}}
 
-        return MTRStartInvokeInteraction(typedBridge, request, exchangeManager, session, successCb, failureCb, self->_endpoint, timedInvokeTimeoutMs);
+        return MTRStartInvokeInteraction(typedBridge, request, exchangeManager, session, successCb, failureCb, self->_endpoint, timedInvokeTimeoutMs, invokeTimeout);
     });
     std::move(*bridge).DispatchAction(self.device);
 }

--- a/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
@@ -3,6 +3,7 @@
 #import <Foundation/Foundation.h>
 
 #import "MTRAsyncCallbackWorkQueue.h"
+#import "MTRBaseClusterUtils.h"
 #import "MTRBaseDevice_Internal.h"
 #import "MTRClusterConstants.h"
 #import "MTRClusters_Internal.h"
@@ -22,6 +23,9 @@ using chip::Callback::Cancelable;
 using namespace chip::app::Clusters;
 using chip::Messaging::ExchangeManager;
 using chip::SessionHandle;
+using chip::Optional;
+using chip::System::Clock::Timeout;
+using chip::System::Clock::Seconds16;
 
 static void MTRClustersLogEnqueue(NSString *logPrefix, MTRAsyncCallbackWorkQueue *workQueue) {
     MTR_LOG_INFO("%@ enqueueWorkItem %@", logPrefix, workQueue);
@@ -120,11 +124,21 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
             [workItem endWork];
           },
           ^(ExchangeManager & exchangeManager, const SessionHandle & session, {{>callbackName}}CallbackType successCb, MTRErrorCallback failureCb, MTRCallbackBridgeBase * bridge) {
-            chip::Optional<uint16_t> timedInvokeTimeoutMs;
+            auto * typedBridge = static_cast<MTR{{>callbackName}}CallbackBridge *>(bridge);
+            Optional<uint16_t> timedInvokeTimeoutMs;
+            Optional<Timeout> invokeTimeout;
             ListFreer listFreer;
             {{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Type request;
             if (timedInvokeTimeoutMsParam != nil) {
               timedInvokeTimeoutMs.SetValue(timedInvokeTimeoutMsParam.unsignedShortValue);
+            }
+            if (params != nil) {
+              if (params.serverSideProcessingTimeout != nil) {
+                // Clamp to a number of seconds that will not overflow 32-bit
+                // int when converted to ms.
+                auto * serverSideProcessingTimeout = MTRClampedNumber(params.serverSideProcessingTimeout, @(0), @(UINT16_MAX));
+                invokeTimeout.SetValue(Seconds16(serverSideProcessingTimeout.unsignedShortValue));
+              }
             }
             {{#if mustUseTimedInvoke}}
             if (!timedInvokeTimeoutMs.HasValue()) {
@@ -145,8 +159,7 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
               {{/last}}
             {{/chip_cluster_command_arguments}}
 
-            chip::Controller::{{asUpperCamelCase parent.name}}Cluster cppCluster(exchangeManager, session, self->_endpoint);
-            return cppCluster.InvokeCommand(request, bridge, successCb, failureCb, timedInvokeTimeoutMs);
+            return MTRStartInvokeInteraction(typedBridge, request, exchangeManager, session, successCb, failureCb, self->_endpoint, timedInvokeTimeoutMs, invokeTimeout);
         });
         std::move(*bridge).DispatchAction(baseDevice);
     };

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
@@ -20,6 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
           (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping parent.name) command=(compatCommandNameRemapping parent.name name)))}}
     _timedInvokeTimeoutMs = nil;
 {{/if}}
+{{#if (isStrEqual source "client")}}
+    _serverSideProcessingTimeout = nil;
+{{/if}}
   }
   return self;
 }
@@ -34,6 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 {{#if (or (isStrEqual source "client")
           (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping parent.name) command=(compatCommandNameRemapping parent.name name)))}}
   other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+{{/if}}
+{{#if (isStrEqual source "client")}}
+  other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 {{/if}}
 
   return other;

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
@@ -40,6 +40,15 @@ NS_ASSUME_NONNULL_BEGIN
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+ @property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 {{! This is using the pre-renaming names for the isAvailableBefore test, because the pre-rename things inherit
     from the post-rename ones and need to have this selector.}}
 {{else if (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping parent.name) command=(compatCommandNameRemapping parent.name name))}}

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
@@ -39,6 +39,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -62,6 +71,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -85,6 +103,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 @interface MTRGroupsClusterAddGroupParams (Deprecated)
@@ -142,6 +169,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 @interface MTRGroupsClusterViewGroupParams (Deprecated)
@@ -201,6 +237,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -246,6 +291,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 @interface MTRGroupsClusterRemoveGroupParams (Deprecated)
@@ -301,6 +355,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -324,6 +387,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 @interface MTRGroupsClusterAddGroupIfIdentifyingParams (Deprecated)
@@ -359,6 +431,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -408,6 +489,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -463,6 +553,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -510,6 +609,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -557,6 +665,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -608,6 +725,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -629,6 +755,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -686,6 +821,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -735,6 +879,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -796,6 +949,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -841,6 +1003,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -860,6 +1031,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -879,6 +1059,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -902,6 +1091,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 @interface MTROnOffClusterOffWithEffectParams (Deprecated)
@@ -927,6 +1125,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -952,6 +1159,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -979,6 +1195,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1006,6 +1231,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1035,6 +1269,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1058,6 +1301,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1085,6 +1337,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1112,6 +1373,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1141,6 +1411,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1164,6 +1443,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1185,6 +1473,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1208,6 +1505,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1233,6 +1539,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1256,6 +1571,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1281,6 +1605,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1304,6 +1637,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1327,6 +1669,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1352,6 +1703,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1375,6 +1735,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1398,6 +1767,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1423,6 +1801,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1446,6 +1833,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1471,6 +1867,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1491,6 +1896,15 @@ MTR_NEWLY_DEPRECATED("This command has been removed")
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 MTR_NEWLY_AVAILABLE
@@ -1526,6 +1940,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1602,6 +2025,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1660,6 +2092,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1695,6 +2136,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1731,6 +2181,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1781,6 +2240,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1824,6 +2292,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1871,6 +2348,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1924,6 +2410,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1947,6 +2442,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -1970,6 +2474,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2019,6 +2532,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2070,6 +2592,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2096,6 +2627,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2156,6 +2696,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2175,6 +2724,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2194,6 +2752,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2213,6 +2780,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2232,6 +2808,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2257,6 +2842,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2287,6 +2881,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 @interface MTRAdministratorCommissioningClusterOpenCommissioningWindowParams (Deprecated)
@@ -2315,6 +2918,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2334,6 +2946,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2355,6 +2976,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2406,6 +3036,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2451,6 +3090,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2504,6 +3152,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2527,6 +3184,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2574,6 +3240,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2595,6 +3270,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2616,6 +3300,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 @interface MTROperationalCredentialsClusterAddTrustedRootCertificateParams (Deprecated)
@@ -2644,6 +3337,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2665,6 +3367,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2709,6 +3420,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2730,6 +3450,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2774,6 +3503,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2795,6 +3533,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2816,6 +3563,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2839,6 +3595,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2872,6 +3637,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2895,6 +3669,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2954,6 +3737,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -2981,6 +3773,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3004,6 +3805,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3057,6 +3867,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3084,6 +3903,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3105,6 +3933,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3156,6 +3993,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3189,6 +4035,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 @interface MTRDoorLockClusterSetUserParams (Deprecated)
@@ -3216,6 +4071,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3284,6 +4148,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3316,6 +4189,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3365,6 +4247,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3419,6 +4310,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3438,6 +4338,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3457,6 +4366,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3476,6 +4394,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3497,6 +4424,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3519,6 +4455,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3540,6 +4485,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3562,6 +4516,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3583,6 +4546,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3602,6 +4574,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3625,6 +4606,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3684,6 +4674,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3707,6 +4706,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3726,6 +4734,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3755,6 +4772,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3782,6 +4808,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3811,6 +4846,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3838,6 +4882,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3865,6 +4918,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3894,6 +4956,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3923,6 +4994,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3952,6 +5032,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -3979,6 +5068,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4008,6 +5106,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4035,6 +5142,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 @interface MTRColorControlClusterMoveToColorTemperatureParams (Deprecated)
@@ -4070,6 +5186,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4097,6 +5222,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4126,6 +5260,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4155,6 +5298,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4188,6 +5340,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4211,6 +5372,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4244,6 +5414,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4279,6 +5458,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4300,6 +5488,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4347,6 +5544,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4369,6 +5575,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4392,6 +5607,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4435,6 +5659,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4454,6 +5687,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4473,6 +5715,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4492,6 +5743,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4511,6 +5771,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4530,6 +5799,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4549,6 +5827,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4568,6 +5855,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4590,6 +5886,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4612,6 +5917,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4657,6 +5971,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4678,6 +6001,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4697,6 +6029,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4716,6 +6057,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4739,6 +6089,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4758,6 +6117,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4779,6 +6147,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4827,6 +6204,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4853,6 +6239,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4898,6 +6293,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4921,6 +6325,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4945,6 +6358,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4967,6 +6389,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -4989,6 +6420,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5035,6 +6475,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5081,6 +6530,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5100,6 +6558,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5149,6 +6616,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5208,6 +6684,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 MTR_NEWLY_AVAILABLE
@@ -5227,6 +6712,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5278,6 +6772,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5329,6 +6832,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5380,6 +6892,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5445,6 +6966,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5498,6 +7028,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5563,6 +7102,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5622,6 +7170,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5730,6 +7287,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5783,6 +7349,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5836,6 +7411,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5889,6 +7473,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5944,6 +7537,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5971,6 +7573,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -5999,6 +7610,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -6025,6 +7645,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -6073,6 +7702,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -6100,6 +7738,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -6124,6 +7771,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -6150,6 +7806,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -6181,6 +7846,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -6207,6 +7881,15 @@ MTR_NEWLY_AVAILABLE
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -6242,6 +7925,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -6267,6 +7959,15 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _identifyTime = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -36,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.identifyTime = self.identifyTime;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -57,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _effectVariant = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -68,6 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.effectIdentifier = self.effectIdentifier;
     other.effectVariant = self.effectVariant;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -89,6 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _groupName = @"";
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -100,6 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.groupID = self.groupID;
     other.groupName = self.groupName;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -177,6 +183,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _groupID = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -187,6 +194,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.groupID = self.groupID;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -266,6 +274,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _groupList = [NSArray array];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -276,6 +285,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.groupList = self.groupList;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -326,6 +336,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _groupID = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -336,6 +347,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.groupID = self.groupID;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -410,6 +422,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -419,6 +432,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRGroupsClusterRemoveAllGroupsParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -439,6 +453,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _groupName = @"";
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -450,6 +465,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.groupID = self.groupID;
     other.groupName = self.groupName;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -490,6 +506,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _extensionFieldSets = [NSArray array];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -504,6 +521,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.sceneName = self.sceneName;
     other.extensionFieldSets = self.extensionFieldSets;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -561,6 +579,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _sceneId = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -572,6 +591,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.groupId = self.groupId;
     other.sceneId = self.sceneId;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -638,6 +658,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _sceneId = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -649,6 +670,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.groupId = self.groupId;
     other.sceneId = self.sceneId;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -703,6 +725,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _groupId = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -713,6 +736,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.groupId = self.groupId;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -765,6 +789,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _sceneId = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -776,6 +801,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.groupId = self.groupId;
     other.sceneId = self.sceneId;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -834,6 +860,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _transitionTime = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -846,6 +873,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.sceneId = self.sceneId;
     other.transitionTime = self.transitionTime;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -865,6 +893,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _groupId = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -875,6 +904,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.groupId = self.groupId;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -939,6 +969,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _extensionFieldSets = [NSArray array];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -953,6 +984,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.sceneName = self.sceneName;
     other.extensionFieldSets = self.extensionFieldSets;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1010,6 +1042,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _sceneId = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1021,6 +1054,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.groupId = self.groupId;
     other.sceneId = self.sceneId;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1093,6 +1127,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _sceneIdTo = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1107,6 +1142,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.groupIdTo = self.groupIdTo;
     other.sceneIdTo = self.sceneIdTo;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1160,6 +1196,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1169,6 +1206,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTROnOffClusterOffParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1185,6 +1223,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1194,6 +1233,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTROnOffClusterOnParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1210,6 +1250,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1219,6 +1260,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTROnOffClusterToggleParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1239,6 +1281,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _effectVariant = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1250,6 +1293,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.effectIdentifier = self.effectIdentifier;
     other.effectVariant = self.effectVariant;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1280,6 +1324,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1289,6 +1334,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTROnOffClusterOnWithRecallGlobalSceneParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1311,6 +1357,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _offWaitTime = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1323,6 +1370,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.onTime = self.onTime;
     other.offWaitTime = self.offWaitTime;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1348,6 +1396,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1361,6 +1410,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1387,6 +1437,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1400,6 +1451,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1427,6 +1479,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1441,6 +1494,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1463,6 +1517,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1474,6 +1529,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1499,6 +1555,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1512,6 +1569,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1538,6 +1596,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1551,6 +1610,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1578,6 +1638,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1592,6 +1653,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1614,6 +1676,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1625,6 +1688,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1644,6 +1708,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _frequency = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1654,6 +1719,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.frequency = self.frequency;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1674,6 +1740,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _invokeID = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1685,6 +1752,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.actionID = self.actionID;
     other.invokeID = self.invokeID;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1708,6 +1776,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _transitionTime = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1720,6 +1789,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.invokeID = self.invokeID;
     other.transitionTime = self.transitionTime;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1741,6 +1811,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _invokeID = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1752,6 +1823,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.actionID = self.actionID;
     other.invokeID = self.invokeID;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1775,6 +1847,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _duration = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1787,6 +1860,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.invokeID = self.invokeID;
     other.duration = self.duration;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1808,6 +1882,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _invokeID = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1819,6 +1894,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.actionID = self.actionID;
     other.invokeID = self.invokeID;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1840,6 +1916,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _invokeID = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1851,6 +1928,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.actionID = self.actionID;
     other.invokeID = self.invokeID;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1874,6 +1952,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _duration = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1886,6 +1965,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.invokeID = self.invokeID;
     other.duration = self.duration;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1907,6 +1987,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _invokeID = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1918,6 +1999,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.actionID = self.actionID;
     other.invokeID = self.invokeID;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1939,6 +2021,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _invokeID = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1950,6 +2033,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.actionID = self.actionID;
     other.invokeID = self.invokeID;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -1973,6 +2057,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _duration = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -1985,6 +2070,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.invokeID = self.invokeID;
     other.duration = self.duration;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2006,6 +2092,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _invokeID = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2017,6 +2104,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.actionID = self.actionID;
     other.invokeID = self.invokeID;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2040,6 +2128,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _duration = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2052,6 +2141,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.invokeID = self.invokeID;
     other.duration = self.duration;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2069,6 +2159,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2078,6 +2169,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRBasicClusterMfgSpecificPingParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2110,6 +2202,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _metadataForProvider = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2127,6 +2220,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.requestorCanConsent = self.requestorCanConsent;
     other.metadataForProvider = self.metadataForProvider;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2234,6 +2328,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _newVersion = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2245,6 +2340,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.updateToken = self.updateToken;
     other.newVersion = self.newVersion;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2305,6 +2401,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _softwareVersion = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2316,6 +2413,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.updateToken = self.updateToken;
     other.softwareVersion = self.softwareVersion;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2347,6 +2445,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _endpoint = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2361,6 +2460,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.metadataForNode = self.metadataForNode;
     other.endpoint = self.endpoint;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2410,6 +2510,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _breadcrumb = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2421,6 +2522,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.expiryLengthSeconds = self.expiryLengthSeconds;
     other.breadcrumb = self.breadcrumb;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2476,6 +2578,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _breadcrumb = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2488,6 +2591,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.countryCode = self.countryCode;
     other.breadcrumb = self.breadcrumb;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2537,6 +2641,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2546,6 +2651,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRGeneralCommissioningClusterCommissioningCompleteParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2598,6 +2704,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _breadcrumb = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2609,6 +2716,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.ssid = self.ssid;
     other.breadcrumb = self.breadcrumb;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2671,6 +2779,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _breadcrumb = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2683,6 +2792,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.credentials = self.credentials;
     other.breadcrumb = self.breadcrumb;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2705,6 +2815,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _breadcrumb = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2716,6 +2827,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.operationalDataset = self.operationalDataset;
     other.breadcrumb = self.breadcrumb;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2738,6 +2850,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _breadcrumb = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2749,6 +2862,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.networkID = self.networkID;
     other.breadcrumb = self.breadcrumb;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2806,6 +2920,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _breadcrumb = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2817,6 +2932,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.networkID = self.networkID;
     other.breadcrumb = self.breadcrumb;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2876,6 +2992,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _breadcrumb = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2888,6 +3005,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.networkIndex = self.networkIndex;
     other.breadcrumb = self.breadcrumb;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -2912,6 +3030,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _transferFileDesignator = [NSData data];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -2924,6 +3043,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.requestedProtocol = self.requestedProtocol;
     other.transferFileDesignator = self.transferFileDesignator;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3008,6 +3128,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _eventTrigger = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3019,6 +3140,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.enableKey = self.enableKey;
     other.eventTrigger = self.eventTrigger;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3037,6 +3159,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3046,6 +3169,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRSoftwareDiagnosticsClusterResetWatermarksParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3062,6 +3186,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3071,6 +3196,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRThreadNetworkDiagnosticsClusterResetCountsParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3087,6 +3213,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3096,6 +3223,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRWiFiNetworkDiagnosticsClusterResetCountsParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3112,6 +3240,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3121,6 +3250,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTREthernetNetworkDiagnosticsClusterResetCountsParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3143,6 +3273,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _timeSource = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3155,6 +3286,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.granularity = self.granularity;
     other.timeSource = self.timeSource;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3182,6 +3314,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _salt = [NSData data];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3196,6 +3329,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.iterations = self.iterations;
     other.salt = self.salt;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3230,6 +3364,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _commissioningTimeout = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3240,6 +3375,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.commissioningTimeout = self.commissioningTimeout;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3257,6 +3393,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3266,6 +3403,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRAdministratorCommissioningClusterRevokeCommissioningParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3284,6 +3422,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _attestationNonce = [NSData data];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3294,6 +3433,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.attestationNonce = self.attestationNonce;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3359,6 +3499,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _certificateType = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3369,6 +3510,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.certificateType = self.certificateType;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3419,6 +3561,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _isForUpdateNOC = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3430,6 +3573,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.csrNonce = self.csrNonce;
     other.isForUpdateNOC = self.isForUpdateNOC;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3491,6 +3635,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _adminVendorId = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3505,6 +3650,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.caseAdminSubject = self.caseAdminSubject;
     other.adminVendorId = self.adminVendorId;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3529,6 +3675,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _icacValue = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3540,6 +3687,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.nocValue = self.nocValue;
     other.icacValue = self.icacValue;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3595,6 +3743,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _label = @"";
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3605,6 +3754,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.label = self.label;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3623,6 +3773,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _fabricIndex = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3633,6 +3784,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.fabricIndex = self.fabricIndex;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3652,6 +3804,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _rootCACertificate = [NSData data];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3662,6 +3815,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.rootCACertificate = self.rootCACertificate;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3694,6 +3848,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _groupKeySet = [MTRGroupKeyManagementClusterGroupKeySetStruct new];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3704,6 +3859,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.groupKeySet = self.groupKeySet;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3723,6 +3879,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _groupKeySetID = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3733,6 +3890,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.groupKeySetID = self.groupKeySetID;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3781,6 +3939,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _groupKeySetID = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3791,6 +3950,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.groupKeySetID = self.groupKeySetID;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3810,6 +3970,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _groupKeySetIDs = [NSArray array];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3820,6 +3981,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.groupKeySetIDs = self.groupKeySetIDs;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3868,6 +4030,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _newMode = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3878,6 +4041,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.newMode = self.newMode;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3896,6 +4060,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _pinCode = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3906,6 +4071,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.pinCode = self.pinCode;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3925,6 +4091,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _pinCode = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3935,6 +4102,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.pinCode = self.pinCode;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3956,6 +4124,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _pinCode = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -3967,6 +4136,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.timeout = self.timeout;
     other.pinCode = self.pinCode;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -3998,6 +4168,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _endMinute = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4014,6 +4185,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.endHour = self.endHour;
     other.endMinute = self.endMinute;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4037,6 +4209,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _userIndex = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4048,6 +4221,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.weekDayIndex = self.weekDayIndex;
     other.userIndex = self.userIndex;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4121,6 +4295,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _userIndex = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4132,6 +4307,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.weekDayIndex = self.weekDayIndex;
     other.userIndex = self.userIndex;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4157,6 +4333,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _localEndTime = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4170,6 +4347,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.localStartTime = self.localStartTime;
     other.localEndTime = self.localEndTime;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4192,6 +4370,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _userIndex = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4203,6 +4382,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.yearDayIndex = self.yearDayIndex;
     other.userIndex = self.userIndex;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4266,6 +4446,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _userIndex = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4277,6 +4458,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.yearDayIndex = self.yearDayIndex;
     other.userIndex = self.userIndex;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4302,6 +4484,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _operatingMode = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4315,6 +4498,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.localEndTime = self.localEndTime;
     other.operatingMode = self.operatingMode;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4335,6 +4519,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _holidayIndex = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4345,6 +4530,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.holidayIndex = self.holidayIndex;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4406,6 +4592,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _holidayIndex = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4416,6 +4603,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.holidayIndex = self.holidayIndex;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4447,6 +4635,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _credentialRule = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4463,6 +4652,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.userType = self.userType;
     other.credentialRule = self.credentialRule;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4498,6 +4688,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _userIndex = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4508,6 +4699,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.userIndex = self.userIndex;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4598,6 +4790,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _userIndex = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4608,6 +4801,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.userIndex = self.userIndex;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4636,6 +4830,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _userType = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4651,6 +4846,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.userStatus = self.userStatus;
     other.userType = self.userType;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4707,6 +4903,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _credential = [MTRDoorLockClusterCredentialStruct new];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4717,6 +4914,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.credential = self.credential;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4780,6 +4978,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _credential = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4790,6 +4989,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.credential = self.credential;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4807,6 +5007,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4816,6 +5017,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRWindowCoveringClusterUpOrOpenParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4832,6 +5034,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4841,6 +5044,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRWindowCoveringClusterDownOrCloseParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4857,6 +5061,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4866,6 +5071,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRWindowCoveringClusterStopMotionParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4884,6 +5090,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _liftValue = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4894,6 +5101,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.liftValue = self.liftValue;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4912,6 +5120,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _liftPercent100thsValue = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4922,6 +5131,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.liftPercent100thsValue = self.liftPercent100thsValue;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4941,6 +5151,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _tiltValue = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4951,6 +5162,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.tiltValue = self.tiltValue;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4969,6 +5181,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _tiltPercent100thsValue = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -4979,6 +5192,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.tiltPercent100thsValue = self.tiltPercent100thsValue;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -4998,6 +5212,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _percentOpen = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5008,6 +5223,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.percentOpen = self.percentOpen;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5025,6 +5241,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5034,6 +5251,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRBarrierControlClusterBarrierControlStopParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5054,6 +5272,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _amount = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5065,6 +5284,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.mode = self.mode;
     other.amount = self.amount;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5129,6 +5349,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _transitions = [NSArray array];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5142,6 +5363,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.modeForSequence = self.modeForSequence;
     other.transitions = self.transitions;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5164,6 +5386,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _modeToReturn = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5175,6 +5398,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.daysToReturn = self.daysToReturn;
     other.modeToReturn = self.modeToReturn;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5192,6 +5416,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5201,6 +5426,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRThermostatClusterClearWeeklyScheduleParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5227,6 +5453,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5241,6 +5468,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5267,6 +5495,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5280,6 +5509,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5307,6 +5537,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5321,6 +5552,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5347,6 +5579,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5360,6 +5593,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5386,6 +5620,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5399,6 +5634,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5426,6 +5662,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5440,6 +5677,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5468,6 +5706,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5482,6 +5721,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5510,6 +5750,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5524,6 +5765,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5550,6 +5792,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5563,6 +5806,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5590,6 +5834,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5604,6 +5849,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5630,6 +5876,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5643,6 +5890,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5684,6 +5932,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5698,6 +5947,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5724,6 +5974,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5737,6 +5988,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5764,6 +6016,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5778,6 +6031,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5806,6 +6060,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5820,6 +6075,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5852,6 +6108,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5868,6 +6125,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5891,6 +6149,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5902,6 +6161,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5931,6 +6191,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5946,6 +6207,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -5980,6 +6242,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _optionsOverride = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -5996,6 +6259,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionsMask = self.optionsMask;
     other.optionsOverride = self.optionsOverride;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6018,6 +6282,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _match = @"";
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6028,6 +6293,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.match = self.match;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6080,6 +6346,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _minorNumber = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6091,6 +6358,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.majorNumber = self.majorNumber;
     other.minorNumber = self.minorNumber;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6110,6 +6378,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _count = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6120,6 +6389,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.count = self.count;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6140,6 +6410,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _data = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6151,6 +6422,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.target = self.target;
     other.data = self.data;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6200,6 +6472,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6209,6 +6482,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRMediaPlaybackClusterPlayParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6225,6 +6499,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6234,6 +6509,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRMediaPlaybackClusterPauseParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6250,6 +6526,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6259,6 +6536,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRMediaPlaybackClusterStopPlaybackParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6275,6 +6553,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6284,6 +6563,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRMediaPlaybackClusterStartOverParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6300,6 +6580,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6309,6 +6590,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRMediaPlaybackClusterPreviousParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6325,6 +6607,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6334,6 +6617,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRMediaPlaybackClusterNextParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6350,6 +6634,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6359,6 +6644,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRMediaPlaybackClusterRewindParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6375,6 +6661,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6384,6 +6671,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRMediaPlaybackClusterFastForwardParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6402,6 +6690,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _deltaPositionMilliseconds = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6412,6 +6701,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.deltaPositionMilliseconds = self.deltaPositionMilliseconds;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6431,6 +6721,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _deltaPositionMilliseconds = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6441,6 +6732,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.deltaPositionMilliseconds = self.deltaPositionMilliseconds;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6492,6 +6784,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _position = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6502,6 +6795,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.position = self.position;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6520,6 +6814,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _index = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6530,6 +6825,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.index = self.index;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6546,6 +6842,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6555,6 +6852,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRMediaInputClusterShowInputStatusParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6571,6 +6869,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6580,6 +6879,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRMediaInputClusterHideInputStatusParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6600,6 +6900,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _name = @"";
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6611,6 +6912,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.index = self.index;
     other.name = self.name;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6628,6 +6930,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6637,6 +6940,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRLowPowerClusterSleepParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6655,6 +6959,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _keyCode = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6665,6 +6970,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.keyCode = self.keyCode;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6715,6 +7021,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _data = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6727,6 +7034,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.autoPlay = self.autoPlay;
     other.data = self.data;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6750,6 +7058,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _brandingInformation = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6762,6 +7071,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.displayString = self.displayString;
     other.brandingInformation = self.brandingInformation;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6813,6 +7123,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _index = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6823,6 +7134,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.index = self.index;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6843,6 +7155,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _name = @"";
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6854,6 +7167,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.index = self.index;
     other.name = self.name;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6875,6 +7189,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _data = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6886,6 +7201,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.application = self.application;
     other.data = self.data;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6905,6 +7221,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _application = [MTRApplicationLauncherClusterApplication new];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6915,6 +7232,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.application = self.application;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6934,6 +7252,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _application = [MTRApplicationLauncherClusterApplication new];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -6944,6 +7263,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.application = self.application;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -6995,6 +7315,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _tempAccountIdentifier = @"";
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7005,6 +7326,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.tempAccountIdentifier = self.tempAccountIdentifier;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -7054,6 +7376,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _setupPIN = @"";
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7065,6 +7388,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.tempAccountIdentifier = self.tempAccountIdentifier;
     other.setupPIN = self.setupPIN;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -7082,6 +7406,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7091,6 +7416,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRAccountLoginClusterLogoutParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -7146,6 +7472,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7155,6 +7482,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRElectricalMeasurementClusterGetProfileInfoCommandParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -7223,6 +7551,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _numberOfIntervals = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7235,6 +7564,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.startTime = self.startTime;
     other.numberOfIntervals = self.numberOfIntervals;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -7252,6 +7582,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7261,6 +7592,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRUnitTestingClusterTestParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -7312,6 +7644,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7321,6 +7654,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRUnitTestingClusterTestNotHandledParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -7372,6 +7706,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7381,6 +7716,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRUnitTestingClusterTestSpecificParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -7432,6 +7768,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7441,6 +7778,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRUnitTestingClusterTestUnknownCommandParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -7511,6 +7849,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg2 = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7522,6 +7861,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.arg1 = self.arg1;
     other.arg2 = self.arg2;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -7575,6 +7915,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg1 = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7585,6 +7926,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.arg1 = self.arg1;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -7651,6 +7993,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg6 = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7666,6 +8009,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.arg5 = self.arg5;
     other.arg6 = self.arg6;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -7729,6 +8073,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg1 = [MTRUnitTestingClusterSimpleStruct new];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7739,6 +8084,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.arg1 = self.arg1;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -7887,6 +8233,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg1 = [MTRUnitTestingClusterNestedStruct new];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7897,6 +8244,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.arg1 = self.arg1;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -7949,6 +8297,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg1 = [NSArray array];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -7959,6 +8308,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.arg1 = self.arg1;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -8011,6 +8361,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg1 = [NSArray array];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -8021,6 +8372,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.arg1 = self.arg1;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -8073,6 +8425,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg1 = [MTRUnitTestingClusterNestedStructList new];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -8083,6 +8436,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.arg1 = self.arg1;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -8135,6 +8489,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg1 = [NSArray array];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -8145,6 +8500,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.arg1 = self.arg1;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -8166,6 +8522,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg1 = [NSArray array];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -8176,6 +8533,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.arg1 = self.arg1;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -8199,6 +8557,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg2 = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -8210,6 +8569,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.arg1 = self.arg1;
     other.arg2 = self.arg2;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -8232,6 +8592,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg1 = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -8242,6 +8603,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.arg1 = self.arg1;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -8285,6 +8647,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _nullableOptionalList = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -8306,6 +8669,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.optionalList = self.optionalList;
     other.nullableOptionalList = self.nullableOptionalList;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -8333,6 +8697,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg1 = [MTRUnitTestingClusterSimpleStruct new];
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -8343,6 +8708,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.arg1 = self.arg1;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -8362,6 +8728,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -8371,6 +8738,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto other = [[MTRUnitTestingClusterTimedInvokeRequestParams alloc] init];
 
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -8392,6 +8760,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg1 = nil;
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -8402,6 +8771,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.arg1 = self.arg1;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -8427,6 +8797,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg3 = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -8439,6 +8810,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.arg2 = self.arg2;
     other.arg3 = self.arg3;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -8461,6 +8833,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _arg1 = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -8471,6 +8844,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     other.arg1 = self.arg1;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -8500,6 +8874,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _takeMutex = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -8514,6 +8889,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.numCallsToFail = self.numCallsToFail;
     other.takeMutex = self.takeMutex;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }
@@ -8538,6 +8914,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _percentage = @(0);
         _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
     }
     return self;
 }
@@ -8550,6 +8927,7 @@ NS_ASSUME_NONNULL_BEGIN
     other.id = self.id;
     other.percentage = self.percentage;
     other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
 
     return other;
 }


### PR DESCRIPTION
The default 2s timeout is way too low for some commands (like ScanNetworks).

Fixes https://github.com/project-chip/connectedhomeip/issues/24333
