### PR TITLE
[Cloudbuild] Replace more arm64 nodeps-clang variants with just nodeps 

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -96,14 +96,14 @@ steps:
               --target linux-arm64-all-clusters-minimal-ipv6only-clang
               --target linux-arm64-bridge-ipv6only-clang
               --target linux-arm64-chip-tool-ipv6only-clang
-              --target linux-arm64-chip-tool-nodeps-ipv6only-clang
+              --target linux-arm64-chip-tool-nodeps-ipv6only
               --target linux-arm64-dynamic-bridge-ipv6only-clang
               --target linux-arm64-light-clang-rpc-ipv6only
               --target linux-arm64-light-clang-rpc-ipv6only-minmdns-verbose
               --target linux-arm64-lock-ipv6only-clang
               --target linux-arm64-minmdns-clang
-              --target linux-arm64-ota-provider-nodeps-ipv6only-clang
-              --target linux-arm64-ota-requestor-nodeps-ipv6only-clang
+              --target linux-arm64-ota-provider-nodeps-ipv6only
+              --target linux-arm64-ota-requestor-nodeps-ipv6only
               --target linux-arm64-python-bindings-clang
               --target linux-arm64-shell-ipv6only-clang
               --target linux-arm64-thermostat-ipv6only-clang


### PR DESCRIPTION
nodeps requires no clang, so builds fail:

```
Executing in build environment: ./scripts/build/build_examples.py --enable-flashbundle --target linux-arm64-all-clusters-clang --target linux-arm64-all-clusters-nodeps-ipv6only --target linux-arm64-all-clusters-minimal-ipv6only-clang --target linux-arm64-bridge-ipv6only-clang --target linux-arm64-chip-tool-ipv6only-clang --target linux-arm64-chip-tool-nodeps-ipv6only-clang --target linux-arm64-dynamic-bridge-ipv6only-clang --target linux-arm64-light-clang-rpc-ipv6only --target linux-arm64-light-…thon-bindings --target linux-x64-rpc-console --target linux-x64-shell-ipv6only --target linux-x64-thermostat-ipv6only --target linux-x64-tv-app-ipv6only --target linux-x64-tv-casting-app-ipv6only build --create-archives /workspace/artifacts/
ERROR:root:'nodeps' does not support 'linux-arm64-chip-tool-nodeps-ipv6only-clang' due to rule EXCEPT IF '-(clang|noble|boringssl|mbedtls)'
Usage: build_examples.py [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...
Try 'build_examples.py --help' for help.
```


