### PR TITLE
Update to docker image 0.6.37

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -33,7 +33,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
 
         steps:
             - uses: Wandalen/wretry.action@v1.0.36

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
@@ -138,7 +138,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
@@ -298,7 +298,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
             options: --sysctl "net.ipv6.conf.all.disable_ipv6=0
@@ -455,7 +455,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -29,7 +29,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
             options: --user root
 
         steps:
@@ -57,7 +57,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-esp32:0.6.35
+            image: connectedhomeip/chip-build-esp32:0.6.37
             options: --user root
 
         steps:
@@ -85,7 +85,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-nrf-platform:0.6.35
+            image: connectedhomeip/chip-build-nrf-platform:0.6.37
             options: --user root
 
         steps:

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -38,7 +38,7 @@ jobs:
         # need to run with privilege, which isn't supported by job.XXX.contaner
         #  https://github.com/actions/container-action/issues/2
         #         container:
-        #             image: connectedhomeip/chip-build-cirque:0.6.35
+        #             image: connectedhomeip/chip-build-cirque:0.6.37
         #             volumes:
         #                 - "/tmp:/tmp"
         #                 - "/dev/pts:/dev/pts"

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -82,7 +82,7 @@ jobs:
 
         runs-on: ubuntu-20.04
         container:
-            image: connectedhomeip/chip-build-doxygen:0.6.35
+            image: connectedhomeip/chip-build-doxygen:0.6.37
 
         if: github.actor != 'restyled-io[bot]'
 

--- a/.github/workflows/examples-ameba.yaml
+++ b/.github/workflows/examples-ameba.yaml
@@ -35,7 +35,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-ameba:0.6.35
+            image: connectedhomeip/chip-build-ameba:0.6.37
             options: --user root
 
         steps:

--- a/.github/workflows/examples-bouffalolab.yaml
+++ b/.github/workflows/examples-bouffalolab.yaml
@@ -35,7 +35,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: connectedhomeip/chip-build-bouffalolab:0.6.35
+      image: connectedhomeip/chip-build-bouffalolab:0.6.37
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
     steps:

--- a/.github/workflows/examples-cc13x2x7_26x2x7.yaml
+++ b/.github/workflows/examples-cc13x2x7_26x2x7.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-ti:0.6.35
+            image: connectedhomeip/chip-build-ti:0.6.37
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -38,7 +38,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: connectedhomeip/chip-build-efr32:0.6.35
+      image: connectedhomeip/chip-build-efr32:0.6.37
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
     steps:

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-esp32:0.6.35
+            image: connectedhomeip/chip-build-esp32:0.6.37
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 
@@ -148,7 +148,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-esp32:0.6.35
+            image: connectedhomeip/chip-build-esp32:0.6.37
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -35,7 +35,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-infineon:0.6.35
+            image: connectedhomeip/chip-build-infineon:0.6.37
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-k32w:0.6.35
+            image: connectedhomeip/chip-build-k32w:0.6.37
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-crosscompile:0.6.35
+            image: connectedhomeip/chip-build-crosscompile:0.6.37
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-imx:0.6.35
+            image: connectedhomeip/chip-build-imx:0.6.37
 
         steps:
             - uses: Wandalen/wretry.action@v1.0.36

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -40,7 +40,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-mbed-os:0.6.35
+            image: connectedhomeip/chip-build-mbed-os:0.6.37
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-mw320.yaml
+++ b/.github/workflows/examples-mw320.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-nrf-platform:0.6.35
+            image: connectedhomeip/chip-build-nrf-platform:0.6.37
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-openiotsdk.yaml
+++ b/.github/workflows/examples-openiotsdk.yaml
@@ -35,7 +35,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-openiotsdk:0.6.35
+            image: connectedhomeip/chip-build-openiotsdk:0.6.37
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
             options: --privileged

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -35,7 +35,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-telink:0.6.35
+            image: connectedhomeip/chip-build-telink:0.6.37
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -33,7 +33,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-tizen:0.6.35
+            image: connectedhomeip/chip-build-tizen:0.6.37
             options: --user root
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-android:0.6.35
+            image: connectedhomeip/chip-build-android:0.6.37
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
 
         steps:
             - uses: Wandalen/wretry.action@v1.0.36

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-esp32-qemu:0.6.35
+            image: connectedhomeip/chip-build-esp32-qemu:0.6.37
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -29,7 +29,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-esp32:0.6.35
+            image: connectedhomeip/chip-build-esp32:0.6.37
 
         steps:
             - uses: Wandalen/wretry.action@v1.0.36
@@ -75,7 +75,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-efr32:0.6.35
+            image: connectedhomeip/chip-build-efr32:0.6.37
         steps:
             - uses: Wandalen/wretry.action@v1.0.36
               name: Checkout

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-android:0.6.35
+            image: connectedhomeip/chip-build-android:0.6.37
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,7 +47,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
 
@@ -377,7 +377,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=0 net.ipv6.conf.all.forwarding=0"
 
@@ -453,7 +453,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=0 net.ipv6.conf.all.forwarding=0"
 

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -37,7 +37,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"

--- a/.github/workflows/zap_regeneration.yaml
+++ b/.github/workflows/zap_regeneration.yaml
@@ -28,7 +28,7 @@ jobs:
 
         runs-on: ubuntu-20.04
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
         defaults:
             run:
                 shell: sh

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -29,7 +29,7 @@ jobs:
 
         runs-on: ubuntu-20.04
         container:
-            image: connectedhomeip/chip-build:0.6.35
+            image: connectedhomeip/chip-build:0.6.37
         defaults:
             run:
                 shell: sh

--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -6,7 +6,7 @@ steps:
           - "--init"
           - "--recursive"
       id: Submodules
-    - name: "connectedhomeip/chip-build-vscode:0.6.35"
+    - name: "connectedhomeip/chip-build-vscode:0.6.37"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -21,7 +21,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.35"
+    - name: "connectedhomeip/chip-build-vscode:0.6.37"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -76,7 +76,7 @@ steps:
               --target k32w-shell
               build
               --create-archives /workspace/artifacts/
-    - name: "connectedhomeip/chip-build-vscode:0.6.35"
+    - name: "connectedhomeip/chip-build-vscode:0.6.37"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.6.35"
+    - name: "connectedhomeip/chip-build-vscode:0.6.37"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 2700s
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.35"
+    - name: "connectedhomeip/chip-build-vscode:0.6.37"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -26,7 +26,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.35"
+    - name: "connectedhomeip/chip-build-vscode:0.6.37"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.6.35"
+    - name: "connectedhomeip/chip-build-vscode:0.6.37"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               git submodule update --init --recursive
       id: Submodules
-    - name: "connectedhomeip/chip-build-vscode:0.6.35"
+    - name: "connectedhomeip/chip-build-vscode:0.6.37"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -22,7 +22,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.35"
+    - name: "connectedhomeip/chip-build-vscode:0.6.37"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -40,7 +40,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "connectedhomeip/chip-build-vscode:0.6.35"
+    - name: "connectedhomeip/chip-build-vscode:0.6.37"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -61,7 +61,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.35"
+    - name: "connectedhomeip/chip-build-vscode:0.6.37"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -83,7 +83,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.35"
+    - name: "connectedhomeip/chip-build-vscode:0.6.37"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -141,7 +141,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.35"
+    - name: "connectedhomeip/chip-build-vscode:0.6.37"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
This will NOT have zap pre-installed and instead relies that our bootstrap.sh includes the right zap version.

Effectively ran:

```sh
rg --no-ignore --hidden ':0\.6\.\d\d' --files-with-matches | xargs sd ':0\.6\...' ':0.6.37'
```

