### PR TITLE
Add a method to send the NOC with CATs when pairing devices

### DIFF
--- a/examples/chip-tool/commands/common/CredentialIssuerCommands.h
+++ b/examples/chip-tool/commands/common/CredentialIssuerCommands.h
@@ -73,6 +73,8 @@ public:
 
     virtual chip::Controller::OperationalCredentialsDelegate * GetCredentialIssuer() = 0;
 
+    virtual void SetCredentialIssuerCATValues(chip::CATValues cats) {}
+
     /**
      * @brief
      *   This function is used to Generate NOC Chain for the Controller/Commissioner. Parameters follow the example implementation,

--- a/examples/chip-tool/commands/common/CredentialIssuerCommands.h
+++ b/examples/chip-tool/commands/common/CredentialIssuerCommands.h
@@ -73,7 +73,7 @@ public:
 
     virtual chip::Controller::OperationalCredentialsDelegate * GetCredentialIssuer() = 0;
 
-    virtual void SetCredentialIssuerCATValues(chip::CATValues cats) {}
+    virtual void SetCredentialIssuerCATValues(chip::CATValues cats) = 0;
 
     /**
      * @brief

--- a/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h
+++ b/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h
@@ -45,6 +45,7 @@ public:
         return CHIP_NO_ERROR;
     }
     chip::Controller::OperationalCredentialsDelegate * GetCredentialIssuer() override { return &mOpCredsIssuer; }
+    void SetCredentialIssuerCATValues(chip::CATValues cats) override { mOpCredsIssuer.SetCATValuesForNextNOCRequest(cats); }
     CHIP_ERROR GenerateControllerNOCChain(chip::NodeId nodeId, chip::FabricId fabricId, const chip::CATValues & cats,
                                           chip::Crypto::P256Keypair & keypair, chip::MutableByteSpan & rcac,
                                           chip::MutableByteSpan & icac, chip::MutableByteSpan & noc) override

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -33,6 +33,21 @@ using namespace ::chip::Controller;
 CHIP_ERROR PairingCommand::RunCommand()
 {
     CurrentCommissioner().RegisterPairingDelegate(this);
+    // Clear the CATs in OperationalCredentialsIssuer
+    mCredIssuerCmds->SetCredentialIssuerCATValues(kUndefinedCATs);
+
+    if (mCASEAuthTags.HasValue() && mCASEAuthTags.Value().size() <= kMaxSubjectCATAttributeCount)
+    {
+        CATValues cats = kUndefinedCATs;
+        for (size_t index = 0; index < mCASEAuthTags.Value().size(); ++index)
+        {
+            cats.values[index] = mCASEAuthTags.Value()[index];
+        }
+        if (cats.AreValid())
+        {
+            mCredIssuerCmds->SetCredentialIssuerCATValues(cats);
+        }
+    }
     return RunInternal(mNodeId);
 }
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -64,6 +64,7 @@ public:
         AddArgument("bypass-attestation-verifier", 0, 1, &mBypassAttestationVerifier,
                     "Bypass the attestation verifier. If not provided or false, the attestation verifier is not bypassed."
                     " If true, the commissioning will continue in case of attestation verification failure.");
+        AddArgument("case-auth-tags", 1, UINT32_MAX, &mCASEAuthTags, "The CATs to be encoded in the NOC sent to the commissionee");
 
         switch (networkType)
         {
@@ -188,6 +189,7 @@ private:
     chip::Optional<bool> mPaseOnly;
     chip::Optional<bool> mSkipCommissioningComplete;
     chip::Optional<bool> mBypassAttestationVerifier;
+    chip::Optional<std::vector<uint32_t>> mCASEAuthTags;
     uint16_t mRemotePort;
     uint16_t mDiscriminator;
     uint32_t mSetupPINCode;

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -374,7 +374,7 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChain(const ByteSpan 
     MutableByteSpan rcacSpan(rcac.Get(), kMaxDERCertLength);
 
     ReturnErrorOnFailure(
-        GenerateNOCChainAfterValidation(assignedId, mNextFabricId, chip::kUndefinedCATs, pubkey, rcacSpan, icacSpan, nocSpan));
+        GenerateNOCChainAfterValidation(assignedId, mNextFabricId, mNextCATs, pubkey, rcacSpan, icacSpan, nocSpan));
 
     // TODO(#13825): Should always generate some IPK. Using a temporary fixed value until APIs are plumbed in to set it end-to-end
     // TODO: Force callers to set IPK if used before GenerateNOCChain will succeed.

--- a/src/controller/ExampleOperationalCredentialsIssuer.h
+++ b/src/controller/ExampleOperationalCredentialsIssuer.h
@@ -69,6 +69,8 @@ public:
 
     void SetFabricIdForNextNOCRequest(FabricId fabricId) override { mNextFabricId = fabricId; }
 
+    void SetCATValuesForNextNOCRequest(CATValues cats) { mNextCATs = cats; }
+
     /**
      * @brief Initialize the issuer with the keypair in the storage.
      *        If the storage doesn't have one, it'll create one, and it to the storage.
@@ -123,6 +125,7 @@ private:
 
     NodeId mNextRequestedNodeId = 1;
     FabricId mNextFabricId      = 1;
+    CATValues mNextCATs         = kUndefinedCATs;
     bool mNodeIdRequested       = false;
     uint64_t mIndex             = 0;
 };


### PR DESCRIPTION
### Problem

We always send the NOC without CATs when we are pairing the devices. We should have a method to set the CATs attribute of the NOC sent to the commissionee.

### Solution

* Add interface for setting CATs in ExampleOperationalCredentialsIssuer
* Add CATs to commissioning parameters

### Test

```
# pairing the light
./chip-tool pairing ble-wifi 1 ssid password 20202021 3840

# pairing the light switch with CATs 
./chip-tool pairing ble-wifi 2 ssid password 20202021 3840 --case-auth-tags 0xABCD0001,0xDCBA0002

# binding the light the the switch
./chip-tool binding write binding '[{"fabricIndex": 1, "node":1, "endpoint":1, "cluster":6}]' 2 1

# the control should fail since the switch does not have the access for light

# add the CAT to the ACL of the light
./chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [112233, 18446744063706988545], "targets":null}]' 1 0

# the control should success now
```