### PR TITLE
Don't try to relock the lock if it's locked when the auto-relock timer fires.

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -3778,8 +3778,19 @@ void MatterDoorLockClusterServerAttributeChangedCallback(const app::ConcreteAttr
 
 void DoorLockServer::DoorLockOnAutoRelockCallback(chip::EndpointId endpointId)
 {
-    emberAfDoorLockClusterPrintln("Door Auto relock timer expired. Locking...");
     emberEventControlSetInactive(&DoorLockServer::Instance().AutolockEvent);
-    DoorLockServer::Instance().SetLockState(endpointId, DlLockState::kLocked, OperationSourceEnum::kAuto);
-    emberAfPluginDoorLockOnAutoRelock(endpointId);
+
+    Nullable<DlLockState> lockState;
+    if (Attributes::LockState::Get(endpointId, lockState) != EMBER_ZCL_STATUS_SUCCESS || lockState.IsNull() ||
+        lockState.Value() != DlLockState::kLocked)
+    {
+        emberAfDoorLockClusterPrintln("Door Auto relock timer expired. %s", "Locking...");
+
+        DoorLockServer::Instance().SetLockState(endpointId, DlLockState::kLocked, OperationSourceEnum::kAuto);
+        emberAfPluginDoorLockOnAutoRelock(endpointId);
+    }
+    else
+    {
+        emberAfDoorLockClusterPrintln("Door Auto relock timer expired. %s", "Already locked.");
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/24766
