### PR TITLE
Fix missing cases in some door lock switch statements.

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server-callback.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-callback.cpp
@@ -195,3 +195,39 @@ emberAfPluginDoorLockSetSchedule(chip::EndpointId endpointId, uint8_t holidayInd
 void __attribute__((weak))
 emberAfPluginDoorLockLockoutStarted(chip::EndpointId endpointId, chip::System::Clock::Timestamp lockoutEndTime)
 {}
+
+bool __attribute__((weak))
+emberAfPluginDoorLockGetNumberOfFingerprintCredentialsSupported(chip::EndpointId endpointId, uint16_t & maxNumberOfCredentials)
+{
+    return false;
+}
+
+bool __attribute__((weak))
+emberAfPluginDoorLockGetNumberOfFingerVeinCredentialsSupported(chip::EndpointId endpointId, uint16_t & maxNumberOfCredentials)
+{
+    return false;
+}
+
+bool __attribute__((weak))
+emberAfPluginDoorLockGetNumberOfFaceCredentialsSupported(chip::EndpointId endpointId, uint16_t & maxNumberOfCredentials)
+{
+    return false;
+}
+
+bool __attribute__((weak))
+emberAfPluginDoorLockGetFingerprintCredentialLengthConstraints(chip::EndpointId endpointId, uint8_t & minLen, uint8_t & maxLen)
+{
+    return false;
+}
+
+bool __attribute__((weak))
+emberAfPluginDoorLockGetFingerVeinCredentialLengthConstraints(chip::EndpointId endpointId, uint8_t & minLen, uint8_t & maxLen)
+{
+    return false;
+}
+
+bool __attribute__((weak))
+emberAfPluginDoorLockGetFaceCredentialLengthConstraints(chip::EndpointId endpointId, uint8_t & minLen, uint8_t & maxLen)
+{
+    return false;
+}

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -1457,6 +1457,15 @@ DlStatus DoorLockServer::credentialLengthWithinRange(chip::EndpointId endpointId
         statusMin = GetAttribute(endpointId, Attributes::MinRFIDCodeLength::Id, Attributes::MinRFIDCodeLength::Get, minLen);
         statusMax = GetAttribute(endpointId, Attributes::MaxRFIDCodeLength::Id, Attributes::MaxRFIDCodeLength::Get, maxLen);
         break;
+    case CredentialTypeEnum::kFingerprint:
+        statusMin = statusMax = emberAfPluginDoorLockGetFingerprintCredentialLengthConstraints(endpointId, minLen, maxLen);
+        break;
+    case CredentialTypeEnum::kFingerVein:
+        statusMin = statusMax = emberAfPluginDoorLockGetFingerVeinCredentialLengthConstraints(endpointId, minLen, maxLen);
+        break;
+    case CredentialTypeEnum::kFace:
+        statusMin = statusMax = emberAfPluginDoorLockGetFaceCredentialLengthConstraints(endpointId, minLen, maxLen);
+        break;
     default:
         return DlStatus::kFailure;
     }
@@ -1495,6 +1504,15 @@ bool DoorLockServer::getMaxNumberOfCredentials(chip::EndpointId endpointId, Cred
         break;
     case CredentialTypeEnum::kRfid:
         status = GetNumberOfRFIDCredentialsSupported(endpointId, maxNumberOfCredentials);
+        break;
+    case CredentialTypeEnum::kFingerprint:
+        status = emberAfPluginDoorLockGetNumberOfFingerprintCredentialsSupported(endpointId, maxNumberOfCredentials);
+        break;
+    case CredentialTypeEnum::kFingerVein:
+        status = emberAfPluginDoorLockGetNumberOfFingerVeinCredentialsSupported(endpointId, maxNumberOfCredentials);
+        break;
+    case CredentialTypeEnum::kFace:
+        status = emberAfPluginDoorLockGetNumberOfFaceCredentialsSupported(endpointId, maxNumberOfCredentials);
         break;
     default:
         return false;
@@ -2391,6 +2409,11 @@ bool DoorLockServer::credentialTypeSupported(chip::EndpointId endpointId, Creden
         return SupportsPIN(endpointId);
     case CredentialTypeEnum::kRfid:
         return SupportsRFID(endpointId);
+    case CredentialTypeEnum::kFingerprint:
+    case CredentialTypeEnum::kFingerVein:
+        return SupportsFingers(endpointId);
+    case CredentialTypeEnum::kFace:
+        return SupportsFace(endpointId);
     default:
         return false;
     }

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -992,3 +992,83 @@ bool emberAfPluginDoorLockSetCredential(chip::EndpointId endpointId, uint16_t cr
  * @param lockoutEndTime Monotonic time of when lockout ends.
  */
 void emberAfPluginDoorLockLockoutStarted(chip::EndpointId endpointId, chip::System::Clock::Timestamp lockoutEndTime);
+
+/**
+ * @brief This callback is called when the Door Lock server needs to find out
+ * the number of Fingerprint credentials supported, since there is no attribute
+ * that represents that value.
+ *
+ * @param[in] endpointId ID of the endpoint that contains the door lock.
+ * @param[out] maxNumberOfCredentials the number of Fingerprint credentials supported by the lock.
+ *
+ * @return false on failure, true on success.  On failure, the cluster
+ * implementation will assume that 0 Fingerprint credentials are supported.
+ */
+bool emberAfPluginDoorLockGetNumberOfFingerprintCredentialsSupported(chip::EndpointId endpointId,
+                                                                     uint16_t & maxNumberOfCredentials);
+
+/**
+ * @brief This callback is called when the Door Lock server needs to find out
+ * the number of FingerVein credentials supported, since there is no attribute
+ * that represents that value.
+ *
+ * @param[in] endpointId ID of the endpoint that contains the door lock.
+ * @param[out] maxNumberOfCredentials the number of FingerVein credentials supported by the lock.
+ *
+ * @return false on failure, true on success.  On failure, the cluster
+ * implementation will assume that 0 FingerVein credentials are supported.
+ */
+bool emberAfPluginDoorLockGetNumberOfFingerVeinCredentialsSupported(chip::EndpointId endpointId, uint16_t & maxNumberOfCredentials);
+
+/**
+ * @brief This callback is called when the Door Lock server needs to find out
+ * the number of Face credentials supported, since there is no attribute
+ * that represents that value.
+ *
+ * @param[in] endpointId ID of the endpoint that contains the door lock.
+ * @param[out] maxNumberOfCredentials the number of Face credentials supported by the lock.
+ *
+ * @return false on failure, true on success.  On failure, the cluster
+ * implementation will assume that 0 Face credentials are supported.
+ */
+bool emberAfPluginDoorLockGetNumberOfFaceCredentialsSupported(chip::EndpointId endpointId, uint16_t & maxNumberOfCredentials);
+
+/**
+ * @brief This callback is called when the Door Lock server needs to find out
+ * the min and max lengths of Fingerprint credentials supported, since there are no
+ * attributes that represents those values.
+ *
+ * @param[in] endpointId ID of the endpoint that contains the door lock.
+ * @param[out] minLen the minimal length, in bytes, of a Fingerprint credential supported by the lock.
+ * @param[out] maxLen the minimal length, in bytes, of a Fingerprint credential supported by the lock.
+ *
+ * @return false on failure, true on success.
+ */
+bool emberAfPluginDoorLockGetFingerprintCredentialLengthConstraints(chip::EndpointId endpointId, uint8_t & minLen,
+                                                                    uint8_t & maxLen);
+
+/**
+ * @brief This callback is called when the Door Lock server needs to find out
+ * the min and max lengths of FingerVein credentials supported, since there are no
+ * attributes that represents those values.
+ *
+ * @param[in] endpointId ID of the endpoint that contains the door lock.
+ * @param[out] minLen the minimal length, in bytes, of a FingerVein credential supported by the lock.
+ * @param[out] maxLen the minimal length, in bytes, of a FingerVein credential supported by the lock.
+ *
+ * @return false on failure, true on success.
+ */
+bool emberAfPluginDoorLockGetFingerVeinCredentialLengthConstraints(chip::EndpointId endpointId, uint8_t & minLen, uint8_t & maxLen);
+
+/**
+ * @brief This callback is called when the Door Lock server needs to find out
+ * the min and max lengths of Face credentials supported, since there are no
+ * attributes that represents those values.
+ *
+ * @param[in] endpointId ID of the endpoint that contains the door lock.
+ * @param[out] minLen the minimal length, in bytes, of a Face credential supported by the lock.
+ * @param[out] maxLen the minimal length, in bytes, of a Face credential supported by the lock.
+ *
+ * @return false on failure, true on success.
+ */
+bool emberAfPluginDoorLockGetFaceCredentialLengthConstraints(chip::EndpointId endpointId, uint8_t & minLen, uint8_t & maxLen);


### PR DESCRIPTION
Some credential types were missing from switch statements in door lock cluster server code, so we did not handle those credentials correctly.


