### PR TITLE
[Silabs] Fix ble advertising on MG12

### DIFF
--- a/examples/platform/silabs/efr32/init_efrPlatform.cpp
+++ b/examples/platform/silabs/efr32/init_efrPlatform.cpp
@@ -66,7 +66,7 @@ void initAntenna(void);
 void init_efrPlatform(void)
 {
     sl_system_init();
-
+    sl_mbedtls_init();
 #if CHIP_ENABLE_OPENTHREAD
 #ifdef MGM24
     sl_openthread_init();


### PR DESCRIPTION
Function that  was removed is present in the GSDK for MG24 but not MG12.

Re-add the missing init function.

