### PR TITLE
Add GetCommissionerNodeId command supports for yaml tests, chip-tool and darwin-framework-tool

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -178,7 +178,7 @@ void CHIPCommand::MaybeTearDownStack()
 CHIP_ERROR CHIPCommand::EnsureCommissionerForIdentity(std::string identity)
 {
     chip::NodeId nodeId;
-    ReturnErrorOnFailure(GetCommissionerNodeId(identity, &nodeId));
+    ReturnErrorOnFailure(GetIdentityNodeId(identity, &nodeId));
     CommissionerIdentity lookupKey{ identity, nodeId };
     if (mCommissioners.find(lookupKey) != mCommissioners.end())
     {
@@ -310,7 +310,7 @@ std::string CHIPCommand::GetIdentity()
     return name;
 }
 
-CHIP_ERROR CHIPCommand::GetCommissionerNodeId(std::string identity, chip::NodeId * nodeId)
+CHIP_ERROR CHIPCommand::GetIdentityNodeId(std::string identity, chip::NodeId * nodeId)
 {
     if (mCommissionerNodeId.HasValue())
     {
@@ -374,7 +374,7 @@ chip::Controller::DeviceCommissioner & CHIPCommand::GetCommissioner(std::string 
     VerifyOrDie(EnsureCommissionerForIdentity(identity) == CHIP_NO_ERROR);
 
     chip::NodeId nodeId;
-    VerifyOrDie(GetCommissionerNodeId(identity, &nodeId) == CHIP_NO_ERROR);
+    VerifyOrDie(GetIdentityNodeId(identity, &nodeId) == CHIP_NO_ERROR);
     CommissionerIdentity lookupKey{ identity, nodeId };
     auto item = mCommissioners.find(lookupKey);
     VerifyOrDie(item != mCommissioners.end());

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -144,7 +144,7 @@ protected:
     CredentialIssuerCommands * mCredIssuerCmds;
 
     std::string GetIdentity();
-    CHIP_ERROR GetCommissionerNodeId(std::string identity, chip::NodeId * nodeId);
+    CHIP_ERROR GetIdentityNodeId(std::string identity, chip::NodeId * nodeId);
     void SetIdentity(const char * name);
 
     // This method returns the commissioner instance to be used for running the command.

--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -27,6 +27,8 @@ constexpr const char * kEventIdKey        = "eventId";
 constexpr const char * kCommandIdKey      = "commandId";
 constexpr const char * kErrorIdKey        = "error";
 constexpr const char * kClusterErrorIdKey = "clusterError";
+constexpr const char * kValueKey          = "value";
+constexpr const char * kNodeIdKey         = "nodeId";
 
 namespace {
 RemoteDataModelLoggerDelegate * gDelegate;
@@ -146,6 +148,18 @@ CHIP_ERROR LogErrorAsJSON(const CHIP_ERROR & error)
     chip::app::StatusIB status;
     status.InitFromChipError(error);
     return LogError(value, status);
+}
+
+CHIP_ERROR LogGetCommissionerNodeId(chip::NodeId value)
+{
+    VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
+
+    Json::Value rootValue;
+    rootValue[kValueKey]             = Json::Value();
+    rootValue[kValueKey][kNodeIdKey] = value;
+
+    auto valueStr = chip::JsonToString(rootValue);
+    return gDelegate->LogJSON(valueStr.c_str());
 }
 
 void SetDelegate(RemoteDataModelLoggerDelegate * delegate)

--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.h
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.h
@@ -38,5 +38,6 @@ CHIP_ERROR LogErrorAsJSON(const chip::app::ConcreteCommandPath & path, const chi
 CHIP_ERROR LogEventAsJSON(const chip::app::EventHeader & header, chip::TLV::TLVReader * data);
 CHIP_ERROR LogErrorAsJSON(const chip::app::EventHeader & header, const chip::app::StatusIB & status);
 CHIP_ERROR LogErrorAsJSON(const CHIP_ERROR & error);
+CHIP_ERROR LogGetCommissionerNodeId(chip::NodeId value);
 void SetDelegate(RemoteDataModelLoggerDelegate * delegate);
 }; // namespace RemoteDataModelLogger

--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -21,6 +21,7 @@
 #include "commands/common/Commands.h"
 #include "commands/pairing/CloseSessionCommand.h"
 #include "commands/pairing/CommissionedListCommand.h"
+#include "commands/pairing/GetCommissionerNodeIdCommand.h"
 #include "commands/pairing/OpenCommissioningWindowCommand.h"
 #include "commands/pairing/PairingCommand.h"
 
@@ -220,6 +221,7 @@ void registerCommandsPairing(Commands & commands, CredentialIssuerCommands * cre
         make_unique<StartUdcServerCommand>(credsIssuerConfig),
         make_unique<OpenCommissioningWindowCommand>(credsIssuerConfig),
         make_unique<CloseSessionCommand>(credsIssuerConfig),
+        make_unique<GetCommissionerNodeIdCommand>(credsIssuerConfig),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/pairing/GetCommissionerNodeIdCommand.h
+++ b/examples/chip-tool/commands/pairing/GetCommissionerNodeIdCommand.h
@@ -1,0 +1,43 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../common/CHIPCommand.h"
+
+class GetCommissionerNodeIdCommand : public CHIPCommand
+{
+public:
+    GetCommissionerNodeIdCommand(CredentialIssuerCommands * credIssuerCommands) :
+        CHIPCommand("get-commissioner-node-id", credIssuerCommands)
+    {}
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override
+    {
+        chip::NodeId id;
+        ReturnErrorOnFailure(GetIdentityNodeId(GetIdentity(), &id));
+        ChipLogProgress(chipTool, "Commissioner Node Id 0x:" ChipLogFormatX64, ChipLogValueX64(id));
+
+        ReturnErrorOnFailure(RemoteDataModelLogger::LogGetCommissionerNodeId(id));
+        SetCommandExitStatus(CHIP_NO_ERROR);
+        return CHIP_NO_ERROR;
+    }
+
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(10); }
+};

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -78,12 +78,6 @@ protected:
 
     chip::Controller::DeviceCommissioner & GetCommissioner(const char * identity) override
     {
-        // Best effort to get NodeId - if this fails, GetCommissioner will also fail
-        chip::NodeId id;
-        if (GetCommissionerNodeId(identity, &id) == CHIP_NO_ERROR)
-        {
-            mCommissionerNodeId.SetValue(id);
-        }
         return CHIPCommand::GetCommissioner(identity);
     };
 
@@ -101,7 +95,6 @@ protected:
 
     chip::Optional<char *> mPICSFilePath;
     chip::Optional<uint16_t> mTimeout;
-    chip::Optional<chip::NodeId> mCommissionerNodeId;
     std::map<std::string, std::unique_ptr<chip::OperationalDeviceProxy>> mDevices;
 
     // When set to false, prevents interaction model events from affecting the current test status.

--- a/examples/chip-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_cluster.zapt
@@ -48,14 +48,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -80,12 +72,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         {{#chip_tests_items}}

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -139,6 +139,8 @@ executable("darwin-framework-tool") {
     "commands/common/MTRLogging.h",
     "commands/pairing/Commands.h",
     "commands/pairing/DeviceControllerDelegateBridge.mm",
+    "commands/pairing/GetCommissionerNodeIdCommand.h",
+    "commands/pairing/GetCommissionerNodeIdCommand.mm",
     "commands/pairing/OpenCommissioningWindowCommand.h",
     "commands/pairing/OpenCommissioningWindowCommand.mm",
     "commands/pairing/PairingCommandBridge.mm",

--- a/examples/darwin-framework-tool/commands/pairing/Commands.h
+++ b/examples/darwin-framework-tool/commands/pairing/Commands.h
@@ -20,6 +20,7 @@
 
 #import <Matter/Matter.h>
 
+#include "GetCommissionerNodeIdCommand.h"
 #include "OpenCommissioningWindowCommand.h"
 #include "PairingCommandBridge.h"
 #include "PreWarmCommissioningCommand.h"
@@ -73,6 +74,7 @@ void registerCommandsPairing(Commands & commands)
         make_unique<Unpair>(),
         make_unique<OpenCommissioningWindowCommand>(),
         make_unique<PreWarmCommissioningCommand>(),
+        make_unique<GetCommissionerNodeIdCommand>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/darwin-framework-tool/commands/pairing/GetCommissionerNodeIdCommand.h
+++ b/examples/darwin-framework-tool/commands/pairing/GetCommissionerNodeIdCommand.h
@@ -1,0 +1,32 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../common/CHIPCommandBridge.h"
+
+class GetCommissionerNodeIdCommand : public CHIPCommandBridge
+{
+public:
+    GetCommissionerNodeIdCommand() : CHIPCommandBridge("get-commissioner-node-id") {}
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(0); }
+};

--- a/examples/darwin-framework-tool/commands/pairing/GetCommissionerNodeIdCommand.mm
+++ b/examples/darwin-framework-tool/commands/pairing/GetCommissionerNodeIdCommand.mm
@@ -1,0 +1,33 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#import <Matter/Matter.h>
+
+#include "GetCommissionerNodeIdCommand.h"
+
+CHIP_ERROR GetCommissionerNodeIdCommand::RunCommand()
+{
+    auto * controller = CurrentCommissioner();
+    VerifyOrReturnError(nil != controller, CHIP_ERROR_INCORRECT_STATE);
+
+    auto id = [controller.controllerNodeId unsignedLongLongValue];
+    ChipLogProgress(chipTool, "Commissioner Node Id 0x:" ChipLogFormatX64, ChipLogValueX64(id));
+
+    SetCommandExitStatus(CHIP_NO_ERROR);
+    return CHIP_NO_ERROR;
+}

--- a/examples/darwin-framework-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/darwin-framework-tool/templates/tests/partials/test_cluster.zapt
@@ -23,17 +23,10 @@ class {{filename}}: public TestCommandBridge
     {
     }
 
-    // Allow yaml to access the current commissioner node id.
-    // Default to 0 (undefined node id) so we know if this isn't
-    // set correctly.
-    // Reset on every step in case it changed.
-    chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-
     /////////// TestCommand Interface /////////
     void NextTest() override
     {
       CHIP_ERROR err = CHIP_NO_ERROR;
-      commissionerNodeId = mCommissionerNodeId.ValueOr(0);
 
       if (0 == mTestIndex)
       {
@@ -140,10 +133,31 @@ class {{filename}}: public TestCommandBridge
         {{#chip_tests_item_parameters}}
           {{>commandValue ns=parent.cluster container=(asPropertyValue dontUnwrapValue=true) definedValue=definedValue depth=0}}
         {{/chip_tests_item_parameters}}
+        {{#if (and (isStrEqual cluster "CommissionerCommands") (isStrEqual command "GetCommissionerNodeId"))}}
+        return {{command}}("{{identity}}", value, ^(const chip::{{command}}Response & values) {
+            {{#chip_tests_item_responses}}
+            {{#chip_tests_item_response_parameters}}
+            {{#if hasExpectedValue}}
+            {
+              id actualValue = values.{{asStructPropertyName name}}
+              {{>check_test_value actual="actualValue" expected=expectedValue cluster=../cluster}}
+            }
+            {{/if}}
+            {{>maybeCheckExpectedConstraints}}
+            {{#if saveAs}}
+            {
+              {{saveAs}} = [[NSNumber alloc] initWithUnsignedLongLong:values.{{asStructPropertyName name}}];
+            }
+            {{/if}}
+            {{/chip_tests_item_response_parameters}}
+            {{/chip_tests_item_responses}}
+            NextTest();
+        });
+        {{else}}
         return {{command}}("{{identity}}", value);
+        {{/if}}
         {{else}}
         MTRBaseDevice * device = GetDevice("{{identity}}");
-        commissionerNodeId = mCommissionerNodeId.ValueOr(0);
         __auto_type * cluster = [[MTRBaseCluster{{>cluster}} alloc] initWithDevice:device endpointID:@({{endpoint}}) queue:mCallbackQueue];
         VerifyOrReturnError(cluster != nil, CHIP_ERROR_INCORRECT_STATE);
 

--- a/src/app/tests/suites/TestCommissionerNodeId.yaml
+++ b/src/app/tests/suites/TestCommissionerNodeId.yaml
@@ -97,6 +97,15 @@ tests:
       response:
           saveAs: alphaIndex
 
+    - label: "Read the commissioner node ID from the alpha fabric"
+      identity: "alpha"
+      cluster: "CommissionerCommands"
+      command: "GetCommissionerNodeId"
+      response:
+          values:
+              - name: "nodeId"
+                saveAs: commissionerNodeIdAlpha
+
     - label: "Read the fabric ID from the beta fabric"
       identity: "beta"
       cluster: "Operational Credentials"
@@ -105,6 +114,15 @@ tests:
       response:
           saveAs: betaIndex
 
+    - label: "Read the commissioner node ID from the beta fabric"
+      identity: "beta"
+      cluster: "CommissionerCommands"
+      command: "GetCommissionerNodeId"
+      response:
+          values:
+              - name: "nodeId"
+                saveAs: commissionerNodeIdBeta
+
     - label: "Read the fabric ID from the gamma fabric"
       identity: "gamma"
       cluster: "Operational Credentials"
@@ -112,6 +130,15 @@ tests:
       attribute: "CurrentFabricIndex"
       response:
           saveAs: gammaIndex
+
+    - label: "Read the commissioner node ID from the gamma fabric"
+      identity: "gamma"
+      cluster: "CommissionerCommands"
+      command: "GetCommissionerNodeId"
+      response:
+          values:
+              - name: "nodeId"
+                saveAs: commissionerNodeIdGamma
 
     - label: "Read the ACL from alpha and check commissioner node id"
       identity: "alpha"
@@ -123,7 +150,7 @@ tests:
                       FabricIndex: alphaIndex,
                       Privilege: 5, # administer
                       AuthMode: 2, # case
-                      Subjects: [commissionerNodeId],
+                      Subjects: [commissionerNodeIdAlpha],
                       Targets: null,
                   },
               ]
@@ -138,7 +165,7 @@ tests:
                       FabricIndex: betaIndex,
                       Privilege: 5, # administer
                       AuthMode: 2, # case
-                      Subjects: [commissionerNodeId],
+                      Subjects: [commissionerNodeIdBeta],
                       Targets: null,
                   },
               ]
@@ -153,7 +180,7 @@ tests:
                       FabricIndex: gammaIndex,
                       Privilege: 5, # administer
                       AuthMode: 2, # case
-                      Subjects: [commissionerNodeId],
+                      Subjects: [commissionerNodeIdGamma],
                       Targets: null,
                   },
               ]
@@ -168,7 +195,7 @@ tests:
                       FabricIndex: betaIndex,
                       Privilege: 5, # administer
                       AuthMode: 2, # case
-                      Subjects: [commissionerNodeId],
+                      Subjects: [commissionerNodeIdBeta],
                       Targets: null,
                   },
               ]
@@ -183,7 +210,7 @@ tests:
                       FabricIndex: gammaIndex,
                       Privilege: 5, # administer
                       AuthMode: 2, # case
-                      Subjects: [commissionerNodeId],
+                      Subjects: [commissionerNodeIdGamma],
                       Targets: null,
                   },
               ]
@@ -198,7 +225,7 @@ tests:
                       FabricIndex: betaIndex,
                       Privilege: 5, # administer
                       AuthMode: 2, # case
-                      Subjects: [commissionerNodeId],
+                      Subjects: [commissionerNodeIdBeta],
                       Targets: null,
                   },
               ]
@@ -213,7 +240,7 @@ tests:
                       FabricIndex: gammaIndex,
                       Privilege: 5, # administer
                       AuthMode: 2, # case
-                      Subjects: [commissionerNodeId],
+                      Subjects: [commissionerNodeIdGamma],
                       Targets: null,
                   },
               ]

--- a/src/app/tests/suites/certification/Test_TC_ACE_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACE_1_1.yaml
@@ -32,6 +32,14 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
+    - label: "Read the commissioner node ID"
+      cluster: "CommissionerCommands"
+      command: "GetCommissionerNodeId"
+      response:
+          values:
+              - name: "nodeId"
+                saveAs: commissionerNodeId
+
     - label: "TP2 - Write ACL giving admin privilege on all EP0"
       command: "writeAttribute"
       attribute: "ACL"

--- a/src/app/tests/suites/certification/Test_TC_ACE_1_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACE_1_5.yaml
@@ -76,6 +76,15 @@ tests:
       response:
           saveAs: th2FabricIndex
 
+    - label: "Read the commissioner node ID from the alpha fabric"
+      identity: "alpha"
+      cluster: "CommissionerCommands"
+      command: "GetCommissionerNodeId"
+      response:
+          values:
+              - name: "nodeId"
+                saveAs: commissionerNodeIdAlpha
+
     - label: "TH1 writes ACL giving view privilege for descriptor cluster"
       command: "writeAttribute"
       attribute: "ACL"
@@ -85,7 +94,7 @@ tests:
                       FabricIndex: th1FabricIndex,
                       Privilege: 5, # administer
                       AuthMode: 2, # case
-                      Subjects: [commissionerNodeId],
+                      Subjects: [commissionerNodeIdAlpha],
                       Targets:
                           [{ Cluster: 0x001f, Endpoint: 0, DeviceType: null }],
                   },
@@ -99,6 +108,15 @@ tests:
                   },
               ]
 
+    - label: "Read the commissioner node ID from the beta fabric"
+      identity: "beta"
+      cluster: "CommissionerCommands"
+      command: "GetCommissionerNodeId"
+      response:
+          values:
+              - name: "nodeId"
+                saveAs: commissionerNodeIdBeta
+
     - label: "TH2 writes ACL giving view privilge for basic cluster"
       identity: beta
       command: "writeAttribute"
@@ -109,7 +127,7 @@ tests:
                       FabricIndex: th2FabricIndex,
                       Privilege: 5, # administer
                       AuthMode: 2, # case
-                      Subjects: [commissionerNodeId],
+                      Subjects: [commissionerNodeIdBeta],
                       Targets:
                           [{ Cluster: 0x001f, Endpoint: 0, DeviceType: null }],
                   },
@@ -158,7 +176,7 @@ tests:
                       FabricIndex: 1,
                       Privilege: 5, # administer
                       AuthMode: 2, # case
-                      Subjects: [commissionerNodeId],
+                      Subjects: [commissionerNodeIdAlpha],
                       Targets: null,
                   },
               ]

--- a/src/app/tests/suites/certification/Test_TC_SC_5_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_5_1.yaml
@@ -33,6 +33,14 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
+    - label: "Read the commissioner node ID"
+      cluster: "CommissionerCommands"
+      command: "GetCommissionerNodeId"
+      response:
+          values:
+              - name: "nodeId"
+                saveAs: commissionerNodeId
+
     - label: "TH adds ACL Operate privileges for Group 0x0103"
       cluster: "Access Control"
       endpoint: 0

--- a/src/app/tests/suites/certification/Test_TC_SC_5_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_5_2.yaml
@@ -33,6 +33,14 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
+    - label: "Read the commissioner node ID"
+      cluster: "CommissionerCommands"
+      command: "GetCommissionerNodeId"
+      response:
+          values:
+              - name: "nodeId"
+                saveAs: commissionerNodeId
+
     - label: "TH adds ACL Operate privileges for Group 0x0103"
       cluster: "Access Control"
       endpoint: 0

--- a/src/app/tests/suites/commands/commissioner/CommissionerCommands.cpp
+++ b/src/app/tests/suites/commands/commissioner/CommissionerCommands.cpp
@@ -45,6 +45,46 @@ CHIP_ERROR CommissionerCommands::Unpair(const char * identity,
     return GetCommissioner(identity).UnpairDevice(value.nodeId);
 }
 
+CHIP_ERROR CommissionerCommands::GetCommissionerNodeId(
+    const char * identity, const chip::app::Clusters::CommissionerCommands::Commands::GetCommissionerNodeId::Type & value)
+{
+    chip::GetCommissionerNodeIdResponse data;
+    data.nodeId = GetCommissioner(identity).GetNodeId();
+
+    chip::app::StatusIB status;
+    status.mStatus = chip::Protocols::InteractionModel::Status::Success;
+
+    constexpr uint32_t kMaxDataLen = 128;
+    uint8_t * buffer               = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(sizeof(uint8_t), kMaxDataLen));
+    if (buffer == nullptr)
+    {
+        ChipLogError(chipTool, "Can not allocate commissioner node id data: %s", chip::ErrorStr(CHIP_ERROR_NO_MEMORY));
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    chip::TLV::TLVWriter writer;
+    writer.Init(buffer, kMaxDataLen);
+    CHIP_ERROR err = data.Encode(writer, chip::TLV::AnonymousTag());
+    if (CHIP_NO_ERROR != err)
+    {
+        ChipLogError(chipTool, "Can not encode commissioner node id data: %s", chip::ErrorStr(err));
+        return err;
+    }
+
+    uint32_t dataLen = writer.GetLengthWritten();
+    writer.Finalize();
+
+    chip::TLV::TLVReader reader;
+    reader.Init(buffer, dataLen);
+    reader.Next();
+
+    OnResponse(status, &reader);
+
+    chip::Platform::MemoryFree(buffer);
+
+    return CHIP_NO_ERROR;
+}
+
 chip::app::StatusIB ConvertToStatusIB(CHIP_ERROR err)
 {
     using chip::app::StatusIB;

--- a/src/app/tests/suites/commands/commissioner/CommissionerCommands.h
+++ b/src/app/tests/suites/commands/commissioner/CommissionerCommands.h
@@ -36,6 +36,9 @@ public:
     CHIP_ERROR PairWithCode(const char * identity,
                             const chip::app::Clusters::CommissionerCommands::Commands::PairWithCode::Type & value);
     CHIP_ERROR Unpair(const char * identity, const chip::app::Clusters::CommissionerCommands::Commands::Unpair::Type & value);
+    CHIP_ERROR
+    GetCommissionerNodeId(const char * identity,
+                          const chip::app::Clusters::CommissionerCommands::Commands::GetCommissionerNodeId::Type & value);
 
     /////////// DevicePairingDelegate Interface /////////
     void OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status) override;

--- a/zzz_generated/placeholder/app1/zap-generated/test/Commands.h
+++ b/zzz_generated/placeholder/app1/zap-generated/test/Commands.h
@@ -50,14 +50,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -83,12 +75,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -212,14 +198,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -241,12 +219,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -299,14 +271,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -328,12 +292,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -378,14 +336,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -407,12 +357,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -473,14 +417,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -502,12 +438,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -602,14 +532,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -631,12 +553,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -698,14 +614,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -727,12 +635,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -844,14 +746,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -873,12 +767,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -935,14 +823,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -964,12 +844,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1015,14 +889,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1044,12 +910,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1106,14 +966,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1135,12 +987,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1217,14 +1063,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1246,12 +1084,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1416,14 +1248,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1445,12 +1269,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1495,14 +1313,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1524,12 +1334,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1590,14 +1394,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1619,12 +1415,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1677,14 +1467,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1706,12 +1488,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1777,14 +1553,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1806,12 +1574,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1864,14 +1626,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1893,12 +1647,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1964,14 +1712,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1993,12 +1733,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -2054,14 +1788,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -2083,12 +1809,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -2198,14 +1918,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -2227,12 +1939,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -2283,14 +1989,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -2312,12 +2010,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -2368,14 +2060,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -2397,12 +2081,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -2448,14 +2126,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -2477,12 +2147,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {

--- a/zzz_generated/placeholder/app2/zap-generated/test/Commands.h
+++ b/zzz_generated/placeholder/app2/zap-generated/test/Commands.h
@@ -50,14 +50,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -83,12 +75,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -212,14 +198,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -241,12 +219,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -299,14 +271,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -328,12 +292,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -378,14 +336,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -407,12 +357,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -473,14 +417,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -502,12 +438,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -602,14 +532,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -631,12 +553,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -698,14 +614,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -727,12 +635,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -844,14 +746,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -873,12 +767,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -935,14 +823,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -964,12 +844,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1015,14 +889,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1044,12 +910,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1106,14 +966,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1135,12 +987,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1217,14 +1063,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1246,12 +1084,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1416,14 +1248,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1445,12 +1269,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1495,14 +1313,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1524,12 +1334,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1590,14 +1394,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1619,12 +1415,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1677,14 +1467,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1706,12 +1488,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1777,14 +1553,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1806,12 +1574,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1864,14 +1626,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1893,12 +1647,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -1964,14 +1712,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -1993,12 +1733,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -2054,14 +1788,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -2083,12 +1809,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -2198,14 +1918,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -2227,12 +1939,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -2283,14 +1989,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -2312,12 +2010,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -2368,14 +2060,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -2397,12 +2081,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {
@@ -2448,14 +2126,6 @@ private:
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
-
         bool shouldContinue = false;
 
         switch (mTestIndex - 1)
@@ -2477,12 +2147,6 @@ private:
     CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
         using namespace chip::app::Clusters;
-        // Allow yaml to access the current commissioner node id.
-        // Default to 0 (undefined node id) so we know if this isn't
-        // set correctly.
-        // Reset on every step in case it changed.
-        chip::NodeId commissionerNodeId = mCommissionerNodeId.ValueOr(0);
-        (void) commissionerNodeId;
         switch (testIndex)
         {
         case 0: {


### PR DESCRIPTION
#### Problem

https://github.com/project-chip/connectedhomeip/pull/24197 has introduced a variable named `commissionedNodeId` for yaml that is directly exposed by the Test Harness. That diverge from the other YAML steps that normally use pseudo-clusters commands in order to do things.
`commissionerNodeId` is used in various tests now, so this PR replace the inner variable mechanism by exposing a new pseudo-cluster command (`CommissionerCommands::GetCommissionerNodeId`) where the value retrieved is saved and reused in the steps that needs it.

This PR requires a ZAP update but it can be reviewed before the ZAP update lands (for the record, the necessary ZAP change is in https://github.com/project-chip/zap/pull/910)