### PR TITLE
On kBindingsChangedViaCluster during UDC, pick target video player's nodeID from BindingTable

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -351,40 +351,40 @@ void CastingServer::DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * eve
         else if (CastingServer::GetInstance()->mUdcInProgress)
         {
             ChipLogProgress(AppServer,
-                            "CastingServer::DeviceEventCallback UDC is in progress while handling kBindingsChangedViaCluster");
+                            "CastingServer::DeviceEventCallback UDC is in progress while handling kBindingsChangedViaCluster with "
+                            "fabricIndex: %d",
+                            event->BindingsChanged.fabricIndex);
             CastingServer::GetInstance()->mUdcInProgress = false;
-            if (CastingServer::GetInstance()->mTargetVideoPlayerNumIPs > 0)
+
+            // find targetPeerNodeId from binding table by matching the binding's fabricIndex with the accessing fabricIndex
+            // received in BindingsChanged event
+            for (const auto & binding : BindingTable::GetInstance())
             {
-                TargetVideoPlayerInfo * connectableVideoPlayerList =
-                    CastingServer::GetInstance()->ReadCachedTargetVideoPlayerInfos();
-                if (connectableVideoPlayerList == nullptr || !connectableVideoPlayerList[0].IsInitialized())
+                ChipLogProgress(
+                    AppServer,
+                    "CastingServer::DeviceEventCallback Read cached binding type=%d fabrixIndex=%d nodeId=0x" ChipLogFormatX64
+                    " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
+                    binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
+                    binding.remote, ChipLogValueMEI(binding.clusterId.ValueOr(0)));
+                if (binding.type == EMBER_UNICAST_BINDING && event->BindingsChanged.fabricIndex == binding.fabricIndex)
                 {
-                    ChipLogError(AppServer, "CastingServer::DeviceEventCallback No cached video players found");
-                    CastingServer::GetInstance()->mCommissioningCompleteCallback(CHIP_ERROR_INCORRECT_STATE);
-                    return;
+                    ChipLogProgress(
+                        NotSpecified,
+                        "CastingServer::DeviceEventCallback Matched accessingFabricIndex with nodeId=0x" ChipLogFormatX64,
+                        ChipLogValueX64(binding.nodeId));
+                    targetPeerNodeId     = binding.nodeId;
+                    targetFabricIndex    = binding.fabricIndex;
+                    runPostCommissioning = true;
+                    break;
                 }
+            }
 
-                for (size_t i = 0; i < kMaxCachedVideoPlayers && connectableVideoPlayerList[i].IsInitialized(); i++)
-                {
-                    if (connectableVideoPlayerList[i].IsSameAs(CastingServer::GetInstance()->mTargetVideoPlayerDeviceName,
-                                                               CastingServer::GetInstance()->mTargetVideoPlayerNumIPs,
-                                                               CastingServer::GetInstance()->mTargetVideoPlayerIpAddress))
-                    {
-                        ChipLogProgress(AppServer,
-                                        "CastingServer::DeviceEventCallback found the video player to initialize/connect to");
-                        targetPeerNodeId     = connectableVideoPlayerList[i].GetNodeId();
-                        targetFabricIndex    = connectableVideoPlayerList[i].GetFabricIndex();
-                        runPostCommissioning = true;
-                    }
-                }
-
-                if (targetPeerNodeId == 0 && runPostCommissioning == false)
-                {
-                    ChipLogError(AppServer,
-                                 "CastingServer::DeviceEventCallback did NOT find the video player to initialize/connect to");
-                    CastingServer::GetInstance()->mCommissioningCompleteCallback(CHIP_ERROR_INCORRECT_STATE);
-                    return;
-                }
+            if (targetPeerNodeId == 0 && runPostCommissioning == false)
+            {
+                ChipLogError(AppServer, "CastingServer::DeviceEventCallback accessingFabricIndex: %d did not match bindings",
+                             event->BindingsChanged.fabricIndex);
+                CastingServer::GetInstance()->mCommissioningCompleteCallback(CHIP_ERROR_INCORRECT_STATE);
+                return;
             }
         }
     }

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -341,7 +341,8 @@ void CastingServer::DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * eve
     if (event->Type == DeviceLayer::DeviceEventType::kBindingsChangedViaCluster)
     {
         ChipLogProgress(AppServer, "CastingServer::DeviceEventCallback kBindingsChangedViaCluster received");
-        if (CastingServer::GetInstance()->GetActiveTargetVideoPlayer()->IsInitialized())
+        if (CastingServer::GetInstance()->GetActiveTargetVideoPlayer()->IsInitialized() &&
+            CastingServer::GetInstance()->GetActiveTargetVideoPlayer()->GetOperationalDeviceProxy() != nullptr)
         {
             ChipLogProgress(AppServer,
                             "CastingServer::DeviceEventCallback already connected to video player, reading server clusters");

--- a/src/app/clusters/bindings/bindings.cpp
+++ b/src/app/clusters/bindings/bindings.cpp
@@ -52,7 +52,7 @@ private:
     CHIP_ERROR ReadBindingTable(EndpointId endpoint, AttributeValueEncoder & encoder);
     CHIP_ERROR WriteBindingTable(const ConcreteDataAttributePath & path, AttributeValueDecoder & decoder);
 
-    CHIP_ERROR NotifyBindingsChanged();
+    CHIP_ERROR NotifyBindingsChanged(FabricIndex accessingFabricIndex = 0);
 };
 
 BindingTableAccess gAttrAccess;
@@ -233,7 +233,7 @@ CHIP_ERROR BindingTableAccess::WriteBindingTable(const ConcreteDataAttributePath
         if (!path.IsListOperation())
         {
             // Notify binding table has changed
-            LogErrorOnFailure(NotifyBindingsChanged());
+            LogErrorOnFailure(NotifyBindingsChanged(accessingFabricIndex));
         }
         return CHIP_NO_ERROR;
     }
@@ -251,10 +251,11 @@ CHIP_ERROR BindingTableAccess::WriteBindingTable(const ConcreteDataAttributePath
     return CHIP_IM_GLOBAL_STATUS(UnsupportedWrite);
 }
 
-CHIP_ERROR BindingTableAccess::NotifyBindingsChanged()
+CHIP_ERROR BindingTableAccess::NotifyBindingsChanged(FabricIndex accessingFabricIndex)
 {
     DeviceLayer::ChipDeviceEvent event;
-    event.Type = DeviceLayer::DeviceEventType::kBindingsChangedViaCluster;
+    event.Type                        = DeviceLayer::DeviceEventType::kBindingsChangedViaCluster;
+    event.BindingsChanged.fabricIndex = accessingFabricIndex;
     return chip::DeviceLayer::PlatformMgr().PostEvent(&event);
 }
 

--- a/src/app/clusters/bindings/bindings.cpp
+++ b/src/app/clusters/bindings/bindings.cpp
@@ -52,7 +52,7 @@ private:
     CHIP_ERROR ReadBindingTable(EndpointId endpoint, AttributeValueEncoder & encoder);
     CHIP_ERROR WriteBindingTable(const ConcreteDataAttributePath & path, AttributeValueDecoder & decoder);
 
-    CHIP_ERROR NotifyBindingsChanged(FabricIndex accessingFabricIndex = 0);
+    CHIP_ERROR NotifyBindingsChanged(FabricIndex accessingFabricIndex);
 };
 
 BindingTableAccess gAttrAccess;
@@ -190,7 +190,7 @@ CHIP_ERROR BindingTableAccess::Write(const ConcreteDataAttributePath & path, Att
 void BindingTableAccess::OnListWriteEnd(const app::ConcreteAttributePath & aPath, bool aWriteWasSuccessful)
 {
     // Notify binding table has changed
-    LogErrorOnFailure(NotifyBindingsChanged());
+    LogErrorOnFailure(NotifyBindingsChanged(0));
 }
 
 CHIP_ERROR BindingTableAccess::WriteBindingTable(const ConcreteDataAttributePath & path, AttributeValueDecoder & decoder)

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -480,6 +480,10 @@ struct ChipDeviceEvent final
             uint64_t nodeId;
             FabricIndex fabricIndex;
         } CommissioningComplete;
+        struct
+        {
+            FabricIndex fabricIndex;
+        } BindingsChanged;
 
         struct
         {


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/24267

### Change summary
1. Added a new BindingsChanged event in CHIPDeviceEvent.h which includes the accessing fabricIndex.
2. Passed the accessing fabricIndex in the BindingsChanged event in bindings.cpp: NotifyBindingsChanged call
3. On kBindingsChangedViaCluster, if we find UDC is in progress, we select the video player (find its nodeId and fabricIndex) from the BindingTable by matching it against the accessing fabricIndex found in the BindingsChanged event.

### Testing
Tested with the Android tv-casting-app and the Linux tv-app as per the instructions in https://github.com/project-chip/connectedhomeip/issues/24267
