### PR TITLE
Allow checking constraint type by struct name

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/constraints.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/constraints.py
@@ -32,7 +32,7 @@ class BaseConstraint(ABC):
         self._types = types
         self._is_null_allowed = is_null_allowed
 
-    def is_met(self, value):
+    def is_met(self, value, value_type_name):
         if value is None:
             return self._is_null_allowed
 
@@ -43,10 +43,10 @@ class BaseConstraint(ABC):
             if not found_type_match:
                 return False
 
-        return self.check_response(value)
+        return self.check_response(value, value_type_name)
 
     @abstractmethod
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         pass
 
 
@@ -55,13 +55,13 @@ class _ConstraintHasValue(BaseConstraint):
         super().__init__(types=[])
         self._has_value = has_value
 
-    def is_met(self, value):
+    def is_met(self, value, value_type_name):
         # We are overriding the BaseConstraint of is_met since has value is a special case where
         # we might not be expecting a value at all, but the basic null check in BaseConstraint
         # is not what we want.
-        return self.check_response(value)
+        return self.check_response(value, value_type_name)
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         has_value = value is not None
         return self._has_value == has_value
 
@@ -71,7 +71,7 @@ class _ConstraintType(BaseConstraint):
         super().__init__(types=[], is_null_allowed=True)
         self._type = type
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         success = False
         if self._type == 'boolean' and type(value) is bool:
             success = True
@@ -195,6 +195,8 @@ class _ConstraintType(BaseConstraint):
             success = value >= -36028797018963967 and value <= 36028797018963967
         elif self._type == 'nullable_int64s' and type(value) is int:
             success = value >= -9223372036854775807 and value <= 9223372036854775807
+        else:
+            success = self._type == value_type_name
         return success
 
 
@@ -203,7 +205,7 @@ class _ConstraintMinLength(BaseConstraint):
         super().__init__(types=[str, bytes, list])
         self._min_length = min_length
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         return len(value) >= self._min_length
 
 
@@ -212,7 +214,7 @@ class _ConstraintMaxLength(BaseConstraint):
         super().__init__(types=[str, bytes, list])
         self._max_length = max_length
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         return len(value) <= self._max_length
 
 
@@ -221,7 +223,7 @@ class _ConstraintIsHexString(BaseConstraint):
         super().__init__(types=[str])
         self._is_hex_string = is_hex_string
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         return all(c in string.hexdigits for c in value) == self._is_hex_string
 
 
@@ -230,7 +232,7 @@ class _ConstraintStartsWith(BaseConstraint):
         super().__init__(types=[str])
         self._starts_with = starts_with
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         return value.startswith(self._starts_with)
 
 
@@ -239,7 +241,7 @@ class _ConstraintEndsWith(BaseConstraint):
         super().__init__(types=[str])
         self._ends_with = ends_with
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         return value.endswith(self._ends_with)
 
 
@@ -248,7 +250,7 @@ class _ConstraintIsUpperCase(BaseConstraint):
         super().__init__(types=[str])
         self._is_upper_case = is_upper_case
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         return value.isupper() == self._is_upper_case
 
 
@@ -257,7 +259,7 @@ class _ConstraintIsLowerCase(BaseConstraint):
         super().__init__(types=[str])
         self._is_lower_case = is_lower_case
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         return value.islower() == self._is_lower_case
 
 
@@ -266,7 +268,7 @@ class _ConstraintMinValue(BaseConstraint):
         super().__init__(types=[int, float], is_null_allowed=True)
         self._min_value = min_value
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         return value >= self._min_value
 
 
@@ -275,7 +277,7 @@ class _ConstraintMaxValue(BaseConstraint):
         super().__init__(types=[int, float], is_null_allowed=True)
         self._max_value = max_value
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         return value <= self._max_value
 
 
@@ -284,7 +286,7 @@ class _ConstraintContains(BaseConstraint):
         super().__init__(types=[list])
         self._contains = contains
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         return set(self._contains).issubset(value)
 
 
@@ -293,7 +295,7 @@ class _ConstraintExcludes(BaseConstraint):
         super().__init__(types=[list])
         self._excludes = excludes
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         return set(self._excludes).isdisjoint(value)
 
 
@@ -302,7 +304,7 @@ class _ConstraintHasMaskSet(BaseConstraint):
         super().__init__(types=[int])
         self._has_masks_set = has_masks_set
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         return all([(value & mask) == mask for mask in self._has_masks_set])
 
 
@@ -311,7 +313,7 @@ class _ConstraintHasMaskClear(BaseConstraint):
         super().__init__(types=[int])
         self._has_masks_clear = has_masks_clear
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         return all([(value & mask) == 0 for mask in self._has_masks_clear])
 
 
@@ -320,7 +322,7 @@ class _ConstraintNotValue(BaseConstraint):
         super().__init__(types=[], is_null_allowed=True)
         self._not_value = not_value
 
-    def check_response(self, value) -> bool:
+    def check_response(self, value, value_type_name) -> bool:
         return value != self._not_value
 
 

--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -233,6 +233,7 @@ class _TestStepWithPlaceholders:
 
         argument_mapping = None
         response_mapping = None
+        response_mapping_name = None
 
         if self.is_attribute:
             attribute = definitions.get_attribute_by_name(
@@ -242,6 +243,7 @@ class _TestStepWithPlaceholders:
                                                      attribute.definition.data_type.name)
                 argument_mapping = attribute_mapping
                 response_mapping = attribute_mapping
+                response_mapping_name = attribute.definition.data_type.name
         else:
             command = definitions.get_command_by_name(
                 self.cluster, self.command)
@@ -250,9 +252,11 @@ class _TestStepWithPlaceholders:
                     definitions, self.cluster, command.input_param)
                 response_mapping = self._as_mapping(
                     definitions, self.cluster, command.output_param)
+                response_mapping_name = command.output_param
 
         self.argument_mapping = argument_mapping
         self.response_mapping = response_mapping
+        self.response_mapping_name = response_mapping_name
         self.update_arguments(self.arguments_with_placeholders)
         self.update_response(self.response_with_placeholders)
 
@@ -677,6 +681,7 @@ class TestStep:
         error_success = 'Constraints check passed'
         error_failure = 'Constraints check failed'
 
+        response_type_name = self._test.response_mapping_name
         for value in self.response['values']:
             if 'constraints' not in value:
                 continue
@@ -684,6 +689,8 @@ class TestStep:
             received_value = response.get('value')
             if not self.is_attribute:
                 expected_name = value.get('name')
+                response_type_name = self._test.response_mapping.get(
+                    expected_name)
                 if received_value is None or expected_name not in received_value:
                     received_value = None
                 else:
@@ -692,7 +699,7 @@ class TestStep:
 
             constraints = get_constraints(value['constraints'])
 
-            if all([constraint.is_met(received_value) for constraint in constraints]):
+            if all([constraint.is_met(received_value, response_type_name) for constraint in constraints]):
                 result.success(check_type, error_success)
             else:
                 # TODO would be helpful to be more verbose here


### PR DESCRIPTION
For yaml tests list Test_TC_APBSC_9_1 and Test_TC_CHANNEL_5_3, they have a constraint type check and provide the string name of the struct type they are expecting. This add the functionality to be able to check that those struct string names match. This is to bring python based yamltest constraint checking more inline with codegen version
