### PR TITLE
Add flag to enable/disable dataCache in ClusterStateCache

### DIFF
--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -86,8 +86,10 @@ public:
         virtual void OnEndpointAdded(ClusterStateCache * cache, EndpointId endpointId){};
     };
 
-    ClusterStateCache(Callback & callback, Optional<EventNumber> highestReceivedEventNumber = Optional<EventNumber>::Missing()) :
-        mCallback(callback), mBufferedReader(*this)
+    ClusterStateCache(Callback & callback, bool cacheData = true,
+                      Optional<EventNumber> highestReceivedEventNumber = Optional<EventNumber>::Missing()) :
+        mCallback(callback),
+        mBufferedReader(*this), mCacheData(cacheData)
     {
         mHighestReceivedEventNumber = highestReceivedEventNumber;
     }
@@ -622,6 +624,7 @@ private:
     std::map<ConcreteEventPath, StatusIB> mEventStatusCache;
     BufferedReadCallback mBufferedReader;
     ConcreteClusterPath mLastReportDataPath = ConcreteClusterPath(kInvalidEndpointId, kInvalidClusterId);
+    bool mCacheData                         = true;
 };
 
 }; // namespace app

--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -86,8 +86,16 @@ public:
         virtual void OnEndpointAdded(ClusterStateCache * cache, EndpointId endpointId){};
     };
 
-    ClusterStateCache(Callback & callback, bool cacheData = true,
-                      Optional<EventNumber> highestReceivedEventNumber = Optional<EventNumber>::Missing()) :
+    /**
+     *
+     * @param [in] callback the derived callback which inherit from ReadClient::Callback
+     * @param [in] highestReceivedEventNumber optional highest received event number, if cache receive the events with the number
+     *             less than or equal to this value, skip those events
+     * @param [in] cacheData boolean to decide whether this cache would store attribute/event data/status,
+     *             the default is true.
+     */
+    ClusterStateCache(Callback & callback, Optional<EventNumber> highestReceivedEventNumber = Optional<EventNumber>::Missing(),
+                      bool cacheData = true) :
         mCallback(callback),
         mBufferedReader(*this), mCacheData(cacheData)
     {

--- a/src/controller/tests/BUILD.gn
+++ b/src/controller/tests/BUILD.gn
@@ -30,6 +30,7 @@ chip_test_suite("tests") {
     test_sources += [ "TestEventCaching.cpp" ]
     test_sources += [ "TestReadChunking.cpp" ]
     test_sources += [ "TestWriteChunking.cpp" ]
+    test_sources += [ "TestEventNumberCaching.cpp" ]
   }
 
   cflags = [ "-Wconversion" ]

--- a/src/controller/tests/TestEventNumberCaching.cpp
+++ b/src/controller/tests/TestEventNumberCaching.cpp
@@ -1,0 +1,281 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "app-common/zap-generated/ids/Attributes.h"
+#include "app-common/zap-generated/ids/Clusters.h"
+#include "app/ClusterStateCache.h"
+#include "app/ConcreteAttributePath.h"
+#include "protocols/interaction_model/Constants.h"
+#include <app-common/zap-generated/cluster-objects.h>
+#include <app/AppConfig.h>
+#include <app/AttributeAccessInterface.h>
+#include <app/BufferedReadCallback.h>
+#include <app/CommandHandlerInterface.h>
+#include <app/EventLogging.h>
+#include <app/InteractionModelEngine.h>
+#include <app/data-model/Decode.h>
+#include <app/tests/AppTestContext.h>
+#include <app/util/DataModelHandler.h>
+#include <app/util/attribute-storage.h>
+#include <controller/InvokeInteraction.h>
+#include <lib/support/ErrorStr.h>
+#include <lib/support/TimeUtils.h>
+#include <lib/support/UnitTestContext.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <lib/support/UnitTestUtils.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <messaging/tests/MessagingContext.h>
+#include <nlunit-test.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+
+namespace {
+
+static uint8_t gDebugEventBuffer[4096];
+static uint8_t gInfoEventBuffer[4096];
+static uint8_t gCritEventBuffer[4096];
+static chip::app::CircularEventBuffer gCircularEventBuffer[3];
+
+class TestContext : public chip::Test::AppContext
+{
+public:
+    static int Initialize(void * context)
+    {
+        if (AppContext::Initialize(context) != SUCCESS)
+            return FAILURE;
+
+        auto * ctx = static_cast<TestContext *>(context);
+
+        if (ctx->mEventCounter.Init(0) != CHIP_NO_ERROR)
+        {
+            return FAILURE;
+        }
+
+        chip::app::LogStorageResources logStorageResources[] = {
+            { &gDebugEventBuffer[0], sizeof(gDebugEventBuffer), chip::app::PriorityLevel::Debug },
+            { &gInfoEventBuffer[0], sizeof(gInfoEventBuffer), chip::app::PriorityLevel::Info },
+            { &gCritEventBuffer[0], sizeof(gCritEventBuffer), chip::app::PriorityLevel::Critical },
+        };
+
+        chip::app::EventManagement::CreateEventManagement(&ctx->GetExchangeManager(),
+                                                          sizeof(logStorageResources) / sizeof(logStorageResources[0]),
+                                                          gCircularEventBuffer, logStorageResources, &ctx->mEventCounter);
+
+        return SUCCESS;
+    }
+
+    static int Finalize(void * context)
+    {
+        chip::app::EventManagement::DestroyEventManagement();
+
+        if (AppContext::Finalize(context) != SUCCESS)
+            return FAILURE;
+
+        return SUCCESS;
+    }
+
+private:
+    MonotonicallyIncreasingCounter<EventNumber> mEventCounter;
+};
+
+nlTestSuite * gSuite = nullptr;
+
+//
+// The generated endpoint_config for the controller app has Endpoint 1
+// already used in the fixed endpoint set of size 1. Consequently, let's use the next
+// number higher than that for our dynamic test endpoint.
+//
+constexpr EndpointId kTestEndpointId = 2;
+
+class TestReadEvents
+{
+public:
+    TestReadEvents() {}
+    static void TestEventNumberCaching(nlTestSuite * apSuite, void * apContext);
+
+private:
+};
+
+//clang-format off
+DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(testClusterAttrs)
+DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
+
+DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(testEndpointClusters)
+DECLARE_DYNAMIC_CLUSTER(Clusters::UnitTesting::Id, testClusterAttrs, nullptr, nullptr), DECLARE_DYNAMIC_CLUSTER_LIST_END;
+
+DECLARE_DYNAMIC_ENDPOINT(testEndpoint, testEndpointClusters);
+
+//clang-format on
+
+class TestReadCallback : public app::ClusterStateCache::Callback
+{
+public:
+    TestReadCallback() : mClusterCacheAdapter(*this, false /*cacheData*/) {}
+    void OnDone(app::ReadClient *) {}
+
+    app::ClusterStateCache mClusterCacheAdapter;
+};
+
+namespace {
+
+void GenerateEvents(nlTestSuite * apSuite, chip::EventNumber & firstEventNumber, chip::EventNumber & lastEventNumber)
+{
+    CHIP_ERROR err                 = CHIP_NO_ERROR;
+    static uint8_t generationCount = 0;
+
+    Clusters::UnitTesting::Events::TestEvent::Type content;
+
+    for (int i = 0; i < 5; i++)
+    {
+        content.arg1 = static_cast<uint8_t>(generationCount++);
+        NL_TEST_ASSERT(apSuite, (err = app::LogEvent(content, kTestEndpointId, lastEventNumber)) == CHIP_NO_ERROR);
+        if (i == 0)
+        {
+            firstEventNumber = lastEventNumber;
+        }
+    }
+}
+
+} // namespace
+
+/*
+ * This validates event caching by forcing a bunch of events to get generated, then reading them back
+ * and upon completion of that operation, check the received version from cache, and note that cache would store
+ * correpsonding attribute data since data cache is disabled.
+ *
+ */
+void TestReadEvents::TestEventNumberCaching(nlTestSuite * apSuite, void * apContext)
+{
+    TestContext & ctx                    = *static_cast<TestContext *>(apContext);
+    auto sessionHandle                   = ctx.GetSessionBobToAlice();
+    app::InteractionModelEngine * engine = app::InteractionModelEngine::GetInstance();
+
+    // Initialize the ember side server logic
+    InitDataModelHandler(&ctx.GetExchangeManager());
+
+    // Register our fake dynamic endpoint.
+    DataVersion dataVersionStorage[ArraySize(testEndpointClusters)];
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, Span<DataVersion>(dataVersionStorage));
+
+    chip::EventNumber firstEventNumber;
+    chip::EventNumber lastEventNumber;
+
+    GenerateEvents(apSuite, firstEventNumber, lastEventNumber);
+
+    app::EventPathParams eventPath;
+    eventPath.mEndpointId = kTestEndpointId;
+    eventPath.mClusterId  = app::Clusters::UnitTesting::Id;
+    app::ReadPrepareParams readParams(sessionHandle);
+
+    readParams.mpEventPathParamsList    = &eventPath;
+    readParams.mEventPathParamsListSize = 1;
+    readParams.mEventNumber.SetValue(firstEventNumber);
+
+    TestReadCallback readCallback;
+
+    {
+        Optional<EventNumber> highestEventNumber;
+        readCallback.mClusterCacheAdapter.GetHighestReceivedEventNumber(highestEventNumber);
+        NL_TEST_ASSERT(apSuite, !highestEventNumber.HasValue());
+        app::ReadClient readClient(engine, &ctx.GetExchangeManager(), readCallback.mClusterCacheAdapter.GetBufferedCallback(),
+                                   app::ReadClient::InteractionType::Read);
+
+        NL_TEST_ASSERT(apSuite, readClient.SendRequest(readParams) == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
+
+        readCallback.mClusterCacheAdapter.ForEachEventData([&apSuite, &readCallback](const app::EventHeader & header) {
+            NL_TEST_ASSERT(apSuite, header.mPath.mClusterId == Clusters::UnitTesting::Id);
+            NL_TEST_ASSERT(apSuite, header.mPath.mEventId == Clusters::UnitTesting::Events::TestEvent::Id);
+            NL_TEST_ASSERT(apSuite, header.mPath.mEndpointId == kTestEndpointId);
+
+            Clusters::UnitTesting::Events::TestEvent::DecodableType eventData;
+            NL_TEST_ASSERT(apSuite, readCallback.mClusterCacheAdapter.Get(header.mEventNumber, eventData) != CHIP_NO_ERROR);
+            return CHIP_NO_ERROR;
+        });
+
+        readCallback.mClusterCacheAdapter.GetHighestReceivedEventNumber(highestEventNumber);
+        NL_TEST_ASSERT(apSuite, highestEventNumber.HasValue() && highestEventNumber.Value() == 4);
+    }
+
+    //
+    // Clear out the event cache and set its highest received event number to a non zero value. Validate that
+    // we don't receive events lower than that value.
+    //
+    {
+        app::ReadClient readClient(engine, &ctx.GetExchangeManager(), readCallback.mClusterCacheAdapter.GetBufferedCallback(),
+                                   app::ReadClient::InteractionType::Read);
+
+        readCallback.mClusterCacheAdapter.ClearEventCache(true);
+        Optional<EventNumber> highestEventNumber;
+        readCallback.mClusterCacheAdapter.GetHighestReceivedEventNumber(highestEventNumber);
+        NL_TEST_ASSERT(apSuite, !highestEventNumber.HasValue());
+        readCallback.mClusterCacheAdapter.SetHighestReceivedEventNumber(3);
+
+        NL_TEST_ASSERT(apSuite, readClient.SendRequest(readParams) == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
+
+        readCallback.mClusterCacheAdapter.ForEachEventData([&apSuite, &readCallback](const app::EventHeader & header) {
+            NL_TEST_ASSERT(apSuite, header.mPath.mClusterId == Clusters::UnitTesting::Id);
+            NL_TEST_ASSERT(apSuite, header.mPath.mEventId == Clusters::UnitTesting::Events::TestEvent::Id);
+            NL_TEST_ASSERT(apSuite, header.mPath.mEndpointId == kTestEndpointId);
+
+            Clusters::UnitTesting::Events::TestEvent::DecodableType eventData;
+            NL_TEST_ASSERT(apSuite, readCallback.mClusterCacheAdapter.Get(header.mEventNumber, eventData) != CHIP_NO_ERROR);
+            return CHIP_NO_ERROR;
+        });
+
+        readCallback.mClusterCacheAdapter.GetHighestReceivedEventNumber(highestEventNumber);
+        NL_TEST_ASSERT(apSuite, highestEventNumber.HasValue() && highestEventNumber.Value() == 4);
+    }
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+
+    emberAfClearDynamicEndpoint(0);
+}
+
+// clang-format off
+const nlTest sTests[] =
+{
+    NL_TEST_DEF("TestEventNumberCaching", TestReadEvents::TestEventNumberCaching),
+    NL_TEST_SENTINEL()
+};
+
+// clang-format on
+
+// clang-format off
+nlTestSuite sSuite =
+{
+    "TestEventNumberCaching",
+    &sTests[0],
+    TestContext::Initialize,
+    TestContext::Finalize
+};
+// clang-format on
+
+} // namespace
+
+int TestEventNumberCaching()
+{
+    gSuite = &sSuite;
+    return chip::ExecuteTestsWithContext<TestContext>(&sSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestEventNumberCaching)

--- a/src/controller/tests/TestEventNumberCaching.cpp
+++ b/src/controller/tests/TestEventNumberCaching.cpp
@@ -127,7 +127,7 @@ DECLARE_DYNAMIC_ENDPOINT(testEndpoint, testEndpointClusters);
 class TestReadCallback : public app::ClusterStateCache::Callback
 {
 public:
-    TestReadCallback() : mClusterCacheAdapter(*this, false /*cacheData*/) {}
+    TestReadCallback() : mClusterCacheAdapter(*this, Optional<EventNumber>::Missing(), false /*cacheData*/) {}
     void OnDone(app::ReadClient *) {}
 
     app::ClusterStateCache mClusterCacheAdapter;

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -275,6 +275,7 @@ public:
     static void TestReadHandler_SubscriptionReportingIntervalsTest9(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandlerResourceExhaustion_MultipleReads(nlTestSuite * apSuite, void * apContext);
     static void TestReadSubscribeAttributeResponseWithCache(nlTestSuite * apSuite, void * apContext);
+    static void TestReadSubscribeAttributeResponseWithVersionOnlyCache(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_KillOverQuotaSubscriptions(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_KillOldestSubscriptions(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_ParallelReads(nlTestSuite * apSuite, void * apContext);
@@ -1411,6 +1412,79 @@ void TestReadInteraction::TestReadSubscribeAttributeResponseWithCache(nlTestSuit
             uint8_t receivedAttribute4[256];
             reader.GetBytes(receivedAttribute4, 256);
             NL_TEST_ASSERT(apSuite, memcmp(receivedAttribute4, expectedAttribute4, 256));
+        }
+        delegate.mNumAttributeResponse = 0;
+    }
+
+    NL_TEST_ASSERT(apSuite, app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients() == 0);
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+}
+
+void TestReadInteraction::TestReadSubscribeAttributeResponseWithVersionOnlyCache(nlTestSuite * apSuite, void * apContext)
+{
+    TestContext & ctx = *static_cast<TestContext *>(apContext);
+    CHIP_ERROR err    = CHIP_NO_ERROR;
+    responseDirective = kSendDataResponse;
+
+    MockInteractionModelApp delegate;
+    chip::app::ClusterStateCache cache(delegate, false /*cachedData*/);
+
+    chip::app::ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
+    //
+    // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
+    // callbacks.
+    //
+    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(&gTestReadInteraction);
+
+    // read of E2C2A* and E3C2A2. Expect cache E2C2 version
+    {
+        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(),
+                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
+        chip::app::AttributePathParams attributePathParams2[2];
+        attributePathParams2[0].mEndpointId  = chip::Test::kMockEndpoint2;
+        attributePathParams2[0].mClusterId   = chip::Test::MockClusterId(3);
+        attributePathParams2[0].mAttributeId = kInvalidAttributeId;
+
+        attributePathParams2[1].mEndpointId            = chip::Test::kMockEndpoint3;
+        attributePathParams2[1].mClusterId             = chip::Test::MockClusterId(2);
+        attributePathParams2[1].mAttributeId           = chip::Test::MockAttributeId(2);
+        readPrepareParams.mpAttributePathParamsList    = attributePathParams2;
+        readPrepareParams.mAttributePathParamsListSize = 2;
+        err                                            = readClient.SendRequest(readPrepareParams);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
+        // There are supported 2 global and 3 non-global attributes in E2C2A* and  1 E3C2A2
+        NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 6);
+        NL_TEST_ASSERT(apSuite, !delegate.mReadError);
+        Optional<DataVersion> version1;
+        app::ConcreteClusterPath clusterPath1(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3));
+        NL_TEST_ASSERT(apSuite, cache.GetVersion(clusterPath1, version1) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(apSuite, version1.HasValue() && (version1.Value() == 0));
+        Optional<DataVersion> version2;
+        app::ConcreteClusterPath clusterPath2(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2));
+        NL_TEST_ASSERT(apSuite, cache.GetVersion(clusterPath2, version2) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(apSuite, !version2.HasValue());
+
+        {
+            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
+                                                     chip::Test::MockAttributeId(2));
+            TLV::TLVReader reader;
+            NL_TEST_ASSERT(apSuite, cache.Get(attributePath, reader) != CHIP_NO_ERROR);
+        }
+
+        {
+            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
+                                                     chip::Test::MockAttributeId(3));
+            TLV::TLVReader reader;
+            NL_TEST_ASSERT(apSuite, cache.Get(attributePath, reader) != CHIP_NO_ERROR);
+        }
+
+        {
+            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
+                                                     chip::Test::MockAttributeId(2));
+            TLV::TLVReader reader;
+            NL_TEST_ASSERT(apSuite, cache.Get(attributePath, reader) != CHIP_NO_ERROR);
         }
         delegate.mNumAttributeResponse = 0;
     }
@@ -4572,6 +4646,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestReadHandler_SubscriptionReportingIntervalsTest7", TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest7),
     NL_TEST_DEF("TestReadHandler_SubscriptionReportingIntervalsTest8", TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest8),
     NL_TEST_DEF("TestReadHandler_SubscriptionReportingIntervalsTest9", TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest9),
+        NL_TEST_DEF("TestReadSubscribeAttributeResponseWithVersionOnlyCache", TestReadInteraction::TestReadSubscribeAttributeResponseWithVersionOnlyCache),
     NL_TEST_DEF("TestReadSubscribeAttributeResponseWithCache", TestReadInteraction::TestReadSubscribeAttributeResponseWithCache),
     NL_TEST_DEF("TestReadHandler_KillOverQuotaSubscriptions", TestReadInteraction::TestReadHandler_KillOverQuotaSubscriptions),
     NL_TEST_DEF("TestReadHandler_KillOldestSubscriptions", TestReadInteraction::TestReadHandler_KillOldestSubscriptions),

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -1427,7 +1427,7 @@ void TestReadInteraction::TestReadSubscribeAttributeResponseWithVersionOnlyCache
     responseDirective = kSendDataResponse;
 
     MockInteractionModelApp delegate;
-    chip::app::ClusterStateCache cache(delegate, false /*cachedData*/);
+    chip::app::ClusterStateCache cache(delegate, Optional<EventNumber>::Missing(), false /*cachedData*/);
 
     chip::app::ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
     //


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/issues/23994
Add flag to enable/disable dataCache in ClusterStateCache and add the tests for event/data version cache without storing the attribute/event data.

