### PR TITLE
Only run bloat check on main repo

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -27,6 +27,9 @@ jobs:
     pull_request_update:
         name: Report on pull requests
 
+        # Don't run on forked repos
+        if: github.repository_owner == 'project-chip'
+
         runs-on: ubuntu-latest
 
         container:


### PR DESCRIPTION
👋 hi! I work on GitHub Actions and noticed that this repository and its forks were consuming a lot of minutes for OSS. This appears to be from a few things:

1. Bloat check runs every 5 minutes.
2. Bloat check checks out the repository with submodules, which takes ~8 minutes.
3. Forks that enable Actions inherit scheduled jobs.

These things together have led to about 500 forks of this repo running Actions constantly to run a report for this repo, which I don't believe to be the intent.

This PR is simple and only runs this scheduled workflow on `project-chip/connectedhomeip` and not on any forks. Existing forks that don't update will unfortunately continue executing, but new forks and any forks that update from this repo will adopt this change and result in less usage overall.

Another thing that I wasn't able to validate was if this report requires the submodules for execution. If not, removing `with: submodules: true` from the checkout step would reduce runtime of the job by about 8 minutes.