### PR TITLE
[matter_yamltests] Update try_update_yaml_node_id_test_runner_state t…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/fixes.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/fixes.py
@@ -100,8 +100,9 @@ def try_add_yaml_support_for_scientific_notation_without_dot(loader):
 # accessory. But this state may not exist in the runner (as in it prevent to have multiple node ids
 # associated to a fabric...) so the 'nodeId' needs to be added back manually.
 def try_update_yaml_node_id_test_runner_state(tests, config):
+    default_identity = 'alpha'
     identities = {
-        'alpha': None if 'nodeId' not in config else config['nodeId']}
+        default_identity: None if 'nodeId' not in config else config['nodeId']}
 
     for test in tests:
         if not test.is_enabled:
@@ -109,11 +110,21 @@ def try_update_yaml_node_id_test_runner_state(tests, config):
 
         identity = test.identity
 
-        if test.cluster == 'CommissionerCommands':
-            if test.command == 'PairWithCode':
+        if test.cluster == 'CommissionerCommands' or test.cluster == 'DelayCommands':
+            if test.command == 'PairWithCode' or test.command == 'WaitForCommissionee':
+                if test.response_with_placeholders:
+                    # It the test expects an error, we should not update the
+                    # nodeId of the identity.
+                    error = test.response_with_placeholders.get('error')
+                    if error:
+                        continue
+
                 for item in test.arguments_with_placeholders['values']:
                     if item['name'] == 'nodeId':
                         identities[identity] = item['value']
         elif identity is not None and identity in identities:
             node_id = identities[identity]
+            test.node_id = node_id
+        elif identity is None and default_identity in identities:
+            node_id = identities[default_identity]
             test.node_id = node_id

--- a/src/controller/python/chip/yaml/runner.py
+++ b/src/controller/python/chip/yaml/runner.py
@@ -241,7 +241,6 @@ class WaitForCommissioneeAction(BaseAction):
 
     def __init__(self, test_step):
         super().__init__(test_step)
-        self._node_id = test_step.node_id
         self._expire_existing_session = False
         # This is the default when no timeout is provided.
         _DEFAULT_TIMEOUT_MS = 10 * 1000
@@ -254,6 +253,7 @@ class WaitForCommissioneeAction(BaseAction):
         args = test_step.arguments['values']
         request_data_as_dict = Converter.convert_list_of_name_value_pair_to_dict(args)
 
+        self._node_id = request_data_as_dict['nodeId']
         self._expire_existing_session = request_data_as_dict.get('expireExistingSession', False)
         if 'timeout' in request_data_as_dict:
             # Timeout is provided in seconds we need to conver to milliseconds.


### PR DESCRIPTION
…o take into account WaitForCommissionee and cases where the node id should not be updated

#### Problem

When `DelayCommands::WaitForCommissionee` is used in the YAML tests, the node id of the used identity is not updated.
Furthermore, when `DelayCommands::WaitForCommissionee` or `CommissionerCommands::PairWithCode` is used but expects a failure, the node id is updated when it should not.