### PR TITLE
[nrfconnect] Changed a few Bluetooth configs to make connection more …

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -104,8 +104,18 @@ config BT_PERIPHERAL_PREF_MIN_INT
 config BT_PERIPHERAL_PREF_MAX_INT
     default 36
 
+# Increase BT timeout to 5 s to improve connection reliability and avoid fast drop outs.
+config BT_PERIPHERAL_PREF_TIMEOUT
+    default 500
+
 config BT_GAP_AUTO_UPDATE_CONN_PARAMS
     default y
+
+# Decrease connection parameters update time, as some Matter controllers request
+# enabling IP networking faster than BT connection parameters are updated, what may result
+# in commissioning instabilities.
+config BT_CONN_PARAM_UPDATE_TIMEOUT
+    default 1000
 
 config BT_GATT_DYNAMIC_DB
     default y

--- a/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.defaults
@@ -63,6 +63,10 @@ config BT_HCI_RAW_RESERVE
 config BT_BUF_CMD_TX_COUNT
     default 10
 
+# Enable support for Wi-Fi and Bluetooth LE coexistance
+config MPSL_CX
+    default y
+
 config ASSERT
     default y
 


### PR DESCRIPTION
…reliable

Summary of changes:
* Enabled Wi-Fi and Bluetooth LE coexistance configuration
* Increased BT connection timeout to make communication work in a more reliable way and prevent fast connection drop outs.
* Decreased BT connection parameters update time, as some Matter controllers request enabling IP networking very fast, what should not happen before BT connection parameters were updated to preferred ones.

