### PR TITLE
Validate target names passed to build_examples.py

### DIFF
--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -61,9 +61,9 @@ jobs:
                         --enable-flashbundle \
                         --target tizen-arm-all-clusters \
                         --target tizen-arm-all-clusters-minimal-no-wifi \
-                        --target chip-tool-ubsan \
-                        --target light \
-                        --target light-no-ble-no-wifi \
+                        --target tizen-arm-chip-tool-ubsan \
+                        --target tizen-arm-light \
+                        --target tizen-arm-light-no-ble-no-wifi \
                         build \
                         --copy-artifacts-to out/artifacts \
                     "

--- a/.gitmodules
+++ b/.gitmodules
@@ -293,4 +293,4 @@
 [submodule "third_party/libwebsockets/repo"]
 	path = third_party/libwebsockets/repo
 	url = https://github.com/warmcat/libwebsockets
-	platforms = linux,darwin
+	platforms = linux,darwin,tizen

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -59,6 +59,18 @@ def ValidateRepoPath(context, parameter, value):
     return value
 
 
+def ValidateTargetNames(context, parameter, values):
+    """
+    Validates that the given target name is valid.
+    """
+    for value in values:
+        if not any(target.StringIntoTargetParts(value.lower())
+                   for target in build.targets.BUILD_TARGETS):
+            raise click.BadParameter(
+                "'%s' is not a valid target name." % value)
+    return values
+
+
 @click.group(chain=True)
 @click.option(
     '--log-level',
@@ -69,6 +81,7 @@ def ValidateRepoPath(context, parameter, value):
     '--target',
     default=[],
     multiple=True,
+    callback=ValidateTargetNames,
     help='Build target(s)'
 )
 @click.option(

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -20,10 +20,10 @@ import sys
 
 import click
 import coloredlogs
-
-import build
 from builders.builder import BuilderOptions
 from runner import PrintOnlyRunner, ShellRunner
+
+import build
 
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 


### PR DESCRIPTION
### Problem

Skipping invalid target names might lead to false positive CI passes in case when target name is invalid. In such case test was never executed. Related to #24643 

### Changes

- added validation for `--target` option in `./scripts/build/build_examples.py --target XXX build` script
- fixed target names in Tizen example workflow file

### Testing

CI will test if there are some other incorrect names in CI workflows. Tested manually:
```
./scripts/build/build_examples.py --target chip-tool build
Usage: build_examples.py [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...
Try 'build_examples.py --help' for help.

Error: Invalid value for '--target': 'chip-tool' is not a valid target name.
```