### PR TITLE
Preserve the old function name for removeStorageDataForKey in Swift.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRStorage.h
+++ b/src/darwin/Framework/CHIP/MTRStorage.h
@@ -48,7 +48,7 @@ MTR_NEWLY_AVAILABLE
  * Delete the key and corresponding data.  Returns YES if the key was present,
  * NO if the key was not present.
  */
-- (BOOL)removeStorageDataForKey:(NSString *)key;
+- (BOOL)removeStorageDataForKey:(NSString *)key NS_SWIFT_NAME(removeStorageData(forKey:));
 
 @end
 


### PR DESCRIPTION
By default, this is getting renamed to "removeData(forKey:)" in Swift, because the protocol is now called MTRStorage and for some reason the Swift name mapping cares about that for just this one function.

This breaks existing consumers.  Use NS_SWIFT_NAME to preserve the existing name.
