### PR TITLE
Typos various tests with yaml tests parser attempt3

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/definitions.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/definitions.py
@@ -64,25 +64,24 @@ class SpecDefinitions:
 
             self.__clusters_by_name[name] = cluster.code
             self.__commands_by_name[name] = {
-                c.name.lower(): c.code for c in cluster.commands}
+                c.name: c.code for c in cluster.commands}
             self.__responses_by_name[name] = {}
             self.__attributes_by_name[name] = {
-                a.definition.name.lower(): a.definition.code for a in cluster.attributes}
+                a.definition.name: a.definition.code for a in cluster.attributes}
             self.__events_by_name[name] = {
-                e.name.lower(): e.code for e in cluster.events}
+                e.name: e.code for e in cluster.events}
 
             self.__bitmaps_by_name[name] = {
-                b.name.lower(): b for b in cluster.bitmaps}
+                b.name: b for b in cluster.bitmaps}
             self.__enums_by_name[name] = {
-                e.name.lower(): e for e in cluster.enums}
+                e.name: e for e in cluster.enums}
             self.__structs_by_name[name] = {
-                s.name.lower(): s for s in cluster.structs}
+                s.name: s for s in cluster.structs}
 
             for struct in cluster.structs:
                 if struct.tag == StructTag.RESPONSE:
                     self.__responses_by_id[code][struct.code] = struct
-                    self.__responses_by_name[name][struct.name.lower(
-                    )] = struct.code
+                    self.__responses_by_name[name][struct.name] = struct.code
 
     def get_cluster_name(self, cluster_id: int) -> str:
         cluster = self.__clusters_by_id.get(cluster_id)
@@ -153,9 +152,6 @@ class SpecDefinitions:
 
         # The idl parser remove spaces
         cluster_name = cluster_name.replace(' ', '')
-        # Many YAML tests formats the name using camelCase despites that the spec mandates
-        # CamelCase. To be compatible with the current tests, everything is converted to lower case.
-        target_name = target_name.lower()
 
         cluster_id = self.__clusters_by_name.get(cluster_name)
         if cluster_id is None:
@@ -164,26 +160,40 @@ class SpecDefinitions:
         target = None
 
         if target_type == _ItemType.Request:
+            self.__enforce_casing(
+                target_name, self.__commands_by_name.get(cluster_name))
             target_id = self.__commands_by_name.get(
                 cluster_name).get(target_name)
             target = self.__get_by_id(cluster_id, target_id, target_type)
         elif target_type == _ItemType.Response:
+            self.__enforce_casing(
+                target_name, self.__responses_by_name.get(cluster_name))
             target_id = self.__responses_by_name.get(
                 cluster_name).get(target_name)
             target = self.__get_by_id(cluster_id, target_id, target_type)
         elif target_type == _ItemType.Event:
+            self.__enforce_casing(
+                target_name, self.__events_by_name.get(cluster_name))
             target_id = self.__events_by_name.get(
                 cluster_name).get(target_name)
             target = self.__get_by_id(cluster_id, target_id, target_type)
         elif target_type == _ItemType.Attribute:
+            self.__enforce_casing(
+                target_name, self.__attributes_by_name.get(cluster_name))
             target_id = self.__attributes_by_name.get(
                 cluster_name).get(target_name)
             target = self.__get_by_id(cluster_id, target_id, target_type)
         elif target_type == _ItemType.Bitmap:
+            self.__enforce_casing(
+                target_name, self.__bitmaps_by_name.get(cluster_name))
             target = self.__bitmaps_by_name.get(cluster_name).get(target_name)
         elif target_type == _ItemType.Enum:
+            self.__enforce_casing(
+                target_name, self.__enums_by_name.get(cluster_name))
             target = self.__enums_by_name.get(cluster_name).get(target_name)
         elif target_type == _ItemType.Struct:
+            self.__enforce_casing(
+                target_name, self.__structs_by_name.get(cluster_name))
             target = self.__structs_by_name.get(cluster_name).get(target_name)
 
         return target
@@ -204,3 +214,12 @@ class SpecDefinitions:
             return None
 
         return targets.get(target_id)
+
+    def __enforce_casing(self, target_name: str, targets: list):
+        if targets.get(target_name) is not None:
+            return
+
+        for name in targets:
+            if name.lower() == target_name.lower():
+                raise KeyError(
+                    f'Unknown target {target_name}. Did you mean {name} ?')

--- a/scripts/py_matter_yamltests/test_spec_definitions.py
+++ b/scripts/py_matter_yamltests/test_spec_definitions.py
@@ -14,10 +14,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from matter_yamltests.definitions import *
-
-import unittest
 import io
+import unittest
+
+from matter_yamltests.definitions import *
 
 source_cluster = '''<?xml version="1.0"?>
   <configurator>
@@ -215,8 +215,8 @@ class TestSpecDefinitions(unittest.TestCase):
             'Test', 'TestCommand'), Command)
         self.assertIsNone(
             definitions.get_command_by_name('test', 'TestCommand'))
-        self.assertIsInstance(definitions.get_command_by_name(
-            'Test', 'testcommand'), Command)
+        self.assertRaises(KeyError, definitions.get_command_by_name,
+                          'Test', 'testcommand')
 
     def test_get_response_by_name(self):
         definitions = SpecDefinitions(
@@ -231,8 +231,8 @@ class TestSpecDefinitions(unittest.TestCase):
             'Test', 'TestCommandResponse'), Struct)
         self.assertIsNone(definitions.get_response_by_name(
             'test', 'TestCommandResponse'))
-        self.assertIsInstance(definitions.get_response_by_name(
-            'Test', 'testcommandresponse'), Struct)
+        self.assertRaises(KeyError, definitions.get_response_by_name,
+                          'Test', 'testcommandresponse')
 
     def test_get_attribute_by_name(self):
         definitions = SpecDefinitions(
@@ -251,10 +251,10 @@ class TestSpecDefinitions(unittest.TestCase):
             'test', 'TestAttribute'))
         self.assertIsNone(definitions.get_attribute_by_name(
             'test', 'TestGlobalAttribute'))
-        self.assertIsInstance(definitions.get_attribute_by_name(
-            'Test', 'testattribute'), Attribute)
-        self.assertIsInstance(definitions.get_attribute_by_name(
-            'Test', 'testglobalattribute'), Attribute)
+        self.assertRaises(KeyError, definitions.get_attribute_by_name,
+                          'Test', 'testattribute')
+        self.assertRaises(KeyError, definitions.get_attribute_by_name,
+                          'Test', 'testglobalattribute')
 
     def test_get_event_by_name(self):
         definitions = SpecDefinitions(
@@ -266,8 +266,8 @@ class TestSpecDefinitions(unittest.TestCase):
         self.assertIsInstance(
             definitions.get_event_by_name('Test', 'TestEvent'), Event)
         self.assertIsNone(definitions.get_event_by_name('test', 'TestEvent'))
-        self.assertIsInstance(
-            definitions.get_event_by_name('Test', 'testevent'), Event)
+        self.assertRaises(
+            KeyError, definitions.get_event_by_name, 'Test', 'testevent')
 
     def test_get_bitmap_by_name(self):
         definitions = SpecDefinitions(
@@ -279,8 +279,8 @@ class TestSpecDefinitions(unittest.TestCase):
         self.assertIsInstance(definitions.get_bitmap_by_name(
             'Test', 'TestBitmap'), Bitmap)
         self.assertIsNone(definitions.get_bitmap_by_name('test', 'TestBitmap'))
-        self.assertIsInstance(definitions.get_bitmap_by_name(
-            'Test', 'testbitmap'), Bitmap)
+        self.assertRaises(KeyError, definitions.get_bitmap_by_name,
+                          'Test', 'testbitmap')
 
     def test_get_enum_by_name(self):
         definitions = SpecDefinitions(
@@ -292,8 +292,8 @@ class TestSpecDefinitions(unittest.TestCase):
         self.assertIsInstance(
             definitions.get_enum_by_name('Test', 'TestEnum'), Enum)
         self.assertIsNone(definitions.get_enum_by_name('test', 'TestEnum'))
-        self.assertIsInstance(
-            definitions.get_enum_by_name('Test', 'testenum'), Enum)
+        self.assertRaises(
+            KeyError, definitions.get_enum_by_name, 'Test', 'testenum')
 
     def test_get_struct_by_name(self):
         definitions = SpecDefinitions(
@@ -305,8 +305,8 @@ class TestSpecDefinitions(unittest.TestCase):
         self.assertIsInstance(definitions.get_struct_by_name(
             'Test', 'TestStruct'), Struct)
         self.assertIsNone(definitions.get_struct_by_name('test', 'TestStruct'))
-        self.assertIsInstance(definitions.get_struct_by_name(
-            'Test', 'teststruct'), Struct)
+        self.assertRaises(
+            KeyError, definitions.get_struct_by_name, 'Test', 'teststruct')
 
     def test_get_type_by_name(self):
         definitions = SpecDefinitions(

--- a/src/app/tests/suites/TV_AccountLoginCluster.yaml
+++ b/src/app/tests/suites/TV_AccountLoginCluster.yaml
@@ -29,7 +29,7 @@ tests:
                 value: nodeId
 
     - label: "Get Setup PIN Command"
-      command: "getSetupPIN"
+      command: "GetSetupPIN"
       timedInteractionTimeoutMs: 10000
       arguments:
           values:
@@ -40,7 +40,7 @@ tests:
               - name: "SetupPIN"
                 value: "tempPin123"
     - label: "Login Command"
-      command: "login"
+      command: "Login"
       timedInteractionTimeoutMs: 10000
       arguments:
           values:
@@ -50,5 +50,5 @@ tests:
                 value: "tempPin123"
 
     - label: "Logout Command"
-      command: "logout"
+      command: "Logout"
       timedInteractionTimeoutMs: 10000

--- a/src/app/tests/suites/TV_ApplicationLauncherCluster.yaml
+++ b/src/app/tests/suites/TV_ApplicationLauncherCluster.yaml
@@ -41,7 +41,7 @@ tests:
           value: null
 
     - label: "Launch App Command"
-      command: "launchApp"
+      command: "LaunchApp"
       arguments:
           values:
               - name: "Data"
@@ -56,7 +56,7 @@ tests:
                 value: 0
 
     - label: "Stop App Command"
-      command: "stopApp"
+      command: "StopApp"
       arguments:
           values:
               - name: "Application"
@@ -69,7 +69,7 @@ tests:
                 value: 0
 
     - label: "Hide App Command"
-      command: "hideApp"
+      command: "HideApp"
       arguments:
           values:
               - name: "Application"

--- a/src/app/tests/suites/TV_AudioOutputCluster.yaml
+++ b/src/app/tests/suites/TV_AudioOutputCluster.yaml
@@ -46,14 +46,14 @@ tests:
           value: 1
 
     - label: "Select Output Command"
-      command: "selectOutput"
+      command: "SelectOutput"
       arguments:
           values:
               - name: "Index"
                 value: 1
 
     - label: "Rename Output Command"
-      command: "renameOutput"
+      command: "RenameOutput"
       arguments:
           values:
               - name: "Index"

--- a/src/app/tests/suites/TV_ChannelCluster.yaml
+++ b/src/app/tests/suites/TV_ChannelCluster.yaml
@@ -90,7 +90,7 @@ tests:
               }
 
     - label: "Change Channel Command"
-      command: "changeChannel"
+      command: "ChangeChannel"
       arguments:
           values:
               - name: "Match"
@@ -103,7 +103,7 @@ tests:
                 value: 0
 
     - label: "Change Channel By Number Command"
-      command: "changeChannelByNumber"
+      command: "ChangeChannelByNumber"
       arguments:
           values:
               - name: "MajorNumber"
@@ -112,7 +112,7 @@ tests:
                 value: 0
 
     - label: "Skip Channel Command"
-      command: "skipChannel"
+      command: "SkipChannel"
       arguments:
           values:
               - name: "Count"

--- a/src/app/tests/suites/TV_ContentLauncherCluster.yaml
+++ b/src/app/tests/suites/TV_ContentLauncherCluster.yaml
@@ -41,7 +41,7 @@ tests:
           value: 0
 
     - label: "Launch Content Command"
-      command: "launchContent"
+      command: "LaunchContent"
       arguments:
           values:
               - name: "AutoPlay"
@@ -69,7 +69,7 @@ tests:
                 value: 0
 
     - label: "Launch URL Command"
-      command: "launchURL"
+      command: "LaunchURL"
       arguments:
           values:
               - name: "ContentURL"

--- a/src/app/tests/suites/TV_KeypadInputCluster.yaml
+++ b/src/app/tests/suites/TV_KeypadInputCluster.yaml
@@ -29,7 +29,7 @@ tests:
                 value: nodeId
 
     - label: "Send Key Command"
-      command: "sendKey"
+      command: "SendKey"
       arguments:
           values:
               - name: "KeyCode"

--- a/src/app/tests/suites/TV_LowPowerCluster.yaml
+++ b/src/app/tests/suites/TV_LowPowerCluster.yaml
@@ -29,4 +29,4 @@ tests:
                 value: nodeId
 
     - label: "Sleep Input Status Command"
-      command: "sleep"
+      command: "Sleep"

--- a/src/app/tests/suites/TV_MediaInputCluster.yaml
+++ b/src/app/tests/suites/TV_MediaInputCluster.yaml
@@ -55,20 +55,20 @@ tests:
           value: 1
 
     - label: "Select Input Command"
-      command: "selectInput"
+      command: "SelectInput"
       arguments:
           values:
               - name: "Index"
                 value: 1
 
     - label: "Hide Input Status Command"
-      command: "hideInputStatus"
+      command: "HideInputStatus"
 
     - label: "Show Input Status Command"
-      command: "showInputStatus"
+      command: "ShowInputStatus"
 
     - label: "Rename Input Command"
-      command: "renameInput"
+      command: "RenameInput"
       arguments:
           values:
               - name: "Index"

--- a/src/app/tests/suites/TV_MediaPlaybackCluster.yaml
+++ b/src/app/tests/suites/TV_MediaPlaybackCluster.yaml
@@ -71,7 +71,7 @@ tests:
           value: 0
 
     - label: "Media Playback Play Command"
-      command: "play"
+      command: "Play"
       response:
           values:
               - name: "Data"
@@ -80,7 +80,7 @@ tests:
                 value: 0
 
     - label: "Media Playback Pause Command"
-      command: "pause"
+      command: "Pause"
       response:
           values:
               - name: "Data"
@@ -98,7 +98,7 @@ tests:
                 value: 0
 
     - label: "Media Playback Start Over Command"
-      command: "startOver"
+      command: "StartOver"
       response:
           values:
               - name: "Data"
@@ -107,7 +107,7 @@ tests:
                 value: 0
 
     - label: "Media Playback Previous Command"
-      command: "previous"
+      command: "Previous"
       response:
           values:
               - name: "Data"
@@ -116,7 +116,7 @@ tests:
                 value: 0
 
     - label: "Media Playback Next Command"
-      command: "next"
+      command: "Next"
       response:
           values:
               - name: "Data"
@@ -125,7 +125,7 @@ tests:
                 value: 0
 
     - label: "Media Playback Rewind Command"
-      command: "rewind"
+      command: "Rewind"
       response:
           values:
               - name: "Data"
@@ -134,7 +134,7 @@ tests:
                 value: 0
 
     - label: "Media Playback Fast Forward Command"
-      command: "fastForward"
+      command: "FastForward"
       response:
           values:
               - name: "Data"
@@ -143,7 +143,7 @@ tests:
                 value: 0
 
     - label: "Media Playback Skip Forward Command"
-      command: "skipForward"
+      command: "SkipForward"
       arguments:
           values:
               - name: "DeltaPositionMilliseconds"
@@ -162,7 +162,7 @@ tests:
           value: { UpdatedAt: 0, Position: 500 }
 
     - label: "Media Playback Skip Backward Command"
-      command: "skipBackward"
+      command: "SkipBackward"
       arguments:
           values:
               - name: "DeltaPositionMilliseconds"
@@ -181,7 +181,7 @@ tests:
           value: { UpdatedAt: 0, Position: 400 }
 
     - label: "Media Playback Seek Command"
-      command: "seek"
+      command: "Seek"
       arguments:
           values:
               - name: "position"

--- a/src/app/tests/suites/TV_TargetNavigatorCluster.yaml
+++ b/src/app/tests/suites/TV_TargetNavigatorCluster.yaml
@@ -45,7 +45,7 @@ tests:
           value: 0
 
     - label: "Navigate Target Request Command"
-      command: "navigateTarget"
+      command: "NavigateTarget"
       arguments:
           values:
               - name: "Target"

--- a/src/app/tests/suites/TestBasicInformation.yaml
+++ b/src/app/tests/suites/TestBasicInformation.yaml
@@ -30,25 +30,25 @@ tests:
 
     - label: "Read location"
       command: "readAttribute"
-      attribute: "location"
+      attribute: "Location"
       response:
           value: "XX"
 
     - label: "Write location"
       command: "writeAttribute"
-      attribute: "location"
+      attribute: "Location"
       arguments:
           value: "US"
 
     - label: "Read back location"
       command: "readAttribute"
-      attribute: "location"
+      attribute: "Location"
       response:
           value: "US"
 
     - label: "Restore initial location value"
       command: "writeAttribute"
-      attribute: "location"
+      attribute: "Location"
       arguments:
           value: "XX"
 

--- a/src/app/tests/suites/TestBinding.yaml
+++ b/src/app/tests/suites/TestBinding.yaml
@@ -30,19 +30,19 @@ tests:
 
     - label: "Write empty binding table"
       command: "writeAttribute"
-      attribute: "binding"
+      attribute: "Binding"
       arguments:
           value: []
 
     - label: "Read empty binding table"
       command: "readAttribute"
-      attribute: "binding"
+      attribute: "Binding"
       response:
           value: []
 
     - label: "Write invalid binding table"
       command: "writeAttribute"
-      attribute: "binding"
+      attribute: "Binding"
       arguments:
           value:
               [
@@ -60,7 +60,7 @@ tests:
 
     - label: "Write binding table (endpoint 1)"
       command: "writeAttribute"
-      attribute: "binding"
+      attribute: "Binding"
       arguments:
           value:
               [
@@ -71,7 +71,7 @@ tests:
 
     - label: "Read binding table (endpoint 1)"
       command: "readAttribute"
-      attribute: "binding"
+      attribute: "Binding"
       response:
           value:
               [
@@ -82,21 +82,21 @@ tests:
 
     - label: "Write binding table (endpoint 0)"
       command: "writeAttribute"
-      attribute: "binding"
+      attribute: "Binding"
       endpoint: 0
       arguments:
           value: [{ FabricIndex: 0, Node: 3, Endpoint: 1 }]
 
     - label: "Read binding table (endpoint 0)"
       command: "readAttribute"
-      attribute: "binding"
+      attribute: "Binding"
       endpoint: 0
       response:
           value: [{ FabricIndex: 1, Node: 3, Endpoint: 1 }]
 
     - label: "Verify endpoint 1 not changed"
       command: "readAttribute"
-      attribute: "binding"
+      attribute: "Binding"
       response:
           value:
               [

--- a/src/app/tests/suites/TestCluster.yaml
+++ b/src/app/tests/suites/TestCluster.yaml
@@ -29,22 +29,22 @@ tests:
                 value: nodeId
 
     - label: "Send Test Command"
-      command: "test"
+      command: "Test"
 
     - label: "Send Test Not Handled Command"
-      command: "testNotHandled"
+      command: "TestNotHandled"
       response:
           error: INVALID_COMMAND
 
     - label: "Send Test Specific Command"
-      command: "testSpecific"
+      command: "TestSpecific"
       response:
           values:
               - name: "returnValue"
                 value: 7
 
     - label: "Send Test Add Arguments Command"
-      command: "testAddArguments"
+      command: "TestAddArguments"
       arguments:
           values:
               - name: "arg1"
@@ -57,7 +57,7 @@ tests:
                 value: 20
 
     - label: "Send failing Test Add Arguments Command"
-      command: "testAddArguments"
+      command: "TestAddArguments"
       arguments:
           values:
               - name: "arg1"
@@ -1007,13 +1007,13 @@ tests:
           value: 0
 
     - label: "Send Test Command to unsupported endpoint"
-      command: "test"
+      command: "Test"
       endpoint: 200
       response:
           error: UNSUPPORTED_ENDPOINT
 
     - label: "Send Test Command to unsupported cluster"
-      command: "test"
+      command: "Test"
       endpoint: 0
       response:
           error: UNSUPPORTED_CLUSTER
@@ -1045,7 +1045,7 @@ tests:
           value: 0
 
     - label: "Send a command with a vendor_id and enum"
-      command: "testEnumsRequest"
+      command: "TestEnumsRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1077,7 +1077,7 @@ tests:
     # Tests for Struct
 
     - label: "Send Test Command With Struct Argument and arg1.b is true"
-      command: "testStructArgumentRequest"
+      command: "TestStructArgumentRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1098,7 +1098,7 @@ tests:
                 value: true
 
     - label: "Send Test Command With Struct Argument and arg1.b is false"
-      command: "testStructArgumentRequest"
+      command: "TestStructArgumentRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1120,7 +1120,7 @@ tests:
 
     - label:
           "Send Test Command With Nested Struct Argument and arg1.c.b is true"
-      command: "testNestedStructArgumentRequest"
+      command: "TestNestedStructArgumentRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1146,7 +1146,7 @@ tests:
                 value: true
 
     - label: "Send Test Command With Nested Struct Argument arg1.c.b is false"
-      command: "testNestedStructArgumentRequest"
+      command: "TestNestedStructArgumentRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1174,7 +1174,7 @@ tests:
     - label:
           "Send Test Command With Nested Struct List Argument and all fields b
           of arg1.d are true"
-      command: "testNestedStructListArgumentRequest"
+      command: "TestNestedStructListArgumentRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1233,7 +1233,7 @@ tests:
     - label:
           "Send Test Command With Nested Struct List Argument and some fields b
           of arg1.d are false"
-      command: "testNestedStructListArgumentRequest"
+      command: "TestNestedStructListArgumentRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1323,7 +1323,7 @@ tests:
     # Tests for List
 
     - label: "Send Test Command With List of INT8U and none of them is set to 0"
-      command: "testListInt8UArgumentRequest"
+      command: "TestListInt8UArgumentRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1334,7 +1334,7 @@ tests:
                 value: true
 
     - label: "Send Test Command With List of INT8U and one of them is set to 0"
-      command: "testListInt8UArgumentRequest"
+      command: "TestListInt8UArgumentRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1345,7 +1345,7 @@ tests:
                 value: false
 
     - label: "Send Test Command With List of INT8U and get it reversed"
-      command: "testListInt8UReverseRequest"
+      command: "TestListInt8UReverseRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1357,7 +1357,7 @@ tests:
 
     - label:
           "Send Test Command With empty List of INT8U and get an empty list back"
-      command: "testListInt8UReverseRequest"
+      command: "TestListInt8UReverseRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1370,7 +1370,7 @@ tests:
     - label:
           "Send Test Command With List of Struct Argument and arg1.b of first
           item is true"
-      command: "testListStructArgumentRequest"
+      command: "TestListStructArgumentRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1405,7 +1405,7 @@ tests:
     - label:
           "Send Test Command With List of Struct Argument and arg1.b of first
           item is false"
-      command: "testListStructArgumentRequest"
+      command: "TestListStructArgumentRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1440,7 +1440,7 @@ tests:
     - label:
           "Send Test Command With List of Nested Struct List Argument and all
           fields b of elements of arg1.d are true"
-      command: "testListNestedStructListArgumentRequest"
+      command: "TestListNestedStructListArgumentRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1501,7 +1501,7 @@ tests:
     - label:
           "Send Test Command With Nested Struct List Argument and some fields b
           of elements of arg1.d are false"
-      command: "testListNestedStructListArgumentRequest"
+      command: "TestListNestedStructListArgumentRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1611,7 +1611,7 @@ tests:
     # Tests for Nullables and Optionals
 
     - label: "Send Test Command with optional arg set."
-      command: "testNullableOptionalRequest"
+      command: "TestNullableOptionalRequest"
       arguments:
           values:
               - name: "arg1"
@@ -1628,7 +1628,7 @@ tests:
                 value: 5
 
     - label: "Send Test Command without its optional arg."
-      command: "testNullableOptionalRequest"
+      command: "TestNullableOptionalRequest"
       response:
           values:
               - name: "wasPresent"

--- a/src/app/tests/suites/TestClusterComplexTypes.yaml
+++ b/src/app/tests/suites/TestClusterComplexTypes.yaml
@@ -34,7 +34,7 @@ tests:
       # field and some of the TestCluster consumers don't do
       # that... and it's not clear that it's ever needed outside of
       # tests.
-      command: "testNullableOptionalRequest"
+      command: "TestNullableOptionalRequest"
       arguments:
           values:
               - name: "arg1"
@@ -52,19 +52,19 @@ tests:
     # SDK APIs have not been updated to do timed invoke properly yet.
 
     - label: "Send command that needs timed invoke without a timeout value"
-      command: "timedInvokeRequest"
+      command: "TimedInvokeRequest"
       response:
           # No timed interaction timeout provided, so not doing a timed interaction.
           error: NEEDS_TIMED_INTERACTION
 
     - label: "Send command that needs timed invoke with a long timeout value"
       # Expecting a success response here.
-      command: "timedInvokeRequest"
+      command: "TimedInvokeRequest"
       timedInteractionTimeoutMs: 10000
 
     - label:
           "Send command that needs timed invoke with a too-short timeout value"
-      command: "timedInvokeRequest"
+      command: "TimedInvokeRequest"
       timedInteractionTimeoutMs: 1
       # Try to ensure that we are unresponsive for long enough that the timeout
       # expires.
@@ -76,13 +76,13 @@ tests:
           "Send command that does not need timed invoke with a long timeout
           value"
       # Expecting a success response here.
-      command: "test"
+      command: "Test"
       timedInteractionTimeoutMs: 10000
 
     - label:
           "Send command that does not need timed invoke with a too-short timeout
           value"
-      command: "test"
+      command: "Test"
       timedInteractionTimeoutMs: 1
       # Try to ensure that we are unresponsive for long enough that the timeout
       # expires.

--- a/src/app/tests/suites/TestConfigVariables.yaml
+++ b/src/app/tests/suites/TestConfigVariables.yaml
@@ -35,7 +35,7 @@ tests:
                 value: nodeId
 
     - label: "Send Test Add Arguments Command"
-      command: "testAddArguments"
+      command: "TestAddArguments"
       arguments:
           values:
               - name: "arg1"
@@ -49,7 +49,7 @@ tests:
                 value: 20
 
     - label: "Send Test Add Arguments Command"
-      command: "testAddArguments"
+      command: "TestAddArguments"
       arguments:
           values:
               - name: "arg1"

--- a/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
+++ b/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
@@ -30,14 +30,14 @@ tests:
 
     - label: "Read maxGroupsPerFabric"
       command: "readAttribute"
-      attribute: "maxGroupsPerFabric"
+      attribute: "MaxGroupsPerFabric"
       response:
           constraints:
               minValue: 4
 
     - label: "Read maxGroupKeysPerFabric"
       command: "readAttribute"
-      attribute: "maxGroupKeysPerFabric"
+      attribute: "MaxGroupKeysPerFabric"
       response:
           constraints:
               minValue: 3

--- a/src/app/tests/suites/TestGroupMessaging.yaml
+++ b/src/app/tests/suites/TestGroupMessaging.yaml
@@ -149,14 +149,14 @@ tests:
     # Test Pair 1 : Check initial value (ensure it's not the test value)
     - label: "Read initial Attribute value"
       command: "readAttribute"
-      attribute: "nodeLabel"
+      attribute: "NodeLabel"
       response:
           value: ""
 
     # Test Pair 2 : Sends a Group Write Attribute
     - label: "Group Write Attribute"
       command: "writeAttribute"
-      attribute: "nodeLabel"
+      attribute: "NodeLabel"
       groupId: 0x0102
       arguments:
           value: "xyzzy"
@@ -174,14 +174,14 @@ tests:
       # Test Pair 2 : Validates previous group write attribute with a unicast to read
     - label: "Read back Attribute"
       command: "readAttribute"
-      attribute: "nodeLabel"
+      attribute: "NodeLabel"
       response:
           value: "xyzzy"
 
     # Test Pair 3 : Sends a Group Write Attribute
     - label: "Restore initial Attribute value"
       command: "writeAttribute"
-      attribute: "nodeLabel"
+      attribute: "NodeLabel"
       groupId: 0x0102
       arguments:
           value: ""
@@ -199,7 +199,7 @@ tests:
     # Test Pair 3 : Validates previous group write attribute with a unicast to read
     - label: "Read back Attribute"
       command: "readAttribute"
-      attribute: "nodeLabel"
+      attribute: "NodeLabel"
       response:
           value: ""
 
@@ -405,7 +405,7 @@ tests:
     - label: "Read initial Attribute value for gamma"
       identity: "gamma"
       command: "readAttribute"
-      attribute: "nodeLabel"
+      attribute: "NodeLabel"
       response:
           value: ""
 
@@ -413,7 +413,7 @@ tests:
     - label: "Group Write Attribute for gamma"
       identity: "gamma"
       command: "writeAttribute"
-      attribute: "nodeLabel"
+      attribute: "NodeLabel"
       groupId: 0x0102
       arguments:
           value: "xyzzy"
@@ -433,7 +433,7 @@ tests:
     - label: "Read back Attribute for gamma"
       identity: "gamma"
       command: "readAttribute"
-      attribute: "nodeLabel"
+      attribute: "NodeLabel"
       response:
           value: "xyzzy"
 
@@ -441,7 +441,7 @@ tests:
     - label: "Restore initial Attribute value for gamma"
       identity: "gamma"
       command: "writeAttribute"
-      attribute: "nodeLabel"
+      attribute: "NodeLabel"
       groupId: 0x0102
       arguments:
           value: ""
@@ -461,7 +461,7 @@ tests:
     - label: "Read back Attribute for gamma"
       identity: "gamma"
       command: "readAttribute"
-      attribute: "nodeLabel"
+      attribute: "NodeLabel"
       response:
           value: ""
 

--- a/src/app/tests/suites/TestIdentifyCluster.yaml
+++ b/src/app/tests/suites/TestIdentifyCluster.yaml
@@ -29,7 +29,7 @@ tests:
                 value: nodeId
 
     - label: "Send Identify command and expect success response"
-      command: "identify"
+      command: "Identify"
       arguments:
           values:
               - name: "IdentifyTime"

--- a/src/app/tests/suites/TestModeSelectCluster.yaml
+++ b/src/app/tests/suites/TestModeSelectCluster.yaml
@@ -81,7 +81,7 @@ tests:
           value: null
 
     - label: "Change to Supported Mode"
-      command: "changeToMode"
+      command: "ChangeToMode"
       arguments:
           values:
               - name: "NewMode"
@@ -95,7 +95,7 @@ tests:
           saveAs: currentModeBeforeToggle
 
     - label: "Change to Unsupported Mode"
-      command: "changeToMode"
+      command: "ChangeToMode"
       arguments:
           values:
               - name: "NewMode"
@@ -105,11 +105,11 @@ tests:
 
     - label: "Toggle OnOff"
       cluster: "On/Off"
-      command: "off"
+      command: "Off"
 
     - label: "Toggle OnOff"
       cluster: "On/Off"
-      command: "on"
+      command: "On"
 
     - label: "Verify Current Mode does not change when OnMode is null"
       command: "readAttribute"
@@ -140,11 +140,11 @@ tests:
 
     - label: "Toggle OnOff"
       cluster: "On/Off"
-      command: "off"
+      command: "Off"
 
     - label: "Toggle OnOff"
       cluster: "On/Off"
-      command: "on"
+      command: "On"
 
     - label: "Verify Current Mode Changes if OnMode is not null"
       command: "readAttribute"
@@ -173,7 +173,7 @@ tests:
           value: 7
 
     - label: "Change CurrentMode to another value"
-      command: "changeToMode"
+      command: "ChangeToMode"
       arguments:
           values:
               - name: "NewMode"

--- a/src/app/tests/suites/TestSaveAs.yaml
+++ b/src/app/tests/suites/TestSaveAs.yaml
@@ -29,7 +29,7 @@ tests:
                 value: nodeId
 
     - label: "Send Test Add Arguments Command"
-      command: "testAddArguments"
+      command: "TestAddArguments"
       arguments:
           values:
               - name: "arg1"
@@ -43,7 +43,7 @@ tests:
                 value: 20
 
     - label: "Send Test Add Arguments Command"
-      command: "testAddArguments"
+      command: "TestAddArguments"
       arguments:
           values:
               - name: "arg1"
@@ -56,7 +56,7 @@ tests:
                 value: TestAddArgumentDefaultValue
 
     - label: "Send Test Add Arguments Command"
-      command: "testAddArguments"
+      command: "TestAddArguments"
       arguments:
           values:
               - name: "arg1"

--- a/src/app/tests/suites/certification/Test_TC_CC_4_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_4_2.yaml
@@ -347,7 +347,7 @@ tests:
     - label: "Turn off light that we turned on"
       PICS: OO.S.C00.Rsp
       cluster: "On/Off"
-      command: "off"
+      command: "Off"
 
     - label: "Check on/off attribute value is false after off command"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_DGTHREAD_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DGTHREAD_2_1.yaml
@@ -34,7 +34,7 @@ tests:
     - label: "TH reads Channel attribute value from DUT"
       PICS: DGTHREAD.S.A0000
       command: "readAttribute"
-      attribute: "channel"
+      attribute: "Channel"
       response:
           constraints:
               type: int16u
@@ -297,7 +297,7 @@ tests:
     - label: "TH reads Weighting attribute value from DUT"
       PICS: DGTHREAD.S.A000a
       command: "readAttribute"
-      attribute: "weighting"
+      attribute: "Weighting"
       response:
           constraints:
               type: int8u


### PR DESCRIPTION
#### Problem

The various typos in the written YAML tests force the parser to be less strict and reduce the consistency of the test suite. This PR fix a bunch of them and removes some `lower()` calls from the parser.