### PR TITLE
[typo] Fix typos in some cluster field names.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -841,7 +841,7 @@ server cluster PowerSourceConfiguration = 46 {
 
 server cluster PowerSource = 47 {
   enum BatChargeFault : ENUM8 {
-    kUnspecfied = 0;
+    kUnspecified = 0;
     kAmbientTooHot = 1;
     kAmbientTooCold = 2;
     kBatteryTooHot = 3;
@@ -881,7 +881,7 @@ server cluster PowerSource = 47 {
   }
 
   enum PowerSourceStatus : ENUM8 {
-    kUnspecfied = 0;
+    kUnspecified = 0;
     kActive = 1;
     kStandby = 2;
     kUnavailable = 3;

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -735,7 +735,7 @@ server cluster PowerSourceConfiguration = 46 {
 
 server cluster PowerSource = 47 {
   enum BatChargeFault : ENUM8 {
-    kUnspecfied = 0;
+    kUnspecified = 0;
     kAmbientTooHot = 1;
     kAmbientTooCold = 2;
     kBatteryTooHot = 3;
@@ -775,7 +775,7 @@ server cluster PowerSource = 47 {
   }
 
   enum PowerSourceStatus : ENUM8 {
-    kUnspecfied = 0;
+    kUnspecified = 0;
     kActive = 1;
     kStandby = 2;
     kUnavailable = 3;

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -387,7 +387,7 @@ server cluster PowerSourceConfiguration = 46 {
 
 server cluster PowerSource = 47 {
   enum BatChargeFault : ENUM8 {
-    kUnspecfied = 0;
+    kUnspecified = 0;
     kAmbientTooHot = 1;
     kAmbientTooCold = 2;
     kBatteryTooHot = 3;
@@ -427,7 +427,7 @@ server cluster PowerSource = 47 {
   }
 
   enum PowerSourceStatus : ENUM8 {
-    kUnspecfied = 0;
+    kUnspecified = 0;
     kActive = 1;
     kStandby = 2;
     kUnavailable = 3;

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -638,7 +638,7 @@ server cluster PowerSourceConfiguration = 46 {
 
 server cluster PowerSource = 47 {
   enum BatChargeFault : ENUM8 {
-    kUnspecfied = 0;
+    kUnspecified = 0;
     kAmbientTooHot = 1;
     kAmbientTooCold = 2;
     kBatteryTooHot = 3;
@@ -678,7 +678,7 @@ server cluster PowerSource = 47 {
   }
 
   enum PowerSourceStatus : ENUM8 {
-    kUnspecfied = 0;
+    kUnspecified = 0;
     kActive = 1;
     kStandby = 2;
     kUnavailable = 3;

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -615,7 +615,7 @@ server cluster PowerSourceConfiguration = 46 {
 
 server cluster PowerSource = 47 {
   enum BatChargeFault : ENUM8 {
-    kUnspecfied = 0;
+    kUnspecified = 0;
     kAmbientTooHot = 1;
     kAmbientTooCold = 2;
     kBatteryTooHot = 3;
@@ -655,7 +655,7 @@ server cluster PowerSource = 47 {
   }
 
   enum PowerSourceStatus : ENUM8 {
-    kUnspecfied = 0;
+    kUnspecified = 0;
     kActive = 1;
     kStandby = 2;
     kUnavailable = 3;

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -557,7 +557,7 @@ server cluster UnitLocalization = 45 {
 
 server cluster PowerSource = 47 {
   enum BatChargeFault : ENUM8 {
-    kUnspecfied = 0;
+    kUnspecified = 0;
     kAmbientTooHot = 1;
     kAmbientTooCold = 2;
     kBatteryTooHot = 3;
@@ -597,7 +597,7 @@ server cluster PowerSource = 47 {
   }
 
   enum PowerSourceStatus : ENUM8 {
-    kUnspecfied = 0;
+    kUnspecified = 0;
     kActive = 1;
     kStandby = 2;
     kUnavailable = 3;

--- a/src/app/zap-templates/zcl/data-model/chip/power-source-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/power-source-cluster.xml
@@ -103,7 +103,7 @@ limitations under the License.
 
   <enum name="BatChargeFault" type="ENUM8">
     <cluster code="0x002F"/>
-    <item name="Unspecfied" value="0x00"/>
+    <item name="Unspecified" value="0x00"/>
     <item name="AmbientTooHot" value="0x01"/>
     <item name="AmbientTooCold" value="0x02"/>
     <item name="BatteryTooHot" value="0x03"/>
@@ -118,7 +118,7 @@ limitations under the License.
 
   <enum name="PowerSourceStatus" type="ENUM8">
     <cluster code="0x002F"/>
-    <item name="Unspecfied" value="0x00"/>
+    <item name="Unspecified" value="0x00"/>
     <item name="Active" value="0x01"/>
     <item name="Standby" value="0x02"/>
     <item name="Unavailable" value="0x03"/>

--- a/src/app/zap-templates/zcl/data-model/silabs/types.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/types.xml
@@ -297,7 +297,7 @@ limitations under the License.
     <item name="SubmittedRegistrationRequest" value="0x3"/>
     <item name="RegistrationRejected" value="0x4"/>
     <item name="Registered" value="0x5"/>
-    <item name="RegisterationNotPossible" value="0x6"/>
+    <item name="RegistrationNotPossible" value="0x6"/>
   </enum>
   <enum name="AnonymousDataState" type="ENUM8">
     <item name="NoSourceFound" value="0x0"/>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -936,7 +936,7 @@ client cluster PowerSourceConfiguration = 46 {
 
 client cluster PowerSource = 47 {
   enum BatChargeFault : ENUM8 {
-    kUnspecfied = 0;
+    kUnspecified = 0;
     kAmbientTooHot = 1;
     kAmbientTooCold = 2;
     kBatteryTooHot = 3;
@@ -976,7 +976,7 @@ client cluster PowerSource = 47 {
   }
 
   enum PowerSourceStatus : ENUM8 {
-    kUnspecfied = 0;
+    kUnspecified = 0;
     kActive = 1;
     kStandby = 2;
     kUnavailable = 3;

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -5696,7 +5696,7 @@ class PowerSource(Cluster):
 
     class Enums:
         class BatChargeFault(MatterIntEnum):
-            kUnspecfied = 0x00
+            kUnspecified = 0x00
             kAmbientTooHot = 0x01
             kAmbientTooCold = 0x02
             kBatteryTooHot = 0x03
@@ -5756,7 +5756,7 @@ class PowerSource(Cluster):
             kUnknownEnumValue = 4,
 
         class PowerSourceStatus(MatterIntEnum):
-            kUnspecfied = 0x00
+            kUnspecified = 0x00
             kActive = 0x01
             kStandby = 0x02
             kUnavailable = 0x03

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -17405,7 +17405,7 @@ typedef NS_OPTIONS(uint32_t, MTRUnitLocalizationFeature) {
 } API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 typedef NS_ENUM(uint8_t, MTRPowerSourceBatChargeFault) {
-    MTRPowerSourceBatChargeFaultUnspecfied API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x00,
+    MTRPowerSourceBatChargeFaultUnspecified MTR_NEWLY_AVAILABLE = 0x00,
     MTRPowerSourceBatChargeFaultAmbientTooHot API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x01,
     MTRPowerSourceBatChargeFaultAmbientTooCold API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x02,
     MTRPowerSourceBatChargeFaultBatteryTooHot API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x03,
@@ -17448,7 +17448,7 @@ typedef NS_ENUM(uint8_t, MTRPowerSourceBatReplaceability) {
 } API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 typedef NS_ENUM(uint8_t, MTRPowerSourceStatus) {
-    MTRPowerSourceStatusUnspecfied API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x00,
+    MTRPowerSourceStatusUnspecified MTR_NEWLY_AVAILABLE = 0x00,
     MTRPowerSourceStatusActive API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x01,
     MTRPowerSourceStatusStandby API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x02,
     MTRPowerSourceStatusUnavailable API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x03,

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
@@ -449,7 +449,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::BatChargeF
     using EnumType = PowerSource::BatChargeFault;
     switch (val)
     {
-    case EnumType::kUnspecfied:
+    case EnumType::kUnspecified:
     case EnumType::kAmbientTooHot:
     case EnumType::kAmbientTooCold:
     case EnumType::kBatteryTooHot:
@@ -524,7 +524,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::PowerSourc
     using EnumType = PowerSource::PowerSourceStatus;
     switch (val)
     {
-    case EnumType::kUnspecfied:
+    case EnumType::kUnspecified:
     case EnumType::kActive:
     case EnumType::kStandby:
     case EnumType::kUnavailable:

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -558,7 +558,7 @@ namespace PowerSource {
 // Enum for BatChargeFault
 enum class BatChargeFault : uint8_t
 {
-    kUnspecfied          = 0x00,
+    kUnspecified         = 0x00,
     kAmbientTooHot       = 0x01,
     kAmbientTooCold      = 0x02,
     kBatteryTooHot       = 0x03,
@@ -633,7 +633,7 @@ enum class BatReplaceability : uint8_t
 // Enum for PowerSourceStatus
 enum class PowerSourceStatus : uint8_t
 {
-    kUnspecfied  = 0x00,
+    kUnspecified = 0x00,
     kActive      = 0x01,
     kStandby     = 0x02,
     kUnavailable = 0x03,


### PR DESCRIPTION
Fixes some typos in data model names in cluster xml definitions.