### PR TITLE
Feature/wifi siwx917 factory reset long press, Increased QSPI clock, RAM and Flash sizes

### DIFF
--- a/examples/light-switch-app/silabs/SiWx917/include/AppTask.h
+++ b/examples/light-switch-app/silabs/SiWx917/include/AppTask.h
@@ -40,6 +40,8 @@
  *********************************************************/
 // Button specific defines for SiWx917
 #define SL_SIMPLE_BUTTON_PRESSED 1U
+#define SL_SIMPLE_BUTTON_RELEASED 0U
+
 #define SIWx917_BTN0 0
 #define SIWx917_BTN1 1
 

--- a/examples/platform/silabs/SiWx917/BaseApplication.cpp
+++ b/examples/platform/silabs/SiWx917/BaseApplication.cpp
@@ -37,6 +37,9 @@
 #endif // DISPLAY_ENABLED
 
 #include "SiWx917DeviceDataProvider.h"
+#include "rsi_board.h"
+#include "rsi_chip.h"
+#include "siwx917_utils.h"
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
@@ -45,9 +48,6 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
-#include "rsi_board.h"
-#include "rsi_chip.h"
-#include "siwx917_utils.h"
 
 #ifdef SL_WIFI
 #include "wfx_host_events.h"
@@ -246,15 +246,13 @@ void BaseApplication::FunctionEventHandler(AppEvent * aEvent)
     {
         return;
     }
-
 }
 
-void BaseApplication::FunctionFactoryReset( void )
+void BaseApplication::FunctionFactoryReset(void)
 {
     SILABS_LOG("#################################################################");
     SILABS_LOG("################### Factory reset triggered #####################");
     SILABS_LOG("#################################################################");
-
 
     // Actually trigger Factory Reset
     mFunction = kFunction_NoneSelected;
@@ -354,7 +352,7 @@ void BaseApplication::LightEventHandler()
 
 void BaseApplication::ButtonHandler(AppEvent * aEvent)
 {
-	uint8_t count = FACTORY_RESET_LOOP_COUNT;
+    uint8_t count = FACTORY_RESET_LOOP_COUNT;
 
     // To trigger software update: press the APP_FUNCTION_BUTTON button briefly (<
     // FACTORY_RESET_TRIGGER_TIMEOUT) To initiate factory reset: press the
@@ -367,7 +365,7 @@ void BaseApplication::ButtonHandler(AppEvent * aEvent)
     {
         if ((!mFunctionTimerActive) && (mFunction == kFunction_NoneSelected))
         {
-	    mFunction = kFunction_FactoryReset;
+            mFunction = kFunction_FactoryReset;
 
             // Wait for sometime to determine button is pressed for Factory reset
             // other functionality
@@ -375,8 +373,10 @@ void BaseApplication::ButtonHandler(AppEvent * aEvent)
         }
     }
 
-    while(!(RSI_NPSSGPIO_GetPin(NPSS_GPIO_0))) {
-        if(count == 0){
+    while (!(RSI_NPSSGPIO_GetPin(NPSS_GPIO_0)))
+    {
+        if (count == 0)
+        {
             FunctionFactoryReset();
             break;
         }
@@ -388,17 +388,18 @@ void BaseApplication::ButtonHandler(AppEvent * aEvent)
         sStatusLED.Blink(500);
 #endif // ENABLE_WSTK_LEDS
 
-        SILABS_LOG("Factory reset triggering in %d sec release button to cancel",count--);
+        SILABS_LOG("Factory reset triggering in %d sec release button to cancel", count--);
 
         // Delay of 1sec before checking the button status again
         vTaskDelay(1000);
     }
 
-    if (count > 0) {
+    if (count > 0)
+    {
 #ifdef ENABLE_WSTK_LEDS
         sStatusLED.Set(false);
 #endif
-        SILABS_LOG("Factory Reset has been Canceled");    // button held past Timeout wait till button is released
+        SILABS_LOG("Factory Reset has been Canceled"); // button held past Timeout wait till button is released
     }
 
     // If the button was released before factory reset got initiated, start BLE advertissement in fast mode
@@ -416,7 +417,10 @@ void BaseApplication::ButtonHandler(AppEvent * aEvent)
             ConnectivityMgr().SetBLEAdvertisingEnabled(true);
             ConnectivityMgr().SetBLEAdvertisingMode(ConnectivityMgr().kFastAdvertising);
         }
-        else { SILABS_LOG("Network is already provisioned, Ble advertissement not enabled"); }
+        else
+        {
+            SILABS_LOG("Network is already provisioned, Ble advertissement not enabled");
+        }
     }
 }
 

--- a/examples/platform/silabs/SiWx917/BaseApplication.cpp
+++ b/examples/platform/silabs/SiWx917/BaseApplication.cpp
@@ -382,7 +382,7 @@ void BaseApplication::ButtonHandler(AppEvent * aEvent)
         }
 
 #ifdef ENABLE_WSTK_LEDS
-        // Turn off all LEDs before starting blink to make sure blink is
+        // Turn off status LED before starting blink to make sure blink is
         // co-ordinated.
         sStatusLED.Set(false);
         sStatusLED.Blink(500);

--- a/examples/platform/silabs/SiWx917/BaseApplication.h
+++ b/examples/platform/silabs/SiWx917/BaseApplication.h
@@ -139,6 +139,13 @@ protected:
     static void FunctionTimerEventHandler(TimerHandle_t xTimer);
 
     /**
+     * @brief Factory reset trigger function
+     *        Trigger factory if called
+     *
+     */
+    static void FunctionFactoryReset(void);
+
+    /**
      * @brief Timer Event processing function
      *        Trigger factory if Press and Hold duration is respected
      *

--- a/examples/platform/silabs/SiWx917/SiWx917/hal/rsi_hal_mcu_platform_init.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/hal/rsi_hal_mcu_platform_init.c
@@ -100,13 +100,13 @@ void RSI_Wakeupsw_config(void)
     RSI_NPSSGPIO_InputBufferEn(NPSS_GPIO_2, 1);
 
     /*Configure the NPSS GPIO mode to wake up  */
-    RSI_NPSSGPIO_SetPinMux(NPSS_GPIO_2, 2);
+    RSI_NPSSGPIO_SetPinMux(NPSS_GPIO_2, NPSSGPIO_PIN_MUX_MODE2);
 
     /*Configure the NPSS GPIO direction to input */
     RSI_NPSSGPIO_SetDir(NPSS_GPIO_2, NPSS_GPIO_DIR_OUTPUT);
 
-    /* Enables rise edge interrupt detection for UULP_VBAT_GPIO_0 */
-    RSI_NPSSGPIO_SetIntLevelLowEnable(NPSS_GPIO_2_INTR);
+    /* Enables fall edge interrupt detection for UULP_VBAT_GPIO_0 */
+    RSI_NPSSGPIO_SetIntFallEdgeEnable(NPSS_GPIO_2_INTR);
 
     /* Un mask the NPSS GPIO interrupt*/
     RSI_NPSSGPIO_IntrUnMask(NPSS_GPIO_2_INTR);
@@ -118,9 +118,9 @@ void RSI_Wakeupsw_config(void)
     RSI_NPSSGPIO_ClrIntr(NPSS_GPIO_2_INTR);
 
     /*Enable the NPSS GPIO interrupt slot*/
-    NVIC_EnableIRQ(21);
+    NVIC_EnableIRQ(NPSS_TO_MCU_GPIO_INTR_IRQn);
 
-    NVIC_SetPriority(21, 7);
+    NVIC_SetPriority(NPSS_TO_MCU_GPIO_INTR_IRQn, 7);
 }
 
 void RSI_Wakeupsw_config_gpio0(void)
@@ -140,8 +140,8 @@ void RSI_Wakeupsw_config_gpio0(void)
     /* Set the GPIO to wake from deep sleep */
     RSI_NPSSGPIO_SetWkpGpio(NPSS_GPIO_0_INTR);
 
-    /* Enables rise edge interrupt detection for UULP_VBAT_GPIO_0 */
-    RSI_NPSSGPIO_SetIntLevelLowEnable(NPSS_GPIO_0_INTR);
+    /* Enables fall edge interrupt detection for UULP_VBAT_GPIO_0 */
+    RSI_NPSSGPIO_SetIntFallEdgeEnable(NPSS_GPIO_0_INTR);
 
     /* Un mask the NPSS GPIO interrupt*/
     RSI_NPSSGPIO_IntrUnMask(NPSS_GPIO_0_INTR);
@@ -153,8 +153,8 @@ void RSI_Wakeupsw_config_gpio0(void)
     RSI_NPSSGPIO_ClrIntr(NPSS_GPIO_0_INTR);
 
     // 21 being the NPSS_TO_MCU_GPIO_INTR_IRQn
-    NVIC_EnableIRQ(21);
-    NVIC_SetPriority(21, 7);
+    NVIC_EnableIRQ(NPSS_TO_MCU_GPIO_INTR_IRQn);
+    NVIC_SetPriority(NPSS_TO_MCU_GPIO_INTR_IRQn, 7);
 }
 
 /*==============================================*/

--- a/examples/platform/silabs/SiWx917/SiWx917/hal/rsi_hal_mcu_platform_init.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/hal/rsi_hal_mcu_platform_init.c
@@ -34,7 +34,7 @@
 
 /* QSPI clock config params */
 #define INTF_PLL_500_CTRL_VALUE 0xD900
-#define INTF_PLL_CLK            160000000 /* PLL out clock 160MHz */
+#define INTF_PLL_CLK 160000000 /* PLL out clock 160MHz */
 
 #define PMU_GOOD_TIME 31  /*Duration in us*/
 #define XTAL_GOOD_TIME 31 /*Duration in us*/
@@ -85,10 +85,13 @@ int soc_pll_config(void)
 #ifdef SWITCH_QSPI_TO_SOC_PLL
     /* program intf pll to 160Mhz */
     SPI_MEM_MAP_PLL(INTF_PLL_500_CTRL_REG9) = INTF_PLL_500_CTRL_VALUE;
-    status = RSI_CLK_SetIntfPllFreq(M4CLK, INTF_PLL_CLK, SOC_PLL_REF_FREQUENCY);
-    if (status != RSI_OK) {
+    status                                  = RSI_CLK_SetIntfPllFreq(M4CLK, INTF_PLL_CLK, SOC_PLL_REF_FREQUENCY);
+    if (status != RSI_OK)
+    {
         SILABS_LOG("Failed to Config Interface PLL Clock, status:%d", status);
-    } else {
+    }
+    else
+    {
         SILABS_LOG("Configured Interface PLL Clock to %d", INTF_PLL_CLK);
     }
 

--- a/examples/platform/silabs/SiWx917/ldscripts/SiWx917.ld
+++ b/examples/platform/silabs/SiWx917/ldscripts/SiWx917.ld
@@ -18,8 +18,8 @@
 
 MEMORY
 {
-	FLASH (rx)  : ORIGIN = 0x08012000, LENGTH = 0x200000
-	RAM (rwx) : ORIGIN = 0xC, LENGTH = 262144
+	FLASH (rx)  : ORIGIN = 0x08012000, LENGTH = 0x400000
+	RAM (rwx) : ORIGIN = 0xC, LENGTH = 0x4FC00
 }
 
 /* Linker script to place sections and symbol values. Should be used together


### PR DESCRIPTION
SiWx917 :
1. Enabled long press for Factory reset.
2. Increased qspi clock(80 MHz) to improve the flash performance
3. RAM and flash sizes are updated for 917 SoC

Factory Reset was earlier function with a single button press, this feature add the long press to trigger factory reset instead of single press.

The user will have the experience as below
------------------------------------------------

<silabs > Factory reset triggering in 5 sec release button to cancel
<silabs > Factory reset triggering in 4 sec release button to cancel
<silabs > Factory reset triggering in 3 sec release button to cancel
<silabs > Factory reset triggering in 2 sec release button to cancel
<silabs > Factory reset triggering in 1 sec release button to cancel
<silabs > #################################################################
<silabs > ################### Factory reset triggered #####################
<silabs > #################################################################