### PR TITLE
[chip-tool] Add flag to enable server interactions

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -102,6 +102,7 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
     factoryInitParams.fabricIndependentStorage = &mDefaultStorage;
     factoryInitParams.operationalKeystore      = &mOperationalKeystore;
     factoryInitParams.opCertStore              = &mOpCertStore;
+    factoryInitParams.enableServerInteractions = NeedsOperationalAdvertising();
 
     // Init group data provider that will be used for all group keys and IPKs for the
     // chip-tool-configured fabrics. This is OK to do once since the fabric tables

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -123,6 +123,11 @@ protected:
     // use member values that Shutdown will normally reset.
     virtual bool DeferInteractiveCleanup() { return false; }
 
+    // If true, the controller will be created with server capabilities enabled,
+    // such as advertising operational nodes over DNS-SD and accepting incoming
+    // CASE sessions.
+    virtual bool NeedsOperationalAdvertising() { return false; }
+
     // Execute any deferred cleanups.  Used when exiting interactive mode.
     static void ExecuteDeferredCleanups(intptr_t ignored);
 

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -276,3 +276,8 @@ bool InteractiveCommand::ParseCommand(char * command, int * status)
 
     return true;
 }
+
+bool InteractiveCommand::NeedsOperationalAdvertising()
+{
+    return mAdvertiseOperational.ValueOr(true);
+}

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.h
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.h
@@ -31,15 +31,20 @@ class InteractiveCommand : public CHIPCommand
 public:
     InteractiveCommand(const char * name, Commands * commandsHandler, CredentialIssuerCommands * credsIssuerConfig) :
         CHIPCommand(name, credsIssuerConfig), mHandler(commandsHandler)
-    {}
+    {
+        AddArgument("advertise-operational", 0, 1, &mAdvertiseOperational,
+                    "Advertise operational node over DNS-SD and accept incoming CASE sessions.");
+    }
 
     /////////// CHIPCommand Interface /////////
     chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(0); }
+    bool NeedsOperationalAdvertising() override;
 
     bool ParseCommand(char * command, int * status);
 
 private:
     Commands * mHandler = nullptr;
+    chip::Optional<bool> mAdvertiseOperational;
 };
 
 class InteractiveStartCommand : public InteractiveCommand


### PR DESCRIPTION
Add "--advertise-operational" flag to the chip-tool's
"interactive start" command that enables server features,
including advertising operational services. This feature
is needed to test persistent subscriptions using chip-tool,
which requires that chip-tool be discoverable after the
publisher node reboots.