### PR TITLE
[HotFix/Android] data is an optional now.

### DIFF
--- a/examples/tv-app/android/include/application-launcher/ApplicationLauncherManager.cpp
+++ b/examples/tv-app/android/include/application-launcher/ApplicationLauncherManager.cpp
@@ -44,8 +44,8 @@ void ApplicationLauncherManager::HandleLaunchApp(CommandResponseHelper<LauncherR
     // TODO: Insert code here
     LauncherResponseType response;
     const char * buf = "data";
-    response.data    = ByteSpan(from_const_char(buf), strlen(buf));
-    response.status  = ApplicationLauncherStatusEnum::kSuccess;
+    response.data.SetValue(ByteSpan(from_const_char(buf), strlen(buf)));
+    response.status = ApplicationLauncherStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -57,8 +57,8 @@ void ApplicationLauncherManager::HandleStopApp(CommandResponseHelper<LauncherRes
     // TODO: Insert code here
     LauncherResponseType response;
     const char * buf = "data";
-    response.data    = ByteSpan(from_const_char(buf), strlen(buf));
-    response.status  = ApplicationLauncherStatusEnum::kSuccess;
+    response.data.SetValue(ByteSpan(from_const_char(buf), strlen(buf)));
+    response.status = ApplicationLauncherStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -70,7 +70,7 @@ void ApplicationLauncherManager::HandleHideApp(CommandResponseHelper<LauncherRes
     // TODO: Insert code here
     LauncherResponseType response;
     const char * buf = "data";
-    response.data    = ByteSpan(from_const_char(buf), strlen(buf));
-    response.status  = ApplicationLauncherStatusEnum::kSuccess;
+    response.data.SetValue(ByteSpan(from_const_char(buf), strlen(buf)));
+    response.status = ApplicationLauncherStatusEnum::kSuccess;
     helper.Success(response);
 }


### PR DESCRIPTION
#### Problem 

Android is still failing to build with: 
```
INFO    ../../examples/tv-app/android/include/application-launcher/ApplicationLauncherManager.cpp:47:22: error: no viable overloaded '='
INFO        response.data    = ByteSpan(from_const_char(buf), strlen(buf));
INFO        ~~~~~~~~~~~~~    ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO    ../../examples/tv-app/android/third_party/connectedhomeip/src/lib/core/Optional.h:86:26: note: candidate function not viable: no known conversion from 'chip::ByteSpan' (aka 'Span<const unsigned char>') to 'const chip::Optional<chip::Span<const unsigned char> >' for 1st argument
INFO        constexpr Optional & operator=(const Optional & other)
INFO    
```