### PR TITLE
Compile libwebsockets with intptr_t support enabled

### DIFF
--- a/third_party/libwebsockets/lws_config.h
+++ b/third_party/libwebsockets/lws_config.h
@@ -50,6 +50,7 @@
 //
 // Implied Options
 //
+#define LWS_HAS_INTPTR_T
 #define LWS_WITH_POLL
 #define LWS_MAX_SMP 1
 


### PR DESCRIPTION
### Problem

If `intptr_t` support is not available (should be detected by the configuration script which is not run in our setup) the libwebsockets project falls back to `unsigned long long` which is not right for 32-bit platforms (e.g. Tizen armv7).

All modern toolchains should support `intptr_t` typedef.

### Changes

- define `LWS_HAS_INTPTR_T` in libwebsockets configuration, so `intptr_t` will be used during compilation

### Testing

CI *should* test is, however, somehow, CI is not failing on Tizen builds on master branch.... Anyway, CI will check whether this change will not break other platforms.

Tested locally. Before this change, Tizen build `./scripts/build/build_examples.py --target tizen-arm-chip-tool build` fails with:
```
INFO    ../../examples/chip-tool/third_party/connectedhomeip/third_party/libwebsockets/repo/lib/roles/listen/ops-listen.c: In function ‘rops_handle_POLLIN_listen’:
INFO    ../../examples/chip-tool/third_party/connectedhomeip/third_party/libwebsockets/repo/lib/roles/listen/ops-listen.c:131:5: error: cast to pointer from integer of different size [-Werr
or=int-to-pointer-cast]
INFO      131 |     (void *)(lws_intptr_t)filt.accept_fd, 0)) {
INFO          |     ^
INFO    ../../examples/chip-tool/third_party/connectedhomeip/third_party/libwebsockets/repo/lib/roles/listen/ops-listen.c: At top level:
INFO    cc1: error: unrecognized command line option ‘-Wno-unknown-warning-option’ [-Werror]
INFO    cc1: all warnings being treated as errors
```