### PR TITLE
[Silabs] Refactor/Cleanup examples build files

### DIFF
--- a/examples/chef/efr32/BUILD.gn
+++ b/examples/chef/efr32/BUILD.gn
@@ -38,28 +38,12 @@ efr32_project_dir = "${chef_project_dir}/efr32"
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
 examples_common_plat_dir = "${chip_root}/examples/platform/silabs"
 app_data_model = "${efr32_project_dir}:chef-comon"
+import("${examples_plat_dir}/args.gni")
 
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
-
-  # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
-  use_wf200 = false
-  use_rs911x = false
-  use_rs911x_sockets = false
-  sl_wfx_config_softap = false
-  sl_wfx_config_scan = true
-
   sample_name = ""
-}
-
-# Sanity check
-assert(!(chip_enable_wifi && chip_enable_openthread))
-assert(!(use_rs911x && chip_enable_openthread))
-assert(!(use_wf200 && chip_enable_openthread))
-if (chip_enable_wifi) {
-  assert(use_rs911x || use_wf200)
-  enable_openthread_cli = false
 }
 
 chip_data_model("chef-common") {
@@ -67,28 +51,6 @@ chip_data_model("chef-common") {
 
   zap_pregenerated_dir = "${chef_project_dir}/out/${sample_name}/zap-generated/"
   is_server = true
-}
-
-# WiFi settings
-if (chip_enable_wifi) {
-  wifi_sdk_dir = "${chip_root}/third_party/efr32_sdk/repo/matter/wifi"
-  efr32_lwip_defs = [ "LWIP_NETIF_API=1" ]
-  efr32_lwip_defs += [
-    "LWIP_IPV4=1",
-    "LWIP_ARP=1",
-    "LWIP_ICMP=1",
-    "LWIP_DHCP=1",
-    "LWIP_IPV6_ND=1",
-    "LWIP_IGMP=1",
-  ]
-
-  if (use_rs911x) {
-    wiseconnect_sdk_root =
-        "${chip_root}/third_party/efr32_sdk/wiseconnect-wifi-bt-sdk"
-    import("${wifi_sdk_dir}/rs911x/rs911x.gni")
-  } else {
-    import("${wifi_sdk_dir}/wf200/wf200.gni")
-  }
 }
 
 efr32_sdk("sdk") {
@@ -105,37 +67,17 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
+  if (use_wf200) {
+    # TODO efr32_sdk should not need a header from this location
+    include_dirs += [ "${examples_plat_dir}/wf200" ]
+  }
+
+  defines = []
   if (chip_enable_pw_rpc) {
     defines += [
       "HAL_VCOM_ENABLE=1",
       "PW_RPC_ENABLED",
     ]
-  }
-
-  # WiFi Settings
-  if (chip_enable_wifi) {
-    if (use_rs911x) {
-      defines += rs911x_defs
-      include_dirs += rs911x_plat_incs
-    } else if (use_wf200) {
-      defines += wf200_defs
-      include_dirs += wf200_plat_incs
-    }
-
-    if (use_rs911x_sockets) {
-      include_dirs += [ "${examples_plat_dir}/wifi/rsi-sockets" ]
-      defines += rs911x_sock_defs
-    } else {
-      # Using LWIP instead of the native TCP/IP stack
-      defines += efr32_lwip_defs
-    }
-
-    if (sl_wfx_config_softap) {
-      defines += [ "SL_WFX_CONFIG_SOFTAP" ]
-    }
-    if (sl_wfx_config_scan) {
-      defines += [ "SL_WFX_CONFIG_SCAN" ]
-    }
   }
 }
 
@@ -157,34 +99,6 @@ efr32_executable("chef_app") {
     ":sdk",
     "${examples_plat_dir}:efr32-common",
   ]
-
-  # WiFi Settings
-  if (chip_enable_wifi) {
-    if (use_rs911x) {
-      sources += rs911x_src_plat
-
-      # All the stuff from wiseconnect
-      sources += rs911x_src_sapi
-
-      # Apparently - the rsi library needs this (though we may not use use it)
-      sources += rs911x_src_sock
-      include_dirs += rs911x_inc_plat
-
-      if (use_rs911x_sockets) {
-        #
-        # Using native sockets inside RS911x
-        #
-        include_dirs += rs911x_sock_inc
-      } else {
-        #
-        # We use LWIP - not built-in sockets
-        #
-        sources += rs911x_src_lwip
-      }
-    } else if (use_wf200) {
-      sources += wf200_plat_src
-      include_dirs += wf200_plat_incs
-    }
   }
 
   if (chip_enable_pw_rpc) {

--- a/examples/chef/efr32/BUILD.gn
+++ b/examples/chef/efr32/BUILD.gn
@@ -35,20 +35,13 @@ assert(current_os == "freertos")
 
 chef_project_dir = "${chip_root}/examples/chef"
 efr32_project_dir = "${chef_project_dir}/efr32"
-examples_plat_dir = "${chip_root}/examples/platform/efr32"
+examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
+examples_common_plat_dir = "${chip_root}/examples/platform/silabs"
+app_data_model = "${efr32_project_dir}:chef-comon"
 
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
-
-  # Monitor & log memory usage at runtime.
-  enable_heap_monitoring = false
-
-  # Enable Sleepy end device
-  enable_sleepy_device = false
-
-  # OTA timeout in seconds
-  OTA_periodic_query_timeout = 86400
 
   # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
   use_wf200 = false
@@ -57,19 +50,8 @@ declare_args() {
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
 
-  # Disable LCD on supported devices
-  disable_lcd = false
-
   sample_name = ""
 }
-
-declare_args() {
-  # Enables LCD Qr Code on supported devices
-  show_qr_code = !disable_lcd
-}
-
-# qr code cannot be true if lcd is disabled
-assert(!(disable_lcd && show_qr_code))
 
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))
@@ -85,13 +67,6 @@ chip_data_model("chef-common") {
 
   zap_pregenerated_dir = "${chef_project_dir}/out/${sample_name}/zap-generated/"
   is_server = true
-}
-
-# ThunderBoards, Explorer Kit and MGM240L do not support LCD (No LCD)
-if (silabs_board == "BRD4166A" || silabs_board == "BRD2601B" ||
-    silabs_board == "BRD2703A" || silabs_board == "BRD4319A") {
-  show_qr_code = false
-  disable_lcd = true
 }
 
 # WiFi settings
@@ -123,15 +98,11 @@ efr32_sdk("sdk") {
   ]
 
   include_dirs = [
-    "${chip_root}/src/platform/EFR32",
+    "${chip_root}/src/platform/silabs/EFR32",
     "${efr32_project_dir}/include",
     "${examples_plat_dir}",
     "${chip_root}/src/lib",
-  ]
-
-  defines = [
-    "BOARD_ID=${silabs_board}",
-    "OTA_PERIODIC_TIMEOUT=${OTA_periodic_query_timeout}",
+    "${examples_common_plat_dir}",
   ]
 
   if (chip_enable_pw_rpc) {
@@ -170,51 +141,22 @@ efr32_sdk("sdk") {
 
 efr32_executable("chef_app") {
   output_name = "chip-efr32-chef-example.out"
+  public_configs = [ "${efr32_sdk_build_root}:silabs_config" ]
   include_dirs = [ "include" ]
   defines = []
 
   sources = [
-    "${examples_plat_dir}/BaseApplication.cpp",
-    "${examples_plat_dir}/efr32_utils.cpp",
-    "${examples_plat_dir}/heap_4_silabs.c",
-    "${examples_plat_dir}/init_efrPlatform.cpp",
-    "${examples_plat_dir}/matter_config.cpp",
     "src/AppTask.cpp",
     "src/LightingManager.cpp",
     "src/ZclCallbacks.cpp",
     "src/main.cpp",
   ]
 
-  if (use_wstk_leds) {
-    sources += [ "${examples_plat_dir}/LEDWidget.cpp" ]
-  }
-
-  if (chip_enable_pw_rpc || chip_build_libshell || enable_openthread_cli ||
-      use_wf200 || use_rs911x) {
-    sources += [ "${examples_plat_dir}/uart.cpp" ]
-  }
-
   deps = [
     ":chef-common",
     ":sdk",
-    "${chip_root}/examples/providers:device_info_provider",
-    "${chip_root}/src/lib",
-    "${chip_root}/src/setup_payload",
+    "${examples_plat_dir}:efr32-common",
   ]
-
-  # OpenThread Settings
-  if (chip_enable_openthread) {
-    deps += [
-      "${chip_root}/third_party/openthread:openthread",
-      "${chip_root}/third_party/openthread:openthread-platform",
-      "${examples_plat_dir}:efr-matter-shell",
-    ]
-  }
-
-  if (chip_enable_ota_requestor) {
-    defines += [ "EFR32_OTA_ENABLED" ]
-    sources += [ "${examples_plat_dir}/OTAConfig.cpp" ]
-  }
 
   # WiFi Settings
   if (chip_enable_wifi) {
@@ -245,19 +187,6 @@ efr32_executable("chef_app") {
     }
   }
 
-  if (!disable_lcd) {
-    sources += [
-      "${examples_plat_dir}/display/demo-ui.c",
-      "${examples_plat_dir}/display/lcd.cpp",
-    ]
-    include_dirs += [ "${examples_plat_dir}/display" ]
-    defines += [ "DISPLAY_ENABLED" ]
-    if (show_qr_code) {
-      defines += [ "QR_CODE_ENABLED" ]
-      deps += [ "${chip_root}/examples/common/QRCode" ]
-    }
-  }
-
   if (chip_enable_pw_rpc) {
     defines += [
       "PW_RPC_ENABLED",
@@ -274,8 +203,8 @@ efr32_executable("chef_app") {
     sources += [
       "${chip_root}/examples/common/pigweed/RpcService.cpp",
       "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
-      "${examples_plat_dir}/PigweedLogger.cpp",
-      "${examples_plat_dir}/Rpc.cpp",
+      "${examples_common_plat_dir}/PigweedLogger.cpp",
+      "${examples_common_plat_dir}/Rpc.cpp",
     ]
 
     deps += [
@@ -303,11 +232,6 @@ efr32_executable("chef_app") {
     ]
   }
 
-  if (enable_heap_monitoring) {
-    sources += [ "${examples_plat_dir}/MemMonitoring.cpp" ]
-    defines += [ "HEAP_MONITORING" ]
-  }
-
   ldscript = "${examples_plat_dir}/ldscripts/${silabs_family}.ld"
 
   inputs = [ ldscript ]
@@ -327,16 +251,6 @@ efr32_executable("chef_app") {
       "-Wl,--defsym",
       "-Wl,SILABS_WIFI=1",
     ]
-  }
-
-  # Attestation Credentials
-  if (chip_build_platform_attestation_credentials_provider) {
-    deps += [ "${examples_plat_dir}:efr32-attestation-credentials" ]
-  }
-
-  # Factory Data Provider
-  if (use_efr32_factory_data_provider) {
-    deps += [ "${examples_plat_dir}:efr32-factory-data-provider" ]
   }
 
   output_dir = root_out_dir

--- a/examples/chef/efr32/BUILD.gn
+++ b/examples/chef/efr32/BUILD.gn
@@ -99,7 +99,6 @@ efr32_executable("chef_app") {
     ":sdk",
     "${examples_plat_dir}:efr32-common",
   ]
-  }
 
   if (chip_enable_pw_rpc) {
     defines += [

--- a/examples/light-switch-app/silabs/SiWx917/BUILD.gn
+++ b/examples/light-switch-app/silabs/SiWx917/BUILD.gn
@@ -49,14 +49,8 @@ declare_args() {
   OTA_periodic_query_timeout = 86400
 
   # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
-  use_wf200 = false
-  use_rs911x = false
-  use_rs911x_sockets = false
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
-
-  # Disable LCD on supported devices
-  disable_lcd = true
 
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
@@ -70,14 +64,6 @@ declare_args() {
   #default Wifi Password
   chip_default_wifi_psk = ""
 }
-
-declare_args() {
-  # Enables LCD Qr Code on supported devices
-  show_qr_code = !disable_lcd
-}
-
-# qr code cannot be true if lcd is disabled
-assert(!(disable_lcd && show_qr_code))
 
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))

--- a/examples/light-switch-app/silabs/efr32/BUILD.gn
+++ b/examples/light-switch-app/silabs/efr32/BUILD.gn
@@ -40,84 +40,6 @@ import("${examples_plat_dir}/args.gni")
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
-
-  # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
-  use_wf200 = false
-  use_rs911x = false
-  use_rs911x_sockets = false
-  sl_wfx_config_softap = false
-  sl_wfx_config_scan = true
-
-  # Argument to Disable IPv4 for wifi(rs911)
-  chip_enable_wifi_ipv4 = false
-
-  # Argument to force enable WPA3 security
-  rs91x_wpa3_only = false
-
-  #default WiFi SSID
-  chip_default_wifi_ssid = ""
-
-  #default Wifi Password
-  chip_default_wifi_psk = ""
-}
-
-# Sanity check
-assert(!(chip_enable_wifi && chip_enable_openthread))
-assert(!(use_rs911x && chip_enable_openthread))
-assert(!(use_wf200 && chip_enable_openthread))
-if (chip_enable_wifi) {
-  assert(use_rs911x || use_wf200)
-  enable_openthread_cli = false
-  import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
-}
-
-defines = []
-
-# WiFi settings
-if (chip_enable_wifi) {
-  if (chip_default_wifi_ssid != "") {
-    defines += [
-      "CHIP_ONNETWORK_PAIRING=1",
-      "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
-    ]
-  }
-  if (chip_default_wifi_psk != "") {
-    assert(chip_default_wifi_ssid != "",
-           "ssid can't be null if psk is provided")
-    defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
-  }
-  wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
-  efr32_lwip_defs = [ "LWIP_NETIF_API=1" ]
-  if (lwip_ipv4) {
-    efr32_lwip_defs += [
-      "LWIP_IPV4=1",
-
-      # adds following options to provide
-      # them to .cpp source files
-      # flags ported from lwipopts file
-      # TODO: move lwipopts to one location
-      "LWIP_ARP=1",
-      "LWIP_ICMP=1",
-      "LWIP_IGMP=1",
-      "LWIP_DHCP=1",
-      "LWIP_DNS=0",
-    ]
-  } else {
-    efr32_lwip_defs += [ "LWIP_IPV4=0" ]
-  }
-  if (lwip_ipv6) {
-    efr32_lwip_defs += [ "LWIP_IPV6=1" ]
-  } else {
-    efr32_lwip_defs += [ "LWIP_IPV6=0" ]
-  }
-
-  if (use_rs911x) {
-    wiseconnect_sdk_root =
-        "${chip_root}/third_party/silabs/wiseconnect-wifi-bt-sdk"
-    import("${examples_plat_dir}/rs911x/rs911x.gni")
-  } else {
-    import("${examples_plat_dir}/wf200/wf200.gni")
-  }
 }
 
 efr32_sdk("sdk") {
@@ -135,37 +57,17 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
+  if (use_wf200) {
+    # TODO efr32_sdk should not need a header from this location
+    include_dirs += [ "${examples_plat_dir}/wf200" ]
+  }
+
+  defines = []
   if (chip_enable_pw_rpc) {
     defines += [
       "HAL_VCOM_ENABLE=1",
       "PW_RPC_ENABLED",
     ]
-  }
-
-  # WiFi Settings
-  if (chip_enable_wifi) {
-    if (use_rs911x) {
-      defines += rs911x_defs
-      include_dirs += rs911x_plat_incs
-    } else if (use_wf200) {
-      defines += wf200_defs
-      include_dirs += wf200_plat_incs
-    }
-
-    if (use_rs911x_sockets) {
-      include_dirs += [ "${examples_plat_dir}/wifi/rsi-sockets" ]
-      defines += rs911x_sock_defs
-    } else {
-      # Using LWIP instead of the native TCP/IP stack
-      defines += efr32_lwip_defs
-    }
-
-    if (sl_wfx_config_softap) {
-      defines += [ "SL_WFX_CONFIG_SOFTAP" ]
-    }
-    if (sl_wfx_config_scan) {
-      defines += [ "SL_WFX_CONFIG_SCAN" ]
-    }
   }
 }
 
@@ -197,44 +99,6 @@ efr32_executable("light_switch_app") {
 
   if (!disable_lcd) {
     defines += [ "IS_DEMO_SWITCH=1" ]
-  }
-
-  # WiFi Settings
-  if (chip_enable_wifi) {
-    if (use_rs911x) {
-      sources += rs911x_src_plat
-
-      # All the stuff from wiseconnect
-      sources += rs911x_src_sapi
-
-      # Apparently - the rsi library needs this (though we may not use use it)
-      sources += rs911x_src_sock
-      include_dirs += rs911x_inc_plat
-
-      if (use_rs911x_sockets) {
-        #
-        # Using native sockets inside RS911x
-        #
-        include_dirs += rs911x_sock_inc
-      } else {
-        #
-        # We use LWIP - not built-in sockets
-        #
-        sources += rs911x_src_lwip
-      }
-    } else if (use_wf200) {
-      sources += wf200_plat_src
-      include_dirs += wf200_plat_incs
-    }
-
-    if (chip_enable_wifi_ipv4) {
-      defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
-    }
-
-    if (rs91x_wpa3_only) {
-      # TODO: Change this macro once WF200 support is provided
-      defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
-    }
   }
 
   if (chip_enable_pw_rpc) {

--- a/examples/light-switch-app/silabs/efr32/BUILD.gn
+++ b/examples/light-switch-app/silabs/efr32/BUILD.gn
@@ -35,18 +35,11 @@ efr32_project_dir = "${chip_root}/examples/light-switch-app/silabs/efr32"
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
 examples_common_plat_dir = "${chip_root}/examples/platform/silabs"
 
+import("${examples_plat_dir}/args.gni")
+
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
-
-  # Monitor & log memory usage at runtime.
-  enable_heap_monitoring = false
-
-  # Enable Sleepy end device
-  enable_sleepy_device = false
-
-  # OTA timeout in seconds
-  OTA_periodic_query_timeout = 86400
 
   # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
   use_wf200 = false
@@ -54,9 +47,6 @@ declare_args() {
   use_rs911x_sockets = false
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
-
-  # Disable LCD on supported devices
-  disable_lcd = false
 
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
@@ -71,20 +61,6 @@ declare_args() {
   chip_default_wifi_psk = ""
 }
 
-declare_args() {
-  # Enables LCD Qr Code on supported devices
-  show_qr_code = !disable_lcd
-
-  # Use default handler to negotiate subscription max interval
-  chip_config_use_icd_subscription_callbacks = enable_sleepy_device
-}
-
-# qr code cannot be true if lcd is disabled
-assert(!(disable_lcd && show_qr_code))
-
-# default read handler cannot be used without being an IC device (SED)
-assert(!chip_config_use_icd_subscription_callbacks || enable_sleepy_device)
-
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))
 assert(!(use_rs911x && chip_enable_openthread))
@@ -93,13 +69,6 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
   enable_openthread_cli = false
   import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
-}
-
-# ThunderBoards, Explorer Kit and MGM240L do not support LCD (No LCD)
-if (silabs_board == "BRD4166A" || silabs_board == "BRD2601B" ||
-    silabs_board == "BRD2703A" || silabs_board == "BRD4319A") {
-  show_qr_code = false
-  disable_lcd = true
 }
 
 defines = []
@@ -166,11 +135,6 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
-  defines += [
-    "BOARD_ID=${silabs_board}",
-    "OTA_PERIODIC_TIMEOUT=${OTA_periodic_query_timeout}",
-  ]
-
   if (chip_enable_pw_rpc) {
     defines += [
       "HAL_VCOM_ENABLE=1",
@@ -214,31 +178,15 @@ efr32_executable("light_switch_app") {
   sources = [
     "${chip_root}/examples/light-switch-app/silabs/common/BindingHandler.cpp",
     "${chip_root}/examples/light-switch-app/silabs/common/LightSwitchMgr.cpp",
-    "${examples_common_plat_dir}/heap_4_silabs.c",
-    "${examples_plat_dir}/BaseApplication.cpp",
-    "${examples_plat_dir}/efr32_utils.cpp",
-    "${examples_plat_dir}/init_efrPlatform.cpp",
-    "${examples_plat_dir}/matter_config.cpp",
     "src/AppTask.cpp",
     "src/ZclCallbacks.cpp",
     "src/main.cpp",
   ]
 
-  if (use_wstk_leds) {
-    sources += [ "${examples_plat_dir}/LEDWidget.cpp" ]
-  }
-
-  if (chip_enable_pw_rpc || chip_build_libshell || enable_openthread_cli ||
-      use_wf200 || use_rs911x) {
-    sources += [ "${examples_plat_dir}/uart.cpp" ]
-  }
-
   deps = [
     ":sdk",
-    "${chip_root}/examples/light-switch-app/light-switch-common",
-    "${chip_root}/examples/providers:device_info_provider",
-    "${chip_root}/src/lib",
-    "${chip_root}/src/setup_payload",
+    "${examples_plat_dir}:efr32-common",
+    app_data_model,
   ]
 
   if (chip_build_libshell) {
@@ -247,33 +195,8 @@ efr32_executable("light_switch_app") {
     ]
   }
 
-  # OpenThread Settings
-  if (chip_enable_openthread) {
-    deps += [
-      "${chip_root}/third_party/openthread:openthread",
-      "${chip_root}/third_party/openthread:openthread-platform",
-      "${examples_plat_dir}:efr-matter-shell",
-    ]
-  }
-
-  # Attestation Credentials
-  if (chip_build_platform_attestation_credentials_provider) {
-    deps += [ "${examples_plat_dir}:efr32-attestation-credentials" ]
-  }
-
-  # Factory Data Provider
-  if (use_efr32_factory_data_provider) {
-    deps += [ "${examples_plat_dir}:efr32-factory-data-provider" ]
-  }
-
-  # Default Read handler for SED
-  if (chip_config_use_icd_subscription_callbacks) {
-    deps += [ "${examples_plat_dir}:efr32-ICD-subscription-callback" ]
-  }
-
-  if (chip_enable_ota_requestor) {
-    defines += [ "EFR32_OTA_ENABLED" ]
-    sources += [ "${examples_plat_dir}/OTAConfig.cpp" ]
+  if (!disable_lcd) {
+    defines += [ "IS_DEMO_SWITCH=1" ]
   }
 
   # WiFi Settings
@@ -314,22 +237,6 @@ efr32_executable("light_switch_app") {
     }
   }
 
-  if (!disable_lcd) {
-    sources += [
-      "${examples_plat_dir}/display/demo-ui.c",
-      "${examples_plat_dir}/display/lcd.cpp",
-    ]
-    include_dirs += [ "${examples_plat_dir}/display" ]
-    defines += [
-      "DISPLAY_ENABLED",
-      "IS_DEMO_SWITCH=1",
-    ]
-    if (show_qr_code) {
-      defines += [ "QR_CODE_ENABLED" ]
-      deps += [ "${chip_root}/examples/common/QRCode" ]
-    }
-  }
-
   if (chip_enable_pw_rpc) {
     defines += [
       "PW_RPC_ENABLED",
@@ -365,11 +272,6 @@ efr32_executable("light_switch_app") {
       "${chip_root}/examples/common",
       "${chip_root}/examples/common/pigweed/efr32",
     ]
-  }
-
-  if (enable_heap_monitoring) {
-    sources += [ "${examples_common_plat_dir}/MemMonitoring.cpp" ]
-    defines += [ "HEAP_MONITORING" ]
   }
 
   ldscript = "${examples_plat_dir}/ldscripts/${silabs_family}.ld"

--- a/examples/light-switch-app/silabs/efr32/args.gni
+++ b/examples/light-switch-app/silabs/efr32/args.gni
@@ -18,6 +18,7 @@ import("${chip_root}/src/platform/silabs/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
+app_data_model = "${chip_root}/examples/light-switch-app/light-switch-common"
 chip_enable_ota_requestor = true
 chip_enable_openthread = true
 openthread_external_platform =

--- a/examples/light-switch-app/silabs/efr32/build_for_wifi_args.gni
+++ b/examples/light-switch-app/silabs/efr32/build_for_wifi_args.gni
@@ -19,3 +19,4 @@ chip_enable_openthread = false
 import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
 
 chip_enable_ota_requestor = true
+app_data_model = "${chip_root}/examples/light-switch-app/light-switch-common"

--- a/examples/lighting-app/silabs/SiWx917/BUILD.gn
+++ b/examples/lighting-app/silabs/SiWx917/BUILD.gn
@@ -49,14 +49,8 @@ declare_args() {
   OTA_periodic_query_timeout = 86400
 
   # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
-  use_wf200 = false
-  use_rs911x = false
-  use_rs911x_sockets = false
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
-
-  # Disable LCD on supported devices
-  disable_lcd = true
 
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
@@ -70,14 +64,6 @@ declare_args() {
   #default Wifi Password
   psk = ""
 }
-
-declare_args() {
-  # Enables LCD Qr Code on supported devices
-  show_qr_code = !disable_lcd
-}
-
-# qr code cannot be true if lcd is disabled
-assert(!(disable_lcd && show_qr_code))
 
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))

--- a/examples/lighting-app/silabs/efr32/BUILD.gn
+++ b/examples/lighting-app/silabs/efr32/BUILD.gn
@@ -40,84 +40,6 @@ import("${examples_plat_dir}/args.gni")
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
-
-  # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
-  use_wf200 = false
-  use_rs911x = false
-  use_rs911x_sockets = false
-  sl_wfx_config_softap = false
-  sl_wfx_config_scan = true
-
-  # Argument to Disable IPv4 for wifi(rs911)
-  chip_enable_wifi_ipv4 = false
-
-  # Argument to force enable WPA3 security on rs91x
-  rs91x_wpa3_only = false
-
-  #default WiFi SSID
-  chip_default_wifi_ssid = ""
-
-  #default Wifi Password
-  chip_default_wifi_psk = ""
-}
-
-# Sanity check
-assert(!(chip_enable_wifi && chip_enable_openthread))
-assert(!(use_rs911x && chip_enable_openthread))
-assert(!(use_wf200 && chip_enable_openthread))
-if (chip_enable_wifi) {
-  assert(use_rs911x || use_wf200)
-  enable_openthread_cli = false
-  import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
-}
-
-defines = []
-
-# WiFi settings
-if (chip_enable_wifi) {
-  if (chip_default_wifi_ssid != "") {
-    defines += [
-      "CHIP_ONNETWORK_PAIRING=1",
-      "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
-    ]
-  }
-  if (chip_default_wifi_psk != "") {
-    assert(chip_default_wifi_ssid != "",
-           "ssid can't be null if psk is provided")
-    defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
-  }
-  wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
-  efr32_lwip_defs = [ "LWIP_NETIF_API=1" ]
-  if (lwip_ipv4) {
-    efr32_lwip_defs += [
-      "LWIP_IPV4=1",
-
-      # adds following options to provide
-      # them to .cpp source files
-      # flags ported from lwipopts file
-      # TODO: move lwipopts to one location
-      "LWIP_ARP=1",
-      "LWIP_ICMP=1",
-      "LWIP_IGMP=1",
-      "LWIP_DHCP=1",
-      "LWIP_DNS=0",
-    ]
-  } else {
-    efr32_lwip_defs += [ "LWIP_IPV4=0" ]
-  }
-  if (lwip_ipv6) {
-    efr32_lwip_defs += [ "LWIP_IPV6=1" ]
-  } else {
-    efr32_lwip_defs += [ "LWIP_IPV6=0" ]
-  }
-
-  if (use_rs911x) {
-    wiseconnect_sdk_root =
-        "${chip_root}/third_party/silabs/wiseconnect-wifi-bt-sdk"
-    import("${examples_plat_dir}/rs911x/rs911x.gni")
-  } else {
-    import("${examples_plat_dir}/wf200/wf200.gni")
-  }
 }
 
 efr32_sdk("sdk") {
@@ -134,37 +56,12 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
+  defines = []
   if (chip_enable_pw_rpc) {
     defines += [
       "HAL_VCOM_ENABLE=1",
       "PW_RPC_ENABLED",
     ]
-  }
-
-  # WiFi Settings
-  if (chip_enable_wifi) {
-    if (use_rs911x) {
-      defines += rs911x_defs
-      include_dirs += rs911x_plat_incs
-    } else if (use_wf200) {
-      defines += wf200_defs
-      include_dirs += wf200_plat_incs
-    }
-
-    if (use_rs911x_sockets) {
-      include_dirs += [ "${examples_plat_dir}/wifi/rsi-sockets" ]
-      defines += rs911x_sock_defs
-    } else {
-      # Using LWIP instead of the native TCP/IP stack
-      defines += efr32_lwip_defs
-    }
-
-    if (sl_wfx_config_softap) {
-      defines += [ "SL_WFX_CONFIG_SOFTAP" ]
-    }
-    if (sl_wfx_config_scan) {
-      defines += [ "SL_WFX_CONFIG_SCAN" ]
-    }
   }
 }
 
@@ -193,44 +90,6 @@ efr32_executable("lighting_app") {
 
   if (!disable_lcd) {
     defines += [ "IS_DEMO_LIGHT=1" ]
-  }
-
-  # WiFi Settings
-  if (chip_enable_wifi) {
-    if (use_rs911x) {
-      sources += rs911x_src_plat
-
-      # All the stuff from wiseconnect
-      sources += rs911x_src_sapi
-
-      # Apparently - the rsi library needs this (though we may not use use it)
-      sources += rs911x_src_sock
-      include_dirs += rs911x_inc_plat
-
-      if (use_rs911x_sockets) {
-        #
-        # Using native sockets inside RS911x
-        #
-        include_dirs += rs911x_sock_inc
-      } else {
-        #
-        # We use LWIP - not built-in sockets
-        #
-        sources += rs911x_src_lwip
-      }
-    } else if (use_wf200) {
-      sources += wf200_plat_src
-      include_dirs += wf200_plat_incs
-    }
-
-    if (chip_enable_wifi_ipv4) {
-      defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
-    }
-
-    if (rs91x_wpa3_only) {
-      # TODO: Change this macro once WF200 support is provided
-      defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
-    }
   }
 
   if (chip_enable_pw_rpc) {

--- a/examples/lighting-app/silabs/efr32/BUILD.gn
+++ b/examples/lighting-app/silabs/efr32/BUILD.gn
@@ -56,6 +56,11 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
+  if (use_wf200) {
+    # TODO efr32_sdk should not need a header from this location
+    include_dirs += [ "${examples_plat_dir}/wf200" ]
+  }
+
   defines = []
   if (chip_enable_pw_rpc) {
     defines += [

--- a/examples/lighting-app/silabs/efr32/BUILD.gn
+++ b/examples/lighting-app/silabs/efr32/BUILD.gn
@@ -35,6 +35,8 @@ efr32_project_dir = "${chip_root}/examples/lighting-app/silabs/efr32"
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
 examples_common_plat_dir = "${chip_root}/examples/platform/silabs"
 
+import("${examples_plat_dir}/args.gni")
+
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
@@ -132,11 +134,6 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
-  defines += [
-    "BOARD_ID=${silabs_board}",
-    "OTA_PERIODIC_TIMEOUT=${OTA_periodic_query_timeout}",
-  ]
-
   if (chip_enable_pw_rpc) {
     defines += [
       "HAL_VCOM_ENABLE=1",
@@ -190,11 +187,13 @@ efr32_executable("lighting_app") {
 
   deps = [
     ":sdk",
-    "${chip_root}/examples/lighting-app/lighting-common",
-    "${examples_plat_dir}:silabs-common",
+    "${examples_plat_dir}:efr32-common",
+    app_data_model,
   ]
 
-  #public_deps = []
+  if (!disable_lcd) {
+    defines += [ "IS_DEMO_LIGHT=1" ]
+  }
 
   # WiFi Settings
   if (chip_enable_wifi) {

--- a/examples/lighting-app/silabs/efr32/BUILD.gn
+++ b/examples/lighting-app/silabs/efr32/BUILD.gn
@@ -39,24 +39,12 @@ declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
 
-  # Monitor & log memory usage at runtime.
-  enable_heap_monitoring = false
-
-  # Enable Sleepy end device
-  enable_sleepy_device = false
-
-  # OTA timeout in seconds
-  OTA_periodic_query_timeout = 86400
-
   # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
   use_wf200 = false
   use_rs911x = false
   use_rs911x_sockets = false
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
-
-  # Disable LCD on supported devices
-  disable_lcd = false
 
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
@@ -71,14 +59,6 @@ declare_args() {
   chip_default_wifi_psk = ""
 }
 
-declare_args() {
-  # Enables LCD Qr Code on supported devices
-  show_qr_code = !disable_lcd
-}
-
-# qr code cannot be true if lcd is disabled
-assert(!(disable_lcd && show_qr_code))
-
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))
 assert(!(use_rs911x && chip_enable_openthread))
@@ -87,14 +67,6 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
   enable_openthread_cli = false
   import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
-}
-
-# ThunderBoards, Explorer Kit and MGM240L do not support LCD (No LCD)
-if (silabs_board == "BRD4166A" || silabs_board == "BRD2601B" ||
-    silabs_board == "BRD2703A" || silabs_board == "BRD4319A" ||
-    silabs_board == "BRD2704A") {
-  show_qr_code = false
-  disable_lcd = true
 }
 
 defines = []
@@ -165,10 +137,6 @@ efr32_sdk("sdk") {
     "OTA_PERIODIC_TIMEOUT=${OTA_periodic_query_timeout}",
   ]
 
-  if (enable_heap_monitoring) {
-    defines += [ "HEAP_MONITORING" ]
-  }
-
   if (chip_enable_pw_rpc) {
     defines += [
       "HAL_VCOM_ENABLE=1",
@@ -214,47 +182,19 @@ efr32_executable("lighting_app") {
   }
 
   sources = [
-    "${examples_common_plat_dir}/heap_4_silabs.c",
-    "${examples_plat_dir}/BaseApplication.cpp",
-    "${examples_plat_dir}/efr32_utils.cpp",
-    "${examples_plat_dir}/init_efrPlatform.cpp",
-    "${examples_plat_dir}/matter_config.cpp",
     "src/AppTask.cpp",
     "src/LightingManager.cpp",
     "src/ZclCallbacks.cpp",
     "src/main.cpp",
   ]
 
-  if (use_wstk_leds) {
-    sources += [ "${examples_plat_dir}/LEDWidget.cpp" ]
-  }
-
-  if (chip_enable_pw_rpc || chip_build_libshell || enable_openthread_cli ||
-      use_wf200 || use_rs911x) {
-    sources += [ "${examples_plat_dir}/uart.cpp" ]
-  }
-
   deps = [
     ":sdk",
     "${chip_root}/examples/lighting-app/lighting-common",
-    "${chip_root}/examples/providers:device_info_provider",
-    "${chip_root}/src/lib",
-    "${chip_root}/src/setup_payload",
+    "${examples_plat_dir}:silabs-common",
   ]
 
-  # OpenThread Settings
-  if (chip_enable_openthread) {
-    deps += [
-      "${chip_root}/third_party/openthread:openthread",
-      "${chip_root}/third_party/openthread:openthread-platform",
-      "${examples_plat_dir}:efr-matter-shell",
-    ]
-  }
-
-  if (chip_enable_ota_requestor) {
-    defines += [ "EFR32_OTA_ENABLED" ]
-    sources += [ "${examples_plat_dir}/OTAConfig.cpp" ]
-  }
+  #public_deps = []
 
   # WiFi Settings
   if (chip_enable_wifi) {
@@ -291,24 +231,6 @@ efr32_executable("lighting_app") {
     if (rs91x_wpa3_only) {
       # TODO: Change this macro once WF200 support is provided
       defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
-    }
-  }
-
-  if (!disable_lcd) {
-    sources += [
-      "${examples_plat_dir}/display/demo-ui.c",
-      "${examples_plat_dir}/display/lcd.cpp",
-    ]
-
-    include_dirs += [ "${examples_plat_dir}/display" ]
-    defines += [
-      "DISPLAY_ENABLED",
-      "IS_DEMO_LIGHT=1",
-    ]
-    if (show_qr_code) {
-      defines += [ "QR_CODE_ENABLED" ]
-
-      deps += [ "${chip_root}/examples/common/QRCode" ]
     }
   }
 
@@ -357,11 +279,6 @@ efr32_executable("lighting_app") {
     ]
   }
 
-  if (enable_heap_monitoring) {
-    sources += [ "${examples_common_plat_dir}/MemMonitoring.cpp" ]
-    defines += [ "HEAP_MONITORING" ]
-  }
-
   ldscript = "${examples_plat_dir}/ldscripts/${silabs_family}.ld"
 
   inputs = [ ldscript ]
@@ -381,16 +298,6 @@ efr32_executable("lighting_app") {
       "-Wl,--defsym",
       "-Wl,SILABS_WIFI=1",
     ]
-  }
-
-  # Attestation Credentials
-  if (chip_build_platform_attestation_credentials_provider) {
-    deps += [ "${examples_plat_dir}:efr32-attestation-credentials" ]
-  }
-
-  # Factory Data Provider
-  if (use_efr32_factory_data_provider) {
-    deps += [ "${examples_plat_dir}:efr32-factory-data-provider" ]
   }
 
   output_dir = root_out_dir

--- a/examples/lighting-app/silabs/efr32/args.gni
+++ b/examples/lighting-app/silabs/efr32/args.gni
@@ -18,6 +18,7 @@ import("${chip_root}/src/platform/silabs/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
+app_data_model = "${chip_root}/examples/lighting-app/lighting-common"
 chip_enable_ota_requestor = true
 chip_enable_openthread = true
 

--- a/examples/lighting-app/silabs/efr32/build_for_wifi_args.gni
+++ b/examples/lighting-app/silabs/efr32/build_for_wifi_args.gni
@@ -19,3 +19,4 @@ chip_enable_openthread = false
 import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
 
 chip_enable_ota_requestor = true
+app_data_model = "${chip_root}/examples/lighting-app/lighting-common"

--- a/examples/lighting-app/silabs/efr32/with_pw_rpc.gni
+++ b/examples/lighting-app/silabs/efr32/with_pw_rpc.gni
@@ -21,6 +21,7 @@ import("${chip_root}/examples/platform/silabs/efr32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
+app_data_model = "${chip_root}/examples/lighting-app/lighting-common"
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
 chip_build_pw_trace_lib = true

--- a/examples/lock-app/silabs/SiWx917/BUILD.gn
+++ b/examples/lock-app/silabs/SiWx917/BUILD.gn
@@ -49,14 +49,8 @@ declare_args() {
   OTA_periodic_query_timeout = 86400
 
   # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
-  use_wf200 = false
-  use_rs911x = false
-  use_rs911x_sockets = false
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
-
-  # Disable LCD on supported devices
-  disable_lcd = true
 
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
@@ -70,14 +64,6 @@ declare_args() {
   #default Wifi Password
   chip_default_wifi_psk = ""
 }
-
-declare_args() {
-  # Enables LCD Qr Code on supported devices
-  show_qr_code = !disable_lcd
-}
-
-# qr code cannot be true if lcd is disabled
-assert(!(disable_lcd && show_qr_code))
 
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))

--- a/examples/lock-app/silabs/efr32/BUILD.gn
+++ b/examples/lock-app/silabs/efr32/BUILD.gn
@@ -103,7 +103,6 @@ efr32_executable("lock_app") {
       "PW_RPC_LOCKING_SERVICE=1",
       "PW_RPC_OTCLI_SERVICE=1",
       "PW_RPC_THREAD_SERVICE=1",
-      "PW_RPC_TRACING_SERVICE=1",
     ]
 
     sources += [
@@ -116,9 +115,6 @@ efr32_executable("lock_app") {
     deps += [
       "$dir_pw_hdlc:rpc_channel_output",
       "$dir_pw_stream:sys_io_stream",
-      "$dir_pw_trace",
-      "$dir_pw_trace_tokenized",
-      "$dir_pw_trace_tokenized:trace_rpc_service",
       "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
       "${chip_root}/examples/common/pigweed:attributes_service.nanopb_rpc",
       "${chip_root}/examples/common/pigweed:button_service.nanopb_rpc",

--- a/examples/lock-app/silabs/efr32/BUILD.gn
+++ b/examples/lock-app/silabs/efr32/BUILD.gn
@@ -40,84 +40,6 @@ import("${examples_plat_dir}/args.gni")
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
-
-  # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
-  use_wf200 = false
-  use_rs911x = false
-  use_rs911x_sockets = false
-  sl_wfx_config_softap = false
-  sl_wfx_config_scan = true
-
-  # Argument to Disable IPv4 for wifi(rs911)
-  chip_enable_wifi_ipv4 = false
-
-  # Argument to force enable WPA3 security
-  rs91x_wpa3_only = false
-
-  #default WiFi SSID
-  chip_default_wifi_ssid = ""
-
-  #default Wifi Password
-  chip_default_wifi_psk = ""
-}
-
-# Sanity check
-assert(!(chip_enable_wifi && chip_enable_openthread))
-assert(!(use_rs911x && chip_enable_openthread))
-assert(!(use_wf200 && chip_enable_openthread))
-if (chip_enable_wifi) {
-  assert(use_rs911x || use_wf200)
-  enable_openthread_cli = false
-  import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
-}
-
-defines = []
-
-# WiFi settings
-if (chip_enable_wifi) {
-  if (chip_default_wifi_ssid != "") {
-    defines += [
-      "CHIP_ONNETWORK_PAIRING=1",
-      "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
-    ]
-  }
-  if (chip_default_wifi_psk != "") {
-    assert(chip_default_wifi_ssid != "",
-           "ssid can't be null if psk is provided")
-    defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
-  }
-  wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
-  efr32_lwip_defs = [ "LWIP_NETIF_API=1" ]
-  if (lwip_ipv4) {
-    efr32_lwip_defs += [
-      "LWIP_IPV4=1",
-
-      # adds following options to provide
-      # them to .cpp source files
-      # flags ported from lwipopts file
-      # TODO: move lwipopts to one location
-      "LWIP_ARP=1",
-      "LWIP_ICMP=1",
-      "LWIP_IGMP=1",
-      "LWIP_DHCP=1",
-      "LWIP_DNS=0",
-    ]
-  } else {
-    efr32_lwip_defs += [ "LWIP_IPV4=0" ]
-  }
-  if (lwip_ipv6) {
-    efr32_lwip_defs += [ "LWIP_IPV6=1" ]
-  } else {
-    efr32_lwip_defs += [ "LWIP_IPV6=0" ]
-  }
-
-  if (use_rs911x) {
-    wiseconnect_sdk_root =
-        "${chip_root}/third_party/silabs/wiseconnect-wifi-bt-sdk"
-    import("${examples_plat_dir}/rs911x/rs911x.gni")
-  } else {
-    import("${examples_plat_dir}/wf200/wf200.gni")
-  }
 }
 
 efr32_sdk("sdk") {
@@ -134,36 +56,17 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
+  if (use_wf200) {
+    # TODO efr32_sdk should not need a header from this location
+    include_dirs += [ "${examples_plat_dir}/wf200" ]
+  }
+
+  defines = []
   if (chip_enable_pw_rpc) {
     defines += [
       "HAL_VCOM_ENABLE=1",
       "PW_RPC_ENABLED",
     ]
-  }
-
-  # WiFi Settings
-  if (chip_enable_wifi) {
-    if (use_rs911x) {
-      defines += rs911x_defs
-      include_dirs += rs911x_plat_incs
-    } else if (use_wf200) {
-      defines += wf200_defs
-      include_dirs += wf200_plat_incs
-    }
-
-    if (use_rs911x_sockets) {
-      include_dirs += [ "${examples_plat_dir}/wifi/rsi-sockets" ]
-      defines += rs911x_sock_defs
-    } else {
-      # Using LWIP instead of the native TCP/IP stack
-      defines += efr32_lwip_defs
-    }
-    if (sl_wfx_config_softap) {
-      defines += [ "SL_WFX_CONFIG_SOFTAP" ]
-    }
-    if (sl_wfx_config_scan) {
-      defines += [ "SL_WFX_CONFIG_SCAN" ]
-    }
   }
 }
 
@@ -188,44 +91,6 @@ efr32_executable("lock_app") {
 
   if (!disable_lcd) {
     defines += [ "IS_DEMO_LOCK=1" ]
-  }
-
-  # WiFi Settings
-  if (chip_enable_wifi) {
-    if (use_rs911x) {
-      sources += rs911x_src_plat
-
-      # All the stuff from wiseconnect
-      sources += rs911x_src_sapi
-
-      # Apparently - the rsi library needs this (though we may not use use it)
-      sources += rs911x_src_sock
-      include_dirs += rs911x_inc_plat
-
-      if (use_rs911x_sockets) {
-        #
-        # Using native sockets inside RS911x
-        #
-        include_dirs += rs911x_sock_inc
-      } else {
-        #
-        # We use LWIP - not built-in sockets
-        #
-        sources += rs911x_src_lwip
-      }
-    } else if (use_wf200) {
-      sources += wf200_plat_src
-      include_dirs += wf200_plat_incs
-    }
-
-    if (chip_enable_wifi_ipv4) {
-      defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
-    }
-
-    if (rs91x_wpa3_only) {
-      # TODO: Change this macro once WF200 support is provided
-      defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
-    }
   }
 
   if (chip_enable_pw_rpc) {

--- a/examples/lock-app/silabs/efr32/BUILD.gn
+++ b/examples/lock-app/silabs/efr32/BUILD.gn
@@ -35,18 +35,11 @@ efr32_project_dir = "${chip_root}/examples/lock-app/silabs/efr32"
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
 examples_common_plat_dir = "${chip_root}/examples/platform/silabs"
 
+import("${examples_plat_dir}/args.gni")
+
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
-
-  # Monitor & log memory usage at runtime.
-  enable_heap_monitoring = false
-
-  # Enable Sleepy end device
-  enable_sleepy_device = false
-
-  # OTA timeout in seconds
-  OTA_periodic_query_timeout = 86400
 
   # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
   use_wf200 = false
@@ -54,9 +47,6 @@ declare_args() {
   use_rs911x_sockets = false
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
-
-  # Disable LCD on supported devices
-  disable_lcd = false
 
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
@@ -71,14 +61,6 @@ declare_args() {
   chip_default_wifi_psk = ""
 }
 
-declare_args() {
-  # Enables LCD Qr Code on supported devices
-  show_qr_code = !disable_lcd
-}
-
-# qr code cannot be true if lcd is disabled
-assert(!(disable_lcd && show_qr_code))
-
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))
 assert(!(use_rs911x && chip_enable_openthread))
@@ -87,13 +69,6 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
   enable_openthread_cli = false
   import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
-}
-
-# ThunderBoards, Explorer Kit and MGM240L do not support LCD (No LCD)
-if (silabs_board == "BRD4166A" || silabs_board == "BRD2601B" ||
-    silabs_board == "BRD2703A" || silabs_board == "BRD4319A") {
-  show_qr_code = false
-  disable_lcd = true
 }
 
 defines = []
@@ -159,11 +134,6 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
-  defines += [
-    "BOARD_ID=${silabs_board}",
-    "OTA_PERIODIC_TIMEOUT=${OTA_periodic_query_timeout}",
-  ]
-
   if (chip_enable_pw_rpc) {
     defines += [
       "HAL_VCOM_ENABLE=1",
@@ -204,53 +174,20 @@ efr32_executable("lock_app") {
   defines = []
 
   sources = [
-    "${examples_common_plat_dir}/heap_4_silabs.c",
-    "${examples_plat_dir}/BaseApplication.cpp",
-    "${examples_plat_dir}/efr32_utils.cpp",
-    "${examples_plat_dir}/init_efrPlatform.cpp",
-    "${examples_plat_dir}/matter_config.cpp",
     "src/AppTask.cpp",
     "src/LockManager.cpp",
     "src/ZclCallbacks.cpp",
     "src/main.cpp",
   ]
 
-  if (use_wstk_leds) {
-    sources += [ "${examples_plat_dir}/LEDWidget.cpp" ]
-  }
-
-  if (chip_enable_pw_rpc || chip_build_libshell || enable_openthread_cli ||
-      use_wf200 || use_rs911x) {
-    sources += [ "${examples_plat_dir}/uart.cpp" ]
-  }
-
-  if (chip_build_libshell) {
-    sources += [ "src/EventHandlerLibShell.cpp" ]
-  }
-
   deps = [
     ":sdk",
-    "${chip_root}/examples/lock-app/lock-common",
-    "${chip_root}/examples/providers:device_info_provider",
-    "${chip_root}/src/lib",
-    "${chip_root}/src/setup_payload",
-    "${chip_root}/third_party/openthread/platforms:libopenthread-platform",
-    "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
-    "${examples_plat_dir}:efr-matter-shell",
+    "${examples_plat_dir}:efr32-common",
+    app_data_model,
   ]
 
-  # OpenThread Settings
-  if (chip_enable_openthread) {
-    deps += [
-      "${chip_root}/third_party/openthread:openthread",
-      "${chip_root}/third_party/openthread:openthread-platform",
-      "${examples_plat_dir}:efr-matter-shell",
-    ]
-  }
-
-  if (chip_enable_ota_requestor) {
-    defines += [ "EFR32_OTA_ENABLED" ]
-    sources += [ "${examples_plat_dir}/OTAConfig.cpp" ]
+  if (!disable_lcd) {
+    defines += [ "IS_DEMO_LOCK=1" ]
   }
 
   # WiFi Settings
@@ -291,22 +228,6 @@ efr32_executable("lock_app") {
     }
   }
 
-  if (!disable_lcd) {
-    sources += [
-      "${examples_plat_dir}/display/demo-ui.c",
-      "${examples_plat_dir}/display/lcd.cpp",
-    ]
-    include_dirs += [ "${examples_plat_dir}/display" ]
-    defines += [
-      "DISPLAY_ENABLED",
-      "IS_DEMO_LOCK=1",
-    ]
-    if (show_qr_code) {
-      defines += [ "QR_CODE_ENABLED" ]
-      deps += [ "${chip_root}/examples/common/QRCode" ]
-    }
-  }
-
   if (chip_enable_pw_rpc) {
     defines += [
       "PW_RPC_ENABLED",
@@ -317,6 +238,7 @@ efr32_executable("lock_app") {
       "PW_RPC_LOCKING_SERVICE=1",
       "PW_RPC_OTCLI_SERVICE=1",
       "PW_RPC_THREAD_SERVICE=1",
+      "PW_RPC_TRACING_SERVICE=1",
     ]
 
     sources += [
@@ -329,6 +251,9 @@ efr32_executable("lock_app") {
     deps += [
       "$dir_pw_hdlc:rpc_channel_output",
       "$dir_pw_stream:sys_io_stream",
+      "$dir_pw_trace",
+      "$dir_pw_trace_tokenized",
+      "$dir_pw_trace_tokenized:trace_rpc_service",
       "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
       "${chip_root}/examples/common/pigweed:attributes_service.nanopb_rpc",
       "${chip_root}/examples/common/pigweed:button_service.nanopb_rpc",
@@ -346,11 +271,6 @@ efr32_executable("lock_app") {
       "${chip_root}/examples/common",
       "${chip_root}/examples/common/pigweed/efr32",
     ]
-  }
-
-  if (enable_heap_monitoring) {
-    sources += [ "${examples_common_plat_dir}/MemMonitoring.cpp" ]
-    defines += [ "HEAP_MONITORING" ]
   }
 
   ldscript = "${examples_plat_dir}/ldscripts/${silabs_family}.ld"
@@ -374,18 +294,9 @@ efr32_executable("lock_app") {
     ]
   }
 
-  # Attestation Credentials
-  if (chip_build_platform_attestation_credentials_provider) {
-    deps += [ "${examples_plat_dir}:efr32-attestation-credentials" ]
-  }
-
-  # Factory Data Provider
-  if (use_efr32_factory_data_provider) {
-    deps += [ "${examples_plat_dir}:efr32-factory-data-provider" ]
-  }
-
   output_dir = root_out_dir
 }
+
 group("efr32") {
   deps = [ ":lock_app" ]
 }

--- a/examples/lock-app/silabs/efr32/args.gni
+++ b/examples/lock-app/silabs/efr32/args.gni
@@ -18,6 +18,7 @@ import("${chip_root}/src/platform/silabs/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
+app_data_model = "${chip_root}/examples/lock-app/lock-common"
 chip_enable_ota_requestor = true
 chip_enable_openthread = true
 openthread_external_platform =

--- a/examples/lock-app/silabs/efr32/build_for_wifi_args.gni
+++ b/examples/lock-app/silabs/efr32/build_for_wifi_args.gni
@@ -19,3 +19,4 @@ chip_enable_openthread = false
 import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
 
 chip_enable_ota_requestor = true
+app_data_model = "${chip_root}/examples/lock-app/lock-common"

--- a/examples/lock-app/silabs/efr32/with_pw_rpc.gni
+++ b/examples/lock-app/silabs/efr32/with_pw_rpc.gni
@@ -21,6 +21,7 @@ import("${chip_root}/examples/platform/silabs/efr32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
+app_data_model = "${chip_root}/examples/lock-app/lock-common"
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
 chip_openthread_ftd = true

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -14,9 +14,15 @@
 
 import("//build_overrides/chip.gni")
 import("//build_overrides/efr32_sdk.gni")
+import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 import("${chip_root}/src/lib/lib.gni")
 import("${chip_root}/src/platform/device.gni")
 import("${efr32_sdk_build_root}/efr32_sdk.gni")
+import("${efr32_sdk_build_root}/silabs_board.gni")
+
+declare_args() {
+  enable_heap_monitoring = false
+}
 
 silabs_common_plat_dir = "${chip_root}/examples/platform/silabs"
 
@@ -125,4 +131,102 @@ source_set("efr32-ICD-subscription-callback") {
   public_deps = [ "${chip_root}/src/app:app" ]
 
   public_configs = [ ":ICD-subscription-callback-config" ]
+}
+
+config("silabs-common-config") {
+  defines = []
+
+  if (!disable_lcd) {
+    include_dirs = [ "display" ]
+
+    defines += [
+      "DISPLAY_ENABLED",
+      "IS_DEMO_LIGHT=1",  #TODO <- by example
+    ]
+  }
+
+  if (show_qr_code) {
+    defines += [ "QR_CODE_ENABLED" ]
+  }
+
+  if (chip_enable_ota_requestor) {
+    defines += [ "EFR32_OTA_ENABLED" ]
+  }
+
+  if (enable_heap_monitoring) {
+    defines += [ "HEAP_MONITORING" ]
+  }
+}
+
+source_set("silabs-common") {
+  deps = []
+  public_deps = []
+
+  include_dirs = [ "." ]
+
+  sources = [
+    "../heap_4_silabs.c",
+    "BaseApplication.cpp",
+    "efr32_utils.cpp",
+    "init_efrPlatform.cpp",
+    "matter_config.cpp",
+  ]
+
+  if (use_wstk_leds) {
+    sources += [ "LEDWidget.cpp" ]
+  }
+
+  if (chip_enable_pw_rpc || chip_build_libshell || enable_openthread_cli ||
+      use_wf200 || use_rs911x) {
+    sources += [ "uart.cpp" ]
+  }
+
+  if (chip_enable_ota_requestor) {
+    sources += [ "OTAConfig.cpp" ]
+  }
+
+  if (!disable_lcd) {
+    sources += [
+      "display/demo-ui.c",
+      "display/lcd.cpp",
+    ]
+
+    include_dirs += [ "display" ]
+    public_deps += [ "${chip_root}/examples/common/QRCode" ]
+  }
+
+  if (enable_heap_monitoring) {
+    sources += [ "../MemMonitoring.cpp" ]
+  }
+
+  # OpenThread Settings
+  if (chip_enable_openthread) {
+    deps += [
+      "${chip_root}/third_party/openthread:openthread",
+      "${chip_root}/third_party/openthread:openthread-platform",
+    ]
+  }
+
+  if (chip_build_libshell) {
+    deps += [ "${examples_plat_dir}:efr-matter-shell" ]
+  }
+
+  # Attestation Credentials
+  if (chip_build_platform_attestation_credentials_provider) {
+    deps += [ ":efr32-attestation-credentials" ]
+  }
+
+  # Factory Data Provider
+  if (use_efr32_factory_data_provider) {
+    deps += [ ":efr32-factory-data-provider" ]
+  }
+
+  public_configs = [ ":silabs-common-config" ]
+
+  public_deps += [
+    "${chip_root}/examples/lighting-app/lighting-common",  #TODO <- by example
+    "${chip_root}/examples/providers:device_info_provider",
+    "${chip_root}/src/lib",
+    "${chip_root}/src/setup_payload",
+  ]
 }

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -25,11 +25,48 @@ declare_args() {
 
   # OTA timeout in seconds
   OTA_periodic_query_timeout = 86400
+
+  # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
+  sl_wfx_config_softap = false
+  sl_wfx_config_scan = true
+
+  # Argument to Disable IPv4 for wifi(rs911)
+  chip_enable_wifi_ipv4 = false
+
+  # Argument to force enable WPA3 security on rs91x
+  rs91x_wpa3_only = false
+
+  #default WiFi SSID
+  chip_default_wifi_ssid = ""
+
+  #default Wifi Password
+  chip_default_wifi_psk = ""
 }
 
 silabs_common_plat_dir = "${chip_root}/examples/platform/silabs"
 
 import("${silabs_common_plat_dir}/efr32/args.gni")
+
+# Sanity check
+assert(!(chip_enable_wifi && chip_enable_openthread))
+assert(!(use_rs911x && chip_enable_openthread))
+assert(!(use_wf200 && chip_enable_openthread))
+
+if (chip_enable_wifi) {
+  assert(use_rs911x || use_wf200)
+  enable_openthread_cli = false
+  import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
+
+  if (use_rs911x) {
+    wiseconnect_sdk_root =
+        "${chip_root}/third_party/silabs/wiseconnect-wifi-bt-sdk"
+    import("rs911x/rs911x.gni")
+  }
+
+  if (use_wf200) {
+    import("wf200/wf200.gni")
+  }
+}
 
 config("chip_examples_project_config") {
   include_dirs = [ "project_include" ]
@@ -160,9 +197,49 @@ config("efr32-common-config") {
   }
 }
 
+config("silabs-wifi-config") {
+  defines = []
+  include_dirs = []
+
+  if (chip_default_wifi_ssid != "") {
+    defines += [
+      "CHIP_ONNETWORK_PAIRING=1",
+      "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
+    ]
+  }
+  if (chip_default_wifi_psk != "") {
+    assert(chip_default_wifi_ssid != "",
+           "ssid can't be null if psk is provided")
+    defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
+  }
+
+  if (use_rs911x) {
+    include_dirs += rs911x_plat_incs
+  } else if (use_wf200) {
+    include_dirs += wf200_plat_incs
+  }
+
+  if (sl_wfx_config_softap) {
+    defines += [ "SL_WFX_CONFIG_SOFTAP" ]
+  }
+  if (sl_wfx_config_scan) {
+    defines += [ "SL_WFX_CONFIG_SCAN" ]
+  }
+
+  if (chip_enable_wifi_ipv4) {
+    defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
+  }
+
+  if (rs91x_wpa3_only) {
+    # TODO: Change this macro once WF200 support is provided
+    defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
+  }
+}
+
 source_set("efr32-common") {
   deps = []
   public_deps = []
+  public_configs = [ ":efr32-common-config" ]
 
   include_dirs = [ "." ]
 
@@ -212,6 +289,39 @@ source_set("efr32-common") {
     ]
   }
 
+  if (chip_enable_wifi) {
+    if (use_rs911x) {
+      sources += rs911x_src_plat
+
+      # All the stuff from wiseconnect
+      sources += rs911x_src_sapi
+
+      # Apparently - the rsi library needs this (though we may not use use it)
+      sources += rs911x_src_sock
+      include_dirs += rs911x_inc_plat
+
+      if (use_rs911x_sockets) {
+        #
+        # Using native sockets inside RS911x
+        #
+        include_dirs += rs911x_sock_inc
+      } else {
+        #
+        # We use LWIP - not built-in sockets
+        #
+        sources += rs911x_src_lwip
+      }
+
+      #add compilation flags for rs991x build. This will be addressed directly in wiseconnect sdk in the next version release of that sdk
+      cflags = rs911x_cflags
+    } else if (use_wf200) {
+      sources += wf200_plat_src
+      include_dirs += wf200_plat_incs
+    }
+
+    public_configs += [ ":silabs-wifi-config" ]
+  }
+
   if (chip_build_libshell) {
     deps += [ "${examples_plat_dir}:efr-matter-shell" ]
   }
@@ -225,8 +335,6 @@ source_set("efr32-common") {
   if (use_efr32_factory_data_provider) {
     public_deps += [ ":efr32-factory-data-provider" ]
   }
-
-  public_configs = [ ":efr32-common-config" ]
 
   public_deps += [
     "${chip_root}/examples/providers:device_info_provider",

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -324,6 +324,9 @@ source_set("efr32-common") {
     "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
-    app_data_model,
   ]
+
+  if (app_data_model != "") {
+    public_deps += [ app_data_model ]
+  }
 }

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -22,9 +22,14 @@ import("${efr32_sdk_build_root}/silabs_board.gni")
 
 declare_args() {
   enable_heap_monitoring = false
+
+  # OTA timeout in seconds
+  OTA_periodic_query_timeout = 86400
 }
 
 silabs_common_plat_dir = "${chip_root}/examples/platform/silabs"
+
+import("${silabs_common_plat_dir}/efr32/args.gni")
 
 config("chip_examples_project_config") {
   include_dirs = [ "project_include" ]
@@ -124,8 +129,8 @@ config("ICD-subscription-callback-config") {
 
 source_set("efr32-ICD-subscription-callback") {
   sources = [
-    "../ICDSubscriptionCallback.cpp",
-    "../ICDSubscriptionCallback.h",
+    "${silabs_common_plat_dir}/ICDSubscriptionCallback.cpp",
+    "${silabs_common_plat_dir}/ICDSubscriptionCallback.h",
   ]
 
   public_deps = [ "${chip_root}/src/app:app" ]
@@ -133,16 +138,13 @@ source_set("efr32-ICD-subscription-callback") {
   public_configs = [ ":ICD-subscription-callback-config" ]
 }
 
-config("silabs-common-config") {
-  defines = []
+config("efr32-common-config") {
+  defines = [ "OTA_PERIODIC_TIMEOUT=${OTA_periodic_query_timeout}" ]
 
   if (!disable_lcd) {
     include_dirs = [ "display" ]
 
-    defines += [
-      "DISPLAY_ENABLED",
-      "IS_DEMO_LIGHT=1",  #TODO <- by example
-    ]
+    defines += [ "DISPLAY_ENABLED" ]
   }
 
   if (show_qr_code) {
@@ -158,19 +160,22 @@ config("silabs-common-config") {
   }
 }
 
-source_set("silabs-common") {
+source_set("efr32-common") {
   deps = []
   public_deps = []
 
   include_dirs = [ "." ]
 
   sources = [
-    "../heap_4_silabs.c",
-    "BaseApplication.cpp",
+    "${silabs_common_plat_dir}/heap_4_silabs.c",
     "efr32_utils.cpp",
     "init_efrPlatform.cpp",
     "matter_config.cpp",
   ]
+
+  if (use_base_app) {
+    sources += [ "BaseApplication.cpp" ]
+  }
 
   if (use_wstk_leds) {
     sources += [ "LEDWidget.cpp" ]
@@ -196,7 +201,7 @@ source_set("silabs-common") {
   }
 
   if (enable_heap_monitoring) {
-    sources += [ "../MemMonitoring.cpp" ]
+    sources += [ "${silabs_common_plat_dir}/MemMonitoring.cpp" ]
   }
 
   # OpenThread Settings
@@ -218,15 +223,15 @@ source_set("silabs-common") {
 
   # Factory Data Provider
   if (use_efr32_factory_data_provider) {
-    deps += [ ":efr32-factory-data-provider" ]
+    public_deps += [ ":efr32-factory-data-provider" ]
   }
 
-  public_configs = [ ":silabs-common-config" ]
+  public_configs = [ ":efr32-common-config" ]
 
   public_deps += [
-    "${chip_root}/examples/lighting-app/lighting-common",  #TODO <- by example
     "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
+    app_data_model,
   ]
 }

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -213,11 +213,6 @@ config("silabs-wifi-config") {
     defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
   }
 
-  #TODO DO I NEED THIS HERE
-  if (use_wf200) {
-    include_dirs += wf200_plat_incs
-  }
-
   if (sl_wfx_config_softap) {
     defines += [ "SL_WFX_CONFIG_SOFTAP" ]
   }

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -213,9 +213,8 @@ config("silabs-wifi-config") {
     defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
   }
 
-  if (use_rs911x) {
-    include_dirs += rs911x_plat_incs
-  } else if (use_wf200) {
+  #TODO DO I NEED THIS HERE
+  if (use_wf200) {
     include_dirs += wf200_plat_incs
   }
 
@@ -295,22 +294,7 @@ source_set("efr32-common") {
 
       # All the stuff from wiseconnect
       sources += rs911x_src_sapi
-
-      # Apparently - the rsi library needs this (though we may not use use it)
-      sources += rs911x_src_sock
       include_dirs += rs911x_inc_plat
-
-      if (use_rs911x_sockets) {
-        #
-        # Using native sockets inside RS911x
-        #
-        include_dirs += rs911x_sock_inc
-      } else {
-        #
-        # We use LWIP - not built-in sockets
-        #
-        sources += rs911x_src_lwip
-      }
 
       #add compilation flags for rs991x build. This will be addressed directly in wiseconnect sdk in the next version release of that sdk
       cflags = rs911x_cflags

--- a/examples/platform/silabs/efr32/args.gni
+++ b/examples/platform/silabs/efr32/args.gni
@@ -19,3 +19,8 @@ chip_device_project_config_include = "<CHIPProjectConfig.h>"
 chip_project_config_include = "<CHIPProjectConfig.h>"
 chip_inet_project_config_include = "<CHIPProjectConfig.h>"
 chip_system_project_config_include = "<CHIPProjectConfig.h>"
+
+declare_args() {
+  app_data_model = ""
+  use_base_app = true
+}

--- a/examples/platform/silabs/efr32/rs911x/rs911x.gni
+++ b/examples/platform/silabs/efr32/rs911x/rs911x.gni
@@ -3,21 +3,15 @@ import("//build_overrides/chip.gni")
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
 wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
 wiseconnect_sdk_root = "${chip_root}/third_party/silabs/wiseconnect-wifi-bt-sdk"
-rs911x_cflags = []
 
 rs911x_src_plat = [
   "${examples_plat_dir}/rs911x/rsi_if.c",
   "${examples_plat_dir}/rs911x/wfx_rsi_host.c",
-  "${wifi_sdk_dir}/wfx_notify.cpp",
   "${examples_plat_dir}/rs911x/hal/rsi_hal_mcu_interrupt.c",
   "${examples_plat_dir}/rs911x/hal/rsi_hal_mcu_ioports.c",
   "${examples_plat_dir}/rs911x/hal/rsi_hal_mcu_timer.c",
   "${examples_plat_dir}/rs911x/hal/efx_spi.c",
-]
-rs911x_plat_incs = [
-  "${wifi_sdk_dir}",
-  "${wifi_sdk_dir}/hal",
-  "${chip_root}/src/platform/EFR32",
+  "${wifi_sdk_dir}/wfx_notify.cpp",
 ]
 
 #
@@ -55,36 +49,16 @@ rs911x_src_sapi = [
   "${wiseconnect_sdk_root}/sapi/driver/rsi_utils.c",
   "${wiseconnect_sdk_root}/sapi/driver/rsi_wlan.c",
   "${wiseconnect_sdk_root}/sapi/rtos/freertos_wrapper/rsi_os_wrapper.c",
-]
 
-foreach(src_file, rs911x_src_sapi) {
-  rs911x_cflags += [ "-Wno-empty-body" ]
-}
-
-rs911x_inc_plat = [
-  "${wifi_sdk_dir}",
-  "${examples_plat_dir}/rs911x",
-  "${examples_plat_dir}/rs911x/hal",
-  "${wiseconnect_sdk_root}/sapi/include",
-]
-
-# Apparently - the rsi library needs this
-rs911x_src_sock = [
+  # Apparently - the rsi library needs this (though we may not use use it)
   "${wiseconnect_sdk_root}/sapi/network/socket/rsi_socket.c",
   "${wiseconnect_sdk_root}/sapi/network/socket/rsi_socket_rom.c",
 ]
-rs911x_sock_inc = [ "${wifi_sdk_dir}/rsi-sockets" ]
 
-#
-# If we use LWIP - not built-in sockets
-#
-rs911x_src_lwip = [
-  "${wifi_sdk_dir}/ethernetif.cpp",
-  "${wifi_sdk_dir}/dhcp_client.cpp",
-  "${wifi_sdk_dir}/lwip_netif.cpp",
-]
+rs911x_cflags = [ "-Wno-empty-body" ]
 
-rs911x_sock_defs = [
-  "RS911X_SOCKETS",
-  "RSI_IPV6_ENABLE",
+rs911x_inc_plat = [
+  "${examples_plat_dir}/rs911x",
+  "${examples_plat_dir}/rs911x/hal",
+  "${wiseconnect_sdk_root}/sapi/include",
 ]

--- a/examples/platform/silabs/efr32/rs911x/rs911x.gni
+++ b/examples/platform/silabs/efr32/rs911x/rs911x.gni
@@ -1,6 +1,4 @@
 import("//build_overrides/chip.gni")
-import("//build_overrides/efr32_sdk.gni")
-import("//build_overrides/pigweed.gni")
 
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
 wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
@@ -85,16 +83,7 @@ rs911x_src_lwip = [
   "${wifi_sdk_dir}/dhcp_client.cpp",
   "${wifi_sdk_dir}/lwip_netif.cpp",
 ]
-rs911x_defs = [
-  "SL_HEAP_SIZE=32768",
-  "SL_WIFI=1",
-  "SL_WFX_USE_SPI",
-  "EFX32_RS911X=1",
-  "RS911X_WIFI",
-  "RSI_WLAN_ENABLE",
-  "RSI_SPI_INTERFACE",
-  "RSI_WITH_OS",
-]
+
 rs911x_sock_defs = [
   "RS911X_SOCKETS",
   "RSI_IPV6_ENABLE",

--- a/examples/platform/silabs/efr32/wf200/wf200.gni
+++ b/examples/platform/silabs/efr32/wf200/wf200.gni
@@ -1,19 +1,8 @@
 import("//build_overrides/chip.gni")
-import("//build_overrides/efr32_sdk.gni")
-import("//build_overrides/pigweed.gni")
 
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
 wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
 
-wf200_defs = [
-  "SL_HEAP_SIZE=24576",
-  "WF200_WIFI=1",
-  "SL_WIFI=1",
-  "SL_WFX_USE_SPI",
-  "SL_WFX_DEBUG_MASK=0x0003",
-]
-softap_defs = "SL_WFX_CONFIG_SOFTAP"
-wifi_scan_defs = "SL_WFX_CONFIG_SCAN"
 wf200_plat_incs = [
   "${wifi_sdk_dir}/",
   "${examples_plat_dir}/wf200",

--- a/examples/platform/silabs/efr32/wf200/wf200.gni
+++ b/examples/platform/silabs/efr32/wf200/wf200.gni
@@ -3,14 +3,8 @@ import("//build_overrides/chip.gni")
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
 wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
 
-wf200_plat_incs = [
-  "${wifi_sdk_dir}/",
-  "${examples_plat_dir}/wf200",
-]
+wf200_plat_incs = [ "${examples_plat_dir}/wf200" ]
 wf200_plat_src = [
-  "${wifi_sdk_dir}/dhcp_client.cpp",
-  "${wifi_sdk_dir}/ethernetif.cpp",
-  "${wifi_sdk_dir}/lwip_netif.cpp",
   "${wifi_sdk_dir}/wfx_notify.cpp",
   "${examples_plat_dir}/wf200/sl_wfx_task.c",
   "${examples_plat_dir}/wf200/wf200_init.c",

--- a/examples/thermostat/silabs/efr32/BUILD.gn
+++ b/examples/thermostat/silabs/efr32/BUILD.gn
@@ -124,7 +124,6 @@ efr32_executable("thermostat_app") {
     "${examples_plat_dir}:efr32-common",
     app_data_model,
   ]
-  }
 
   if (chip_enable_pw_rpc) {
     defines += [

--- a/examples/thermostat/silabs/efr32/BUILD.gn
+++ b/examples/thermostat/silabs/efr32/BUILD.gn
@@ -35,18 +35,11 @@ efr32_project_dir = "${chip_root}/examples/thermostat/silabs/efr32"
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
 examples_common_plat_dir = "${chip_root}/examples/platform/silabs"
 
+import("${examples_plat_dir}/args.gni")
+
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
-
-  # Monitor & log memory usage at runtime.
-  enable_heap_monitoring = false
-
-  # Enable Sleepy end device
-  enable_sleepy_device = false
-
-  # OTA timeout in seconds
-  OTA_periodic_query_timeout = 86400
 
   # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
   use_wf200 = false
@@ -54,9 +47,6 @@ declare_args() {
   use_rs911x_sockets = false
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
-
-  # Disable LCD on supported devices
-  disable_lcd = false
 
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
@@ -72,14 +62,6 @@ declare_args() {
   use_temp_sensor = silabs_board != "BRD2703A" && silabs_board != "BRD4319A"
 }
 
-declare_args() {
-  # Enables LCD Qr Code on supported devices
-  show_qr_code = !disable_lcd
-}
-
-# qr code cannot be true if lcd is disabled
-assert(!(disable_lcd && show_qr_code))
-
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))
 assert(!(use_rs911x && chip_enable_openthread))
@@ -88,13 +70,6 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
   enable_openthread_cli = false
   import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
-}
-
-# ThunderBoards, Explorer Kit and MGM240L do not support LCD (No LCD)
-if (silabs_board == "BRD4166A" || silabs_board == "BRD2601B" ||
-    silabs_board == "BRD2703A" || silabs_board == "BRD4319A") {
-  show_qr_code = false
-  disable_lcd = true
 }
 
 defines = []
@@ -160,11 +135,6 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
-  defines += [
-    "BOARD_ID=${silabs_board}",
-    "OTA_PERIODIC_TIMEOUT=${OTA_periodic_query_timeout}",
-  ]
-
   if (chip_enable_pw_rpc) {
     defines += [
       "HAL_VCOM_ENABLE=1",
@@ -218,21 +188,12 @@ efr32_executable("thermostat_app") {
   defines = []
 
   sources = [
-    "${examples_common_plat_dir}/heap_4_silabs.c",
-    "${examples_plat_dir}/BaseApplication.cpp",
-    "${examples_plat_dir}/efr32_utils.cpp",
-    "${examples_plat_dir}/init_efrPlatform.cpp",
-    "${examples_plat_dir}/matter_config.cpp",
     "src/AppTask.cpp",
     "src/SensorManager.cpp",
     "src/TemperatureManager.cpp",
     "src/ZclCallbacks.cpp",
     "src/main.cpp",
   ]
-
-  if (use_wstk_leds) {
-    sources += [ "${examples_plat_dir}/LEDWidget.cpp" ]
-  }
 
   if (use_temp_sensor) {
     sources += [
@@ -247,46 +208,16 @@ efr32_executable("thermostat_app") {
     ]
   }
 
-  if (chip_enable_pw_rpc || chip_build_libshell || enable_openthread_cli ||
-      use_wf200 || use_rs911x) {
-    sources += [ "${examples_plat_dir}/uart.cpp" ]
+  if (!disable_lcd) {
+    sources += [ "src/ThermostatUI.cpp" ]
+    defines += [ "IS_DEMO_THERMOSTAT=1" ]
   }
 
   deps = [
     ":sdk",
-    "${chip_root}/examples/providers:device_info_provider",
-    "${chip_root}/examples/thermostat/thermostat-common",
-    "${chip_root}/src/lib",
-    "${chip_root}/src/setup_payload",
+    "${examples_plat_dir}:efr32-common",
+    app_data_model,
   ]
-
-  # OpenThread Settings
-  if (chip_enable_openthread) {
-    deps += [
-      "${chip_root}/third_party/openthread:openthread",
-      "${chip_root}/third_party/openthread:openthread-platform",
-      "${examples_plat_dir}:efr-matter-shell",
-    ]
-  }
-
-  # Attestation Credentials
-  if (chip_build_platform_attestation_credentials_provider) {
-    deps += [ "${examples_plat_dir}:efr32-attestation-credentials" ]
-  }
-
-  # Factory Data Provider
-  if (use_efr32_factory_data_provider) {
-    deps += [ "${examples_plat_dir}:efr32-factory-data-provider" ]
-  }
-
-  if (chip_enable_ota_requestor) {
-    defines += [ "EFR32_OTA_ENABLED" ]
-    sources += [ "${examples_plat_dir}/OTAConfig.cpp" ]
-  }
-
-  if (chip_enable_wifi_ipv4) {
-    defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
-  }
 
   # WiFi Settings
   if (chip_enable_wifi) {
@@ -315,22 +246,9 @@ efr32_executable("thermostat_app") {
       sources += wf200_plat_src
       include_dirs += wf200_plat_incs
     }
-  }
 
-  if (!disable_lcd) {
-    sources += [
-      "${examples_plat_dir}/display/demo-ui.c",
-      "${examples_plat_dir}/display/lcd.cpp",
-      "src/ThermostatUI.cpp",
-    ]
-    include_dirs += [ "${examples_plat_dir}/display" ]
-    defines += [
-      "DISPLAY_ENABLED",
-      "IS_DEMO_THERMOSTAT=1",
-    ]
-    if (show_qr_code) {
-      defines += [ "QR_CODE_ENABLED" ]
-      deps += [ "${chip_root}/examples/common/QRCode" ]
+    if (chip_enable_wifi_ipv4) {
+      defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
     }
   }
 
@@ -369,11 +287,6 @@ efr32_executable("thermostat_app") {
       "${chip_root}/examples/common",
       "${chip_root}/examples/common/pigweed/efr32",
     ]
-  }
-
-  if (enable_heap_monitoring) {
-    sources += [ "${examples_common_plat_dir}/MemMonitoring.cpp" ]
-    defines += [ "HEAP_MONITORING" ]
   }
 
   ldscript = "${examples_plat_dir}/ldscripts/${silabs_family}.ld"

--- a/examples/thermostat/silabs/efr32/BUILD.gn
+++ b/examples/thermostat/silabs/efr32/BUILD.gn
@@ -41,84 +41,9 @@ declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
 
-  # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
-  use_wf200 = false
-  use_rs911x = false
-  use_rs911x_sockets = false
-  sl_wfx_config_softap = false
-  sl_wfx_config_scan = true
-
-  # Argument to Disable IPv4 for wifi(rs911)
-  chip_enable_wifi_ipv4 = false
-
-  #default WiFi SSID
-  chip_default_wifi_ssid = ""
-
-  #default Wifi Password
-  chip_default_wifi_psk = ""
-
   # Enable the temperature sensor
   # Some boards do not have a temperature sensor
   use_temp_sensor = silabs_board != "BRD2703A" && silabs_board != "BRD4319A"
-}
-
-# Sanity check
-assert(!(chip_enable_wifi && chip_enable_openthread))
-assert(!(use_rs911x && chip_enable_openthread))
-assert(!(use_wf200 && chip_enable_openthread))
-if (chip_enable_wifi) {
-  assert(use_rs911x || use_wf200)
-  enable_openthread_cli = false
-  import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
-}
-
-defines = []
-
-# WiFi settings
-if (chip_enable_wifi) {
-  if (chip_default_wifi_ssid != "") {
-    defines += [
-      "CHIP_ONNETWORK_PAIRING=1",
-      "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
-    ]
-  }
-  if (chip_default_wifi_psk != "") {
-    assert(chip_default_wifi_ssid != "",
-           "ssid can't be null if psk is provided")
-    defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
-  }
-  wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
-  efr32_lwip_defs = [ "LWIP_NETIF_API=1" ]
-  if (lwip_ipv4) {
-    efr32_lwip_defs += [
-      "LWIP_IPV4=1",
-
-      # adds following options to provide
-      # them to .cpp source files
-      # flags ported from lwipopts file
-      # TODO: move lwipopts to one location
-      "LWIP_ARP=1",
-      "LWIP_ICMP=1",
-      "LWIP_IGMP=1",
-      "LWIP_DHCP=1",
-      "LWIP_DNS=0",
-    ]
-  } else {
-    efr32_lwip_defs += [ "LWIP_IPV4=0" ]
-  }
-  if (lwip_ipv6) {
-    efr32_lwip_defs += [ "LWIP_IPV6=1" ]
-  } else {
-    efr32_lwip_defs += [ "LWIP_IPV6=0" ]
-  }
-
-  if (use_rs911x) {
-    wiseconnect_sdk_root =
-        "${chip_root}/third_party/silabs/wiseconnect-wifi-bt-sdk"
-    import("${examples_plat_dir}/rs911x/rs911x.gni")
-  } else {
-    import("${examples_plat_dir}/wf200/wf200.gni")
-  }
 }
 
 efr32_sdk("sdk") {
@@ -135,6 +60,12 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
+  if (use_wf200) {
+    # TODO efr32_sdk should not need a header from this location
+    include_dirs += [ "${examples_plat_dir}/wf200" ]
+  }
+
+  defines = []
   if (chip_enable_pw_rpc) {
     defines += [
       "HAL_VCOM_ENABLE=1",
@@ -142,31 +73,6 @@ efr32_sdk("sdk") {
     ]
   }
 
-  # WiFi Settings
-  if (chip_enable_wifi) {
-    if (use_rs911x) {
-      defines += rs911x_defs
-      include_dirs += rs911x_plat_incs
-    } else if (use_wf200) {
-      defines += wf200_defs
-      include_dirs += wf200_plat_incs
-    }
-
-    if (use_rs911x_sockets) {
-      include_dirs += [ "${examples_plat_dir}/wifi/rsi-sockets" ]
-      defines += rs911x_sock_defs
-    } else {
-      # Using LWIP instead of the native TCP/IP stack
-      defines += efr32_lwip_defs
-    }
-
-    if (sl_wfx_config_softap) {
-      defines += [ "SL_WFX_CONFIG_SOFTAP" ]
-    }
-    if (sl_wfx_config_scan) {
-      defines += [ "SL_WFX_CONFIG_SCAN" ]
-    }
-  }
   if (use_temp_sensor) {
     include_dirs += [
       "${efr32_sdk_root}/platform/driver/i2cspm/inc",
@@ -218,38 +124,6 @@ efr32_executable("thermostat_app") {
     "${examples_plat_dir}:efr32-common",
     app_data_model,
   ]
-
-  # WiFi Settings
-  if (chip_enable_wifi) {
-    if (use_rs911x) {
-      sources += rs911x_src_plat
-
-      # All the stuff from wiseconnect
-      sources += rs911x_src_sapi
-
-      # Apparently - the rsi library needs this (though we may not use use it)
-      sources += rs911x_src_sock
-      include_dirs += rs911x_inc_plat
-
-      if (use_rs911x_sockets) {
-        #
-        # Using native sockets inside RS911x
-        #
-        include_dirs += rs911x_sock_inc
-      } else {
-        #
-        # We use LWIP - not built-in sockets
-        #
-        sources += rs911x_src_lwip
-      }
-    } else if (use_wf200) {
-      sources += wf200_plat_src
-      include_dirs += wf200_plat_incs
-    }
-
-    if (chip_enable_wifi_ipv4) {
-      defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
-    }
   }
 
   if (chip_enable_pw_rpc) {

--- a/examples/thermostat/silabs/efr32/args.gni
+++ b/examples/thermostat/silabs/efr32/args.gni
@@ -18,6 +18,7 @@ import("${chip_root}/src/platform/silabs/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
+app_data_model = "${chip_root}/examples/thermostat/thermostat-common"
 chip_enable_ota_requestor = true
 chip_enable_openthread = true
 

--- a/examples/thermostat/silabs/efr32/build_for_wifi_args.gni
+++ b/examples/thermostat/silabs/efr32/build_for_wifi_args.gni
@@ -19,3 +19,4 @@ chip_enable_openthread = false
 import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
 
 chip_enable_ota_requestor = true
+app_data_model = "${chip_root}/examples/thermostat/thermostat-common"

--- a/examples/window-app/silabs/SiWx917/BUILD.gn
+++ b/examples/window-app/silabs/SiWx917/BUILD.gn
@@ -43,14 +43,8 @@ declare_args() {
   OTA_periodic_query_timeout = 86400
 
   # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
-  use_wf200 = false
-  use_rs911x = false
-  use_rs911x_sockets = false
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
-
-  # Disable LCD on supported devices
-  disable_lcd = true
 
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
@@ -64,14 +58,6 @@ declare_args() {
   #default Wifi Password
   chip_default_wifi_psk = ""
 }
-
-declare_args() {
-  # Enables LCD Qr Code on supported devices
-  show_qr_code = !disable_lcd
-}
-
-# qr code cannot be true if lcd is disabled
-assert(!(disable_lcd && show_qr_code))
 
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))

--- a/examples/window-app/silabs/efr32/BUILD.gn
+++ b/examples/window-app/silabs/efr32/BUILD.gn
@@ -29,18 +29,11 @@ efr32_project_dir = "${project_dir}/silabs/efr32"
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
 examples_common_plat_dir = "${chip_root}/examples/platform/silabs"
 
+import("${examples_plat_dir}/args.gni")
+
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
-
-  # Monitor & log memory usage at runtime.
-  enable_heap_monitoring = false
-
-  # Enable Sleepy end device
-  enable_sleepy_device = false
-
-  # OTA timeout in seconds
-  OTA_periodic_query_timeout = 86400
 
   # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
   use_wf200 = false
@@ -48,9 +41,6 @@ declare_args() {
   use_rs911x_sockets = false
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
-
-  # Disable LCD on supported devices
-  disable_lcd = false
 
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
@@ -65,14 +55,6 @@ declare_args() {
   chip_default_wifi_psk = ""
 }
 
-declare_args() {
-  # Enables LCD Qr Code on supported devices
-  show_qr_code = !disable_lcd
-}
-
-# qr code cannot be true if lcd is disabled
-assert(!(disable_lcd && show_qr_code))
-
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))
 assert(!(use_rs911x && chip_enable_openthread))
@@ -81,13 +63,6 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
   enable_openthread_cli = false
   import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
-}
-
-# ThunderBoards, Explorer Kit and MGM240L do not support LCD (No LCD)
-if (silabs_board == "BRD4166A" || silabs_board == "BRD2601B" ||
-    silabs_board == "BRD2703A" || silabs_board == "BRD4319A") {
-  show_qr_code = false
-  disable_lcd = true
 }
 
 defines = []
@@ -153,11 +128,6 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
-  defines += [
-    "BOARD_ID=${silabs_board}",
-    "OTA_PERIODIC_TIMEOUT=${OTA_periodic_query_timeout}",
-  ]
-
   # WiFi Settings
   if (chip_enable_wifi) {
     if (use_rs911x) {
@@ -196,45 +166,21 @@ efr32_executable("window_app") {
   defines = []
 
   sources = [
-    "${examples_common_plat_dir}/heap_4_silabs.c",
-    "${examples_plat_dir}/efr32_utils.cpp",
-    "${examples_plat_dir}/init_efrPlatform.cpp",
-    "${examples_plat_dir}/matter_config.cpp",
     "${project_dir}/common/src/WindowApp.cpp",
     "${project_dir}/common/src/ZclCallbacks.cpp",
     "src/WindowAppImpl.cpp",
     "src/main.cpp",
   ]
 
-  if (use_wstk_leds) {
-    sources += [ "${examples_plat_dir}/LEDWidget.cpp" ]
-  }
-
-  if (chip_build_libshell || enable_openthread_cli || use_wf200 || use_rs911x) {
-    sources += [ "${examples_plat_dir}/uart.cpp" ]
+  if (!disable_lcd) {
+    sources += [ "src/LcdPainter.cpp" ]
   }
 
   deps = [
     ":sdk",
-    "${chip_root}/examples/providers:device_info_provider",
-    "${chip_root}/examples/window-app/common:window-common",
-    "${chip_root}/src/lib",
-    "${chip_root}/src/setup_payload",
+    "${examples_plat_dir}:efr32-common",
+    app_data_model,
   ]
-
-  # OpenThread Settings
-  if (chip_enable_openthread) {
-    deps += [
-      "${chip_root}/third_party/openthread:openthread",
-      "${chip_root}/third_party/openthread:openthread-platform",
-      "${examples_plat_dir}:efr-matter-shell",
-    ]
-  }
-
-  if (chip_enable_ota_requestor) {
-    defines += [ "EFR32_OTA_ENABLED" ]
-    sources += [ "${examples_plat_dir}/OTAConfig.cpp" ]
-  }
 
   # WiFi Settings
   if (chip_enable_wifi) {
@@ -274,27 +220,6 @@ efr32_executable("window_app") {
     }
   }
 
-  if (!disable_lcd) {
-    sources += [
-      "${examples_plat_dir}/display/demo-ui.c",
-      "${examples_plat_dir}/display/lcd.cpp",
-      "src/LcdPainter.cpp",
-    ]
-    include_dirs += [ "${examples_plat_dir}/display" ]
-    defines += [ "DISPLAY_ENABLED" ]
-
-    if (show_qr_code) {
-      deps += [ "${chip_root}/examples/common/QRCode" ]
-      defines += [ "QR_CODE_ENABLED" ]
-    }
-  }
-
-  if (enable_heap_monitoring) {
-    defines += [ "HEAP_MONITORING" ]
-
-    sources += [ "${examples_common_plat_dir}/MemMonitoring.cpp" ]
-  }
-
   ldscript = "${examples_plat_dir}/ldscripts/${silabs_family}.ld"
 
   inputs = [ ldscript ]
@@ -314,16 +239,6 @@ efr32_executable("window_app") {
       "-Wl,--defsym",
       "-Wl,SILABS_WIFI=1",
     ]
-  }
-
-  # Attestation Credentials
-  if (chip_build_platform_attestation_credentials_provider) {
-    deps += [ "${examples_plat_dir}:efr32-attestation-credentials" ]
-  }
-
-  # Factory Data Provider
-  if (use_efr32_factory_data_provider) {
-    deps += [ "${examples_plat_dir}:efr32-factory-data-provider" ]
   }
 }
 

--- a/examples/window-app/silabs/efr32/BUILD.gn
+++ b/examples/window-app/silabs/efr32/BUILD.gn
@@ -34,84 +34,6 @@ import("${examples_plat_dir}/args.gni")
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
-
-  # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
-  use_wf200 = false
-  use_rs911x = false
-  use_rs911x_sockets = false
-  sl_wfx_config_softap = false
-  sl_wfx_config_scan = true
-
-  # Argument to Disable IPv4 for wifi(rs911)
-  chip_enable_wifi_ipv4 = false
-
-  # Argument to force enable WPA3 security
-  rs91x_wpa3_only = false
-
-  #default WiFi SSID
-  chip_default_wifi_ssid = ""
-
-  #default Wifi Password
-  chip_default_wifi_psk = ""
-}
-
-# Sanity check
-assert(!(chip_enable_wifi && chip_enable_openthread))
-assert(!(use_rs911x && chip_enable_openthread))
-assert(!(use_wf200 && chip_enable_openthread))
-if (chip_enable_wifi) {
-  assert(use_rs911x || use_wf200)
-  enable_openthread_cli = false
-  import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
-}
-
-defines = []
-
-# WiFi settings
-if (chip_enable_wifi) {
-  if (chip_default_wifi_ssid != "") {
-    defines += [
-      "CHIP_ONNETWORK_PAIRING=1",
-      "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
-    ]
-  }
-  if (chip_default_wifi_psk != "") {
-    assert(chip_default_wifi_ssid != "",
-           "ssid can't be null if psk is provided")
-    defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
-  }
-  wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
-  efr32_lwip_defs = [ "LWIP_NETIF_API=1" ]
-  if (lwip_ipv4) {
-    efr32_lwip_defs += [
-      "LWIP_IPV4=1",
-
-      # adds following options to provide
-      # them to .cpp source files
-      # flags ported from lwipopts file
-      # TODO: move lwipopts to one location
-      "LWIP_ARP=1",
-      "LWIP_ICMP=1",
-      "LWIP_IGMP=1",
-      "LWIP_DHCP=1",
-      "LWIP_DNS=0",
-    ]
-  } else {
-    efr32_lwip_defs += [ "LWIP_IPV4=0" ]
-  }
-  if (lwip_ipv6) {
-    efr32_lwip_defs += [ "LWIP_IPV6=1" ]
-  } else {
-    efr32_lwip_defs += [ "LWIP_IPV6=0" ]
-  }
-
-  if (use_rs911x) {
-    wiseconnect_sdk_root =
-        "${chip_root}/third_party/silabs/wiseconnect-wifi-bt-sdk"
-    import("${examples_plat_dir}/rs911x/rs911x.gni")
-  } else {
-    import("${examples_plat_dir}/wf200/wf200.gni")
-  }
 }
 
 efr32_sdk("sdk") {
@@ -128,30 +50,9 @@ efr32_sdk("sdk") {
     "${examples_common_plat_dir}",
   ]
 
-  # WiFi Settings
-  if (chip_enable_wifi) {
-    if (use_rs911x) {
-      defines += rs911x_defs
-      include_dirs += rs911x_plat_incs
-    } else if (use_wf200) {
-      defines += wf200_defs
-      include_dirs += wf200_plat_incs
-    }
-
-    if (use_rs911x_sockets) {
-      include_dirs += [ "${examples_plat_dir}/wifi/rsi-sockets" ]
-      defines += rs911x_sock_defs
-    } else {
-      # Using LWIP instead of the native TCP/IP stack
-      defines += efr32_lwip_defs
-    }
-
-    if (sl_wfx_config_softap) {
-      defines += [ "SL_WFX_CONFIG_SOFTAP" ]
-    }
-    if (sl_wfx_config_scan) {
-      defines += [ "SL_WFX_CONFIG_SCAN" ]
-    }
+  if (use_wf200) {
+    # TODO efr32_sdk should not need a header from this location
+    include_dirs += [ "${examples_plat_dir}/wf200" ]
   }
 }
 
@@ -181,44 +82,6 @@ efr32_executable("window_app") {
     "${examples_plat_dir}:efr32-common",
     app_data_model,
   ]
-
-  # WiFi Settings
-  if (chip_enable_wifi) {
-    if (use_rs911x) {
-      sources += rs911x_src_plat
-
-      # All the stuff from wiseconnect
-      sources += rs911x_src_sapi
-
-      # Apparently - the rsi library needs this (though we may not use use it)
-      sources += rs911x_src_sock
-      include_dirs += rs911x_inc_plat
-
-      if (use_rs911x_sockets) {
-        #
-        # Using native sockets inside RS911x
-        #
-        include_dirs += rs911x_sock_inc
-      } else {
-        #
-        # We use LWIP - not built-in sockets
-        #
-        sources += rs911x_src_lwip
-      }
-    } else if (use_wf200) {
-      sources += wf200_plat_src
-      include_dirs += wf200_plat_incs
-    }
-
-    if (chip_enable_wifi_ipv4) {
-      defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
-    }
-
-    if (rs91x_wpa3_only) {
-      # TODO: Change this macro once WF200 support is provided
-      defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
-    }
-  }
 
   ldscript = "${examples_plat_dir}/ldscripts/${silabs_family}.ld"
 

--- a/examples/window-app/silabs/efr32/args.gni
+++ b/examples/window-app/silabs/efr32/args.gni
@@ -18,7 +18,10 @@ import("${chip_root}/src/platform/silabs/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
+app_data_model = "${chip_root}/examples/window-app/common:window-common"
 chip_enable_ota_requestor = true
 chip_enable_openthread = true
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"
+
+use_base_app = false

--- a/examples/window-app/silabs/efr32/build_for_wifi_args.gni
+++ b/examples/window-app/silabs/efr32/build_for_wifi_args.gni
@@ -19,3 +19,4 @@ import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
 
 chip_enable_ota_requestor = true
 app_data_model = "${chip_root}/examples/window-app/common:window-common"
+use_base_app = false

--- a/examples/window-app/silabs/efr32/build_for_wifi_args.gni
+++ b/examples/window-app/silabs/efr32/build_for_wifi_args.gni
@@ -18,3 +18,4 @@ chip_enable_openthread = false
 import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
 
 chip_enable_ota_requestor = true
+app_data_model = "${chip_root}/examples/window-app/common:window-common"

--- a/src/platform/silabs/EFR32/BUILD.gn
+++ b/src/platform/silabs/EFR32/BUILD.gn
@@ -111,5 +111,10 @@ static_library("EFR32") {
       "${silabs_platform_dir}/NetworkCommissioningWiFiDriver.cpp",
       "${silabs_platform_dir}/NetworkCommissioningWiFiDriver.h",
     ]
+
+    include_dirs = [ "wifi" ]
+
+    public_configs =
+        [ "${chip_root}/examples/platform/silabs/efr32:silabs-wifi-config" ]
   }
 }

--- a/src/platform/silabs/EFR32/BUILD.gn
+++ b/src/platform/silabs/EFR32/BUILD.gn
@@ -18,6 +18,7 @@ import("${chip_root}/src/platform/device.gni")
 
 import("${chip_root}/build/chip/buildconfig_header.gni")
 import("${chip_root}/src/crypto/crypto.gni")
+import("${chip_root}/third_party/silabs/silabs_board.gni")
 
 silabs_platform_dir = "${chip_root}/src/platform/silabs"
 
@@ -29,6 +30,19 @@ if (chip_enable_openthread) {
 
 if (chip_crypto == "platform") {
   import("//build_overrides/mbedtls.gni")
+}
+
+config("efr32-platform-wifi-config") {
+  include_dirs = [ "wifi" ]
+  defines = []
+
+  if (use_rs911x && use_rs911x_sockets) {
+    include_dirs += [ "wifi/rsi-sockets" ]
+    defines += [
+      "RS911X_SOCKETS",
+      "RSI_IPV6_ENABLE",
+    ]
+  }
 }
 
 static_library("EFR32") {
@@ -110,11 +124,21 @@ static_library("EFR32") {
       "${silabs_platform_dir}/ConnectivityManagerImpl_WIFI.cpp",
       "${silabs_platform_dir}/NetworkCommissioningWiFiDriver.cpp",
       "${silabs_platform_dir}/NetworkCommissioningWiFiDriver.h",
+      "wifi/wfx_host_events.h",
+      "wifi/wfx_msgs.h",
+      "wifi/wifi_config.h",
     ]
 
-    include_dirs = [ "wifi" ]
+    if (use_wf200 || !use_rs911x_sockets) {
+      sources += [
+        "wifi/dhcp_client.cpp",
+        "wifi/dhcp_client.h",
+        "wifi/ethernetif.cpp",
+        "wifi/ethernetif.h",
+        "wifi/lwip_netif.cpp",
+      ]
+    }
 
-    public_configs =
-        [ "${chip_root}/examples/platform/silabs/efr32:silabs-wifi-config" ]
+    public_configs = [ ":efr32-platform-wifi-config" ]
   }
 }

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -56,7 +56,6 @@ efr32_sdk("sdk") {
   ]
 
   defines = [
-    "BOARD_ID=${silabs_board}",
     "SILABS_LOG_ENABLED=1",
     "PW_RPC_ENABLED",
 

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -34,7 +34,6 @@ declare_args() {
   enable_openthread_cli = true
 
   kvs_max_entries = 75
-  use_external_flash = true
 
   # Use Silabs factory data provider example.
   # Users can implement their own.
@@ -42,20 +41,6 @@ declare_args() {
 
   # Enable Segger System View
   use_system_view = false
-}
-
-# Explorer Kit and MGM240L do not have external flash
-if (silabs_board == "BRD2703A" || silabs_board == "BRD4319A") {
-  use_external_flash = false
-}
-
-# Enable LEDs by default
-use_wstk_leds = true
-
-# Board does not support LEDs and Buttons at the same time
-if (silabs_board == "BRD4317A" || silabs_board == "BRD4316A" ||
-    silabs_board == "BRD4319A") {
-  use_wstk_leds = false
 }
 
 assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -42,9 +42,6 @@ declare_args() {
 
   # Enable Sleepy end device
   enable_sleepy_device = false
-
-  # OTA timeout in seconds
-  OTA_periodic_query_timeout = 86400
 }
 
 assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -42,8 +42,6 @@ declare_args() {
 
   # Enable Sleepy end device
   enable_sleepy_device = false
-
-  use_rs911x_sockets = false
 }
 
 assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")
@@ -212,13 +210,10 @@ template("efr32_sdk") {
         ]
       }
 
-      if (use_rs911x_sockets) {
-        include_dirs += [ "wifi/rsi-sockets" ]
-        defines += rs911x_sock_defs
-      } else {
+      if (use_wf200 || !use_rs911x_sockets) {
         import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
-        defines += [ "LWIP_NETIF_API=1" ]
 
+        defines += [ "LWIP_NETIF_API=1" ]
         if (lwip_ipv4) {
           defines += [
             "LWIP_IPV4=1",

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -42,6 +42,8 @@ declare_args() {
 
   # Enable Sleepy end device
   enable_sleepy_device = false
+
+  use_rs911x_sockets = false
 }
 
 assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")
@@ -57,12 +59,6 @@ template("efr32_sdk") {
   }
 
   assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")
-  use_wf200 = false
-  if (defined(invoker.use_wf200)) {
-    if (invoker.use_wf200) {
-      use_wf200 = true
-    }
-  }
 
   sdk_target_name = target_name
 
@@ -193,6 +189,60 @@ template("efr32_sdk") {
 
       #"__STACK_SIZE=0",
     ]
+
+    if (defined(invoker.chip_enable_wifi) && invoker.chip_enable_wifi) {
+      if (use_rs911x) {
+        defines += [
+          "SL_HEAP_SIZE=32768",
+          "SL_WIFI=1",
+          "SL_WFX_USE_SPI",
+          "EFX32_RS911X=1",
+          "RS911X_WIFI",
+          "RSI_WLAN_ENABLE",
+          "RSI_SPI_INTERFACE",
+          "RSI_WITH_OS",
+        ]
+      } else if (use_wf200) {
+        defines += [
+          "SL_HEAP_SIZE=24576",
+          "WF200_WIFI=1",
+          "SL_WIFI=1",
+          "SL_WFX_USE_SPI",
+          "SL_WFX_DEBUG_MASK=0x0003",
+        ]
+      }
+
+      if (use_rs911x_sockets) {
+        include_dirs += [ "wifi/rsi-sockets" ]
+        defines += rs911x_sock_defs
+      } else {
+        import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
+        defines += [ "LWIP_NETIF_API=1" ]
+
+        if (lwip_ipv4) {
+          defines += [
+            "LWIP_IPV4=1",
+
+            # adds following options to provide
+            # them to .cpp source files
+            # flags ported from lwipopts file
+            # TODO: move lwipopts to one location
+            "LWIP_ARP=1",
+            "LWIP_ICMP=1",
+            "LWIP_IGMP=1",
+            "LWIP_DHCP=1",
+            "LWIP_DNS=0",
+          ]
+        } else {
+          defines += [ "LWIP_IPV4=0" ]
+        }
+        if (lwip_ipv4) {
+          defines += [ "LWIP_IPV6=1" ]
+        } else {
+          defines += [ "LWIP_IPV6=0" ]
+        }
+      }
+    }
 
     if (use_system_view) {
       _include_dirs += [
@@ -396,13 +446,6 @@ template("efr32_sdk") {
 
     if (silabs_family == "efr32mg24" || silabs_family == "mgm24") {
       cflags += [ "-mcmse" ]
-    }
-
-    if (defined(invoker.use_rs911x)) {
-      if (invoker.use_rs911x == true) {
-        #add compilation flags for rs991x build. This will be addressed directly in wiseconnect sdk in the next version release of that sdk
-        cflags += invoker.rs911x_cflags
-      }
     }
 
     if (defined(invoker.defines)) {

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -30,7 +30,6 @@ declare_args() {
   enable_openthread_cli = true
 
   kvs_max_entries = 75
-  use_external_flash = true
 
   # Use Silabs factory data provider example.
   # Users can implement their own.
@@ -39,31 +38,13 @@ declare_args() {
   # Enable Segger System View
   use_system_view = false
 
-  # Enable Buttons by default
-  use_wstk_buttons = true
-
-  # Enable LEDs by default
-  use_wstk_leds = true
-
   sleep_time_ms = 3300000  # 55 mins sleep
-}
 
-# Explorer Kit and MGM240L do not have external flash
-if (silabs_board == "BRD2703A" || silabs_board == "BRD4318A" ||
-    silabs_board == "BRD4319A") {
-  use_external_flash = false
-}
+  # Enable Sleepy end device
+  enable_sleepy_device = false
 
-# Board does not support LEDs and Buttons at the same time
-if (silabs_board == "BRD4317A" || silabs_board == "BRD4316A" ||
-    silabs_board == "BRD4319A" || silabs_board == "BRD4318A") {
-  use_wstk_leds = false
-}
-
-# Board does not support buttons
-if (silabs_board == "BRD2704A") {
-  use_wstk_buttons = false
-  use_external_flash = false
+  # OTA timeout in seconds
+  OTA_periodic_query_timeout = 86400
 }
 
 assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")
@@ -110,7 +91,6 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform/CMSIS/Core/Include",
       "${efr32_sdk_root}/platform/CMSIS/RTOS2/Include",
       "${efr32_sdk_root}/platform/common/inc",
-      "${efr32_sdk_root}/platform/driver/button/inc",
       "${efr32_sdk_root}/platform/emdrv/common/inc",
       "${efr32_sdk_root}/platform/emdrv/gpiointerrupt/inc",
       "${efr32_sdk_root}/platform/emdrv/dmadrv/config",
@@ -249,15 +229,13 @@ template("efr32_sdk") {
       _include_dirs += [ "${efr32_sdk_root}/platform/driver/button/inc" ]
     }
 
-    if (defined(invoker.enable_sleepy_device)) {
-      if (invoker.enable_sleepy_device) {
-        defines += [
-          "CHIP_DEVICE_CONFIG_ENABLE_SED=1",
-          "SL_CATALOG_POWER_MANAGER_PRESENT",
-          "SL_CATALOG_SLEEPTIMER_PRESENT",
-          "SL_SLEEP_TIME_MS=${sleep_time_ms}",
-        ]
-      }
+    if (enable_sleepy_device) {
+      defines += [
+        "CHIP_DEVICE_CONFIG_ENABLE_SED=1",
+        "SL_CATALOG_POWER_MANAGER_PRESENT",
+        "SL_CATALOG_SLEEPTIMER_PRESENT",
+        "SL_SLEEP_TIME_MS=${sleep_time_ms}",
+      ]
     }
 
     if (chip_build_libshell) {  # matter shell
@@ -276,12 +254,10 @@ template("efr32_sdk") {
     if ((defined(invoker.chip_enable_pw_rpc) && invoker.chip_enable_pw_rpc) ||
         chip_build_libshell || enable_openthread_cli ||
         (defined(invoker.chip_enable_wifi) && invoker.chip_enable_wifi) ||
-        (defined(invoker.show_qr_code) && invoker.show_qr_code) ||
-        (defined(invoker.disable_lcd) && !invoker.disable_lcd) ||
-        (defined(invoker.use_external_flash) && use_external_flash)) {
+        show_qr_code || disable_lcd || use_external_flash) {
       defines += [ "CONFIG_ENABLE_UART" ]
 
-      if (defined(invoker.use_external_flash) && use_external_flash) {
+      if (use_external_flash) {
         defines += [ "CONFIG_USE_EXTERNAL_FLASH" ]
 
         _include_dirs += [ "${efr32_sdk_root}/hardware/driver/mx25_flash_shutdown/inc/sl_mx25_flash_shutdown_usart" ]
@@ -667,10 +643,8 @@ template("efr32_sdk") {
       ]
     }
 
-    if (defined(invoker.enable_sleepy_device)) {
-      if (invoker.enable_sleepy_device) {
-        sources += [ "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/SiliconLabs/tick_power_manager.c" ]
-      }
+    if (enable_sleepy_device) {
+      sources += [ "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/SiliconLabs/tick_power_manager.c" ]
     }
 
     if (defined(enable_fem)) {
@@ -683,9 +657,7 @@ template("efr32_sdk") {
     if ((defined(invoker.chip_enable_pw_rpc) && invoker.chip_enable_pw_rpc) ||
         chip_build_libshell || enable_openthread_cli ||
         (defined(invoker.chip_enable_wifi) && invoker.chip_enable_wifi) ||
-        (defined(invoker.show_qr_code) && invoker.show_qr_code) ||
-        (defined(invoker.disable_lcd) && !invoker.disable_lcd) ||
-        (defined(invoker.use_external_flash) && use_external_flash)) {
+        show_qr_code || !disable_lcd || use_external_flash) {
       sources += [
         "${efr32_sdk_root}/hardware/driver/memlcd/src/memlcd_usart/sl_memlcd_spi.c",
         "${efr32_sdk_root}/platform/emdrv/uartdrv/src/uartdrv.c",
@@ -695,13 +667,12 @@ template("efr32_sdk") {
         "${sdk_support_root}/matter/efr32/${silabs_family}/${silabs_board}/autogen/sl_uartdrv_init.c",
       ]
 
-      if (defined(invoker.use_external_flash) && use_external_flash) {
+      if (use_external_flash) {
         sources += [ "${efr32_sdk_root}/hardware/driver/mx25_flash_shutdown/src/sl_mx25_flash_shutdown_usart/sl_mx25_flash_shutdown.c" ]
       }
     }
 
-    if ((defined(invoker.show_qr_code) && invoker.show_qr_code) ||
-        (defined(invoker.disable_lcd) && !invoker.disable_lcd)) {
+    if (show_qr_code || !disable_lcd) {
       sources += [
         "${efr32_sdk_root}/hardware/driver/memlcd/src/sl_memlcd.c",
         "${efr32_sdk_root}/hardware/driver/memlcd/src/sl_memlcd_display.c",

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -33,6 +33,7 @@ declare_args() {
   # WIFI rcp boards options for wifi apps.
   use_wf200 = false
   use_rs911x = false
+  use_rs911x_sockets = false
 }
 
 declare_args() {

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -15,6 +15,25 @@
 declare_args() {
   # EFR32 board used
   silabs_board = ""
+
+  # LCD is enabled by default
+  # Boards BRD4166A, BRD2601B, BRD2703A and BRD4319A do not have a LCD so they disable it explicitly
+  disable_lcd = false
+
+  # Enable Buttons by default
+  use_wstk_buttons = true
+
+  # Enable LEDs on development board by default
+  # Boards BRD4317A, BRD4316A and BRD4319A disable this explicitly
+  use_wstk_leds = true
+
+  # Boards BRD2703A and BRD4319A disable this explicitly
+  use_external_flash = true
+}
+
+declare_args() {
+  # Enables LCD Qr Code on supported devices
+  show_qr_code = !disable_lcd
 }
 
 if (silabs_board == "") {
@@ -56,6 +75,10 @@ if (silabs_board == "BRD4304A") {
 } else if (silabs_board == "BRD4166A") {
   silabs_family = "efr32mg12"
   silabs_mcu = "EFR32MG12P332F1024GL125"
+
+  # ThunderBoards don't have a LCD
+  show_qr_code = false
+  disable_lcd = true
 } else if (silabs_board == "BRD4170A") {
   silabs_family = "efr32mg12"
   silabs_mcu = "EFR32MG12P433F1024GM68"
@@ -81,26 +104,63 @@ if (silabs_board == "BRD4304A") {
 } else if (silabs_board == "BRD2601B") {
   silabs_family = "efr32mg24"
   silabs_mcu = "EFR32MG24B310F1536IM48"
+
+  # ThunderBoards don't have a LCD,
+  show_qr_code = false
+  disable_lcd = true
 } else if (silabs_board == "BRD2703A") {
   silabs_family = "efr32mg24"
   silabs_mcu = "EFR32MG24B020F1536IM48"
+
+  # Explorer Kits do not have an external flash nor a LCD
+  use_external_flash = false
+  show_qr_code = false
+  disable_lcd = true
 } else if (silabs_board == "BRD4316A") {
   silabs_family = "mgm24"
   silabs_mcu = "MGM240PB22VNA"
+
+  # Board does not support LEDs and Buttons at the same time
+  use_wstk_leds = false
 } else if (silabs_board == "BRD4317A") {
   silabs_family = "mgm24"
   silabs_mcu = "MGM240PB32VNA"
+
+  # Board does not support LEDs and Buttons at the same time
+  use_wstk_leds = false
 } else if (silabs_board == "BRD4319A") {
   silabs_family = "mgm24"
   silabs_mcu = "MGM240L022RNF"
+
+  # Board does not support LEDs and Buttons at the same time
+  use_wstk_leds = false
+
+  # MGM240L do not have an external flash or LCD
+  use_external_flash = false
+  show_qr_code = false
+  disable_lcd = true
 } else if (silabs_board == "BRD2704A") {
   silabs_family = "mgm24"
   silabs_mcu = "MGM240PB32VNA"
+
+  # Explorer Kits do not have an external flash, buttons nor a LCD
+  use_wstk_buttons = false
+  use_external_flash = false
+  show_qr_code = false
+  disable_lcd = true
 } else if (silabs_board == "BRD4318A") {
   silabs_family = "mgm24"
   silabs_mcu = "MGM240SD22VNA"
+
+  use_wstk_leds = false
+  use_external_flash = false
+  show_qr_code = false
+  disable_lcd = true
 } else {
   print(
       "Please provide a valid value for SILABS_BOARD env variable (currently supported BRD4304A, BRD4161A, BRD4163A, BRD4164A BRD4166A, BRD4170A, BRD4186C, BRD4187C, BRD2601B, BRD2703A, BRD4317A, BRD2704A)")
   assert(false, "The board ${silabs_board} is unsupported")
 }
+
+# qr code cannot be true if lcd is disabled
+assert(!(disable_lcd && show_qr_code))

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -29,6 +29,10 @@ declare_args() {
 
   # Boards BRD2703A and BRD4319A disable this explicitly
   use_external_flash = true
+
+  # WIFI rcp boards options for wifi apps.
+  use_wf200 = false
+  use_rs911x = false
 }
 
 declare_args() {

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -90,6 +90,8 @@ if (silabs_board == "BRD4304A") {
 } else if (silabs_board == "BRD4325A") {
   silabs_family = "SiWx917"
   silabs_mcu = "EFR32MG12P432F1024GL125"
+  disable_lcd = true
+  show_qr_code = false
 } else if (silabs_board == "BRD4180A") {
   assert(
       false,


### PR DESCRIPTION
Silabs Sample apps GN build is convoluted and duplicates a lot of args and conditions in each example's `BUILD.gn`.
This PR aims to reduce this duplication, regroup board or sdk arguments,  and common example platform sources building to a common location. 

Platforms affected by the refactoring:
EFR32 MG12 or MG24 families thread apps
EFR32 + wf200 or rs9116 wifi RCP apps

SiWx917 platform still needs a cleanup. It will be done in a second phase. Only some arguments duplicated have been removed from its build.gn s.

Tested the build of all Silabs sample examples on the 4 platforms + tested a few different boards and configurations. 

