### PR TITLE
Fix cloudbuild targets: It is "all-clusters" and not "all-clusters-app"

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -63,7 +63,7 @@ steps:
               --target esp32-m5stack-all-clusters-minimal-rpc-ipv6only
               --target esp32-m5stack-ota-requestor
               --target genio-lighting-app
-              --target imx-all-clusters-app
+              --target imx-all-clusters
               --target imx-chip-tool
               --target imx-thermostat
               --target infineon-psoc6-all-clusters
@@ -83,8 +83,8 @@ steps:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
               --target linux-arm64-all-clusters-clang
-              --target linux-arm64-all-clusters-app-nodeps
-              --target linux-arm64-all-clusters-app-nodeps-ipv6only
+              --target linux-arm64-all-clusters-nodeps
+              --target linux-arm64-all-clusters-nodeps-ipv6only
               --target linux-arm64-all-clusters-ipv6only-clang
               --target linux-arm64-all-clusters-minimal-clang
               --target linux-arm64-all-clusters-minimal-ipv6only-clang
@@ -141,7 +141,7 @@ steps:
               --target mbed-CY8CPROTO_062_4343W-light-release
               --target mbed-CY8CPROTO_062_4343W-lock-release
               --target mbed-CY8CPROTO_062_4343W-pigweed-release
-              --target mw320-all-clusters-app
+              --target mw320-all-clusters
               --target nrf-nrf52840dk-all-clusters
               --target nrf-nrf52840dk-all-clusters-minimal
               --target nrf-nrf52840dk-light-rpc

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -92,7 +92,7 @@ steps:
               ./scripts/build/build_examples.py
               --enable-flashbundle
               --target linux-arm64-all-clusters-clang
-              --target linux-arm64-all-clusters-app-nodeps-ipv6only-clang
+              --target linux-arm64-all-clusters-nodeps-ipv6only
               --target linux-arm64-all-clusters-minimal-ipv6only-clang
               --target linux-arm64-bridge-ipv6only-clang
               --target linux-arm64-chip-tool-ipv6only-clang
@@ -110,7 +110,7 @@ steps:
               --target linux-arm64-tv-app-ipv6only-clang
               --target linux-arm64-tv-casting-app-ipv6only-clang
               --target linux-x64-address-resolve-tool
-              --target linux-x64-all-clusters-app-nodeps-ipv6only
+              --target linux-x64-all-clusters-nodeps
               --target linux-x64-all-clusters-coverage
               --target linux-x64-bridge-ipv6only
               --target linux-x64-chip-cert


### PR DESCRIPTION
Cloudbuild builds were failing with:

```
...
Step #5 - "Linux": Usage: build_examples.py [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...
Step #5 - "Linux": Try 'build_examples.py --help' for help.
Step #5 - "Linux": 
Step #5 - "Linux": Error: Invalid value for '--target': 'linux-arm64-all-clusters-app-nodeps-ipv6only-clang' is not a valid target name.
Finished Step #5 - "Linux
```