### PR TITLE
repl tests xml parsing: Ignore global commands parsing from xml

### DIFF
--- a/scripts/py_matter_idl/matter_idl/zapxml/handlers/handlers.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/handlers/handlers.py
@@ -579,6 +579,12 @@ class GlobalHandler(BaseHandler):
                 return BaseHandler(self.context, handled=HandledDepth.SINGLE_TAG)
 
             return GlobalAttributeHandler(self.context, AttrsToAttribute(attrs))
+        elif name.lower() == 'command':
+            # NOTE: global commands are NOT a thing in matter currently.
+            #       they occur in silabs/general.xml and are Read/WriteAttribute
+            #       and similar
+            LOGGER.info("Ignoring global command: %s" % attrs['name'])
+            return BaseHandler(self.context, handled=HandledDepth.ENTIRE_TREE)
         else:
             return BaseHandler(self.context)
 


### PR DESCRIPTION
Without this, we will get warnings that global::commands::* are not handled.

Matter does not seem to have a concept of global commands, so we skip these when parsing.

Also logged the name in case log level is reduced.