### PR TITLE
Enable Subscription Persistence and Resumption for ESP32

### DIFF
--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -99,10 +99,8 @@ declare_args() {
   }
 
   # Enable Subscription persistence / resumption for CI and supported platforms
-  if (chip_device_platform == "darwin" ||
-      chip_device_platform == "linux" ||
-      chip_device_platform == "esp32" ||
-      chip_device_platform == "fake") {
+  if (chip_device_platform == "darwin" || chip_device_platform == "linux" ||
+      chip_device_platform == "esp32" || chip_device_platform == "fake") {
     chip_persist_subscriptions = true
   } else {
     chip_persist_subscriptions = false

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -99,7 +99,9 @@ declare_args() {
   }
 
   # Enable Subscription persistence / resumption for CI and supported platforms
-  if (chip_device_platform == "darwin" || chip_device_platform == "linux" ||
+  if (chip_device_platform == "darwin" ||
+      chip_device_platform == "linux" ||
+      chip_device_platform == "esp32" ||
       chip_device_platform == "fake") {
     chip_persist_subscriptions = true
   } else {


### PR DESCRIPTION
This enables the 1.1 feature Subscription Persistence and Resumption for ESP32, so that we can get more CI and other testing by default, so we can find issues early and fix as needed.

@shubhamdp @dhrishi for attention.