### PR TITLE
Fix some typos related to the readEvent command in Test_TC_ACL_2_7.yaml, Test_TC_ACL_2_8.yaml and Test_TC_ACL_2_10.yaml

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_ACL_2_10.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_10.yaml
@@ -112,15 +112,15 @@ tests:
           value:
               [
                   {
-                      Privilege: "5",
-                      AuthMode: "2",
+                      Privilege: 5,
+                      AuthMode: 2,
                       Subjects: [TH1CommissionerNodeId, 1111],
                       Targets: null,
                       FabricIndex: TH1FabricIndex,
                   },
                   {
-                      Privilege: "3",
-                      AuthMode: "3",
+                      Privilege: 3,
+                      AuthMode: 3,
                       Subjects: [3333],
                       Targets: null,
                       FabricIndex: TH1FabricIndex,
@@ -137,15 +137,15 @@ tests:
           value:
               [
                   {
-                      Privilege: "5",
-                      AuthMode: "2",
+                      Privilege: 5,
+                      AuthMode: 2,
                       Subjects: [TH2CommissionerNodeId, 2222],
                       Targets: null,
                       FabricIndex: TH2FabricIndex,
                   },
                   {
-                      Privilege: "3",
-                      AuthMode: "3",
+                      Privilege: 3,
+                      AuthMode: 3,
                       Subjects: [4444],
                       Targets: null,
                       FabricIndex: TH2FabricIndex,
@@ -217,15 +217,15 @@ tests:
           value:
               [
                   {
-                      Privilege: "5",
-                      AuthMode: "2",
+                      Privilege: 5,
+                      AuthMode: 2,
                       Subjects: [TH1CommissionerNodeId, 1111],
                       Targets: null,
                       FabricIndex: TH1FabricIndex,
                   },
                   {
-                      Privilege: "3",
-                      AuthMode: "3",
+                      Privilege: 3,
+                      AuthMode: 3,
                       Subjects: [3333],
                       Targets: null,
                       FabricIndex: TH1FabricIndex,
@@ -252,15 +252,15 @@ tests:
           value:
               [
                   {
-                      Privilege: "5",
-                      AuthMode: "2",
+                      Privilege: 5,
+                      AuthMode: 2,
                       Subjects: [TH2CommissionerNodeId, 2222],
                       Targets: null,
                       FabricIndex: TH2FabricIndex,
                   },
                   {
-                      Privilege: "3",
-                      AuthMode: "3",
+                      Privilege: 3,
+                      AuthMode: 3,
                       Subjects: [4444],
                       Targets: null,
                       FabricIndex: TH2FabricIndex,
@@ -311,15 +311,15 @@ tests:
           value:
               [
                   {
-                      Privilege: "5",
-                      AuthMode: "2",
+                      Privilege: 5,
+                      AuthMode: 2,
                       Subjects: [TH1CommissionerNodeId, 1111],
                       Targets: null,
                       FabricIndex: TH1FabricIndex,
                   },
                   {
-                      Privilege: "3",
-                      AuthMode: "3",
+                      Privilege: 3,
+                      AuthMode: 3,
                       Subjects: [3333],
                       Targets: null,
                       FabricIndex: TH1FabricIndex,

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_7.yaml
@@ -144,16 +144,14 @@ tests:
       event: "AccessControlExtensionChanged"
       response:
           value:
-              [
-                  {
-                      AdminNodeID: TH1CommissionerNodeId,
-                      AdminPasscodeID: null,
-                      ChangeType: 1,
-                      LatestValue:
-                          { Data: D_OK_EMPTY, FabricIndex: TH1FabricIndex },
-                  },
+              {
+                  AdminNodeID: TH1CommissionerNodeId,
+                  AdminPasscodeID: null,
+                  ChangeType: 1,
+                  LatestValue:
+                      { Data: D_OK_EMPTY, FabricIndex: TH1FabricIndex },
                   FabricIndex: TH1FabricIndex,
-              ]
+              }
 
     - label:
           "Step 11:TH2 reads DUT Endpoint 0 AccessControl cluster
@@ -164,13 +162,11 @@ tests:
       event: "AccessControlExtensionChanged"
       response:
           value:
-              [
-                  {
-                      AdminNodeID: TH2CommissionerNodeId,
-                      AdminPasscodeID: null,
-                      ChangeType: 1,
-                      LatestValue:
-                          { Data: D_OK_SINGLE, FabricIndex: TH2FabricIndex },
-                  },
+              {
+                  AdminNodeID: TH2CommissionerNodeId,
+                  AdminPasscodeID: null,
+                  ChangeType: 1,
+                  LatestValue:
+                      { Data: D_OK_SINGLE, FabricIndex: TH2FabricIndex },
                   FabricIndex: TH2FabricIndex,
-              ]
+              }

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_8.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_8.yaml
@@ -172,8 +172,8 @@ tests:
                           ChangeType: 1,
                           LatestValue:
                               {
-                                  Privilege: "5",
-                                  AuthMode: "2",
+                                  Privilege: 5,
+                                  AuthMode: 2,
                                   Subjects: [TH1CommissionerNodeId],
                                   Targets: null,
                                   FabricIndex: TH1FabricIndex,
@@ -188,8 +188,8 @@ tests:
                           ChangeType: 2,
                           LatestValue:
                               {
-                                  Privilege: "5",
-                                  AuthMode: "2",
+                                  Privilege: 5,
+                                  AuthMode: 2,
                                   Subjects: [TH1CommissionerNodeId],
                                   Targets: null,
                                   FabricIndex: TH1FabricIndex,
@@ -204,8 +204,8 @@ tests:
                           ChangeType: 1,
                           LatestValue:
                               {
-                                  Privilege: "5",
-                                  AuthMode: "2",
+                                  Privilege: 5,
+                                  AuthMode: 2,
                                   Subjects: [TH1CommissionerNodeId, 1111],
                                   Targets: null,
                                   FabricIndex: TH1FabricIndex,
@@ -229,8 +229,8 @@ tests:
                           ChangeType: 1,
                           LatestValue:
                               {
-                                  Privilege: "5",
-                                  AuthMode: "2",
+                                  Privilege: 5,
+                                  AuthMode: 2,
                                   Subjects: [TH2CommissionerNodeId],
                                   Targets: null,
                                   FabricIndex: TH2FabricIndex,
@@ -245,8 +245,8 @@ tests:
                           ChangeType: 2,
                           LatestValue:
                               {
-                                  Privilege: "5",
-                                  AuthMode: "2",
+                                  Privilege: 5,
+                                  AuthMode: 2,
                                   Subjects: [TH2CommissionerNodeId],
                                   Targets: null,
                                   FabricIndex: TH2FabricIndex,
@@ -261,8 +261,8 @@ tests:
                           ChangeType: 1,
                           LatestValue:
                               {
-                                  Privilege: "5",
-                                  AuthMode: "2",
+                                  Privilege: 5,
+                                  AuthMode: 2,
                                   Subjects: [TH2CommissionerNodeId, 2222],
                                   Targets: null,
                                   FabricIndex: TH2FabricIndex,


### PR DESCRIPTION
#### Problem

In `Test_TC_ACL_2_7.yaml` the `value` field is not correctly written. It prevents codegen.
In `Test_TC_ACL_2_8.yaml` and `Test_TC_ACL_2_10.yaml`  the `privilege` and `authMode` fields uses strings instead of numbers. This is fine for the codegen version, but does not fit well with the python runtime version.