### PR TITLE
Improve error reporting in chip-tool when the wrong quotes are used.

### DIFF
--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -72,6 +72,35 @@ std::vector<std::string> GetArgumentsFromJson(Command * command, Json::Value & v
     return args;
 };
 
+// Check for arguments with a starting '"' but no ending '"': those
+// would indicate that people are using double-quoting, not single
+// quoting, on arguments with spaces.
+static void DetectAndLogMismatchedDoubleQuotes(int argc, char ** argv)
+{
+    for (int curArg = 0; curArg < argc; ++curArg)
+    {
+        char * arg = argv[curArg];
+        if (!arg)
+        {
+            continue;
+        }
+
+        auto len = strlen(arg);
+        if (len == 0)
+        {
+            continue;
+        }
+
+        if (arg[0] == '"' && arg[len - 1] != '"')
+        {
+            ChipLogError(chipTool,
+                         "Mismatched '\"' detected in argument: '%s'.  Use single quotes to delimit arguments with spaces "
+                         "in them: 'x y', not \"x y\".",
+                         arg);
+        }
+    }
+}
+
 } // namespace
 
 void Commands::Register(const char * clusterName, commands_list commandsList)
@@ -219,31 +248,7 @@ CHIP_ERROR Commands::RunCommand(int argc, char ** argv, bool interactive)
     {
         if (interactive)
         {
-            // Check for arguments with a starting '"' but no ending '"': those
-            // would indicate that people are using double-quoting, not single
-            // quoting, on arguments with spaces.
-            for (int curArg = argumentsPosition; curArg < argc - argumentsPosition; ++curArg)
-            {
-                char * arg = argv[curArg];
-                if (!arg)
-                {
-                    continue;
-                }
-
-                auto len = strlen(arg);
-                if (len == 0)
-                {
-                    continue;
-                }
-
-                if (arg[0] == '"' && arg[len - 1] != '"')
-                {
-                    ChipLogError(chipTool,
-                                 "Mismatched '\"' detected in argument: '%s'.  Use single quotes to delimit arguments with spaces "
-                                 "in them: 'x y', not \"x y\".",
-                                 arg);
-                }
-            }
+            DetectAndLogMismatchedDoubleQuotes(argc - argumentsPosition, &argv[argumentsPosition]);
         }
         ShowCommand(argv[0], argv[1], command);
         return CHIP_ERROR_INVALID_ARGUMENT;

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -217,6 +217,34 @@ CHIP_ERROR Commands::RunCommand(int argc, char ** argv, bool interactive)
     int argumentsPosition = isGlobalCommand ? 4 : 3;
     if (!command->InitArguments(argc - argumentsPosition, &argv[argumentsPosition]))
     {
+        if (interactive)
+        {
+            // Check for arguments with a starting '"' but no ending '"': those
+            // would indicate that people are using double-quoting, not single
+            // quoting, on arguments with spaces.
+            for (int curArg = argumentsPosition; curArg < argc - argumentsPosition; ++curArg)
+            {
+                char * arg = argv[curArg];
+                if (!arg)
+                {
+                    continue;
+                }
+
+                auto len = strlen(arg);
+                if (len == 0)
+                {
+                    continue;
+                }
+
+                if (arg[0] == '"' && arg[len - 1] != '"')
+                {
+                    ChipLogError(chipTool,
+                                 "Mismatched '\"' detected in argument: '%s'.  Use single quotes to delimit arguments with spaces "
+                                 "in them: 'x y', not \"x y\".",
+                                 arg);
+                }
+            }
+        }
         ShowCommand(argv[0], argv[1], command);
         return CHIP_ERROR_INVALID_ARGUMENT;
     }


### PR DESCRIPTION
In interactive mode, arguments are delimited by single quotes.  If our argument init fails, and we have arguments that include mismatched double quotes, there's a good chance the wrong quotes were used in the command, and we should log that.

