### PR TITLE
Add missing cluster codes to bitmaps in ethernet-network-diagnostics-cluster.xml and wifi-network-diagnostics-cluster.xml

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -1476,6 +1476,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1520,6 +1525,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -1299,6 +1299,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1333,6 +1338,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -1103,6 +1103,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1145,6 +1150,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -959,6 +959,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1003,6 +1008,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.matter
+++ b/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.matter
@@ -951,6 +951,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -995,6 +1000,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/dynamic-bridge-app/bridge-common/bridge-app.matter
+++ b/examples/dynamic-bridge-app/bridge-common/bridge-app.matter
@@ -1103,6 +1103,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1145,6 +1150,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -1153,6 +1153,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1197,6 +1202,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -1105,6 +1105,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1149,6 +1154,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -1021,6 +1021,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1065,6 +1070,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -1155,6 +1155,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1199,6 +1204,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -1132,6 +1132,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1176,6 +1181,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
+++ b/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
@@ -548,6 +548,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -590,6 +595,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -1113,6 +1113,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1155,6 +1160,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -1155,6 +1155,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1197,6 +1202,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -1322,6 +1322,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1364,6 +1369,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -1169,6 +1169,11 @@ server cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1211,6 +1216,11 @@ server cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/src/app/zap-templates/zcl/data-model/chip/ethernet-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/ethernet-network-diagnostics-cluster.xml
@@ -29,6 +29,11 @@ limitations under the License.
     <item name="Rate200G" value="0x08"/>
     <item name="Rate400G" value="0x09"/>                
   </enum>
+  <bitmap name="EthernetNetworkDiagnosticsFeature" type="BITMAP32">
+    <cluster code="0x0037"/>
+    <field name="PacketCounts" mask="0x1"/>
+    <field name="ErrorCounts" mask="0x2"/>
+  </bitmap>  
   <cluster>
     <domain>General</domain>
     <name>Ethernet Network Diagnostics</name>
@@ -48,8 +53,4 @@ limitations under the License.
       <description>Reception of this command SHALL reset the attributes: PacketRxCount, PacketTxCount, TxErrCount, CollisionCount, OverrunCount to 0</description>
     </command>           
   </cluster>
-  <bitmap name="EthernetNetworkDiagnosticsFeature" type="BITMAP32">
-    <field name="PacketCounts" mask="0x1"/>
-    <field name="ErrorCounts" mask="0x2"/>
-  </bitmap>  
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/wifi-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/wifi-network-diagnostics-cluster.xml
@@ -46,6 +46,11 @@ limitations under the License.
     <item name="Connected" value="0x00"/>
     <item name="NotConnected" value="0x01"/>
   </enum>  
+  <bitmap name="WiFiNetworkDiagnosticsFeature" type="BITMAP32">
+    <cluster code="0x0036"/>
+    <field name="PacketCounts" mask="0x1"/>
+    <field name="ErrorCounts" mask="0x2"/>
+  </bitmap>  
   <cluster>
     <domain>General</domain>
     <name>WiFi Network Diagnostics</name>
@@ -82,8 +87,4 @@ limitations under the License.
       <field id="0" name="ConnectionStatus" type="WiFiConnectionStatus"/>
     </event>                  
   </cluster>
-  <bitmap name="WiFiNetworkDiagnosticsFeature" type="BITMAP32">
-    <field name="PacketCounts" mask="0x1"/>
-    <field name="ErrorCounts" mask="0x2"/>
-  </bitmap>  
 </configurator>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -1620,6 +1620,11 @@ client cluster WiFiNetworkDiagnostics = 54 {
     kAx = 5;
   }
 
+  bitmap WiFiNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
+  }
+
   info event Disconnection = 0 {
     INT16U reasonCode = 0;
   }
@@ -1667,6 +1672,11 @@ client cluster EthernetNetworkDiagnostics = 55 {
     kRate100G = 7;
     kRate200G = 8;
     kRate400G = 9;
+  }
+
+  bitmap EthernetNetworkDiagnosticsFeature : BITMAP32 {
+    kPacketCounts = 0x1;
+    kErrorCounts = 0x2;
   }
 
   readonly attribute nullable PHYRateEnum PHYRate = 0;

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -9802,6 +9802,11 @@ class WiFiNetworkDiagnostics(Cluster):
             kUnknownEnumValue = 6,
 
 
+    class Bitmaps:
+        class WiFiNetworkDiagnosticsFeature(IntFlag):
+            kPacketCounts = 0x1
+            kErrorCounts = 0x2
+
 
 
     class Commands:
@@ -10228,6 +10233,11 @@ class EthernetNetworkDiagnostics(Cluster):
             # enum value. This specific should never be transmitted.
             kUnknownEnumValue = 10,
 
+
+    class Bitmaps:
+        class EthernetNetworkDiagnosticsFeature(IntFlag):
+            kPacketCounts = 0x1
+            kErrorCounts = 0x2
 
 
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -17811,6 +17811,11 @@ typedef NS_ENUM(uint8_t, MTRWiFiNetworkDiagnosticsWiFiVersionType) {
     = 0x05,
 } API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
+typedef NS_OPTIONS(uint32_t, MTRWiFiNetworkDiagnosticsFeature) {
+    MTRWiFiNetworkDiagnosticsFeaturePacketCounts MTR_NEWLY_AVAILABLE = 0x1,
+    MTRWiFiNetworkDiagnosticsFeatureErrorCounts MTR_NEWLY_AVAILABLE = 0x2,
+} MTR_NEWLY_AVAILABLE;
+
 typedef NS_ENUM(uint8_t, MTREthernetNetworkDiagnosticsPHYRate) {
     MTREthernetNetworkDiagnosticsPHYRateRate10M MTR_NEWLY_AVAILABLE = 0x00,
     MTREthernetNetworkDiagnosticsPHYRateRate100M MTR_NEWLY_AVAILABLE = 0x01,
@@ -17857,6 +17862,11 @@ typedef NS_ENUM(uint8_t, MTREthernetNetworkDiagnosticsPHYRateType) {
     = 0x09,
 } API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
     MTR_NEWLY_DEPRECATED("Please use MTREthernetNetworkDiagnosticsPHYRate");
+
+typedef NS_OPTIONS(uint32_t, MTREthernetNetworkDiagnosticsFeature) {
+    MTREthernetNetworkDiagnosticsFeaturePacketCounts MTR_NEWLY_AVAILABLE = 0x1,
+    MTREthernetNetworkDiagnosticsFeatureErrorCounts MTR_NEWLY_AVAILABLE = 0x2,
+} MTR_NEWLY_AVAILABLE;
 
 typedef NS_ENUM(uint8_t, MTRTimeSynchronizationGranularity) {
     MTRTimeSynchronizationGranularityNoTimeGranularity API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x00,

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -1071,6 +1071,13 @@ enum class WiFiVersionType : uint8_t
 using WiFiVersionType                                                                  = EmberAfWiFiVersionType;
 static WiFiVersionType __attribute__((unused)) kWiFiVersionTypekUnknownEnumValue       = static_cast<WiFiVersionType>(6);
 #endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
+
+// Bitmap for WiFiNetworkDiagnosticsFeature
+enum class WiFiNetworkDiagnosticsFeature : uint32_t
+{
+    kPacketCounts = 0x1,
+    kErrorCounts  = 0x2,
+};
 } // namespace WiFiNetworkDiagnostics
 
 namespace EthernetNetworkDiagnostics {
@@ -1101,6 +1108,13 @@ enum class PHYRateEnum : uint8_t
 using PHYRateEnum                                                                      = EmberAfPHYRateEnum;
 static PHYRateEnum __attribute__((unused)) kPHYRateEnumkUnknownEnumValue               = static_cast<PHYRateEnum>(10);
 #endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
+
+// Bitmap for EthernetNetworkDiagnosticsFeature
+enum class EthernetNetworkDiagnosticsFeature : uint32_t
+{
+    kPacketCounts = 0x1,
+    kErrorCounts  = 0x2,
+};
 } // namespace EthernetNetworkDiagnostics
 
 namespace TimeSynchronization {


### PR DESCRIPTION
#### Problem

`EthernetNetworkDiagnosticsFeature` and `WiFiNetworkDiagnosticsFeature` are missing cluster codes. This PR just adds those with `./scripts/tools/zap_regen_all.py`.