### PR TITLE
[nrfconnect] Fixed window covering compilation failure

### DIFF
--- a/examples/window-app/nrfconnect/main/include/AppTask.h
+++ b/examples/window-app/nrfconnect/main/include/AppTask.h
@@ -27,7 +27,7 @@
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_BT
-#include "dfu_over_smp.h"
+#include "DFUOverSMP.h"
 #endif
 
 struct k_timer;


### PR DESCRIPTION
Included file name has incorrect case convention, so compiler is not able to find the file and fails.



