### PR TITLE
[dnssd] Replace invalid forced reset logic

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -46,13 +46,17 @@ namespace {
 
 void OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
 {
-    if (event->Type == DeviceLayer::DeviceEventType::kDnssdPlatformInitialized
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-        || event->Type == DeviceLayer::DeviceEventType::kSEDIntervalChange
-#endif
-    )
+    switch (event->Type)
     {
+    case DeviceLayer::DeviceEventType::kDnssdPlatformInitialized:
+    case DeviceLayer::DeviceEventType::kDnssdRestartNeeded:
+#if CHIP_DEVICE_CONFIG_ENABLE_SED
+    case event->Type == DeviceLayer::DeviceEventType::kSEDIntervalChange:
+#endif
         app::DnssdServer::Instance().StartServer();
+        break;
+    default:
+        break;
     }
 }
 

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -51,7 +51,7 @@ void OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
     case DeviceLayer::DeviceEventType::kDnssdPlatformInitialized:
     case DeviceLayer::DeviceEventType::kDnssdRestartNeeded:
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
-    case event->Type == DeviceLayer::DeviceEventType::kSEDIntervalChange:
+    case DeviceLayer::DeviceEventType::kSEDIntervalChange:
 #endif
         app::DnssdServer::Instance().StartServer();
         break;

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -217,6 +217,11 @@ enum PublicEventTypes
     kDnssdPlatformInitialized,
 
     /**
+     * DNS-SD needs restart
+     */
+    kDnssdRestartNeeded,
+
+    /**
      * Signals that bindings were updated.
      */
     kBindingsChangedViaCluster,

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -217,7 +217,7 @@ enum PublicEventTypes
     kDnssdPlatformInitialized,
 
     /**
-     * DNS-SD needs restart
+     * Signals that DNS-SD backend was restarted and services must be published again.
      */
     kDnssdRestartNeeded,
 

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -396,17 +396,15 @@ void DiscoveryImplPlatform::HandleDnssdInit(void * context, CHIP_ERROR initError
         // class that it is contained in).
         publisher->mResolverProxy.Init(nullptr);
 
-#if !CHIP_DEVICE_LAYER_NONE
         // Post an event that will start advertising
-        chip::DeviceLayer::ChipDeviceEvent event;
-        event.Type = chip::DeviceLayer::DeviceEventType::kDnssdPlatformInitialized;
+        DeviceLayer::ChipDeviceEvent event;
+        event.Type = DeviceLayer::DeviceEventType::kDnssdPlatformInitialized;
 
-        CHIP_ERROR error = chip::DeviceLayer::PlatformMgr().PostEvent(&event);
+        CHIP_ERROR error = DeviceLayer::PlatformMgr().PostEvent(&event);
         if (error != CHIP_NO_ERROR)
         {
             ChipLogError(Discovery, "Posting DNS-SD platform initialized event failed with %" CHIP_ERROR_FORMAT, error.Format());
         }
-#endif
     }
     else
     {
@@ -418,24 +416,17 @@ void DiscoveryImplPlatform::HandleDnssdInit(void * context, CHIP_ERROR initError
 void DiscoveryImplPlatform::HandleDnssdError(void * context, CHIP_ERROR error)
 {
     DiscoveryImplPlatform * publisher = static_cast<DiscoveryImplPlatform *>(context);
+
     if (error == CHIP_ERROR_FORCED_RESET)
     {
-        if (publisher->mIsOperationalNodePublishing)
-        {
-            publisher->Advertise(publisher->mOperationalNodeAdvertisingParams);
-        }
+        DeviceLayer::ChipDeviceEvent event;
+        event.Type = DeviceLayer::DeviceEventType::kDnssdRestartNeeded;
+        error      = DeviceLayer::PlatformMgr().PostEvent(&event);
 
-        if (publisher->mIsCommissionableNodePublishing)
+        if (error != CHIP_NO_ERROR)
         {
-            publisher->Advertise(publisher->mCommissionableNodeAdvertisingParams);
+            ChipLogError(Discovery, "Failed to post DNS-SD restart event: %" CHIP_ERROR_FORMAT, error.Format());
         }
-
-        if (publisher->mIsCommissionerNodePublishing)
-        {
-            publisher->Advertise(publisher->mCommissionerNodeAdvertisingParams);
-        }
-
-        publisher->FinalizeServiceUpdate();
     }
     else
     {
@@ -550,9 +541,7 @@ CHIP_ERROR DiscoveryImplPlatform::PublishService(const char * serviceType, TextE
                                       sizeof(Name##SubTypeBuf), params.Get##Name()));
 
 #define PUBLISH_RECORDS(Type)                                                                                                      \
-    ReturnErrorOnFailure(PublishService(k##Type##ServiceName, textEntries, textEntrySize, subTypes, subTypeSize, params));         \
-    m##Type##NodeAdvertisingParams = params;                                                                                       \
-    mIs##Type##NodePublishing      = true;
+    ReturnErrorOnFailure(PublishService(k##Type##ServiceName, textEntries, textEntrySize, subTypes, subTypeSize, params));
 
 CHIP_ERROR DiscoveryImplPlatform::Advertise(const OperationalAdvertisingParameters & params)
 {
@@ -606,10 +595,6 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const CommissionAdvertisingParameter
 CHIP_ERROR DiscoveryImplPlatform::RemoveServices()
 {
     ReturnErrorOnFailure(ChipDnssdRemoveServices());
-
-    mIsOperationalNodePublishing    = false;
-    mIsCommissionableNodePublishing = false;
-    mIsCommissionerNodePublishing   = false;
 
     return CHIP_NO_ERROR;
 }

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -64,6 +64,13 @@ public:
     static DiscoveryImplPlatform & GetInstance();
 
 private:
+    enum class State : uint8_t
+    {
+        kUninitialized,
+        kInitializing,
+        kInitialized
+    };
+
     DiscoveryImplPlatform();
 
     DiscoveryImplPlatform(const DiscoveryImplPlatform &) = delete;
@@ -83,10 +90,8 @@ private:
                               size_t subTypeSize, uint16_t port, Inet::InterfaceId interfaceId, const chip::ByteSpan & mac,
                               DnssdServiceProtocol procotol, PeerId peerId);
 
+    State mState = State::kUninitialized;
     uint8_t mCommissionableInstanceName[sizeof(uint64_t)];
-
-    bool mDnssdInitialized = false;
-
     ResolverProxy mResolverProxy;
 
     static DiscoveryImplPlatform sManager;

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -83,12 +83,6 @@ private:
                               size_t subTypeSize, uint16_t port, Inet::InterfaceId interfaceId, const chip::ByteSpan & mac,
                               DnssdServiceProtocol procotol, PeerId peerId);
 
-    OperationalAdvertisingParameters mOperationalNodeAdvertisingParams;
-    CommissionAdvertisingParameters mCommissionableNodeAdvertisingParams;
-    CommissionAdvertisingParameters mCommissionerNodeAdvertisingParams;
-    bool mIsOperationalNodePublishing    = false;
-    bool mIsCommissionableNodePublishing = false;
-    bool mIsCommissionerNodePublishing   = false;
     uint8_t mCommissionableInstanceName[sizeof(uint64_t)];
 
     bool mDnssdInitialized = false;


### PR DESCRIPTION
The platform implementation of DNS-SD contains a mechanism for restarting the advertising when the platform returns the CHIP_ERROR_FORCED_RESET error. This mechanism is broken as it assumes that only one operational service is used and    it uses extra RAM although it is only used by Linux.

Switch to an event-based approach that allows the DNS-SD server to restart the advertising when needed.

Additionally, handle the case in which `DiscoveryImplPlatform::InitImpl()` is called while the initialization is in progress