### PR TITLE
Fix OnOff GlobalSceneControl incorrect state change 

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -761,15 +761,14 @@ static EmberAfStatus moveToLevelHandler(EndpointId endpoint, CommandId commandId
     schedule(endpoint, computeCallbackWaitTimeMs(state->callbackSchedule, state->eventDurationMs));
     status = EMBER_ZCL_STATUS_SUCCESS;
 
-    if (commandId == Commands::MoveToLevelWithOnOff::Id)
+#ifdef EMBER_AF_PLUGIN_ON_OFF
+    // Check that the received MoveToLevelWithOnOff produces a On action and that the onoff support the lighting featuremap
+    if (commandId == Commands::MoveToLevelWithOnOff::Id && state->moveToLevel != state->minLevel &&
+        OnOffServer::Instance().SupportsLightingApplications(endpoint))
     {
-        uint32_t featureMap;
-        if (Attributes::FeatureMap::Get(endpoint, &featureMap) == EMBER_ZCL_STATUS_SUCCESS &&
-            READBITS(featureMap, EMBER_AF_LEVEL_CONTROL_FEATURE_LIGHTING))
-        {
-            OnOff::Attributes::GlobalSceneControl::Set(endpoint, true);
-        }
+        OnOff::Attributes::GlobalSceneControl::Set(endpoint, true);
     }
+#endif // EMBER_AF_PLUGIN_ON_OFF
 
     return status;
 }


### PR DESCRIPTION
This PR Fixes #24638
MoveToLevelWithOnOff should only set the GlobalSceneControl to true if it produced a On action when the on off feature map cluster indicate the lighting feature.

The wrong cluster's featuremap was also verified. The command is from the level cluster but the GlobalSceneControl attributes is enable with to the onoff ligthing featuremap.

Tested using the lighting app on efr32 and the chip-tool tests Test_TC_OO_2_3
`[1675282792.995858][398020:398025] CHIP:TOO:  **** Test Complete: Test_TC_OO_2_3`