### PR TITLE
chip-repl tests: xml parsing to report location of where unrecognized handlers reside

### DIFF
--- a/scripts/py_matter_idl/matter_idl/zapxml/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/__init__.py
@@ -50,6 +50,8 @@ class ParseHandler(xml.sax.handler.ContentHandler):
         if self._include_meta_data:
             self._idl.parse_file_name = filename
 
+        self._context.file_name = filename
+
     def Finish(self) -> Idl:
         self._context.PostProcess(self._idl)
         return self._idl

--- a/scripts/py_matter_idl/matter_idl/zapxml/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/__init__.py
@@ -15,12 +15,11 @@
 import logging
 import typing
 import xml.sax.handler
-
 from dataclasses import dataclass
-from typing import Optional, Union, List
+from typing import List, Optional, Union
 
-from matter_idl.zapxml.handlers import Context, ZapXmlHandler
 from matter_idl.matter_idl_types import Idl
+from matter_idl.zapxml.handlers import Context, ZapXmlHandler
 
 
 class ParseHandler(xml.sax.handler.ContentHandler):

--- a/scripts/py_matter_idl/matter_idl/zapxml/handlers/context.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/handlers/context.py
@@ -103,7 +103,6 @@ class Context:
 
         return f"{self.file_name}:{meta.line}:{meta.column}"
 
-
     def GetGlobalAttribute(self, code):
         if code in self._global_attributes:
             return self._global_attributes[code]

--- a/scripts/py_matter_idl/matter_idl/zapxml/handlers/context.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/handlers/context.py
@@ -81,6 +81,7 @@ class Context:
     def __init__(self, locator: Optional[xml.sax.xmlreader.Locator] = None):
         self.path = ProcessingPath()
         self.locator = locator
+        self.file_name = None
         self._not_handled = set()
         self._idl_post_processors = []
 
@@ -92,6 +93,16 @@ class Context:
             return None
 
         return ParseMetaData(line=self.locator.getLineNumber(), column=self.locator.getColumnNumber())
+
+    def ParseLogLocation(self) -> Optional[str]:
+        if not self.file_name:
+            return None
+        meta = self.GetCurrentLocationMeta()
+        if not meta:
+            return None
+
+        return f"{self.file_name}:{meta.line}:{meta.column}"
+
 
     def GetGlobalAttribute(self, code):
         if code in self._global_attributes:
@@ -112,7 +123,13 @@ class Context:
     def MarkTagNotHandled(self):
         path = str(self.path)
         if path not in self._not_handled:
-            logging.warning("TAG %s was not handled/recognized" % path)
+            msg = "TAG %s was not handled/recognized" % path
+
+            where = self.ParseLogLocation()
+            if where:
+                msg = msg + " at " + where
+
+            logging.warning(msg)
             self._not_handled.add(path)
 
     def AddIdlPostProcessor(self, processor: IdlPostProcessor):


### PR DESCRIPTION
We have a lot of logs saying `WARNING:root:TAG configurator::global::command::description was not handled/recognized` when running repl tests.

Unfortunately this is not clear as to where that is, so I made a change so now it will report `silabs/general.xml` in this case. This way we can review what handlers need to be checked or ignored.

