### PR TITLE
[matter_yamltest / chip-repl] Disable Test_TC_OO_2_4 because it seems…

### DIFF
--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -88,6 +88,7 @@ def _GetManualTests() -> Set[ManualTest]:
     manualtests.add(ManualTest(yaml="Test_TC_MEDIAPLAYBACK_6_2.yaml", reason="TODO"))
     manualtests.add(ManualTest(yaml="Test_TC_MEDIAPLAYBACK_6_3.yaml", reason="TODO"))
     manualtests.add(ManualTest(yaml="Test_TC_MEDIAPLAYBACK_6_4.yaml", reason="TODO"))
+    manualtests.add(ManualTest(yaml="Test_TC_OO_2_4.yaml", reason="Flaky"))
     manualtests.add(ManualTest(yaml="Test_TC_PCC_2_1.yaml", reason="TODO"))
     manualtests.add(ManualTest(yaml="Test_TC_PS_2_1.yaml", reason="TODO"))
     manualtests.add(ManualTest(yaml="Test_TC_SC_5_1.yaml", reason="TODO"))


### PR DESCRIPTION
… flaky

#### Problem

The test seems to fails times to times for unrelated changes. Some examples of such failures are: 
 * https://github.com/project-chip/connectedhomeip/actions/runs/4063114764/jobs/6998035822
 * https://github.com/project-chip/connectedhomeip/actions/runs/4062889692/jobs/6994472945
