### PR TITLE
Add a timer to track whether we have received BDX init after a query on Darwin

### DIFF
--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -669,7 +669,6 @@ void MTROTAProviderDelegateBridge::HandleQueryImage(
                       } else {
                           handler->AddResponse(cachedCommandPath, response);
                       }
-                      handler->AddResponse(cachedCommandPath, response);
                       handle.Release();
                       gOtaSender.ResetState();
                   }

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -664,7 +664,7 @@ void MTROTAProviderDelegateBridge::HandleQueryImage(
                       if (!isBDXProtocolSupported) {
                           Commands::QueryImageResponse::Type protocolNotSupportedResponse;
                           protocolNotSupportedResponse.status
-                              = static_cast<OTAQueryStatus>(MTROTASoftwareUpdateProviderOTAQueryStatusBusy);
+                              = static_cast<OTAQueryStatus>(MTROTASoftwareUpdateProviderOTAQueryStatusDownloadProtocolNotSupported);
                           handler->AddResponse(cachedCommandPath, protocolNotSupportedResponse);
                       } else {
                           handler->AddResponse(cachedCommandPath, response);

--- a/src/protocols/bdx/TransferFacilitator.cpp
+++ b/src/protocols/bdx/TransferFacilitator.cpp
@@ -102,6 +102,7 @@ CHIP_ERROR Responder::PrepareForTransfer(System::Layer * layer, TransferRole rol
 
     mPollFreq    = pollFreq;
     mSystemLayer = layer;
+    mStopPolling = false;
 
     ReturnErrorOnFailure(mTransfer.WaitForTransfer(role, xferControlOpts, maxBlockSize, timeout));
 

--- a/src/protocols/bdx/TransferFacilitator.cpp
+++ b/src/protocols/bdx/TransferFacilitator.cpp
@@ -112,6 +112,7 @@ CHIP_ERROR Responder::PrepareForTransfer(System::Layer * layer, TransferRole rol
 void Responder::ResetTransfer()
 {
     mTransfer.Reset();
+    mStopPolling = true;
 }
 
 CHIP_ERROR Initiator::InitiateTransfer(System::Layer * layer, TransferRole role, const TransferSession::TransferInitData & initData,


### PR DESCRIPTION
…image was successful

- Currently if an ota requester has a successful query image and an image it available but if for any reason, the ota requester doesn't send BDX init, the provider will be stuck until we reboot the resident. In order to have a fail safe, we are adding a timer that starts after query image returns image available and waits for a BDX init to come. In case BDX init doesn't come, it times out and resets state

- Add code to reset state if any API fails on the provider once we prepare for BDX transfer

- Stop polling when BDX transfer reset is called

- Return QueryImageResponse status busy instead of general failure if the sdk is busy and gets a sexond query image so accessory can handle the error correctly and retry until the sdk is done

Fixes #24679 

