### PR TITLE
[placeholder] The post command callback does not fired anymore after …

### DIFF
--- a/examples/placeholder/linux/include/MatterCallbacks.h
+++ b/examples/placeholder/linux/include/MatterCallbacks.h
@@ -52,7 +52,8 @@ TestCommand * GetTargetTest()
     return test.get();
 }
 
-void MatterPostCommandReceivedCallback(const chip::app::ConcreteCommandPath & commandPath)
+void MatterPostCommandReceivedCallback(const chip::app::ConcreteCommandPath & commandPath,
+                                       const chip::Access::SubjectDescriptor & subjectDescriptor)
 {
     auto test = GetTargetTest();
     VerifyOrReturn(test != nullptr && test->isRunning);


### PR DESCRIPTION
…#20357

#### Problem

The signature has changed so the `weak` symbol override does not work anymore.
