### PR TITLE
Fix java-matter-controller crash when try to show command helper info

### DIFF
--- a/examples/java-matter-controller/java/src/com/matter/controller/Main.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/Main.java
@@ -112,9 +112,6 @@ public class Main {
 
     try {
       commandManager.run(args);
-    } catch (IllegalArgumentException e) {
-      logger.log(Level.INFO, "Arguments init failed with exception: " + e.getMessage());
-      System.exit(1);
     } catch (Exception e) {
       logger.log(Level.INFO, "Run command failed with exception: " + e.getMessage());
       System.exit(1);

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/common/CommandManager.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/common/CommandManager.java
@@ -96,8 +96,14 @@ public final class CommandManager {
     // need skip over binary and command name and only get arguments
     String[] temp = Arrays.copyOfRange(args, 2, args.length);
 
-    command.initArguments(temp.length, temp);
-    showCommand(args[0], command);
+    try {
+      command.initArguments(temp.length, temp);
+    } catch (IllegalArgumentException e) {
+      logger.log(Level.INFO, "Arguments init failed with exception: " + e.getMessage());
+      showCommand(args[0], command);
+      System.exit(1);
+    }
+
     command.run();
   }
 


### PR DESCRIPTION
When we try to show command helper info, such as: 
`java -Djava.library.path=out/linux-x64-java-matter-controller/lib/jni -jar out/linux-x64-java-matter-controller/bin/java-matter-controller pairing ethernet ?`

java-matter-controller crashed. With this fix

```
yufengw@yufengw:~/connectedhomeip$ java -Djava.library.path=out/linux-x64-java-matter-controller/lib/jni -jar out/linux-x64-java-matter-controller/bin/java-matter-controller pairing ethernet ?
INFO: Usage:
  java-matter-controller pairing ethernet node-id setup-pin-code discriminator device-remote-ip device-remote-port timeout [--paa-trust-store-path] [--cd-trust-store-path] [--commissioner-name] [--commissioner-nodeid] [--use-max-sized-certs] [--only-allow-trusted-cd-keys]
INFO: 
[--paa-trust-store-path]:
  Path to directory holding PAA certificate information.  Can be absolute or relative to the current working directory.

[--cd-trust-store-path]:
  Path to directory holding CD certificate information.  Can be absolute or relative to the current working directory.

[--commissioner-name]:
  Name of fabric to use. Valid values are "alpha", "beta", "gamma", and integers greater than or equal to 4.  The default if not specified is "alpha".

[--commissioner-nodeid]:
  The node id to use for java-matter-controller.  If not provided, kTestControllerNodeId (112233, 0x1B669) will be used.

[--use-max-sized-certs]:
  Maximize the size of operational certificates. If not provided or 0 ("false"), normally sized operational certificates are generated.

[--only-allow-trusted-cd-keys]:
  Only allow trusted CD verifying keys (disallow test keys). If not provided or 0 ("false"), untrusted CD verifying keys are allowed. If 1 ("true"), test keys are disallowed.

```




