### PR TITLE
[Silabs][CI] Remove redundant step

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -102,15 +102,6 @@ jobs:
              /tmp/bloat_reports/
       - name: Clean out build output
         run: rm -rf ./out
-      - name: Build example EFR32 Lighting App for BRD4161A with RPCs
-        timeout-minutes: 15
-        run: |
-          scripts/examples/gn_efr32_example.sh examples/lighting-app/silabs/efr32/ out/lighting_app_debug_rpc BRD4161A "is_debug=false" \
-            disable_lcd=true 'import("//with_pw_rpc.gni")'
-          .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py efr32 BRD4161A+rpc lighting-app \
-            out/lighting_app_debug_rpc/BRD4161A/chip-efr32-lighting-example.out /tmp/bloat_reports/
-      - name: Clean out build output
-        run: rm -rf ./out
       - name: Build example EFR32+WF200 WiFi Lock app for BRD4161A
         timeout-minutes: 15
         run: |


### PR DESCRIPTION
Lighting PW-rpc build is part of the previous CI step` Build some BRD4187C variants`. Building it again separately for BRD4161a is just redundant. 

Removing that step saves ~5 mins of CI