### PR TITLE
Add chip/barrier-control-cluster.xml by extracting the relevant content from silabs/ha.xml and silabs/types.xml and add missing cluster codes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -173,6 +173,7 @@ jobs:
                       src/app/zap-templates/zcl/data-model/chip/wifi-network-diagnostics-cluster.xml \
                       src/app/zap-templates/zcl/data-model/chip/window-covering.xml \
                       src/app/zap-templates/zcl/data-model/chip/matter-devices.xml \
+                      src/app/zap-templates/zcl/data-model/draft/barrier-control-cluster.xml \
                       src/app/zap-templates/zcl/data-model/silabs/general.xml \
                       src/app/zap-templates/zcl/data-model/silabs/ha-devices.xml \
                       src/app/zap-templates/zcl/data-model/silabs/ha.xml \

--- a/src/app/zap-templates/zcl/data-model/draft/barrier-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/draft/barrier-control-cluster.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2023 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="Closures"/>
+
+  <bitmap name="BarrierControlCapabilities" type="BITMAP8">
+    <field name="partialBarrier" mask="0x01"/>
+  </bitmap>
+
+  <bitmap name="BarrierControlSafetyStatus" type="BITMAP16">
+    <field name="remoteLockout" mask="0x01"/>
+    <field name="temperDetected" mask="0x02"/>
+    <field name="failedCommunication" mask="0x04"/>
+    <field name="positionFailure" mask="0x08"/>
+  </bitmap>
+
+  <enum name="BarrierControlBarrierPosition" type="INT8U">
+    <item name="Closed" value="0"/>
+    <item name="Open" value="100"/>
+    <item name="Unknown" value="0xFF"/>
+  </enum>
+
+  <enum name="BarrierControlMovingState" type="ENUM8">
+    <item name="Stopped" value="0x00"/>
+    <item name="Closing" value="0x01"/>
+    <item name="Opening" value="0x02"/>
+  </enum>
+
+  <cluster>
+    <name>Barrier Control</name>
+    <domain>Closures</domain>
+    <code>0x0103</code>
+    <define>BARRIER_CONTROL_CLUSTER</define>
+    <description>This cluster provides control of a barrier (garage door).</description>
+
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+
+    <attribute side="server" code="0x0001" define="BARRIER_MOVING_STATE" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="false">barrier moving state</attribute>
+    <attribute side="server" code="0x0002" define="BARRIER_SAFETY_STATUS" type="BITMAP16" min="0x0000" max="0xFFFF" writable="false" optional="false">barrier safety status</attribute>
+    <attribute side="server" code="0x0003" define="BARRIER_CAPABILITIES" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="false">barrier capabilities</attribute>
+    <attribute side="server" code="0x0004" define="BARRIER_OPEN_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier open events</attribute>
+    <attribute side="server" code="0x0005" define="BARRIER_CLOSE_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier close events</attribute>
+    <attribute side="server" code="0x0006" define="BARRIER_COMMAND_OPEN_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier command open events</attribute>
+    <attribute side="server" code="0x0007" define="BARRIER_COMMAND_CLOSE_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier command close events</attribute>
+    <attribute side="server" code="0x0008" define="BARRIER_OPEN_PERIOD" type="INT16U" min="0x0000" max="0xFFFE" writable="true" optional="true">barrier open period</attribute>
+    <attribute side="server" code="0x0009" define="BARRIER_CLOSE_PERIOD" type="INT16U" min="0x0000" max="0xFFFE" writable="true" optional="true">barrier close period</attribute>
+    <attribute side="server" code="0x000A" define="BARRIER_POSITION" type="INT8U" min="0x0000" max="0xFF" writable="false" optional="false">barrier position</attribute>
+
+    <command source="client" code="0x00" name="BarrierControlGoToPercent" optional="false">
+      <description>
+        Command to instruct a barrier to go to a percent open state.
+      </description>
+      <arg name="percentOpen" type="INT8U"/>
+    </command>
+
+    <command source="client" code="0x01" name="BarrierControlStop" optional="false">
+      <description>
+        Command that instructs the barrier to stop moving.
+      </description>
+    </command>
+
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/ha.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ha.xml
@@ -450,36 +450,6 @@ limitations under the License.
       <access op="write" role="manage"/>
     </attribute>
   </cluster>
-  <cluster>
-    <name>Barrier Control</name>
-    <domain>Closures</domain>
-    <description>This cluster provides control of a barrier (garage door).</description>
-    <code>0x0103</code>
-    <define>BARRIER_CONTROL_CLUSTER</define>
-    <client init="false" tick="false">true</client>
-    <server init="false" tick="false">true</server>
-    <attribute side="server" code="0x0001" define="BARRIER_MOVING_STATE" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="false">barrier moving state</attribute>
-    <attribute side="server" code="0x0002" define="BARRIER_SAFETY_STATUS" type="BITMAP16" min="0x0000" max="0xFFFF" writable="false" optional="false">barrier safety status</attribute>
-    <attribute side="server" code="0x0003" define="BARRIER_CAPABILITIES" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="false">barrier capabilities</attribute>
-    <attribute side="server" code="0x0004" define="BARRIER_OPEN_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier open events</attribute>
-    <attribute side="server" code="0x0005" define="BARRIER_CLOSE_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier close events</attribute>
-    <attribute side="server" code="0x0006" define="BARRIER_COMMAND_OPEN_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier command open events</attribute>
-    <attribute side="server" code="0x0007" define="BARRIER_COMMAND_CLOSE_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier command close events</attribute>
-    <attribute side="server" code="0x0008" define="BARRIER_OPEN_PERIOD" type="INT16U" min="0x0000" max="0xFFFE" writable="true" optional="true">barrier open period</attribute>
-    <attribute side="server" code="0x0009" define="BARRIER_CLOSE_PERIOD" type="INT16U" min="0x0000" max="0xFFFE" writable="true" optional="true">barrier close period</attribute>
-    <attribute side="server" code="0x000A" define="BARRIER_POSITION" type="INT8U" min="0x0000" max="0xFF" writable="false" optional="false">barrier position</attribute>
-    <command source="client" code="0x00" name="BarrierControlGoToPercent" optional="false" cli="zcl barrier-control go-to-percent">
-      <description>
-        Command to instruct a barrier to go to a percent open state.
-      </description>
-      <arg name="percentOpen" type="INT8U"/>
-    </command>
-    <command source="client" code="0x01" name="BarrierControlStop" optional="false" cli="zcl barrier-control stop">
-      <description>
-        Command that instructs the barrier to stop moving.
-      </description>
-    </command>
-  </cluster>
   <cluster introducedIn="ha-1.2-05-3520-29">
     <name>Electrical Measurement</name>
     <domain>Home Automation</domain>

--- a/src/app/zap-templates/zcl/data-model/silabs/types-silabs.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/types-silabs.xml
@@ -584,24 +584,4 @@ limitations under the License.
     <field name="ExecuteIfOff" mask="0x1"/>
     <field name="CoupleColorTempToLevel" mask="0x02"/>
   </bitmap>
-  <!-- Barrier Control Cluster -->
-  <bitmap name="BarrierControlCapabilities" type="BITMAP8">
-    <field name="partialBarrier" mask="0x01"/>
-  </bitmap>
-  <bitmap name="BarrierControlSafetyStatus" type="BITMAP16">
-    <field name="remoteLockout" mask="0x01"/>
-    <field name="temperDetected" mask="0x02"/>
-    <field name="failedCommunication" mask="0x04"/>
-    <field name="positionFailure" mask="0x08"/>
-  </bitmap>
-  <enum name="BarrierControlBarrierPosition" type="INT8U">
-    <item name="Closed" value="0"/>
-    <item name="Open" value="100"/>
-    <item name="Unknown" value="0xFF"/>
-  </enum>
-  <enum name="BarrierControlMovingState" type="ENUM8">
-    <item name="Stopped" value="0x00"/>
-    <item name="Closing" value="0x01"/>
-    <item name="Opening" value="0x02"/>
-  </enum>
 </configurator>

--- a/src/app/zap-templates/zcl/zcl-with-test-extensions.json
+++ b/src/app/zap-templates/zcl/zcl-with-test-extensions.json
@@ -5,6 +5,7 @@
     "xmlRoot": [
         ".",
         "./data-model/chip/",
+        "./data-model/draft/",
         "./data-model/silabs/",
         "./data-model/test"
     ],
@@ -19,6 +20,7 @@
         "application-basic-cluster.xml",
         "application-launcher-cluster.xml",
         "audio-output-cluster.xml",
+        "barrier-control-cluster.xml",
         "basic-information-cluster.xml",
         "binding-cluster.xml",
         "boolean-state-cluster.xml",

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -2,7 +2,12 @@
     "description": "Matter SDK ZCL data",
     "category": "matter",
     "version": 1,
-    "xmlRoot": [".", "./data-model/chip/", "./data-model/silabs/"],
+    "xmlRoot": [
+        ".",
+        "./data-model/chip/",
+        "./data-model/draft/",
+        "./data-model/silabs/"
+    ],
     "_comment": "Ensure access-control-definitions.xml is first in xmlFile array",
     "xmlFile": [
         "access-control-definitions.xml",
@@ -14,6 +19,7 @@
         "application-basic-cluster.xml",
         "application-launcher-cluster.xml",
         "audio-output-cluster.xml",
+        "barrier-control-cluster.xml",
         "basic-information-cluster.xml",
         "binding-cluster.xml",
         "boolean-state-cluster.xml",


### PR DESCRIPTION
#### Problem

`BarrierControl` cluster lives in `src/app/zap-templates/zcl/data-model/silabs/ha.xml` and `src/app/zap-templates/zcl/data-model/silabs/types.xml` and miss some cluster codes. This PR makes it a single file in `src/app/zap-templates/zcl/data-model/chip/barrier-control-cluster.xml` and adds the relevant cluster codes before running `zap_regen_all.py`

This is a WIP since I need to see why some code has been removed from `scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/IMClusterCommandHandler.cpp` and CI will likely fails.