### PR TITLE
Send the sdk status whether its ready to do BDX for firmware update a…

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -243,8 +243,10 @@ static NSString * const kErrorOtaProviderInit = @"Init failure while creating an
         }
 
         if (startupParams.otaProviderDelegate) {
-            if (![startupParams.otaProviderDelegate respondsToSelector:@selector(handleQueryImageForNodeID:
-                                                                                                controller:params:completion:)]
+            if (![startupParams.otaProviderDelegate
+                    respondsToSelector:@selector(handleQueryImageForNodeID:controller:params:canStartNewBDXSession:completion:)]
+                && ![startupParams.otaProviderDelegate respondsToSelector:@selector(handleQueryImageForNodeID:
+                                                                                                   controller:params:completion:)]
                 && ![startupParams.otaProviderDelegate
                     respondsToSelector:@selector(handleQueryImageForNodeID:controller:params:completionHandler:)]) {
                 MTR_LOG_ERROR("Error: MTROTAProviderDelegate does not support handleQueryImageForNodeID");

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegate.h
@@ -43,7 +43,7 @@ typedef void (^MTRApplyUpdateRequestCompletionHandlerDeprecated)(
  *
  * While the selectors on this protocol are marked @optional, in practice an
  * implementation must provide an implementation for one of each pair of
- * selectors (e.g. one of the two handleQueryImageForNodeID selectors must be
+ * selectors (e.g. one of the three handleQueryImageForNodeID selectors must be
  * implemented).  The selector ending in "completion:" will be used if present;
  * otherwise the one ending in "completionHandler:" will be used.
  */
@@ -58,6 +58,11 @@ typedef void (^MTRApplyUpdateRequestCompletionHandlerDeprecated)(
  * an error response to the client.  Otherwise it must have a non-nil data,
  * which will be returned to the client.
  */
+- (void)handleQueryImageForNodeID:(NSNumber *)nodeID
+                       controller:(MTRDeviceController *)controller
+                           params:(MTROTASoftwareUpdateProviderClusterQueryImageParams *)params
+            canStartNewBDXSession:(bool)canStartNewBDXSession
+                       completion:(MTRQueryImageCompletionHandler)completion MTR_NEWLY_AVAILABLE;
 - (void)handleQueryImageForNodeID:(NSNumber *)nodeID
                        controller:(MTRDeviceController *)controller
                            params:(MTROTASoftwareUpdateProviderClusterQueryImageParams *)params


### PR DESCRIPTION
…s part of query image response

- It's possible that the sdk could be busy with another BDX session when we get a query image. Without this change we are unbale to share the sdk status with the OTA delegate.

- With this change, we can share the sdk status whether its busy with the OTA delegate which can then make decisions based on that info
