### PR TITLE
Only update placeholder if pics is enabled

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -401,12 +401,13 @@ class TestStep:
         self._runtime_config_variable_storage = runtime_config_variable_storage
         self.arguments = copy.deepcopy(test.arguments_with_placeholders)
         self.response = copy.deepcopy(test.response_with_placeholders)
-        self._update_placeholder_values(self.arguments)
-        self._update_placeholder_values(self.response)
-        self._test.node_id = self._config_variable_substitution(
-            self._test.node_id)
-        test.update_arguments(self.arguments)
-        test.update_response(self.response)
+        if test.is_pics_enabled:
+            self._update_placeholder_values(self.arguments)
+            self._update_placeholder_values(self.response)
+            self._test.node_id = self._config_variable_substitution(
+                self._test.node_id)
+            test.update_arguments(self.arguments)
+            test.update_response(self.response)
 
     @property
     def is_enabled(self):


### PR DESCRIPTION
For test like Test_TC_TSTAT_2_1 there are test steps like saving a variable and then using that are only run if a particular PICS code is provided. When the test step is disabled due to PICS code not being provided, we would not be able to substitute the variable placeholder value causing an issue inside `_update_placeholder_values`. Now we only perform placeholder value update if pics is enabled