### PR TITLE
[Silabs] Use Gecko SDK precompiled openthread librairies

### DIFF
--- a/third_party/silabs/BUILD.gn
+++ b/third_party/silabs/BUILD.gn
@@ -27,8 +27,10 @@ if (silabs_board == "BRD4325A") {  # CCP board
 declare_args() {
   # Build target to use for efr32 SDK. Use this to set global SDK defines.
   efr32_sdk_target = ""
-  sl_ot_efr32_root = "${chip_root}/third_party/openthread/ot-efr32"
-  sl_openthread_root = "${chip_root}/third_party/openthread/ot-efr32/openthread"
+  sl_ot_efr32_root =
+      "${chip_root}/third_party/silabs/gecko_sdk/protocol/openthread"
+  sl_openthread_root =
+      "${chip_root}/third_party/silabs/gecko_sdk/util/third_party/openthread"
   use_thread_coap_lib = false
   sl_matter_version_str = ""
 }
@@ -82,15 +84,15 @@ if (use_silabs_thread_lib) {
     include_dirs = [
       "${chip_root}/examples/platform/silabs/efr32",
       "${sdk_support_root}/matter/efr32/${silabs_family}/${silabs_board}",
-      "${sl_ot_efr32_root}/src/src",
+      "${sl_ot_efr32_root}/platform-abstraction/efr32",
       "${sl_openthread_root}/src/",
     ]
   }
 
   source_set("openthread_core_config_efr32") {
     sources = [
-      "${sl_ot_efr32_root}/src/src/openthread-core-efr32-config-check.h",
-      "${sl_ot_efr32_root}/src/src/openthread-core-efr32-config.h",
+      "${sl_ot_efr32_root}/platform-abstraction/efr32/openthread-core-efr32-config-check.h",
+      "${sl_ot_efr32_root}/platform-abstraction/efr32/openthread-core-efr32-config.h",
     ]
 
     public_deps = [

--- a/third_party/silabs/BUILD.gn
+++ b/third_party/silabs/BUILD.gn
@@ -87,6 +87,9 @@ if (use_silabs_thread_lib) {
       "${sl_ot_efr32_root}/platform-abstraction/efr32",
       "${sl_openthread_root}/src/",
     ]
+
+    # temporarily disable check until gsdk pulls in a more recent version
+    cflags = [ "-Wno-format-nonliteral" ]
   }
 
   source_set("openthread_core_config_efr32") {

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -603,14 +603,13 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/util/third_party/mbedtls/library/sha512.c",
       "${efr32_sdk_root}/util/third_party/mbedtls/library/ssl_cache.c",
       "${efr32_sdk_root}/util/third_party/mbedtls/library/ssl_ciphersuites.c",
-
-      # "${efr32_sdk_root}/util/third_party/mbedtls/library/ssl_cli.c",
+      "${efr32_sdk_root}/util/third_party/mbedtls/library/ssl_client.c",
       "${efr32_sdk_root}/util/third_party/mbedtls/library/ssl_cookie.c",
       "${efr32_sdk_root}/util/third_party/mbedtls/library/ssl_msg.c",
-
-      # "${efr32_sdk_root}/util/third_party/mbedtls/library/ssl_srv.c",
       "${efr32_sdk_root}/util/third_party/mbedtls/library/ssl_ticket.c",
       "${efr32_sdk_root}/util/third_party/mbedtls/library/ssl_tls.c",
+      "${efr32_sdk_root}/util/third_party/mbedtls/library/ssl_tls12_client.c",
+      "${efr32_sdk_root}/util/third_party/mbedtls/library/ssl_tls12_server.c",
       "${efr32_sdk_root}/util/third_party/mbedtls/library/ssl_tls13_keys.c",
       "${efr32_sdk_root}/util/third_party/mbedtls/library/threading.c",
       "${efr32_sdk_root}/util/third_party/mbedtls/library/timing.c",


### PR DESCRIPTION
#### Description
Use precompiled librairies found in the silabs gecko sdk instead of the github repository


#### Tests
Manual tests with an EFR32MG24 to validate librairies work
