### PR TITLE
[matter_yamltests] Update values from config variables at beginning t…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/fixes.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/fixes.py
@@ -59,6 +59,10 @@ def convert_yaml_octet_string_to_bytes(s: str) -> bytes:
 
     This handles any c-style hex escapes (e.g. \x5a) and hex: prefix
     '''
+    # Step 0: Check if this is already of type bytes
+    if isinstance(s, bytes):
+        return s
+
     # Step 1: handle explicit "hex:" prefix
     if s.startswith('hex:'):
         return binascii.unhexlify(s[4:])

--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -243,12 +243,12 @@ class _TestStepWithPlaceholders:
                 response_mapping = self._as_mapping(
                     definitions, self.cluster, command.output_param)
 
-        self._update_with_definition(
-            self.arguments_with_placeholders, argument_mapping)
-        self._update_with_definition(
-            self.response_with_placeholders, response_mapping)
+        self.argument_mapping = argument_mapping
+        self.response_mapping = response_mapping
+        self.update_arguments(self.arguments_with_placeholders)
+        self.update_response(self.response_with_placeholders)
 
-        # This performs a very basic sanity parse time check of constrains. This parsing happens
+        # This performs a very basic sanity parse time check of constraints. This parsing happens
         # again inside post processing response since at that time we will have required variables
         # to substitute in. This parsing check here has value since some test can take a really
         # long time to run so knowing earlier on that the test step would have failed at parsing
@@ -295,6 +295,14 @@ class _TestStepWithPlaceholders:
             target_name = target_name.lower()
 
         return target_name
+
+    def update_arguments(self, arguments_with_placeholders):
+        self._update_with_definition(
+            arguments_with_placeholders, self.argument_mapping)
+
+    def update_response(self, response_with_placeholders):
+        self._update_with_definition(
+            response_with_placeholders, self.response_mapping)
 
     def _update_with_definition(self, container: dict, mapping_type):
         if not container or not mapping_type:
@@ -384,6 +392,8 @@ class TestStep:
         self.response = copy.deepcopy(test.response_with_placeholders)
         self._update_placeholder_values(self.arguments)
         self._update_placeholder_values(self.response)
+        test.update_arguments(self.arguments)
+        test.update_response(self.response)
 
     @property
     def is_enabled(self):


### PR DESCRIPTION
…o make it possible to decode hex: values to bytes

#### Problem


Some of the yaml tests contains variables with `hex:` notation. It confuses the parser since those are never converted to the proper python type.

The current PR does an extra step at test startup to takes it into account.