### PR TITLE
[chip-tool] Add missing RemoteDataModelLogger::LogEventAsJson call

### DIFF
--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -85,6 +85,8 @@ public:
             return;
         }
 
+        ReturnOnFailure(RemoteDataModelLogger::LogEventAsJSON(eventHeader, data));
+
         CHIP_ERROR error = DataModelLogger::LogEvent(eventHeader, data);
         if (CHIP_NO_ERROR != error)
         {


### PR DESCRIPTION
#### Problem


`Events` are not logged and forwarded over the wire by the `RemoteDataModelLogger`. This PR just add the missing line...

