### PR TITLE
Ensure repl tests stack cleanup even on errors.

### DIFF
--- a/scripts/py_matter_idl/matter_idl/zapxml/handlers/handlers.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/handlers/handlers.py
@@ -22,6 +22,9 @@ from .context import Context, IdlPostProcessor
 from .parsing import AttrsToAccessPrivilege, AttrsToAttribute, ParseInt
 
 
+LOGGER = logging.getLogger('matter-xml-parser')
+
+
 class ClusterNameHandler(BaseHandler):
     """Handles /configurator/cluster/name elements."""
 
@@ -137,7 +140,7 @@ class AttributeHandler(BaseHandler):
                 elif attrs['op'] == 'write':
                     self._attribute.writeacl = role
                 else:
-                    logging.error("Unknown access: %r" % attrs['op'])
+                    LOGGER.error("Unknown access: %r" % attrs['op'])
 
             return BaseHandler(self.context, handled=HandledDepth.SINGLE_TAG)
         elif name.lower() == 'description':
@@ -230,7 +233,7 @@ class StructHandler(BaseHandler, IdlPostProcessor):
                         found = True
 
                 if not found:
-                    logging.error('Enum %s could not find cluster (code %d/0x%X)' %
+                    LOGGER.error('Enum %s could not find cluster (code %d/0x%X)' %
                                   (self._struct.name, code, code))
         else:
             idl.structs.append(self._struct)
@@ -279,7 +282,7 @@ class EnumHandler(BaseHandler, IdlPostProcessor):
                     found = True
 
             if not found:
-                logging.error('Enum %s could not find its cluster (code %d/0x%X)' %
+                LOGGER.error('Enum %s could not find its cluster (code %d/0x%X)' %
                               (self._enum.name, self._cluster_code, self._cluster_code))
 
     def EndProcessing(self):
@@ -319,7 +322,7 @@ class BitmapHandler(BaseHandler):
             # Log only instead of critical, as not our XML is well formed.
             # For example at the time of writing this, SwitchFeature in switch-cluster.xml
             # did not have a code associated with it.
-            logging.error("Bitmap %r has no cluster codes" % self._bitmap)
+            LOGGER.error("Bitmap %r has no cluster codes" % self._bitmap)
             return
 
         for code in self._cluster_codes:
@@ -329,7 +332,7 @@ class BitmapHandler(BaseHandler):
                     c.bitmaps.append(self._bitmap)
                     found = True
             if not found:
-                logging.error('Bitmap %s could not find its cluster (code %d/0x%X)' %
+                LOGGER.error('Bitmap %s could not find its cluster (code %d/0x%X)' %
                               (self._bitmap.name, code, code))
 
     def EndProcessing(self):
@@ -413,7 +416,7 @@ class CommandHandler(BaseHandler):
             if self._command:
                 self._command.invokeacl = AttrsToAccessPrivilege(attrs)
             else:
-                logging.warning(
+                LOGGER.warning(
                     "Ignored access role for reply %r" % self._struct)
             return BaseHandler(self.context, handled=HandledDepth.SINGLE_TAG)
         elif name.lower() == 'arg':
@@ -448,7 +451,7 @@ class ClusterGlobalAttributeHandler(BaseHandler):
         if name.lower() == 'featurebit':
             # It is uncler what featurebits mean. likely a bitmap should be created
             # here, however only one such example exists currently: door-lock-cluster.xml
-            logging.info('Ignoring featurebit tag for global attribute 0x%X (%d)' % (
+            LOGGER.info('Ignoring featurebit tag for global attribute 0x%X (%d)' % (
                 self._code, self._code))
             return BaseHandler(self.context, handled=HandledDepth.SINGLE_TAG)
         else:
@@ -533,7 +536,7 @@ class ClusterExtensionHandler(ClusterHandler, IdlPostProcessor):
                 c.commands.extend(self._cluster.commands)
 
         if not found:
-            logging.error('Could not extend cluster 0x%X (%d): cluster not found' %
+            LOGGER.error('Could not extend cluster 0x%X (%d): cluster not found' %
                           (self._cluster_code, self._cluster_code))
 
 
@@ -572,7 +575,7 @@ class GlobalHandler(BaseHandler):
             if attrs['side'].lower() == 'client':
                 # We expect to also have 'server' equivalent, so ignore client
                 # side attributes
-                logging.debug(
+                LOGGER.debug(
                     'Ignoring global client-side attribute %s' % (attrs['code']))
                 return BaseHandler(self.context, handled=HandledDepth.SINGLE_TAG)
 

--- a/scripts/py_matter_idl/matter_idl/zapxml/handlers/handlers.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/handlers/handlers.py
@@ -21,7 +21,6 @@ from .base import BaseHandler, HandledDepth
 from .context import Context, IdlPostProcessor
 from .parsing import AttrsToAccessPrivilege, AttrsToAttribute, ParseInt
 
-
 LOGGER = logging.getLogger('matter-xml-parser')
 
 
@@ -234,7 +233,7 @@ class StructHandler(BaseHandler, IdlPostProcessor):
 
                 if not found:
                     LOGGER.error('Enum %s could not find cluster (code %d/0x%X)' %
-                                  (self._struct.name, code, code))
+                                 (self._struct.name, code, code))
         else:
             idl.structs.append(self._struct)
 
@@ -283,7 +282,7 @@ class EnumHandler(BaseHandler, IdlPostProcessor):
 
             if not found:
                 LOGGER.error('Enum %s could not find its cluster (code %d/0x%X)' %
-                              (self._enum.name, self._cluster_code, self._cluster_code))
+                             (self._enum.name, self._cluster_code, self._cluster_code))
 
     def EndProcessing(self):
         self.context.AddIdlPostProcessor(self)
@@ -333,7 +332,7 @@ class BitmapHandler(BaseHandler):
                     found = True
             if not found:
                 LOGGER.error('Bitmap %s could not find its cluster (code %d/0x%X)' %
-                              (self._bitmap.name, code, code))
+                             (self._bitmap.name, code, code))
 
     def EndProcessing(self):
         self.context.AddIdlPostProcessor(self)
@@ -537,7 +536,7 @@ class ClusterExtensionHandler(ClusterHandler, IdlPostProcessor):
 
         if not found:
             LOGGER.error('Could not extend cluster 0x%X (%d): cluster not found' %
-                          (self._cluster_code, self._cluster_code))
+                         (self._cluster_code, self._cluster_code))
 
 
 class GlobalAttributeHandler(BaseHandler):

--- a/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
+++ b/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
@@ -14,6 +14,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import atexit
 import os
 import tempfile
 import traceback
@@ -38,6 +39,10 @@ _DEFAULT_CHIP_ROOT = os.path.abspath(
 _CLUSTER_XML_DIRECTORY_PATH = os.path.abspath(
     os.path.join(_DEFAULT_CHIP_ROOT, "src/app/zap-templates/zcl/data-model/"))
 
+
+def StackShutdown():
+    certificateAuthorityManager.Shutdown()
+    builtins.chipStack.Shutdown()
 
 @click.command()
 @click.option(
@@ -78,9 +83,18 @@ def main(setup_code, yaml_path, node_id, pics_file):
         dev_ctrl = ca_list[0].adminList[0].NewController()
         dev_ctrl.CommissionWithCode(setup_code, node_id)
 
+        def _StackShutDown():
+            # Tearing down chip stack. If not done in the correct order test will fail.
+            certificate_authority_manager.Shutdown()
+            chip_stack.Shutdown()
+
+        atexit.register(_StackShutDown)
+
         try:
             # Creating Cluster definition.
-            clusters_definitions = SpecDefinitionsFromPath(_CLUSTER_XML_DIRECTORY_PATH + '/*/*.xml')
+            clusters_definitions = SpecDefinitionsFromPath(
+                _CLUSTER_XML_DIRECTORY_PATH + '/*/*.xml',
+            )
 
             # Parsing YAML test and setting up chip-repl yamltests runner.
             yaml = TestParser(yaml_path, pics_file, clusters_definitions)
@@ -105,9 +119,6 @@ def main(setup_code, yaml_path, node_id, pics_file):
             exit(-2)
 
         runner.shutdown()
-        # Tearing down chip stack. If not done in the correct order test will fail.
-        certificate_authority_manager.Shutdown()
-        chip_stack.Shutdown()
 
 
 if __name__ == '__main__':

--- a/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
+++ b/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
@@ -44,6 +44,7 @@ def StackShutdown():
     certificateAuthorityManager.Shutdown()
     builtins.chipStack.Shutdown()
 
+
 @click.command()
 @click.option(
     '--setup-code',


### PR DESCRIPTION
Without this, the script would fail with SEGFAULT due to the stack init doing a 
`DeviceControllerFactory::GetInstance().RetainSystemState();`
in `src/controller/python/ChipDeviceController-ScriptBinding.cpp`

This moves the cleanup code in an `atexit` registration.

Also made parser logging to go to a dedicated logger in case we want to control that log verbosity.