### PR TITLE
Make sure we stop resolves triggered by a browse when the browse stops on Darwin.

### DIFF
--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -145,7 +145,13 @@ MdnsContexts::~MdnsContexts()
 
 CHIP_ERROR MdnsContexts::Add(GenericContext * context, DNSServiceRef sdRef)
 {
-    VerifyOrReturnError(context != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(context != nullptr || sdRef != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    if (context == nullptr)
+    {
+        DNSServiceRefDeallocate(sdRef);
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
 
     if (sdRef == nullptr)
     {

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -105,6 +105,23 @@ public:
 
     void Delete(GenericContext * context);
 
+    /**
+     * Fill the provided vector with all contexts for which the given predicate
+     * returns true.
+     */
+    template <typename F>
+    void FindAllMatchingPredicate(F predicate, std::vector<GenericContext *> & results)
+    {
+        results.clear();
+        for (auto & ctx : mContexts)
+        {
+            if (predicate(ctx))
+            {
+                results.push_back(ctx);
+            }
+        }
+    }
+
 private:
     MdnsContexts(){};
     static MdnsContexts sInstance;


### PR DESCRIPTION
Without this change, if there is a PTR record that matches whatever we are browsing but no corresponding SRV record, we would end up leaking a resolve forever.

Tested by modifying minimal mdns SrvResponder::AddAllResponses to no-op instead of actually adding any responses, then trying to commission the device running the modified minimal mdns.  Without this change, when the browse stops the resolves it triggered keep going.  With this change, termination of the browse also terminates the resolves.

Fixes https://github.com/project-chip/connectedhomeip/issues/24074
