### PR TITLE
Fix the boot loop crash on M5Stack

### DIFF
--- a/examples/all-clusters-app/esp32/main/AppTask.cpp
+++ b/examples/all-clusters-app/esp32/main/AppTask.cpp
@@ -161,6 +161,13 @@ void AppTask::ActionCompleted(BoltLockManager::Action_t aAction)
     }
 }
 
+CHIP_ERROR AppTask::LockInit()
+{
+    ReturnErrorOnFailure(BoltLockMgr().InitLockState());
+    BoltLockMgr().SetCallbacks(ActionInitiated, ActionCompleted);
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR AppTask::Init()
 {
     /* Print chip information */
@@ -179,10 +186,7 @@ CHIP_ERROR AppTask::Init()
                                   (void *) this,    // init timer id = app task obj context
                                   TimerEventHandler // timer callback handler
     );
-
-    CHIP_ERROR err = BoltLockMgr().InitLockState();
-
-    BoltLockMgr().SetCallbacks(ActionInitiated, ActionCompleted);
+    VerifyOrReturnError(sFunctionTimer != NULL, CHIP_ERROR_NO_MEMORY, ESP_LOGE(TAG, "Failed to create function selection timer"));
 
     statusLED1.Init(STATUS_LED_GPIO_NUM);
     // Our second LED doesn't map to any physical LEDs so far, just to virtual
@@ -199,7 +203,7 @@ CHIP_ERROR AppTask::Init()
     InitDeviceDisplay();
 #endif
 
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 void AppTask::AppTaskMain(void * pvParameter)

--- a/examples/all-clusters-app/esp32/main/include/AppTask.h
+++ b/examples/all-clusters-app/esp32/main/include/AppTask.h
@@ -39,6 +39,7 @@ public:
     void PostEvent(const AppEvent * event);
     void ButtonEventHandler(uint8_t btnIdx, uint8_t btnAction);
     static void ButtonPressedAction(AppEvent * aEvent);
+    CHIP_ERROR LockInit();
 
 private:
     CHIP_ERROR Init();

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -119,7 +119,7 @@ static void InitServer(intptr_t context)
     CHIP_ERROR err = GetAppTask().LockInit();
     if (err != CHIP_NO_ERROR)
     {
-        ESP_LOGE(TAG, "Failed to initialize app task lock, err:%" CHIP_FORMAT_ERROR, err.Format());
+        ESP_LOGE(TAG, "Failed to initialize app task lock, err:%" CHIP_ERROR_FORMAT, err.Format());
     }
 
 #if CONFIG_DEVICE_TYPE_M5STACK

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -115,6 +115,13 @@ static void InitServer(intptr_t context)
     emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
 
     InitBindingHandlers();
+
+    CHIP_ERROR err = GetAppTask().LockInit();
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "Failed to initialize app task lock, err:%" CHIP_FORMAT_ERROR, err.Format());
+    }
+
 #if CONFIG_DEVICE_TYPE_M5STACK
     SetupPretendDevices();
 #endif

--- a/examples/platform/esp32/lock/BoltLockManager.cpp
+++ b/examples/platform/esp32/lock/BoltLockManager.cpp
@@ -764,7 +764,6 @@ CHIP_ERROR BoltLockManager::InitLockState()
     // Initial lock state
     chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlLockState> state;
     chip::EndpointId endpointId{ 1 };
-    chip::DeviceLayer::PlatformMgr().LockChipStack();
     chip::app::Clusters::DoorLock::Attributes::LockState::Get(endpointId, state);
 
     uint8_t numberOfCredentialsPerUser = 0;
@@ -815,8 +814,6 @@ CHIP_ERROR BoltLockManager::InitLockState()
             endpointId);
         numberOfHolidaySchedules = 10;
     }
-
-    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
     CHIP_ERROR err = BoltLockMgr().Init(state,
                                         ParamBuilder()


### PR DESCRIPTION
This is the regression from #24547, which is accessing the attributes even before Server is ready. Moved the lock initialization after service is initialized.

Fixes #24593

#### Tests
No boot loop and was able to commission the M5 stack. 