### PR TITLE
[matter_yamltests] Fix the pics checker

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/pics_checker.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pics_checker.py
@@ -92,12 +92,12 @@ class PICSChecker():
 
         if token == '&&':
             self.__expression_index += 1
-            rightExpr = self.__evaluate_sub_expression(tokens, pics)
+            rightExpr = self.__evaluate_expression(tokens, pics)
             return leftExpr and rightExpr
 
         if token == '||':
             self.__expression_index += 1
-            rightExpr = self.__evaluate_sub_expression(tokens, pics)
+            rightExpr = self.__evaluate_expression(tokens, pics)
             return leftExpr or rightExpr
 
         raise InvalidPICSParsingError(f'Unknown token: {token}')
@@ -115,7 +115,7 @@ class PICSChecker():
 
         if token == '!':
             self.__expression_index += 1
-            expr = self.__evaluate_expression(tokens, pics)
+            expr = self.__evaluate_sub_expression(tokens, pics)
             return not expr
 
         token = self.__normalize(token)

--- a/scripts/py_matter_yamltests/test_pics_checker.py
+++ b/scripts/py_matter_yamltests/test_pics_checker.py
@@ -65,6 +65,15 @@ simple_config_with_invalid_entry_6 = '''
 A.D=1=
 '''
 
+simple_real_config = '''
+# Color Control Cluster
+CC.S.F00=0
+CC.S.F01=1
+CC.S.F02=1
+CC.S.F03=1
+CC.S.F04=1
+'''
+
 
 class TestPICSChecker(unittest.TestCase):
     def test_no_file(self):
@@ -167,6 +176,13 @@ class TestPICSChecker(unittest.TestCase):
         with patch("builtins.open", mock_open(read_data=simple_config_with_invalid_entry_6)) as mock_file:
             self.assertRaises(InvalidPICSConfigurationError,
                               PICSChecker, mock_file)
+
+    @patch('builtins.open', mock_open(read_data=simple_real_config))
+    def test_simple_real_config(self):
+        pics_checker = PICSChecker('')
+        self.assertIsInstance(pics_checker, PICSChecker)
+        self.assertFalse(pics_checker.check(
+            '( !CC.S.F00 && !CC.S.F01 && !CC.S.F02 && !CC.S.F03 && !CC.S.F04 )'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### Problem

When running tests locally with `matter_yamltests` and `chip-tool` I found out that the PICS checker implementation fails on some expressions from the YAML test suites. I fixed that and have added a test for the expression that was failing.

