### PR TITLE
[YamlTests] Update the casing of arguments for Test_TC_ALOGIN_12_1.ya…

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_ALOGIN_12_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ALOGIN_12_1.yaml
@@ -47,7 +47,7 @@ tests:
       command: "LaunchApp"
       arguments:
           values:
-              - name: "data"
+              - name: "Data"
                 value: "Hello World"
               - name: "Application"
                 value:

--- a/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_7.yaml
@@ -42,7 +42,7 @@ tests:
       command: "LaunchApp"
       arguments:
           values:
-              - name: "data"
+              - name: "Data"
                 value: "Hello World"
               - name: "Application"
                 value:


### PR DESCRIPTION
…ml and Test_TC_APPLAUNCHER_3_7.yaml

#### Problem

The casing of some `arguments` of some YAML tests does not match the spec. I found that trying to run the `matter_yamltests` package which is strict about casing.
