### PR TITLE
[Ameba] dont store wifi info in kvs if ssid is empty

### DIFF
--- a/src/platform/Ameba/AmebaUtils.cpp
+++ b/src/platform/Ameba/AmebaUtils.cpp
@@ -76,6 +76,12 @@ CHIP_ERROR AmebaUtils::EnableStationMode(void)
 CHIP_ERROR AmebaUtils::SetWiFiConfig(rtw_wifi_config_t * config)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    // don't store if ssid is null
+    if (config->ssid[0] == 0)
+    {
+        return CHIP_NO_ERROR;
+    }
+
     /* Store Wi-Fi Configurations in Storage */
     err = PersistedStorage::KeyValueStoreMgr().Put(kWiFiSSIDKeyName, config->ssid, sizeof(config->ssid));
     SuccessOrExit(err);

--- a/src/platform/Ameba/NetworkCommissioningDriver.h
+++ b/src/platform/Ameba/NetworkCommissioningDriver.h
@@ -127,8 +127,8 @@ private:
     bool NetworkMatch(const WiFiNetwork & network, ByteSpan networkId);
     CHIP_ERROR StartScanWiFiNetworks(ByteSpan ssid);
 
-    WiFiNetwork mSavedNetwork;
-    WiFiNetwork mStagingNetwork;
+    WiFiNetwork mSavedNetwork   = { 0 };
+    WiFiNetwork mStagingNetwork = { 0 };
     ScanCallback * mpScanCallback;
     ConnectCallback * mpConnectCallback;
     NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;


### PR DESCRIPTION
- #24684 
- We added external method to persist wifi credentials when using onnetwork commissioning
- However, when using onnetwork commissioning, `CommitConfiguration` is storing empty `mStagingNetwork` into KVS, overwriting our saved wifi credentials
- Add check to only store wifi credentials to KVS when SSID is not empty