### PR TITLE
Fix target name for chip cert on arm cross compile

### DIFF
--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -73,7 +73,7 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
-                        --target linux-arm64-chip-cert \
+                        --target linux-arm64-chip-cert-clang \
                         --target linux-arm64-all-clusters-clang \
                         --target linux-arm64-chip-tool-ipv6only-clang \
                         --target linux-arm64-lock-clang \


### PR DESCRIPTION
#24644 found that the arm64 cross compile target was wrong (log says `'arm64' does not support 'linux-arm64-chip-cert' due to rule ONLY IF '-(clang|nodeps)'`.

Updated to add -clang to the build instruction like all other build targets.
