### PR TITLE
[matter_yamltests] Remove support for generic success/error messages

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -580,13 +580,7 @@ class TestStep:
 
         expected_error = self.response.get('error') if self.response else None
 
-        # Handle generic success/error
-        if type(response) is str and response == 'failure':
-            received_error = response
-        elif type(response) is str and response == 'success':
-            received_error = None
-        else:
-            received_error = response.get('error')
+        received_error = response.get('error')
 
         if expected_error and received_error and expected_error == received_error:
             result.success(check_type, error_success.format(

--- a/src/controller/python/chip/yaml/runner.py
+++ b/src/controller/python/chip/yaml/runner.py
@@ -654,8 +654,8 @@ class ReplTestRunner:
         if result.response is None:
             # TODO Once yamltest and idl python packages are properly packaged as a single module
             # the type we are returning will be formalized. For now TestStep.post_process_response
-            # expects this particular case to be sent as a string.
-            return 'success' if result.status == _ActionStatus.SUCCESS else 'failure'
+            # expects this particular case to be sent an empty dict or a dict with an error.
+            return {} if result.status == _ActionStatus.SUCCESS else {'error': 'FAILURE'}
 
         response = result.response
 


### PR DESCRIPTION
#### Problem

Instead of using strings and making exceptions for "generic" success/error, this just pass objects around. It make it simpler to update the code related to response handling at the end...