### PR TITLE
[matter_yamltests] Ensure that the PICSChecker code does not throw if…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/pics_checker.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pics_checker.py
@@ -39,10 +39,11 @@ class InvalidPICSParsingError(Exception):
 
 class PICSChecker():
     """Class to compute a PICS expression"""
-    __pics: None
-    __expression_index: 0
 
     def __init__(self, pics_file: str):
+        self.__pics = {}
+        self.__expression_index = 0
+
         if pics_file is not None:
             self.__pics = self.__parse(pics_file)
 

--- a/scripts/py_matter_yamltests/test_pics_checker.py
+++ b/scripts/py_matter_yamltests/test_pics_checker.py
@@ -67,6 +67,11 @@ A.D=1=
 
 
 class TestPICSChecker(unittest.TestCase):
+    def test_no_file(self):
+        pics_checker = PICSChecker(None)
+        self.assertIsInstance(pics_checker, PICSChecker)
+        self.assertFalse(pics_checker.check('A.A'))
+
     @patch('builtins.open', mock_open(read_data=empty_config))
     def test_empty_config(self):
         pics_checker = PICSChecker('')


### PR DESCRIPTION
… no file is used

#### Problem

`matter_yamltests` pics checker throw if no file is used. This PR updates the code a little bit such that it does not throw anymore and add a test for that case.
