### PR TITLE
Fix Android build failure no member named 'StatusName' in namespace '…

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -59,6 +59,8 @@ static_library("chip-tool-utils") {
     "commands/common/Commands.h",
     "commands/common/CredentialIssuerCommands.h",
     "commands/common/HexConversion.h",
+    "commands/common/RemoteDataModelLogger.cpp",
+    "commands/common/RemoteDataModelLogger.h",
     "commands/delay/SleepCommand.cpp",
     "commands/delay/WaitForCommissioneeCommand.cpp",
     "commands/discover/DiscoverCommand.cpp",

--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -74,7 +74,7 @@ public:
         CHIP_ERROR error = status.ToChipError();
         if (CHIP_NO_ERROR != error)
         {
-            ReturnOnFailure(DataModelLogger::LogErrorAsJSON(path, status));
+            ReturnOnFailure(RemoteDataModelLogger::LogErrorAsJSON(path, status));
 
             ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
             mError = error;
@@ -83,7 +83,7 @@ public:
 
         if (data != nullptr)
         {
-            ReturnOnFailure(DataModelLogger::LogCommandAsJSON(path, data));
+            ReturnOnFailure(RemoteDataModelLogger::LogCommandAsJSON(path, data));
 
             error = DataModelLogger::LogCommand(path, data);
             if (CHIP_NO_ERROR != error)
@@ -97,7 +97,7 @@ public:
 
     virtual void OnError(const chip::app::CommandSender * client, CHIP_ERROR error) override
     {
-        ReturnOnFailure(DataModelLogger::LogErrorAsJSON(error));
+        ReturnOnFailure(RemoteDataModelLogger::LogErrorAsJSON(error));
 
         ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(error));
         mError = error;

--- a/examples/chip-tool/commands/clusters/DataModelLogger.h
+++ b/examples/chip-tool/commands/clusters/DataModelLogger.h
@@ -26,23 +26,8 @@
 #include <app/EventHeader.h>
 #include <app/MessageDef/StatusIB.h>
 #include <app/data-model/DecodableList.h>
+#include <commands/common/RemoteDataModelLogger.h>
 #include <lib/support/BytesToHex.h>
-#include <lib/support/jsontlv/TlvJson.h>
-
-constexpr const char * kClusterIdKey      = "clusterId";
-constexpr const char * kEndpointIdKey     = "endpointId";
-constexpr const char * kAttributeIdKey    = "attributeId";
-constexpr const char * kEventIdKey        = "eventId";
-constexpr const char * kCommandIdKey      = "commandId";
-constexpr const char * kErrorIdKey        = "error";
-constexpr const char * kClusterErrorIdKey = "clusterError";
-
-class DataModelLoggerJSONDelegate
-{
-public:
-    CHIP_ERROR virtual LogJSON(const char *) = 0;
-    virtual ~DataModelLoggerJSONDelegate(){};
-};
 
 class DataModelLogger
 {
@@ -51,119 +36,7 @@ public:
     static CHIP_ERROR LogCommand(const chip::app::ConcreteCommandPath & path, chip::TLV::TLVReader * data);
     static CHIP_ERROR LogEvent(const chip::app::EventHeader & header, chip::TLV::TLVReader * data);
 
-    static CHIP_ERROR LogAttributeAsJSON(const chip::app::ConcreteDataAttributePath & path, chip::TLV::TLVReader * data)
-    {
-        VerifyOrReturnError(mJSONDelegate != nullptr, CHIP_NO_ERROR);
-
-        Json::Value value;
-        value[kClusterIdKey]   = path.mClusterId;
-        value[kEndpointIdKey]  = path.mEndpointId;
-        value[kAttributeIdKey] = path.mAttributeId;
-
-        chip::TLV::TLVReader reader;
-        reader.Init(*data);
-        ReturnErrorOnFailure(chip::TlvToJson(reader, value));
-
-        auto valueStr = chip::JsonToString(value);
-        return mJSONDelegate->LogJSON(valueStr.c_str());
-    }
-
-    static CHIP_ERROR LogErrorAsJSON(const chip::app::ConcreteDataAttributePath & path, const chip::app::StatusIB & status)
-    {
-        VerifyOrReturnError(mJSONDelegate != nullptr, CHIP_NO_ERROR);
-
-        Json::Value value;
-        value[kClusterIdKey]   = path.mClusterId;
-        value[kEndpointIdKey]  = path.mEndpointId;
-        value[kAttributeIdKey] = path.mAttributeId;
-
-        return LogError(value, status);
-    }
-
-    static CHIP_ERROR LogCommandAsJSON(const chip::app::ConcreteCommandPath & path, chip::TLV::TLVReader * data)
-    {
-        VerifyOrReturnError(mJSONDelegate != nullptr, CHIP_NO_ERROR);
-
-        Json::Value value;
-        value[kClusterIdKey]  = path.mClusterId;
-        value[kEndpointIdKey] = path.mEndpointId;
-        value[kCommandIdKey]  = path.mCommandId;
-
-        chip::TLV::TLVReader reader;
-        reader.Init(*data);
-        ReturnErrorOnFailure(chip::TlvToJson(reader, value));
-
-        auto valueStr = chip::JsonToString(value);
-        return mJSONDelegate->LogJSON(valueStr.c_str());
-    }
-
-    static CHIP_ERROR LogErrorAsJSON(const chip::app::ConcreteCommandPath & path, const chip::app::StatusIB & status)
-    {
-        VerifyOrReturnError(mJSONDelegate != nullptr, CHIP_NO_ERROR);
-
-        Json::Value value;
-        value[kClusterIdKey]  = path.mClusterId;
-        value[kEndpointIdKey] = path.mEndpointId;
-        value[kCommandIdKey]  = path.mCommandId;
-
-        return LogError(value, status);
-    }
-
-    static CHIP_ERROR LogEventAsJSON(const chip::app::EventHeader & header, chip::TLV::TLVReader * data)
-    {
-        VerifyOrReturnError(mJSONDelegate != nullptr, CHIP_NO_ERROR);
-
-        Json::Value value;
-        value[kClusterIdKey]  = header.mPath.mClusterId;
-        value[kEndpointIdKey] = header.mPath.mEndpointId;
-        value[kEventIdKey]    = header.mPath.mEventId;
-
-        chip::TLV::TLVReader reader;
-        reader.Init(*data);
-        ReturnErrorOnFailure(chip::TlvToJson(reader, value));
-
-        auto valueStr = chip::JsonToString(value);
-        return mJSONDelegate->LogJSON(valueStr.c_str());
-    }
-
-    static CHIP_ERROR LogErrorAsJSON(const chip::app::EventHeader & header, const chip::app::StatusIB & status)
-    {
-        VerifyOrReturnError(mJSONDelegate != nullptr, CHIP_NO_ERROR);
-
-        Json::Value value;
-        value[kClusterIdKey]  = header.mPath.mClusterId;
-        value[kEndpointIdKey] = header.mPath.mEndpointId;
-        value[kEventIdKey]    = header.mPath.mEventId;
-
-        return LogError(value, status);
-    }
-
-    static CHIP_ERROR LogErrorAsJSON(const CHIP_ERROR & error)
-    {
-        Json::Value value;
-        chip::app::StatusIB status;
-        status.InitFromChipError(error);
-        return LogError(value, status);
-    }
-
-    static void SetJSONDelegate(DataModelLoggerJSONDelegate * delegate) { mJSONDelegate = delegate; }
-
 private:
-    static CHIP_ERROR LogError(Json::Value & value, const chip::app::StatusIB & status)
-    {
-        if (status.mClusterStatus.HasValue())
-        {
-            auto statusValue          = status.mClusterStatus.Value();
-            value[kClusterErrorIdKey] = statusValue;
-        }
-
-        auto statusName    = chip::Protocols::InteractionModel::StatusName(status.mStatus);
-        value[kErrorIdKey] = statusName;
-
-        auto valueStr = chip::JsonToString(value);
-        return mJSONDelegate->LogJSON(valueStr.c_str());
-    }
-
     static CHIP_ERROR LogValue(const char * label, size_t indent, bool value)
     {
         DataModelLogger::LogString(label, indent, value ? "TRUE" : "FALSE");
@@ -323,5 +196,4 @@ private:
     }
 
     static size_t ComputePrefixSize(const std::string label, size_t indent) { return ComputePrefix(label, indent).size(); }
-    static DataModelLoggerJSONDelegate * mJSONDelegate;
 };

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -37,7 +37,7 @@ public:
         CHIP_ERROR error = status.ToChipError();
         if (CHIP_NO_ERROR != error)
         {
-            ReturnOnFailure(DataModelLogger::LogErrorAsJSON(path, status));
+            ReturnOnFailure(RemoteDataModelLogger::LogErrorAsJSON(path, status));
 
             ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
             mError = error;
@@ -51,7 +51,7 @@ public:
             return;
         }
 
-        ReturnOnFailure(DataModelLogger::LogAttributeAsJSON(path, data));
+        ReturnOnFailure(RemoteDataModelLogger::LogAttributeAsJSON(path, data));
 
         error = DataModelLogger::LogAttribute(path, data);
         if (CHIP_NO_ERROR != error)
@@ -70,7 +70,7 @@ public:
             CHIP_ERROR error = status->ToChipError();
             if (CHIP_NO_ERROR != error)
             {
-                ReturnOnFailure(DataModelLogger::LogErrorAsJSON(eventHeader, *status));
+                ReturnOnFailure(RemoteDataModelLogger::LogErrorAsJSON(eventHeader, *status));
 
                 ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
                 mError = error;

--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -109,7 +109,7 @@ public:
         CHIP_ERROR error = status.ToChipError();
         if (CHIP_NO_ERROR != error)
         {
-            ReturnOnFailure(DataModelLogger::LogErrorAsJSON(path, status));
+            ReturnOnFailure(RemoteDataModelLogger::LogErrorAsJSON(path, status));
 
             ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
             mError = error;
@@ -118,7 +118,7 @@ public:
 
     void OnError(const chip::app::WriteClient * client, CHIP_ERROR error) override
     {
-        ReturnOnFailure(DataModelLogger::LogErrorAsJSON(error));
+        ReturnOnFailure(RemoteDataModelLogger::LogErrorAsJSON(error));
 
         ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(error));
         mError = error;

--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -1,0 +1,155 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "RemoteDataModelLogger.h"
+
+#include <lib/support/jsontlv/TlvJson.h>
+
+constexpr const char * kClusterIdKey      = "clusterId";
+constexpr const char * kEndpointIdKey     = "endpointId";
+constexpr const char * kAttributeIdKey    = "attributeId";
+constexpr const char * kEventIdKey        = "eventId";
+constexpr const char * kCommandIdKey      = "commandId";
+constexpr const char * kErrorIdKey        = "error";
+constexpr const char * kClusterErrorIdKey = "clusterError";
+
+namespace {
+RemoteDataModelLoggerDelegate * gDelegate;
+
+CHIP_ERROR LogError(Json::Value & value, const chip::app::StatusIB & status)
+{
+    if (status.mClusterStatus.HasValue())
+    {
+        auto statusValue          = status.mClusterStatus.Value();
+        value[kClusterErrorIdKey] = statusValue;
+    }
+
+#if CHIP_CONFIG_IM_STATUS_CODE_VERBOSE_FORMAT
+    auto statusName    = chip::Protocols::InteractionModel::StatusName(status.mStatus);
+    value[kErrorIdKey] = statusName;
+#else
+    auto statusName    = status.mStatus;
+    value[kErrorIdKey] = chip::to_underlying(statusName);
+#endif // CHIP_CONFIG_IM_STATUS_CODE_VERBOSE_FORMAT
+
+    auto valueStr = chip::JsonToString(value);
+    return gDelegate->LogJSON(valueStr.c_str());
+}
+} // namespace
+
+namespace RemoteDataModelLogger {
+CHIP_ERROR LogAttributeAsJSON(const chip::app::ConcreteDataAttributePath & path, chip::TLV::TLVReader * data)
+{
+    VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
+
+    Json::Value value;
+    value[kClusterIdKey]   = path.mClusterId;
+    value[kEndpointIdKey]  = path.mEndpointId;
+    value[kAttributeIdKey] = path.mAttributeId;
+
+    chip::TLV::TLVReader reader;
+    reader.Init(*data);
+    ReturnErrorOnFailure(chip::TlvToJson(reader, value));
+
+    auto valueStr = chip::JsonToString(value);
+    return gDelegate->LogJSON(valueStr.c_str());
+}
+
+CHIP_ERROR LogErrorAsJSON(const chip::app::ConcreteDataAttributePath & path, const chip::app::StatusIB & status)
+{
+    VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
+
+    Json::Value value;
+    value[kClusterIdKey]   = path.mClusterId;
+    value[kEndpointIdKey]  = path.mEndpointId;
+    value[kAttributeIdKey] = path.mAttributeId;
+
+    return LogError(value, status);
+}
+
+CHIP_ERROR LogCommandAsJSON(const chip::app::ConcreteCommandPath & path, chip::TLV::TLVReader * data)
+{
+    VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
+
+    Json::Value value;
+    value[kClusterIdKey]  = path.mClusterId;
+    value[kEndpointIdKey] = path.mEndpointId;
+    value[kCommandIdKey]  = path.mCommandId;
+
+    chip::TLV::TLVReader reader;
+    reader.Init(*data);
+    ReturnErrorOnFailure(chip::TlvToJson(reader, value));
+
+    auto valueStr = chip::JsonToString(value);
+    return gDelegate->LogJSON(valueStr.c_str());
+}
+
+CHIP_ERROR LogErrorAsJSON(const chip::app::ConcreteCommandPath & path, const chip::app::StatusIB & status)
+{
+    VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
+
+    Json::Value value;
+    value[kClusterIdKey]  = path.mClusterId;
+    value[kEndpointIdKey] = path.mEndpointId;
+    value[kCommandIdKey]  = path.mCommandId;
+
+    return LogError(value, status);
+}
+
+CHIP_ERROR LogEventAsJSON(const chip::app::EventHeader & header, chip::TLV::TLVReader * data)
+{
+    VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
+
+    Json::Value value;
+    value[kClusterIdKey]  = header.mPath.mClusterId;
+    value[kEndpointIdKey] = header.mPath.mEndpointId;
+    value[kEventIdKey]    = header.mPath.mEventId;
+
+    chip::TLV::TLVReader reader;
+    reader.Init(*data);
+    ReturnErrorOnFailure(chip::TlvToJson(reader, value));
+
+    auto valueStr = chip::JsonToString(value);
+    return gDelegate->LogJSON(valueStr.c_str());
+}
+
+CHIP_ERROR LogErrorAsJSON(const chip::app::EventHeader & header, const chip::app::StatusIB & status)
+{
+    VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
+
+    Json::Value value;
+    value[kClusterIdKey]  = header.mPath.mClusterId;
+    value[kEndpointIdKey] = header.mPath.mEndpointId;
+    value[kEventIdKey]    = header.mPath.mEventId;
+
+    return LogError(value, status);
+}
+
+CHIP_ERROR LogErrorAsJSON(const CHIP_ERROR & error)
+{
+    Json::Value value;
+    chip::app::StatusIB status;
+    status.InitFromChipError(error);
+    return LogError(value, status);
+}
+
+void SetDelegate(RemoteDataModelLoggerDelegate * delegate)
+{
+    gDelegate = delegate;
+}
+}; // namespace RemoteDataModelLogger

--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.h
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.h
@@ -1,0 +1,42 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <app/ConcreteAttributePath.h>
+#include <app/ConcreteCommandPath.h>
+#include <app/EventHeader.h>
+#include <app/MessageDef/StatusIB.h>
+
+class RemoteDataModelLoggerDelegate
+{
+public:
+    CHIP_ERROR virtual LogJSON(const char *) = 0;
+    virtual ~RemoteDataModelLoggerDelegate(){};
+};
+
+namespace RemoteDataModelLogger {
+CHIP_ERROR LogAttributeAsJSON(const chip::app::ConcreteDataAttributePath & path, chip::TLV::TLVReader * data);
+CHIP_ERROR LogErrorAsJSON(const chip::app::ConcreteDataAttributePath & path, const chip::app::StatusIB & status);
+CHIP_ERROR LogCommandAsJSON(const chip::app::ConcreteCommandPath & path, chip::TLV::TLVReader * data);
+CHIP_ERROR LogErrorAsJSON(const chip::app::ConcreteCommandPath & path, const chip::app::StatusIB & status);
+CHIP_ERROR LogEventAsJSON(const chip::app::EventHeader & header, chip::TLV::TLVReader * data);
+CHIP_ERROR LogErrorAsJSON(const chip::app::EventHeader & header, const chip::app::StatusIB & status);
+CHIP_ERROR LogErrorAsJSON(const CHIP_ERROR & error);
+void SetDelegate(RemoteDataModelLoggerDelegate * delegate);
+}; // namespace RemoteDataModelLogger

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -197,7 +197,7 @@ CHIP_ERROR InteractiveServerCommand::RunCommand()
     // is dumped to stdout while the user is typing a command.
     chip::Logging::SetLogRedirectCallback(InteractiveServerLoggingCallback);
 
-    DataModelLogger::SetJSONDelegate(this);
+    RemoteDataModelLogger::SetDelegate(this);
     ReturnErrorOnFailure(mWebSocketServer.Run(mPort, this));
 
     gInteractiveServerResult.Reset();

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.h
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.h
@@ -53,7 +53,7 @@ public:
     CHIP_ERROR RunCommand() override;
 };
 
-class InteractiveServerCommand : public InteractiveCommand, public WebSocketServerDelegate, public DataModelLoggerJSONDelegate
+class InteractiveServerCommand : public InteractiveCommand, public WebSocketServerDelegate, public RemoteDataModelLoggerDelegate
 {
 public:
     InteractiveServerCommand(Commands * commandsHandler, CredentialIssuerCommands * credsIssuerConfig) :
@@ -68,7 +68,7 @@ public:
     /////////// WebSocketServerDelegate Interface /////////
     bool OnWebSocketMessageReceived(char * msg) override;
 
-    /////////// DataModelLoggerJSONDelegate interface /////////
+    /////////// RemoteDataModelLoggerDelegate interface /////////
     CHIP_ERROR LogJSON(const char * json) override;
 
 private:

--- a/examples/chip-tool/templates/logging/DataModelLogger-src.zapt
+++ b/examples/chip-tool/templates/logging/DataModelLogger-src.zapt
@@ -4,8 +4,6 @@
 
 using namespace chip::app::Clusters;
 
-DataModelLoggerJSONDelegate * DataModelLogger::mJSONDelegate = nullptr;
-
 {{#structs_with_clusters groupByStructName=1}}
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const chip::app::Clusters::{{#unless (is_number_greater_than structClusterCount 1)}}{{as_camel_cased clusterName false}}{{else}}detail{{/unless}}::Structs::{{name}}::DecodableType & value)
 {

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -44,6 +44,8 @@ chip_data_model("tv-casting-common") {
     "${chip_root}/examples/chip-tool/commands/common/Commands.h",
     "${chip_root}/examples/chip-tool/commands/common/CredentialIssuerCommands.h",
     "${chip_root}/examples/chip-tool/commands/common/HexConversion.h",
+    "${chip_root}/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp",
+    "${chip_root}/examples/chip-tool/commands/common/RemoteDataModelLogger.h",
     "${chip_root}/src/controller/ExamplePersistentStorage.cpp",
     "${chip_root}/src/controller/ExamplePersistentStorage.h",
     "${chip_root}/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp",

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -21,8 +21,6 @@
 
 using namespace chip::app::Clusters;
 
-DataModelLoggerJSONDelegate * DataModelLogger::mJSONDelegate = nullptr;
-
 CHIP_ERROR
 DataModelLogger::LogValue(const char * label, size_t indent,
                           const chip::app::Clusters::AccessControl::Structs::AccessControlEntryStruct::DecodableType & value)


### PR DESCRIPTION
…chip::Protocols::InteractionModel'

#### Problem

Android full builds fails on master because `CHIP_CONFIG_IM_STATUS_CODE_VERBOSE_FORMAT` is not enabled on Android platform. This PR fix that using an #ifdef and shuffle a little bit the code to address the comment https://github.com/project-chip/connectedhomeip/pull/24387#discussion_r1084325156 and partially https://github.com/project-chip/connectedhomeip/pull/24387#discussion_r1084303615