### PR TITLE
Add Startup Script of Compute Engine

### DIFF
--- a/integrations/compute_engine/README.md
+++ b/integrations/compute_engine/README.md
@@ -1,0 +1,29 @@
+## Startup Script of Compute Engine
+
+A startup script is a file that contains commands that run when a virtual
+machine instance boots. Compute Engine provides support for running startup
+scripts on Linux and Windows virtual machines.
+
+### Create a virtual machine instance using startup script
+
+The `startup-script.sh` could be used as the startup script of a virtual machine
+instance which run Matter coverage report and publish the result via an App
+Engine service.
+
+You can create a virtual machine instance by using the gcloud compute instances
+create command with the `--metadata-from-file` flag.
+
+```
+gcloud compute instances create VM_NAME \
+  --image-project=PROJECT_NAME \
+  --image-family=ubuntu-22.04 \
+  --metadata-from-file=startup-script=FILE_PATH
+```
+
+Replace the following:
+
+`PROJECT_NAME`: the name of the project host the virtual machine instance
+
+`VM_NAME`: the name of the virtual machine instance
+
+`FILE_PATH`: the relative path to the startup script file

--- a/integrations/compute_engine/startup-script.sh
+++ b/integrations/compute_engine/startup-script.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+cd /tmp
+rm -rf connectedhomeip
+git clone --recurse-submodules https://github.com/project-chip/connectedhomeip.git
+cd connectedhomeip
+./scripts/build_coverage.sh 2>&1 | tee /tmp/matter_build.log
+cd out/coverage/coverage
+gcloud app deploy webapp_config.yaml 2>&1 | tee /tmp/matter_publish.log
+versions=$(gcloud app versions list \
+    --service default \
+    --sort-by '~VERSION.ID' \
+    --format 'value(VERSION.ID)' | sed 1,5d)
+for version in "$versions"; do
+    gcloud app versions delete "$version" \
+        --service default \
+        --quiet
+done


### PR DESCRIPTION
Currently, we have a startup script configured directly on the virtual machine (VM) instance to preform Matter coverage report in Google Cloud.  This is not maintainable. 

Check in the startup script into github repo and the this file as metadata to a VM when we create it for future maintainability. 




