### PR TITLE
[matter_yamltests] Add try_apply_float_to_integer_fix since Test_TC_C…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/fixes.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/fixes.py
@@ -35,6 +35,18 @@ def try_apply_yaml_cpp_longlong_limitation_fix(value):
     return value
 
 
+def try_apply_float_to_integer_fix(value):
+    '''Fix math operations where values ends up beeing a float for integer types.
+
+    For example one of the color control test configure the ColoremperatureMireds value to be:
+        (ColorTempPhysicalMinMireds + ColorTempPhysicalMaxMireds)/2
+    In this specific example it ends up as '32639.5', which is invalid.
+    '''
+    if isinstance(value, float):
+        return int(value)
+    return value
+
+
 def try_apply_yaml_unrepresentable_integer_for_javascript_fixes(value):
     '''Fix up large integers that are represented within a string.
 

--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -371,11 +371,14 @@ class _TestStepWithPlaceholders:
         # the wrong thing below.
         if value is not None and value not in self._parsing_config_variable_storage:
             if mapping_type == 'int64u' or mapping_type == 'int64s' or mapping_type == 'bitmap64' or mapping_type == 'epoch_us':
+                value = fixes.try_apply_float_to_integer_fix(value)
                 value = fixes.try_apply_yaml_cpp_longlong_limitation_fix(value)
                 value = fixes.try_apply_yaml_unrepresentable_integer_for_javascript_fixes(
                     value)
             elif mapping_type == 'single' or mapping_type == 'double':
                 value = fixes.try_apply_yaml_float_written_as_strings(value)
+            elif isinstance(value, float) and mapping_type != 'single' and mapping_type != 'double':
+                value = fixes.try_apply_float_to_integer_fix(value)
             elif mapping_type == 'octet_string' or mapping_type == 'long_octet_string':
                 value = fixes.convert_yaml_octet_string_to_bytes(value)
             elif mapping_type == 'boolean':


### PR DESCRIPTION
…C_6_2 makes math operation to configure a value that ends up as a float while a int is expected

#### Problem

When running tests with `matter_yamltests` and `chip-tool` locally I found out that some dynamic values are ending up as float when they should ends up as an integer. In C++ this was sort of automatic but we need to make it manually now.

