### PR TITLE
Add ability to check for PICS top level support

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -845,6 +845,7 @@ class TestParser:
 
         pics_checker = PICSChecker(pics_file)
         tests = _value_or_none(data, 'tests')
+        self.is_test_pics_enabled = pics_checker.check(self.PICS)
         self.tests = YamlTests(
             self._parsing_config_variable_storage, definitions, pics_checker, tests)
 

--- a/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
+++ b/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
@@ -107,6 +107,10 @@ def main(setup_code, yaml_path, node_id, pics_file):
             runner = ReplTestRunner(
                 clusters_definitions, certificate_authority_manager, dev_ctrl)
 
+            if not yaml.is_test_pics_enabled:
+                _StackShutDown()
+                return
+
             # Executing and validating test
             for test_step in yaml.tests:
                 test_action = runner.encode(test_step)


### PR DESCRIPTION
This adds top level PICS property boolean indicating whether the entire test should be run. This also has chip-repl based yamltest runner adhear to that top level PICS code

