### PR TITLE
Add namespace usage to fix android tv compile

### DIFF
--- a/examples/tv-app/android/java/AppImpl.cpp
+++ b/examples/tv-app/android/java/AppImpl.cpp
@@ -45,6 +45,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 
+using namespace app::Clusters;
 using namespace chip;
 using namespace chip::AppPlatform;
 using namespace chip::DeviceLayer;


### PR DESCRIPTION
Fixes errors like:

```
INFO    ../../examples/tv-app/android/java/AppImpl.cpp:89:27: error: use of undeclared identifier 'Descriptor'; did you mean 'app::Clusters::Descriptor'?
INFO    DECLARE_DYNAMIC_ATTRIBUTE(Descriptor::Attributes::DeviceTypeList::Id, ARRAY, kDescriptorAttributeArraySize, 0), /* device list */
INFO                              ^~~~~~~~~~
INFO                              app::Clusters::Descriptor
INFO    ../../examples/tv-app/android/third_party/connectedhomeip/src/app/util/attribute-storage.h:75:30: note: expanded from macro 'DECLARE_DYNAMIC_ATTRIBUTE'
INFO            ZAP_EMPTY_DEFAULT(), attId, attSizeBytes, ZAP_TYPE(attType), attrMask | ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE)               \
INFO                                 ^
INFO    ../../examples/tv-app/android/third_party/connectedhomeip/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h:378:11: note: 'app::Clusters::Descriptor' declared here
INFO    namespace Descriptor {
...
```