### PR TITLE
Update some more TargetInfo structures after #24498

### DIFF
--- a/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
@@ -54,11 +54,11 @@ CHIP_ERROR TargetNavigatorManager::HandleGetTargetList(AttributeValueEncoder & a
                 if (value[attrId].isArray())
                 {
                     return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
-                        int i                = 0;
-                        std::string targetId = to_string(
-                            static_cast<uint32_t>(chip::app::Clusters::TargetNavigator::Structs::TargetInfo::Fields::kIdentifier));
+                        int i                  = 0;
+                        std::string targetId   = to_string(static_cast<uint32_t>(
+                            chip::app::Clusters::TargetNavigator::Structs::TargetInfoStruct::Fields::kIdentifier));
                         std::string targetName = to_string(
-                            static_cast<uint32_t>(chip::app::Clusters::TargetNavigator::Structs::TargetInfo::Fields::kName));
+                            static_cast<uint32_t>(chip::app::Clusters::TargetNavigator::Structs::TargetInfoStruct::Fields::kName));
                         for (Json::Value & entry : value[attrId])
                         {
                             if (!entry[targetId].isUInt() || !entry[targetName].isString() || entry[targetId].asUInt() > 255)

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
@@ -321,11 +321,11 @@ jobject TargetListSuccessHandlerJNI::ConvertToJObject(
     auto iter = responseData.begin();
     while (iter.Next())
     {
-        const chip::app::Clusters::TargetNavigator::Structs::TargetInfo::DecodableType & targetInfo = iter.GetValue();
+        const chip::app::Clusters::TargetNavigator::Structs::TargetInfoStruct::DecodableType & targetInfo = iter.GetValue();
 
         jclass responseTypeClass = nullptr;
-        CHIP_ERROR err =
-            JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/TargetNavigatorTypes$TargetInfo", responseTypeClass);
+        CHIP_ERROR err = JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/TargetNavigatorTypes$TargetInfoStruct",
+                                                                  responseTypeClass);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "ConvertToJObject: Class for Response Type not found!");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
@@ -324,8 +324,8 @@ jobject TargetListSuccessHandlerJNI::ConvertToJObject(
         const chip::app::Clusters::TargetNavigator::Structs::TargetInfoStruct::DecodableType & targetInfo = iter.GetValue();
 
         jclass responseTypeClass = nullptr;
-        CHIP_ERROR err = JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/TargetNavigatorTypes$TargetInfoStruct",
-                                                                  responseTypeClass);
+        CHIP_ERROR err =
+            JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/TargetNavigatorTypes$TargetInfo", responseTypeClass);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "ConvertToJObject: Class for Response Type not found!");

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -1637,12 +1637,12 @@
                     objCTargetList = [NSMutableArray arrayWithCapacity:targetInfoCount];
                     auto iter = targetList.begin();
                     while (iter.Next()) {
-                        const chip::app::Clusters::TargetNavigator::Structs::TargetInfo::DecodableType & targetInfo
+                        const chip::app::Clusters::TargetNavigator::Structs::TargetInfoStruct::DecodableType & targetInfo
                             = iter.GetValue();
-                        TargetNavigator_TargetInfo * objCTargetInfo = [[TargetNavigator_TargetInfo alloc]
+                        TargetNavigator_TargetInfoStruct * objCTargetInfo = [[TargetNavigator_TargetInfoStruct alloc]
                             initWithIdentifier:@(targetInfo.identifier)
                                           name:[NSString stringWithUTF8String:targetInfo.name.data()]];
-                        [objCTargetList addObject:objCTargetInfo];
+                        [objCTargetList addObject:objCTargetInfoStruct];
                     }
                 }
                 callback(objCTargetList);


### PR DESCRIPTION
Android fails on tv app:

```
app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp -o obj/App/app/src/main/jni/cpp/libTvCastingApp.MatterCallbackHandler-JNI.cpp.o
244
INFO    ../../examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp:324:62: error: no member named 'TargetInfo' in namespace 'chip::app::Clusters::TargetNavigator::Structs'
245
INFO            const chip::app::Clusters::TargetNavigator::Structs::TargetInfo::DecodableType & targetInfo = iter.GetValue();
```

Also saw some darwin files using targetInfo, so updated those too. 


