### PR TITLE
Move thermostat related bitmap/enums from silabs/types.xml to thermostat-cluster.xml, add missing cluster codes and renamed enums/bitmaps fields to match the spec

### DIFF
--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -2267,6 +2267,21 @@ server cluster Thermostat = 513 {
     kBoth = 2;
   }
 
+  enum StartOfWeek : ENUM8 {
+    kSunday = 0;
+    kMonday = 1;
+    kTuesday = 2;
+    kWednesday = 3;
+    kThursday = 4;
+    kFriday = 5;
+    kSaturday = 6;
+  }
+
+  enum TemperatureSetpointHold : ENUM8 {
+    kSetpointHoldOff = 0;
+    kSetpointHoldOn = 1;
+  }
+
   enum ThermostatControlSequence : ENUM8 {
     kCoolingOnly = 0;
     kCoolingWithReheat = 1;
@@ -2310,6 +2325,12 @@ server cluster Thermostat = 513 {
     kCoolSetpointPresent = 0x2;
   }
 
+  bitmap ThermostatAlarmMask : BITMAP8 {
+    kInitializationFailure = 0x1;
+    kHardwareFailure = 0x2;
+    kSelfCalibrationFailure = 0x4;
+  }
+
   bitmap ThermostatFeature : BITMAP32 {
     kHeating = 0x1;
     kCooling = 0x2;
@@ -2317,6 +2338,26 @@ server cluster Thermostat = 513 {
     kScheduleConfiguration = 0x8;
     kSetback = 0x10;
     kAutoMode = 0x20;
+  }
+
+  bitmap ThermostatOccupancy : BITMAP8 {
+    kOccupied = 0x1;
+  }
+
+  bitmap ThermostatRemoteSensing : BITMAP8 {
+    kLocalTemperature = 0x1;
+    kOutdoorTemperature = 0x2;
+    kOccupancy = 0x4;
+  }
+
+  bitmap ThermostatRunningState : BITMAP16 {
+    kHeat = 0x1;
+    kCool = 0x2;
+    kFan = 0x4;
+    kHeatStage2 = 0x8;
+    kCoolStage2 = 0x10;
+    kFanStage2 = 0x20;
+    kFanStage3 = 0x40;
   }
 
   struct ThermostatScheduleTransition {
@@ -2328,7 +2369,7 @@ server cluster Thermostat = 513 {
   readonly attribute nullable int16s localTemperature = 0;
   attribute int16s occupiedHeatingSetpoint = 18;
   attribute access(write: manage) ThermostatControlSequence controlSequenceOfOperation = 27;
-  attribute access(write: manage) enum8 systemMode = 28;
+  attribute access(write: manage) ThermostatSystemMode systemMode = 28;
   readonly attribute bitmap32 featureMap = 65532;
   readonly attribute int16u clusterRevision = 65533;
 

--- a/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
+++ b/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
@@ -1172,6 +1172,21 @@ client cluster Thermostat = 513 {
     kBoth = 2;
   }
 
+  enum StartOfWeek : ENUM8 {
+    kSunday = 0;
+    kMonday = 1;
+    kTuesday = 2;
+    kWednesday = 3;
+    kThursday = 4;
+    kFriday = 5;
+    kSaturday = 6;
+  }
+
+  enum TemperatureSetpointHold : ENUM8 {
+    kSetpointHoldOff = 0;
+    kSetpointHoldOn = 1;
+  }
+
   enum ThermostatControlSequence : ENUM8 {
     kCoolingOnly = 0;
     kCoolingWithReheat = 1;
@@ -1215,6 +1230,12 @@ client cluster Thermostat = 513 {
     kCoolSetpointPresent = 0x2;
   }
 
+  bitmap ThermostatAlarmMask : BITMAP8 {
+    kInitializationFailure = 0x1;
+    kHardwareFailure = 0x2;
+    kSelfCalibrationFailure = 0x4;
+  }
+
   bitmap ThermostatFeature : BITMAP32 {
     kHeating = 0x1;
     kCooling = 0x2;
@@ -1224,11 +1245,31 @@ client cluster Thermostat = 513 {
     kAutoMode = 0x20;
   }
 
+  bitmap ThermostatOccupancy : BITMAP8 {
+    kOccupied = 0x1;
+  }
+
+  bitmap ThermostatRemoteSensing : BITMAP8 {
+    kLocalTemperature = 0x1;
+    kOutdoorTemperature = 0x2;
+    kOccupancy = 0x4;
+  }
+
+  bitmap ThermostatRunningState : BITMAP16 {
+    kHeat = 0x1;
+    kCool = 0x2;
+    kFan = 0x4;
+    kHeatStage2 = 0x8;
+    kCoolStage2 = 0x10;
+    kFanStage2 = 0x20;
+    kFanStage3 = 0x40;
+  }
+
   readonly attribute nullable int16s localTemperature = 0;
   attribute int16s occupiedCoolingSetpoint = 17;
   attribute int16s occupiedHeatingSetpoint = 18;
   attribute access(write: manage) ThermostatControlSequence controlSequenceOfOperation = 27;
-  attribute access(write: manage) enum8 systemMode = 28;
+  attribute access(write: manage) ThermostatSystemMode systemMode = 28;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
   readonly attribute attrib_id attributeList[] = 65531;

--- a/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
+++ b/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
@@ -1034,6 +1034,21 @@ server cluster Thermostat = 513 {
     kBoth = 2;
   }
 
+  enum StartOfWeek : ENUM8 {
+    kSunday = 0;
+    kMonday = 1;
+    kTuesday = 2;
+    kWednesday = 3;
+    kThursday = 4;
+    kFriday = 5;
+    kSaturday = 6;
+  }
+
+  enum TemperatureSetpointHold : ENUM8 {
+    kSetpointHoldOff = 0;
+    kSetpointHoldOn = 1;
+  }
+
   enum ThermostatControlSequence : ENUM8 {
     kCoolingOnly = 0;
     kCoolingWithReheat = 1;
@@ -1077,6 +1092,12 @@ server cluster Thermostat = 513 {
     kCoolSetpointPresent = 0x2;
   }
 
+  bitmap ThermostatAlarmMask : BITMAP8 {
+    kInitializationFailure = 0x1;
+    kHardwareFailure = 0x2;
+    kSelfCalibrationFailure = 0x4;
+  }
+
   bitmap ThermostatFeature : BITMAP32 {
     kHeating = 0x1;
     kCooling = 0x2;
@@ -1086,9 +1107,29 @@ server cluster Thermostat = 513 {
     kAutoMode = 0x20;
   }
 
+  bitmap ThermostatOccupancy : BITMAP8 {
+    kOccupied = 0x1;
+  }
+
+  bitmap ThermostatRemoteSensing : BITMAP8 {
+    kLocalTemperature = 0x1;
+    kOutdoorTemperature = 0x2;
+    kOccupancy = 0x4;
+  }
+
+  bitmap ThermostatRunningState : BITMAP16 {
+    kHeat = 0x1;
+    kCool = 0x2;
+    kFan = 0x4;
+    kHeatStage2 = 0x8;
+    kCoolStage2 = 0x10;
+    kFanStage2 = 0x20;
+    kFanStage3 = 0x40;
+  }
+
   readonly attribute nullable int16s localTemperature = 0;
   readonly attribute nullable int16s outdoorTemperature = 1;
-  readonly attribute bitmap8 occupancy = 2;
+  readonly attribute ThermostatOccupancy occupancy = 2;
   readonly attribute int16s absMinHeatSetpointLimit = 3;
   readonly attribute int16s absMaxHeatSetpointLimit = 4;
   readonly attribute int16s absMinCoolSetpointLimit = 5;
@@ -1106,11 +1147,11 @@ server cluster Thermostat = 513 {
   attribute access(write: manage) int16s minCoolSetpointLimit = 23;
   attribute access(write: manage) int16s maxCoolSetpointLimit = 24;
   attribute access(write: manage) int8s minSetpointDeadBand = 25;
-  attribute access(write: manage) bitmap8 remoteSensing = 26;
+  attribute access(write: manage) ThermostatRemoteSensing remoteSensing = 26;
   attribute access(write: manage) ThermostatControlSequence controlSequenceOfOperation = 27;
-  attribute access(write: manage) enum8 systemMode = 28;
-  readonly attribute enum8 thermostatRunningMode = 30;
-  readonly attribute enum8 startOfWeek = 32;
+  attribute access(write: manage) ThermostatSystemMode systemMode = 28;
+  readonly attribute ThermostatRunningMode thermostatRunningMode = 30;
+  readonly attribute StartOfWeek startOfWeek = 32;
   readonly attribute int8u numberOfWeeklyTransitions = 33;
   readonly attribute int8u numberOfDailyTransitions = 34;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
@@ -16,6 +16,127 @@ limitations under the License.
 -->
 <configurator>
   <domain name="HVAC"/>
+
+  <bitmap name="ThermostatOccupancy" type="BITMAP8">
+    <cluster code="0x0201"/>
+    <field name="Occupied" mask="0x1"/>
+  </bitmap>
+
+  <bitmap name="ThermostatRemoteSensing" type="BITMAP8">
+    <cluster code="0x0201"/>
+    <field name="LocalTemperature" mask="0x1"/>
+    <field name="OutdoorTemperature" mask="0x2"/>
+    <field name="Occupancy" mask="0x4"/>
+  </bitmap>
+
+  <enum name="ThermostatControlSequence" type="ENUM8">
+    <cluster code="0x0201"/>
+    <item name="CoolingOnly" value="0x0"/>
+    <item name="CoolingWithReheat" value="0x1"/>
+    <item name="HeatingOnly" value="0x2"/>
+    <item name="HeatingWithReheat" value="0x3"/>
+    <item name="CoolingAndHeating" value="0x4"/>
+    <item name="CoolingAndHeatingWithReheat" value="0x5"/>
+  </enum>
+
+  <enum name="ThermostatSystemMode" type="ENUM8">
+    <cluster code="0x0201"/>
+    <item name="Off" value="0x0"/>
+    <item name="Auto" value="0x1"/>
+    <item name="Cool" value="0x3"/>
+    <item name="Heat" value="0x4"/>
+    <item name="EmergencyHeat" value="0x5"/>
+    <item name="Precooling" value="0x6"/>
+    <item name="FanOnly" value="0x7"/>
+    <item name="Dry" value="0x8"/>
+    <item name="Sleep" value="0x9"/>
+  </enum>
+
+  <bitmap name="ThermostatAlarmMask" type="BITMAP8">
+    <cluster code="0x0201"/>
+    <field name="InitializationFailure" mask="0x1"/>
+    <field name="HardwareFailure" mask="0x2"/>
+    <field name="SelfCalibrationFailure" mask="0x4"/>
+  </bitmap>
+
+  <enum name="ThermostatRunningMode" type="ENUM8">
+    <cluster code="0x0201"/>
+    <item name="Off" value="0x00"/>
+    <item name="Cool" value="0x03"/>
+    <item name="Heat" value="0x04"/>
+  </enum>
+
+  <enum name="StartOfWeek" type="ENUM8">
+    <cluster code="0x0201"/>
+    <item name="Sunday" value="0x00"/>
+    <item name="Monday" value="0x01"/>
+    <item name="Tuesday" value="0x02"/>
+    <item name="Wednesday" value="0x03"/>
+    <item name="Thursday" value="0x04"/>
+    <item name="Friday" value="0x05"/>
+    <item name="Saturday" value="0x06"/>
+  </enum>
+
+  <enum name="TemperatureSetpointHold" type="ENUM8">
+    <cluster code="0x0201"/>
+    <item name="SetpointHoldOff" value="0x00"/>
+    <item name="SetpointHoldOn" value="0x01"/>
+  </enum>
+
+  <bitmap name="ThermostatRunningState" type="BITMAP16">
+    <cluster code="0x0201"/>
+    <field name="Heat" mask="0x0001"/>
+    <field name="Cool" mask="0x0002"/>
+    <field name="Fan" mask="0x0004"/>
+    <field name="HeatStage2" mask="0x0008"/>
+    <field name="CoolStage2" mask="0x0010"/>
+    <field name="FanStage2" mask="0x0020"/>
+    <field name="FanStage3" mask="0x0040"/>
+  </bitmap>
+
+  <bitmap name="ThermostatFeature" type="BITMAP32">
+    <cluster code="0x0201"/>
+    <field name="Heating" mask="0x1"/>
+    <field name="Cooling" mask="0x2"/>
+    <field name="Occupancy" mask="0x4"/>
+    <field name="ScheduleConfiguration" mask="0x8"/>
+    <field name="Setback" mask="0x10"/>
+    <field name="AutoMode" mask="0x20"/>
+  </bitmap>
+
+  <bitmap name="DayOfWeek" type="BITMAP8">
+    <cluster code="0x0201"/>
+    <field name="Sunday" mask="0x01"/>
+    <field name="Monday" mask="0x02"/>
+    <field name="Tuesday" mask="0x04"/>
+    <field name="Wednesday" mask="0x08"/>
+    <field name="Thursday" mask="0x10"/>
+    <field name="Friday" mask="0x20"/>
+    <field name="Saturday" mask="0x40"/>
+    <field name="Away" mask="0x80"/>
+  </bitmap>
+
+  <bitmap name="ModeForSequence" type="BITMAP8">
+    <cluster code="0x0201"/>
+    <field name="HeatSetpointPresent" mask="0x01"/>
+    <field name="CoolSetpointPresent" mask="0x02"/>
+  </bitmap>
+
+  <struct name="ThermostatScheduleTransition">
+    <cluster code="0x0201"/>
+    <item fieldId="0" name="TransitionTime" type="INT16U"/>
+    <!-- See https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/6217 for HeatSetpoint and CoolSetpoint.  They might end up being nullable. -->
+    <item fieldId="1" name="HeatSetpoint" type="INT16S" isNullable="true"/>
+    <item fieldId="2" name="CoolSetpoint" type="INT16S" isNullable="true"/>
+  </struct>
+
+  <enum name="SetpointAdjustMode" type="ENUM8">
+    <cluster code="0x0201"/>
+    <item name="Heat" value="0x0"/>
+    <item name="Cool" value="0x1"/>
+    <item name="Both" value="0x2"/>
+  </enum>
+
   <cluster>
     <name>Thermostat</name>
 	<domain>HVAC</domain>
@@ -27,7 +148,7 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="5"/>
     <attribute side="server" code="0x0000" define="LOCAL_TEMPERATURE" type="INT16S" min="0x954D" max="0x7FFF" writable="false" reportable="true" optional="false" isNullable="true">LocalTemperature</attribute>
     <attribute side="server" code="0x0001" define="OUTDOOR_TEMPERATURE" type="INT16S" min="0x954D" max="0x7FFF" writable="false" optional="true" isNullable="true">OutdoorTemperature</attribute>
-    <attribute side="server" code="0x0002" define="THERMOSTAT_OCCUPANCY" type="BITMAP8" min="0x00" max="0x01" writable="false" default="0x01" optional="true">Occupancy</attribute>
+    <attribute side="server" code="0x0002" define="THERMOSTAT_OCCUPANCY" type="ThermostatOccupancy" min="0x00" max="0x01" writable="false" default="0x01" optional="true">Occupancy</attribute>
     <!-- OCCUPANCY -->
     <attribute side="server" code="0x0003" define="ABS_MIN_HEAT_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="false" default="700" optional="true">AbsMinHeatSetpointLimit</attribute>
     <attribute side="server" code="0x0004" define="ABS_MAX_HEAT_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="false" default="3000" optional="true">AbsMaxHeatSetpointLimit</attribute>
@@ -74,7 +195,7 @@ limitations under the License.
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
     </attribute>
-    <attribute side="server" code="0x001A" define="REMOTE_SENSING" type="BITMAP8" min="0x00" max="0x07" writable="true" default="0x00" optional="true">
+    <attribute side="server" code="0x001A" define="REMOTE_SENSING" type="ThermostatRemoteSensing" min="0x00" max="0x07" writable="true" default="0x00" optional="true">
       <description>RemoteSensing</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
@@ -84,16 +205,16 @@ limitations under the License.
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
     </attribute>
-    <attribute side="server" code="0x001C" define="SYSTEM_MODE" type="ENUM8" min="0x00" max="0x07" writable="true" default="0x01" optional="false">
+    <attribute side="server" code="0x001C" define="SYSTEM_MODE" type="ThermostatSystemMode" min="0x00" max="0x07" writable="true" default="0x01" optional="false">
       <description>SystemMode</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
     </attribute>
-    <attribute side="server" code="0x001E" define="THERMOSTAT_RUNNING_MODE" type="ENUM8" min="0x00" max="0x04" writable="false" optional="true">ThermostatRunningMode</attribute>
-    <attribute side="server" code="0x0020" define="START_OF_WEEK" type="ENUM8" min="0x00" max="0x06" writable="false" optional="true">StartOfWeek</attribute>
+    <attribute side="server" code="0x001E" define="THERMOSTAT_RUNNING_MODE" type="ThermostatRunningMode" min="0x00" max="0x04" writable="false" optional="true">ThermostatRunningMode</attribute>
+    <attribute side="server" code="0x0020" define="START_OF_WEEK" type="StartOfWeek" min="0x00" max="0x06" writable="false" optional="true">StartOfWeek</attribute>
     <attribute side="server" code="0x0021" define="NUMBER_OF_WEEKLY_TRANSITIONS" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">NumberOfWeeklyTransitions</attribute>
     <attribute side="server" code="0x0022" define="NUMBER_OF_DAILY_TRANSITIONS" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">NumberOfDailyTransitions</attribute>
-    <attribute side="server" code="0x0023" define="TEMPERATURE_SETPOINT_HOLD" type="ENUM8" min="0x00" max="0x01" writable="true" default="0x00" optional="true">
+    <attribute side="server" code="0x0023" define="TEMPERATURE_SETPOINT_HOLD" type="TemperateSetpointHold" min="0x00" max="0x01" writable="true" default="0x00" optional="true">
       <description>TemperatureSetpointHold</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
@@ -108,7 +229,7 @@ limitations under the License.
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
     </attribute>
-    <attribute side="server" code="0x0029" define="THERMOSTAT_RUNNING_STATE" type="BITMAP16" writable="false" optional="true">ThermostatRunningState</attribute>
+    <attribute side="server" code="0x0029" define="THERMOSTAT_RUNNING_STATE" type="ThermostatRunningState" writable="false" optional="true">ThermostatRunningState</attribute>
     <attribute side="server" code="0x0030" define="SETPOINT_CHANGE_SOURCE" type="ENUM8" writable="false" optional="true">SetpointChangeSource</attribute>
     <attribute side="server" code="0x0031" define="SETPOINT_CHANGE_AMOUNT" type="INT16S" writable="false" default="0x8000" optional="true" isNullable="true">SetpointChangeAmount</attribute>
     <attribute side="server" code="0x0032" define="SETPOINT_CHANGE_SOURCE_TIMESTAMP" type="epoch_s" writable="false" optional="true">SetpointChangeSourceTimestamp</attribute>
@@ -207,23 +328,4 @@ limitations under the License.
       <arg name="Transitions" type="ThermostatScheduleTransition" array="true"/>
     </command>
   </cluster>
-
-  <bitmap name="ThermostatFeature" type="BITMAP32">
-    <cluster code="0x0201"/>
-    <field name="Heating" mask="0x1"/>
-    <field name="Cooling" mask="0x2"/>
-    <field name="Occupancy" mask="0x4"/>
-    <field name="ScheduleConfiguration" mask="0x8"/>
-    <field name="Setback" mask="0x10"/>
-    <field name="AutoMode" mask="0x20"/>
-  </bitmap>
-
-  <struct name="ThermostatScheduleTransition">
-    <cluster code="0x0201"/>
-    <item fieldId="0" name="TransitionTime" type="INT16U"/>
-    <!-- See https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/6217 for HeatSetpoint and CoolSetpoint.  They might end up being nullable. -->
-    <item fieldId="1" name="HeatSetpoint" type="INT16S" isNullable="true"/>
-    <item fieldId="2" name="CoolSetpoint" type="INT16S" isNullable="true"/>
-  </struct>
-
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/types.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/types.xml
@@ -43,19 +43,6 @@ limitations under the License.
     <field name="MasterZoneDst" mask="0x4"/>
     <field name="Superseding" mask="0x8"/>
   </bitmap>
-  <bitmap name="ThermostatOccupancy" type="BITMAP8">
-    <field name="occupied" mask="0x1"/>
-  </bitmap>
-  <bitmap name="ThermostatSensing" type="BITMAP8">
-    <field name="localTempSensedRemotely" mask="0x1"/>
-    <field name="outdoorTempSensedRemotely" mask="0x2"/>
-    <field name="occupancySensedRemotely" mask="0x4"/>
-  </bitmap>
-  <bitmap name="ThermostatAlarmMask" type="BITMAP8">
-    <field name="initializationFailure" mask="0x1"/>
-    <field name="hardwareFailure" mask="0x2"/>
-    <field name="selfcalibrationFailure" mask="0x4"/>
-  </bitmap>
   <bitmap name="BallastStatus" type="BITMAP8">
     <field name="NonOperational" mask="0x1"/>
     <field name="LampNotInSocket" mask="0x2"/>
@@ -141,33 +128,6 @@ limitations under the License.
     <cluster code="0x0008"/>
     <item name="Up" value="0x0"/>
     <item name="Down" value="0x1"/>
-  </enum>
-  <enum name="ThermostatControlSequence" type="ENUM8">
-    <cluster code="0x0201"/>
-    <item name="CoolingOnly" value="0x0"/>
-    <item name="CoolingWithReheat" value="0x1"/>
-    <item name="HeatingOnly" value="0x2"/>
-    <item name="HeatingWithReheat" value="0x3"/>
-    <item name="CoolingAndHeating" value="0x4"/>
-    <item name="CoolingAndHeatingWithReheat" value="0x5"/>
-  </enum>
-  <enum name="ThermostatSystemMode" type="ENUM8">
-    <cluster code="0x0201"/>
-    <item name="Off" value="0x0"/>
-    <item name="Auto" value="0x1"/>
-    <item name="Cool" value="0x3"/>
-    <item name="Heat" value="0x4"/>
-    <item name="EmergencyHeat" value="0x5"/>
-    <item name="Precooling" value="0x6"/>
-    <item name="FanOnly" value="0x7"/>
-    <item name="Dry" value="0x8"/>
-    <item name="Sleep" value="0x9"/>
-  </enum>
-  <enum name="SetpointAdjustMode" type="ENUM8">
-    <cluster code="0x0201"/>
-    <item name="Heat" value="0x0"/>
-    <item name="Cool" value="0x1"/>
-    <item name="Both" value="0x2"/>
   </enum>
   <enum name="FanMode" type="ENUM8">
     <item name="off" value="0x0"/>
@@ -547,50 +507,6 @@ limitations under the License.
     <item name="IdAdded" value="0x05"/>
     <item name="IdDeleted" value="0x06"/>
   </enum>
-  <enum name="ThermostatRunningMode" type="ENUM8">
-    <cluster code="0x0201"/>
-    <item name="Off" value="0x00"/>
-    <item name="Cool" value="0x03"/>
-    <item name="Heat" value="0x04"/>
-  </enum>
-  <enum name="StartOfWeek" type="ENUM8">
-    <item name="Sunday" value="0x00"/>
-    <item name="Monday" value="0x01"/>
-    <item name="Tuesday" value="0x02"/>
-    <item name="Wednesday" value="0x03"/>
-    <item name="Thursday" value="0x04"/>
-    <item name="Friday" value="0x05"/>
-    <item name="Saturday" value="0x06"/>
-  </enum>
-  <enum name="TemperatureSetpointHold" type="ENUM8">
-    <item name="SetpointHoldOff" value="0x00"/>
-    <item name="SetpointHoldOn" value="0x01"/>
-  </enum>
-  <bitmap name="ThermostatRunningState" type="BITMAP16">
-    <field name="HeatStateOn" mask="0x0001"/>
-    <field name="CoolStateOn" mask="0x0002"/>
-    <field name="FanStateOn" mask="0x0004"/>
-    <field name="HeatSecondStageStateOn" mask="0x0008"/>
-    <field name="CoolSecondStageStateOn" mask="0x0010"/>
-    <field name="FanSecondStageStateOn" mask="0x0020"/>
-    <field name="FanThirdStageStateOn" mask="0x0040"/>
-  </bitmap>
-  <bitmap name="DayOfWeek" type="BITMAP8">
-    <cluster code="0x0201"/>
-    <field name="Sunday" mask="0x01"/>
-    <field name="Monday" mask="0x02"/>
-    <field name="Tuesday" mask="0x04"/>
-    <field name="Wednesday" mask="0x08"/>
-    <field name="Thursday" mask="0x10"/>
-    <field name="Friday" mask="0x20"/>
-    <field name="Saturday" mask="0x40"/>
-    <field name="Away" mask="0x80"/>
-  </bitmap>
-  <bitmap name="ModeForSequence" type="BITMAP8">
-    <cluster code="0x0201"/>
-    <field name="HeatSetpointPresent" mask="0x01"/>
-    <field name="CoolSetpointPresent" mask="0x02"/>
-  </bitmap>
   <enum name="ProductTypeId" type="ENUM16">
     <item name="WhiteGoods" value="0x0000"/>
     <item name="Dishwasher" value="0x5601"/>


### PR DESCRIPTION
#### Problem

The `Thermostat` cluster bitmaps/enums that belongs to the cluster lives for some of them in `src/app/zap-templates/zcl/data-model/silabs/types.xml` 

I moved them in `src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml`, add some missing cluster codes and add the tight bitmap/enum mapping to some attributes when it the bitmap/enums was already existing.