### PR TITLE
[HotFix] Rename PlaybackPosition to PlaybackPositionStruct in example…

### DIFF
--- a/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
+++ b/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
@@ -192,9 +192,9 @@ CHIP_ERROR AppMediaPlaybackManager::HandleGetSampledPosition(AttributeValueEncod
             if (!value[attrId].empty() && value[attrId].isObject())
             {
                 std::string updatedAt = to_string(
-                    static_cast<uint32_t>(chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::Fields::kUpdatedAt));
+                    static_cast<uint32_t>(chip::app::Clusters::MediaPlayback::Structs::PlaybackPositionStruct::Fields::kUpdatedAt));
                 std::string position = to_string(
-                    static_cast<uint32_t>(chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::Fields::kPosition));
+                    static_cast<uint32_t>(chip::app::Clusters::MediaPlayback::Structs::PlaybackPositionStruct::Fields::kPosition));
                 if (!value[attrId][updatedAt].empty() && !value[attrId][position].empty() && value[attrId][updatedAt].isUInt() &&
                     value[attrId][position].isUInt())
                 {


### PR DESCRIPTION
#### Problem

Android still fails to build with: 
```
INFO    ../../examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp:195:88: error: no member named 'PlaybackPosition' in namespace 'chip::app::Clusters::MediaPlayback::Structs'
INFO                        static_cast<uint32_t>(chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::Fields::kUpdatedAt));
INFO                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
INFO    ../../examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp:197:88: error: no member named 'PlaybackPosition' in namespace
``
