### PR TITLE
Fixed the warnings in light example from connectedhomeip.

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -673,7 +673,7 @@ menu "CHIP Device Layer"
 
         config ENABLE_ESP32_LOCATIONCAPABILITY
             depends on ENABLE_ESP32_FACTORY_DATA_PROVIDER
-            bool "Enable ESP32 Device LocationCapability "
+            bool "Enable ESP32 Device LocationCapability"
             default n
             help
                 Enable ESP32 Device LocationCapability

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -407,7 +407,7 @@ CHIP_ERROR EventManagement::LogEventPrivate(EventLoggingDelegate * apDelegate, c
     CHIP_ERROR err               = CHIP_NO_ERROR;
     uint32_t requestSize         = 0;
     aEventNumber                 = 0;
-    CircularTLVWriter checkpoint = writer;
+    CircularTLVWriter checkpoint;
     CircularEventBuffer * buffer = nullptr;
     EventLoadOutContext ctxt     = EventLoadOutContext(writer, aEventOptions.mPriority, mLastEventNumber);
     EventOptions opts;

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -3238,7 +3238,7 @@ bool DoorLockServer::HandleRemoteLockOperation(chip::app::CommandHandler * comma
     EndpointId endpoint     = commandPath.mEndpointId;
     DlOperationError reason = DlOperationError::kUnspecified;
     Nullable<uint16_t> pinUserIdx; // Will get set to non-null if we find a user for the PIN.
-    Optional<uint16_t> pinCredIdx; // Will get set to a value if the PIN is one we know about.
+    Optional<uint16_t> pinCredIdx(0); // Will get set to a value if the PIN is one we know about.
     bool success   = false;
     bool sendEvent = true;
 

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -1071,7 +1071,7 @@ void emberAfOnOffClusterLevelControlEffectCallback(EndpointId endpoint, bool new
 {
     app::DataModel::Nullable<uint8_t> resolvedLevel;
     app::DataModel::Nullable<uint8_t> temporaryCurrentLevelCache;
-    app::DataModel::Nullable<uint16_t> transitionTime;
+    app::DataModel::Nullable<uint16_t> transitionTime(0);
 
     uint16_t currentOnOffTransitionTime;
     EmberAfStatus status;

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -1051,7 +1051,7 @@ bool emberAfOperationalCredentialsClusterCSRRequestCallback(app::CommandHandler 
         }
         csrSpan = MutableByteSpan{ csr.Get(), csrLength };
 
-        Optional<FabricIndex> fabricIndexForCsr;
+        Optional<FabricIndex> fabricIndexForCsr(0);
         if (isForUpdateNoc)
         {
             fabricIndexForCsr.SetValue(commandObj->GetAccessingFabricIndex());

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -338,7 +338,7 @@ LimitStatus CheckLimitState(uint16_t position, AbsoluteLimits limits)
 
 bool IsPercent100thsValid(Percent100ths percent100ths)
 {
-    if (CHECK_BOUNDS_VALID(WC_PERCENT100THS_MIN_OPEN, percent100ths, WC_PERCENT100THS_MAX_CLOSED))
+    if ((WC_PERCENT100THS_MIN_OPEN< percent100ths)||(percent100ths> WC_PERCENT100THS_MAX_CLOSED))
         return true;
 
     return false;

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -114,8 +114,7 @@ void emberAfEndpointConfigure()
 {
     uint16_t ep;
 
-    static_assert(FIXED_ENDPOINT_COUNT <= std::numeric_limits<decltype(ep)>::max(),
-                  "FIXED_ENDPOINT_COUNT must not exceed the size of the endpoint data type");
+    assert(FIXED_ENDPOINT_COUNT <= std::numeric_limits<decltype(ep)>::max());
 
 #if !defined(EMBER_SCRIPTED_TEST)
     uint16_t fixedEndpoints[]             = FIXED_ENDPOINT_ARRAY;
@@ -139,7 +138,7 @@ void emberAfEndpointConfigure()
 
     emberEndpointCount                = FIXED_ENDPOINT_COUNT;
     DataVersion * currentDataVersions = fixedEndpointDataVersions;
-    for (ep = 0; ep < FIXED_ENDPOINT_COUNT; ep++)
+    for (ep = 0; ep < emberEndpointCount; ep++)
     {
         emAfEndpoints[ep].endpoint       = endpointNumber(ep);
         emAfEndpoints[ep].deviceTypeList = endpointDeviceTypeList(ep);


### PR DESCRIPTION
- Problem: To fix the warnings that were encountered in the light example from connectedhomeip.

-  For issue[ #163](https://github.com/espressif/esp-matter/issues/163) fixed the warnings from connectedhomeip.

- The build of the light example was successful with no warnings from connectedhomeip.




