### PR TITLE
[HotFix] Rename PlaybackPosition structure to PlaybackPositionStruct …

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
@@ -252,11 +252,11 @@ jobject SampledPositionSuccessHandlerJNI::ConvertToJObject(
     jobject jSampledPosition = nullptr;
     if (!responseData.IsNull())
     {
-        const chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::DecodableType & playbackPosition =
+        const chip::app::Clusters::MediaPlayback::Structs::PlaybackPositionStruct::DecodableType & playbackPosition =
             responseData.Value();
 
         jclass responseTypeClass = nullptr;
-        CHIP_ERROR err = JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/MediaPlaybackTypes$PlaybackPosition",
+        CHIP_ERROR err = JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/MediaPlaybackTypes$PlaybackPositionStruct",
                                                                   responseTypeClass);
         if (err != CHIP_NO_ERROR)
         {


### PR DESCRIPTION
…after #24509

#### Problem 

#24509 has updated the xml definition for the `Media Playback` cluster such that it match the spec. But some non-generated jni bridge in the `tv-casting-app` is still using the old name.

