### PR TITLE
[repl tests] Allow the ability to run all tests in the test suite (including manual)

### DIFF
--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -19,6 +19,7 @@ import os
 import sys
 import time
 import typing
+import enum
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -30,6 +31,12 @@ from chiptest.glob_matcher import GlobMatcher
 
 DEFAULT_CHIP_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+class ManualHandling(enum.Enum):
+    INCLUDE = enum.auto()
+    SKIP = enum.auto()
+    ONLY = enum.auto()
 
 
 def FindBinaryPath(name: str):
@@ -60,7 +67,7 @@ class RunContext:
     in_unshare: bool
     chip_tool: str
     dry_run: bool
-    skip_manual: bool
+    manual_handling: ManualHandling
 
 
 @click.group(chain=True)
@@ -107,11 +114,11 @@ class RunContext:
     help='Internal flag for running inside a unshared environment'
 )
 @click.option(
-    '--run-all-manual-tests',
+    '--manual',
     hidden=True,
-    is_flag=True,
-    default=False,
-    help='Internal flag to run all manual tests'
+    type=click.Choice(['skip', 'only', 'include'], case_sensitive=False),
+    default='skip',
+    help='Internal flag to determine how to handle manual tests',
 )
 @click.option(
     '--run-yamltests-with-chip-repl',
@@ -123,7 +130,7 @@ class RunContext:
     help='Binary path of chip tool app to use to run the test')
 @click.pass_context
 def main(context, dry_run, log_level, target, target_glob, target_skip_glob,
-         no_log_timestamps, root, internal_inside_unshare, run_all_manual_tests, run_yamltests_with_chip_repl, chip_tool):
+         no_log_timestamps, root, internal_inside_unshare, manual, run_yamltests_with_chip_repl, chip_tool):
     # Ensures somewhat pretty logging of what is going on
     log_fmt = '%(asctime)s.%(msecs)03d %(levelname)-7s %(message)s'
     if no_log_timestamps:
@@ -140,7 +147,16 @@ def main(context, dry_run, log_level, target, target_glob, target_skip_glob,
     tests = all_tests
 
     # Default to only non-manual tests unless explicit targets are specified.
-    skip_manual = not run_all_manual_tests and ('all' in target)
+    if 'all' in target:
+        if manual == 'skip':
+            manual_handling = ManualHandling.SKIP
+        elif manual == 'only':
+            manual_handling = ManualHandling.ONLY
+        else:
+            manual_handling = ManualHandling.INCLUDE
+    else:
+            manual_handling = ManualHandling.INCLUDE
+
     if 'all' not in target:
         tests = []
         for name in target:
@@ -152,7 +168,6 @@ def main(context, dry_run, log_level, target, target_glob, target_skip_glob,
 
     if target_glob:
         matcher = GlobMatcher(target_glob.lower())
-        # Globs ignore manual tests, because it's too easy to mess up otherwise.
         tests = [test for test in tests if matcher.matches(test.name.lower())]
 
     if len(tests) == 0:
@@ -171,7 +186,7 @@ def main(context, dry_run, log_level, target, target_glob, target_skip_glob,
     context.obj = RunContext(root=root, tests=tests,
                              in_unshare=internal_inside_unshare,
                              chip_tool=chip_tool, dry_run=dry_run,
-                             skip_manual=skip_manual)
+                             manual_handling=manual_handling)
 
 
 @main.command(
@@ -279,8 +294,12 @@ def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, o
     for i in range(iterations):
         logging.info("Starting iteration %d" % (i+1))
         for test in context.obj.tests:
-            if context.obj.skip_manual and test.is_manual:
-                continue
+            if test.is_manual:
+                if context.obj.manual_handling == ManualHandling.SKIP:
+                    continue
+            else:
+                if context.obj.manual_handling == ManualHandling.ONLY:
+                    continue
 
             test_start = time.monotonic()
             try:

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -115,10 +115,10 @@ class RunContext:
 )
 @click.option(
     '--manual',
-    hidden=True,
     type=click.Choice(['skip', 'only', 'include'], case_sensitive=False),
     default='skip',
-    help='Internal flag to determine how to handle manual tests',
+    show_default=True,
+    help='Internal flag to determine how to handle manual tests. ONLY for "all" test choice.",
 )
 @click.option(
     '--run-yamltests-with-chip-repl',

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -118,7 +118,7 @@ class RunContext:
     type=click.Choice(['skip', 'only', 'include'], case_sensitive=False),
     default='skip',
     show_default=True,
-    help='Internal flag to determine how to handle manual tests. ONLY for "all" test choice.",
+    help='Internal flag to determine how to handle manual tests. ONLY for "all" test choice.',
 )
 @click.option(
     '--run-yamltests-with-chip-repl',

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import enum
 import logging
 import os
 import sys
 import time
 import typing
-import enum
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -155,7 +155,7 @@ def main(context, dry_run, log_level, target, target_glob, target_skip_glob,
         else:
             manual_handling = ManualHandling.INCLUDE
     else:
-            manual_handling = ManualHandling.INCLUDE
+        manual_handling = ManualHandling.INCLUDE
 
     if 'all' not in target:
         tests = []


### PR DESCRIPTION
While we are developing things, it seems very convenient to just run all tests even if they fail, to see what passes/fails.
This is faster than running 1 by 1 as startup of network namespaces takes a while.

Usage is like:

```sh
export BUILD_VARIANT=no-ble-tsan-clang
export PYTHONPATH=$PW_PROJECT_ROOT/scripts/py_matter_idl/:$PW_PROJECT_ROOT/scripts/py_matter_yamltests

./scripts/tests/run_test_suite.py \
    --run-yamltests-with-chip-repl \
    --manual include \
    run \
    --iterations 1 \
    --test-timeout-seconds 120 \
    --all-clusters-app ./out/linux-x64-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
    --lock-app ./out/linux-x64-lock-${BUILD_VARIANT}/chip-lock-app \
    --ota-provider-app ./out/linux-x64-ota-provider-${BUILD_VARIANT}/chip-ota-provider-app \
    --ota-requestor-app ./out/linux-x64-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
    --tv-app ./out/linux-x64-tv-app-${BUILD_VARIANT}/chip-tv-app \
    --bridge-app ./out/linux-x64-bridge-${BUILD_VARIANT}/chip-bridge-app \
    --keep-going
```

And this gives me a full list of what tests pass and fail (assuming I only grep success/pass lines). It looks like:

```
2023-01-27 15:41:22.494 ERROR   Config_Example                 - FAILED in 1.47 seconds
2023-01-27 15:41:23.908 ERROR   Config_Variables_Example       - FAILED in 1.41 seconds
2023-01-27 15:41:25.549 ERROR   DL_LockUnlock                  - FAILED in 1.64 seconds
2023-01-27 15:41:27.980 INFO    DL_Schedules                   - Completed in 2.43 seconds
2023-01-27 15:41:30.863 INFO    DL_UsersAndCredentials         - Completed in 2.88 seconds
2023-01-27 15:41:32.326 ERROR   OTA_SuccessfulTransfer         - FAILED in 1.46 seconds
2023-01-27 15:41:33.740 ERROR   PICS_Example                   - FAILED in 1.41 seconds
2023-01-27 15:41:35.156 ERROR   Response_Example               - FAILED in 1.41 seconds
2023-01-27 15:41:36.591 INFO    TV_AccountLoginCluster         - Completed in 1.43 seconds
2023-01-27 15:41:38.069 INFO    TV_ApplicationBasicCluster     - Completed in 1.48 seconds
2023-01-27 15:41:39.547 INFO    TV_ApplicationLauncherCluster  - Completed in 1.48 seconds
2023-01-27 15:41:41.126 INFO    TV_AudioOutputCluster          - Completed in 1.58 seconds
2023-01-27 15:41:42.654 INFO    TV_ChannelCluster              - Completed in 1.53 seconds
2023-01-27 15:41:44.132 INFO    TV_ContentLauncherCluster      - Completed in 1.48 seconds
2023-01-27 15:41:45.610 INFO    TV_KeypadInputCluster          - Completed in 1.48 seconds
2023-01-27 15:41:47.038 INFO    TV_LowPowerCluster             - Completed in 1.43 seconds
2023-01-27 15:41:48.515 INFO    TV_MediaInputCluster           - Completed in 1.48 seconds
2023-01-27 15:41:50.144 INFO    TV_MediaPlaybackCluster        - Completed in 1.63 seconds
2023-01-27 15:41:51.622 INFO    TV_TargetNavigatorCluster      - Completed in 1.48 seconds
2023-01-27 15:41:53.050 INFO    TV_WakeOnLanCluster            - Completed in 1.43 seconds
2023-01-27 15:41:54.778 INFO    TestAccessControlCluster       - Completed in 1.73 seconds
2023-01-27 15:41:56.356 INFO    TestAccessControlConstraints   - Completed in 1.58 seconds
2023-01-27 15:41:57.820 ERROR   TestArmFailSafe                - FAILED in 1.46 seconds
2023-01-27 15:41:59.341 ERROR   TestBasicInformation           - FAILED in 1.52 seconds
2023-01-27 15:42:00.819 INFO    TestBinding                    - Completed in 1.48 seconds
2023-01-27 15:42:02.282 ERROR   TestCASERecovery               - FAILED in 1.46 seconds
2023-01-27 15:42:03.759 INFO    TestClientMonitoringCluster    - Completed in 1.48 seconds
...
```