### PR TITLE
Remove unused static in K32W factory data provider

### DIFF
--- a/src/platform/nxp/k32w/k32w0/K32W0Config.cpp
+++ b/src/platform/nxp/k32w/k32w0/K32W0Config.cpp
@@ -146,6 +146,7 @@ CHIP_ERROR K32WConfig::WriteConfigValueStr(Key key, const char * str, size_t str
         SuccessOrExit(err);
         buffer = RamStorage::GetBuffer();
         status = PDM_eSaveRecordDataInIdleTask(kNvmIdChipConfigData, buffer, buffer->ramBufferLen + kRamDescHeaderSize);
+        SuccessOrExit(err = MapPdmStatusToChipError(status));
     }
 
 exit:

--- a/src/platform/nxp/k32w/k32w0/K32W0FactoryDataProvider.cpp
+++ b/src/platform/nxp/k32w/k32w0/K32W0FactoryDataProvider.cpp
@@ -73,7 +73,6 @@ static constexpr size_t kDiscriminatorId  = 7;
 static constexpr size_t kMaxId = kDiscriminatorId;
 
 static uint16_t maxLengths[kMaxId + 1];
-static uint32_t factoryDataActualSize = 0;
 
 typedef otaUtilsResult_t (*OtaUtils_EEPROM_ReadData)(uint16_t nbBytes, uint32_t address, uint8_t * pInbuf);
 
@@ -213,7 +212,7 @@ CHIP_ERROR K32W0FactoryDataProvider::GetSetupDiscriminator(uint16_t & setupDiscr
     uint16_t temp          = 0;
 
     ReturnErrorOnFailure(SearchForId(kDiscriminatorId, (uint8_t *) &discriminator, sizeof(discriminator), temp));
-    setupDiscriminator = (uint16_t)(discriminator & 0x0000FFFF);
+    setupDiscriminator = (uint16_t) (discriminator & 0x0000FFFF);
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/nxp/k32w/k32w0/K32W0FactoryDataProvider.cpp
+++ b/src/platform/nxp/k32w/k32w0/K32W0FactoryDataProvider.cpp
@@ -212,7 +212,7 @@ CHIP_ERROR K32W0FactoryDataProvider::GetSetupDiscriminator(uint16_t & setupDiscr
     uint16_t temp          = 0;
 
     ReturnErrorOnFailure(SearchForId(kDiscriminatorId, (uint8_t *) &discriminator, sizeof(discriminator), temp));
-    setupDiscriminator = (uint16_t) (discriminator & 0x0000FFFF);
+    setupDiscriminator = (uint16_t)(discriminator & 0x0000FFFF);
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
`./gn_build.sh` says:

```
/../src/platform/nxp/k32w/k32w0/K32W0FactoryDataProvider.cpp -o k32w_lighting_app/obj/src/platform/nxp/k32w/k32w0/k32w0.K32W0FactoryDataProvider.cpp.o
../../src/platform/nxp/k32w/k32w0/K32W0FactoryDataProvider.cpp:76:17: error: 'chip::DeviceLayer::factoryDataActualSize' defined but not used [-Werror=unused-variable]
   76 | static uint32_t factoryDataActualSize = 0;
      |                 ^~~~~~~~~~~~~~~~~~~~~
cc1plus: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnosticsstatic uint32_t factoryDataActualSize = 0;
```