### PR TITLE
[YAML tests] Add PICS code to Color Control WaitForDelay steps

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_CC_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_3_1.yaml
@@ -63,6 +63,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -89,6 +90,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -106,6 +108,7 @@ tests:
               maxValue: 92
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -123,6 +126,7 @@ tests:
               maxValue: 115
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -140,6 +144,7 @@ tests:
               maxValue: 138
 
     - label: "Wait 5s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -175,6 +180,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -201,6 +207,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -228,6 +235,7 @@ tests:
                 value: "y"
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -245,6 +253,7 @@ tests:
               maxValue: 224
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -262,6 +271,7 @@ tests:
               maxValue: 155
 
     - label: "Wait 5s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -297,6 +307,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -323,6 +334,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -340,6 +352,7 @@ tests:
               maxValue: 92
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -357,6 +370,7 @@ tests:
               maxValue: 115
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -374,6 +388,7 @@ tests:
               maxValue: 138
 
     - label: "Wait 5s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -409,6 +424,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -435,6 +451,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -452,6 +469,7 @@ tests:
               maxValue: 115
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -469,6 +487,7 @@ tests:
               maxValue: 92
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -486,6 +505,7 @@ tests:
               maxValue: 69
 
     - label: "Wait 5s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_3_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_3_2.yaml
@@ -62,6 +62,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -86,6 +87,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -103,6 +105,7 @@ tests:
               maxValue: 255
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -120,6 +123,7 @@ tests:
               maxValue: 52
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -153,6 +157,7 @@ tests:
               maxValue: 110
 
     - label: "Wait 2s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -188,6 +193,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -212,6 +218,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -229,6 +236,7 @@ tests:
               maxValue: 12
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -246,6 +254,7 @@ tests:
               maxValue: 247
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -279,6 +288,7 @@ tests:
               maxValue: 190
 
     - label: "Wait 2s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_3_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_3_3.yaml
@@ -62,6 +62,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -88,6 +89,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -105,6 +107,7 @@ tests:
               maxValue: 254
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -122,6 +125,7 @@ tests:
               maxValue: 6
 
     - label: "Wait 5s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -157,6 +161,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -183,6 +188,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -200,6 +206,7 @@ tests:
               maxValue: 23
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -217,6 +224,7 @@ tests:
               maxValue: 255
 
     - label: "Wait 5s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_4_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_4_1.yaml
@@ -63,6 +63,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -87,6 +88,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -104,6 +106,7 @@ tests:
               maxValue: 92
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -121,6 +124,7 @@ tests:
               maxValue: 115
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -138,6 +142,7 @@ tests:
               maxValue: 138
 
     - label: "Wait 5s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_4_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_4_2.yaml
@@ -60,6 +60,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -84,6 +85,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -101,6 +103,7 @@ tests:
               maxValue: 230
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -118,6 +121,7 @@ tests:
               maxValue: 254
 
     - label: "Wait 5s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -151,6 +155,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -175,6 +180,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -192,6 +198,7 @@ tests:
               maxValue: 81
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -209,6 +216,7 @@ tests:
               maxValue: 23
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -242,6 +250,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -266,6 +275,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -308,6 +318,7 @@ tests:
               maxValue: 230
 
     - label: "Wait 2s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_4_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_4_3.yaml
@@ -60,6 +60,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -86,6 +87,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -103,6 +105,7 @@ tests:
               maxValue: 253
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -120,6 +123,7 @@ tests:
               maxValue: 254
 
     - label: "Wait 5s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -155,6 +159,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -188,6 +193,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -214,6 +220,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -231,6 +238,7 @@ tests:
               maxValue: 35
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -248,6 +256,7 @@ tests:
               maxValue: 12
 
     - label: "Wait 5s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -283,6 +292,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_4_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_4_4.yaml
@@ -63,6 +63,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -107,6 +108,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -133,6 +135,7 @@ tests:
               maxValue: 80
 
     - label: "Wait 10s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -160,6 +163,7 @@ tests:
               maxValue: 92
 
     - label: "Wait 5s"
+      PICS: CC.S.F00
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_5_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_5_1.yaml
@@ -62,6 +62,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -106,6 +107,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -132,6 +134,7 @@ tests:
               maxValue: 19660
 
     - label: "Wait 10s"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -158,6 +161,7 @@ tests:
               maxValue: 15073
 
     - label: "Wait 5s"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -222,6 +226,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -271,6 +276,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -311,6 +317,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -351,6 +358,7 @@ tests:
                 value: 1
 
     - label: "Wait 100ms"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -414,6 +422,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -463,6 +472,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -507,6 +517,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -547,6 +558,7 @@ tests:
                 value: 1
 
     - label: "Wait 100ms"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_5_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_5_2.yaml
@@ -62,6 +62,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -84,6 +85,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -110,6 +112,7 @@ tests:
               maxValue: 31100
 
     - label: "Wait 10s"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -136,6 +139,7 @@ tests:
               maxValue: 32200
 
     - label: "Wait 10s"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_5_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_5_3.yaml
@@ -62,6 +62,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -88,6 +89,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -114,6 +116,7 @@ tests:
               maxValue: 20000
 
     - label: "Wait 10s"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -140,6 +143,7 @@ tests:
               maxValue: 16100
 
     - label: "Wait 5s"
+      PICS: CC.S.F03
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_6_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6_1.yaml
@@ -94,6 +94,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -118,6 +119,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -135,6 +137,7 @@ tests:
               maxValue: 334
 
     - label: "Wait 10s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -152,6 +155,7 @@ tests:
               maxValue: 310
 
     - label: "Wait 10s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -169,6 +173,7 @@ tests:
               maxValue: 288
 
     - label: "Wait 5s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_6_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6_2.yaml
@@ -96,6 +96,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -127,6 +128,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -144,6 +146,7 @@ tests:
               maxValue: ColorTempPhysicalMaxMiredsValue
 
     - label: "Wait 10s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -161,6 +164,7 @@ tests:
               maxValue: ColorTempPhysicalMaxMiredsValue
 
     - label: "Wait 5s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -202,6 +206,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -219,6 +224,7 @@ tests:
               maxValue: ColorTempPhysicalMaxMiredsValue
 
     - label: "Wait 10s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -236,6 +242,7 @@ tests:
               maxValue: ColorTempPhysicalMaxMiredsValue
 
     - label: "Wait 5s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -277,6 +284,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -317,6 +325,7 @@ tests:
               maxValue: ColorTempPhysicalMaxMiredsValue
 
     - label: "Wait 2s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_6_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6_3.yaml
@@ -96,6 +96,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -129,6 +130,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -146,6 +148,7 @@ tests:
               maxValue: ColorTempPhysicalMaxMiredsValue
 
     - label: "Wait 10s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -163,6 +166,7 @@ tests:
               maxValue: ColorTempPhysicalMaxMiredsValue
 
     - label: "Wait 5s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -207,6 +211,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -224,6 +229,7 @@ tests:
               maxValue: ColorTempPhysicalMaxMiredsValue
 
     - label: "Wait 10s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -241,6 +247,7 @@ tests:
               maxValue: ColorTempPhysicalMaxMiredsValue
 
     - label: "Wait 5s"
+      PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_7_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_7_1.yaml
@@ -63,6 +63,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -89,6 +90,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -106,6 +108,7 @@ tests:
               maxValue: 9200
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -123,6 +126,7 @@ tests:
               maxValue: 11500
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -140,6 +144,7 @@ tests:
               maxValue: 13800
 
     - label: "Wait 5s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -175,6 +180,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -201,6 +207,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -218,6 +225,7 @@ tests:
               maxValue: 25300
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -235,6 +243,7 @@ tests:
               maxValue: 41300
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -252,6 +261,7 @@ tests:
               maxValue: 62100
 
     - label: "Wait 5s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -287,6 +297,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -313,6 +324,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -330,6 +342,7 @@ tests:
               maxValue: 9200
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -347,6 +360,7 @@ tests:
               maxValue: 11500
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -364,6 +378,7 @@ tests:
               maxValue: 13800
 
     - label: "Wait 5s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -399,6 +414,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -425,6 +441,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -442,6 +459,7 @@ tests:
               maxValue: 11500
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -459,6 +477,7 @@ tests:
               maxValue: 9200
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -476,6 +495,7 @@ tests:
               maxValue: 6900
 
     - label: "Wait 5s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_7_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_7_2.yaml
@@ -62,6 +62,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -86,6 +87,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -103,6 +105,7 @@ tests:
               maxValue: 28750
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -120,6 +123,7 @@ tests:
               maxValue: 34500
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -153,6 +157,7 @@ tests:
               maxValue: 40250
 
     - label: "Wait 2s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -189,6 +194,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -213,6 +219,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -230,6 +237,7 @@ tests:
               maxValue: 23000
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -247,6 +255,7 @@ tests:
               maxValue: 17250
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -280,6 +289,7 @@ tests:
               maxValue: 11500
 
     - label: "Wait 2s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_7_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_7_3.yaml
@@ -62,6 +62,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -88,6 +89,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -105,6 +107,7 @@ tests:
               maxValue: 9200
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -122,6 +125,7 @@ tests:
               maxValue: 11500
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -139,6 +143,7 @@ tests:
               maxValue: 13800
 
     - label: "Wait 5s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -174,6 +179,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -200,6 +206,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -217,6 +224,7 @@ tests:
               maxValue: 11500
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -234,6 +242,7 @@ tests:
               maxValue: 9200
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -251,6 +260,7 @@ tests:
               maxValue: 6900
 
     - label: "Wait 5s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_7_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_7_4.yaml
@@ -64,6 +64,7 @@ tests:
                 value: 0
 
     - label: "Wait 100ms"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -108,6 +109,7 @@ tests:
                 value: 0
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -135,6 +137,7 @@ tests:
               maxValue: 80
 
     - label: "Wait 10s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -162,6 +165,7 @@ tests:
               maxValue: 92
 
     - label: "Wait 5s"
+      PICS: CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_9_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_9_1.yaml
@@ -63,6 +63,7 @@ tests:
                 value: 0
 
     - label: "Wait for 1000ms"
+      PICS: CC.S.F02 && CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -225,6 +226,7 @@ tests:
           value: 16384
 
     - label: "Wait for 30S"
+      PICS: CC.S.F02 && CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -252,6 +254,7 @@ tests:
               maxValue: 65535
 
     - label: "Wait for 30S"
+      PICS: CC.S.F02 && CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -382,6 +385,7 @@ tests:
           value: 16384
 
     - label: "Wait for 30S"
+      PICS: CC.S.F02 && CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -409,6 +413,7 @@ tests:
               maxValue: 65535
 
     - label: "Wait for 30S"
+      PICS: CC.S.F02 && CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -490,6 +495,7 @@ tests:
                 value: 0
 
     - label: "Wait 1000ms"
+      PICS: CC.S.F02 && CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -572,6 +578,7 @@ tests:
           value: 16384
 
     - label: "Wait for 30S"
+      PICS: CC.S.F02 && CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -599,6 +606,7 @@ tests:
               maxValue: 65535
 
     - label: "Wait for 30S"
+      PICS: CC.S.F02 && CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -729,6 +737,7 @@ tests:
           value: 16384
 
     - label: "Wait for 30S"
+      PICS: CC.S.F02 && CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -756,6 +765,7 @@ tests:
               maxValue: 65535
 
     - label: "Wait for 30S"
+      PICS: CC.S.F02 && CC.S.F01
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_9_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_9_2.yaml
@@ -64,6 +64,7 @@ tests:
                 value: 0
 
     - label: "Wait for 1000ms"
+      PICS: CC.S.F01 && CC.S.F02
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -161,6 +162,7 @@ tests:
           value: 16384
 
     - label: "Wait for 30S"
+      PICS: CC.S.F01 && CC.S.F02
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -188,6 +190,7 @@ tests:
               maxValue: 65535
 
     - label: "Wait for 30S"
+      PICS: CC.S.F01 && CC.S.F02
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -236,6 +239,7 @@ tests:
           value: 1
 
     - label: "Wait for 30S"
+      PICS: CC.S.F01 && CC.S.F02
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -263,6 +267,7 @@ tests:
               maxValue: 65535
 
     - label: "Wait for 30S"
+      PICS: CC.S.F01 && CC.S.F02
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_9_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_9_3.yaml
@@ -63,6 +63,7 @@ tests:
                 value: 0
 
     - label: "Wait for 1000ms"
+      PICS: CC.S.F01 && CC.S.F02
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -160,6 +161,7 @@ tests:
           value: 16384
 
     - label: "Wait for 30S"
+      PICS: CC.S.F01 && CC.S.F02
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -187,6 +189,7 @@ tests:
               maxValue: 65535
 
     - label: "Wait for 30S"
+      PICS: CC.S.F01 && CC.S.F02
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -234,6 +237,7 @@ tests:
           value: 60
 
     - label: "Wait for 60S"
+      PICS: CC.S.F01 && CC.S.F02
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
@@ -252,6 +256,7 @@ tests:
               maxValue: 65535
 
     - label: "Wait for 60S"
+      PICS: CC.S.F01 && CC.S.F02
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:


### PR DESCRIPTION
#### Problem

We are losing minutes of CI times on waiting for nothing for all the tests that really depends on `CC.S.F00`. This one is turned off by default for our CI runs, but we ends up waiting between 2 skipped steps...