### PR TITLE
Import chip::app::Clusters instead of app::Clusters

### DIFF
--- a/examples/tv-app/android/java/AppImpl.cpp
+++ b/examples/tv-app/android/java/AppImpl.cpp
@@ -45,8 +45,8 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 
-using namespace app::Clusters;
 using namespace chip;
+using namespace chip::app::Clusters;
 using namespace chip::AppPlatform;
 using namespace chip::DeviceLayer;
 


### PR DESCRIPTION
Based on code review: https://github.com/project-chip/connectedhomeip/pull/24820#discussion_r1094699909
