### PR TITLE
Fix crash if chip-tool gets an error status response.

### DIFF
--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -144,6 +144,8 @@ CHIP_ERROR LogErrorAsJSON(const chip::app::EventHeader & header, const chip::app
 
 CHIP_ERROR LogErrorAsJSON(const CHIP_ERROR & error)
 {
+    VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
+
     Json::Value value;
     chip::app::StatusIB status;
     status.InitFromChipError(error);


### PR DESCRIPTION
We are trying to do JSON logging without a delegate in that case.


