### PR TITLE
Use the right cluster id for setting window covering delegate.

### DIFF
--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -593,7 +593,7 @@ EmberAfStatus GetMotionLockStatus(chip::EndpointId endpoint)
 
 void SetDefaultDelegate(EndpointId endpoint, Delegate * delegate)
 {
-    uint16_t ep = emberAfFindClusterServerEndpointIndex(endpoint, Channel::Id);
+    uint16_t ep = emberAfFindClusterServerEndpointIndex(endpoint, WindowCovering::Id);
 
     // if endpoint is found and is not a dynamic endpoint
     if (ep != 0xFFFF && ep < EMBER_AF_WINDOW_COVERING_CLUSTER_SERVER_ENDPOINT_COUNT)


### PR DESCRIPTION
The existing setup would fail unless there was also a Channel cluster around (i.e. pretty much anywhere out of all-clusters-app).

Fixes https://github.com/project-chip/connectedhomeip/issues/24721
