### PR TITLE
Fix timestamps in Diagnostic Logs cluster to follow the spec.

### DIFF
--- a/examples/log-source-app/log-source-common/log-source-app.matter
+++ b/examples/log-source-app/log-source-common/log-source-app.matter
@@ -320,8 +320,8 @@ server cluster DiagnosticLogs = 50 {
   response struct RetrieveLogsResponse = 1 {
     LogsStatus status = 0;
     OCTET_STRING logContent = 1;
-    epoch_s UTCTimeStamp = 2;
-    INT32U timeSinceBoot = 3;
+    optional epoch_us UTCTimeStamp = 2;
+    optional systime_us timeSinceBoot = 3;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -108,6 +108,8 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     ChipLogProgress(AppServer, "Server initializing...");
     assertChipStackLockedByCurrentThread();
 
+    mInitTimestamp = System::SystemClock().GetMonotonicMicroseconds64();
+
     CASESessionManagerConfig caseSessionManagerConfig;
     DeviceLayer::DeviceInfoProvider * deviceInfoprovider = nullptr;
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -370,7 +370,10 @@ public:
 
     void ScheduleFactoryReset();
 
-    System::Clock::Microseconds64 TimeSinceInit() { return System::SystemClock().GetMonotonicMicroseconds64() - mInitTimestamp; }
+    System::Clock::Microseconds64 TimeSinceInit() const
+    {
+        return System::SystemClock().GetMonotonicMicroseconds64() - mInitTimestamp;
+    }
 
     static Server & GetInstance() { return sServer; }
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -55,6 +55,7 @@
 #include <protocols/secure_channel/SimpleSessionResumptionStorage.h>
 #endif
 #include <protocols/user_directed_commissioning/UserDirectedCommissioning.h>
+#include <system/SystemClock.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
 #include <transport/TransportMgrBase.h>
@@ -369,6 +370,8 @@ public:
 
     void ScheduleFactoryReset();
 
+    System::Clock::Microseconds64 TimeSinceInit() { return System::SystemClock().GetMonotonicMicroseconds64() - mInitTimestamp; }
+
     static Server & GetInstance() { return sServer; }
 
 private:
@@ -566,6 +569,8 @@ private:
     uint16_t mOperationalServicePort;
     uint16_t mUserDirectedCommissioningPort;
     Inet::InterfaceId mInterfaceId;
+
+    System::Clock::Microseconds64 mInitTimestamp;
 };
 
 } // namespace chip

--- a/src/app/zap-templates/common/override.js
+++ b/src/app/zap-templates/common/override.js
@@ -71,6 +71,7 @@ function atomicType(arg)
   case 'percent100ths':
     return 'chip::Percent100ths';
   case 'epoch_us':
+  case 'systime_us':
     return 'uint64_t';
   case 'epoch_s':
   case 'utc':

--- a/src/app/zap-templates/zcl/data-model/chip/diagnostic-logs-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/diagnostic-logs-cluster.xml
@@ -53,8 +53,8 @@ limitations under the License.
             <description>Response to the RetrieveLogsRequest</description>
             <arg name="Status" type="LogsStatus"/>
             <arg name="LogContent" type="OCTET_STRING"/>
-            <arg name="UTCTimeStamp" type="epoch_s"/>
-            <arg name="TimeSinceBoot" type="INT32U"/>
+            <arg name="UTCTimeStamp" type="epoch_us" optional="true"/>
+            <arg name="TimeSinceBoot" type="systime_us" optional="true"/>
         </command>
     </cluster>
 </configurator>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -1317,8 +1317,8 @@ client cluster DiagnosticLogs = 50 {
   response struct RetrieveLogsResponse = 1 {
     LogsStatus status = 0;
     OCTET_STRING logContent = 1;
-    epoch_s UTCTimeStamp = 2;
-    INT32U timeSinceBoot = 3;
+    optional epoch_us UTCTimeStamp = 2;
+    optional systime_us timeSinceBoot = 3;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -7225,7 +7225,11 @@ public class ChipClusters {
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface RetrieveLogsResponseCallback {
-      void onSuccess(Integer status, byte[] logContent, Long UTCTimeStamp, Long timeSinceBoot);
+      void onSuccess(
+          Integer status,
+          byte[] logContent,
+          Optional<Long> UTCTimeStamp,
+          Optional<Long> timeSinceBoot);
 
       void onError(Exception error);
     }

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
@@ -3223,17 +3223,20 @@ public class ClusterInfoMapping {
 
     @Override
     public void onSuccess(
-        Integer Status, byte[] LogContent, Long UTCTimeStamp, Long TimeSinceBoot) {
+        Integer Status,
+        byte[] LogContent,
+        Optional<Long> UTCTimeStamp,
+        Optional<Long> TimeSinceBoot) {
       Map<CommandResponseInfo, Object> responseValues = new LinkedHashMap<>();
       CommandResponseInfo StatusResponseValue = new CommandResponseInfo("Status", "Integer");
       responseValues.put(StatusResponseValue, Status);
       CommandResponseInfo LogContentResponseValue = new CommandResponseInfo("LogContent", "byte[]");
       responseValues.put(LogContentResponseValue, LogContent);
       CommandResponseInfo UTCTimeStampResponseValue =
-          new CommandResponseInfo("UTCTimeStamp", "Long");
+          new CommandResponseInfo("UTCTimeStamp", "Optional<Long>");
       responseValues.put(UTCTimeStampResponseValue, UTCTimeStamp);
       CommandResponseInfo TimeSinceBootResponseValue =
-          new CommandResponseInfo("TimeSinceBoot", "Long");
+          new CommandResponseInfo("TimeSinceBoot", "Optional<Long>");
       responseValues.put(TimeSinceBootResponseValue, TimeSinceBoot);
       callback.onSuccess(responseValues);
     }

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -7845,14 +7845,14 @@ class DiagnosticLogs(Cluster):
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=DiagnosticLogs.Enums.LogsStatus),
                             ClusterObjectFieldDescriptor(Label="logContent", Tag=1, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="UTCTimeStamp", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="timeSinceBoot", Tag=3, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="UTCTimeStamp", Tag=2, Type=typing.Optional[uint]),
+                            ClusterObjectFieldDescriptor(Label="timeSinceBoot", Tag=3, Type=typing.Optional[uint]),
                     ])
 
             status: 'DiagnosticLogs.Enums.LogsStatus' = 0
             logContent: 'bytes' = b""
-            UTCTimeStamp: 'uint' = 0
-            timeSinceBoot: 'uint' = 0
+            UTCTimeStamp: 'typing.Optional[uint]' = None
+            timeSinceBoot: 'typing.Optional[uint]' = None
 
 
     class Attributes:

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge.mm
@@ -14388,10 +14388,18 @@ void MTRDiagnosticLogsClusterRetrieveLogsResponseCallbackBridge::OnSuccessFn(
         response.logContent = [NSData dataWithBytes:data.logContent.data() length:data.logContent.size()];
     }
     {
-        response.utcTimeStamp = [NSNumber numberWithUnsignedInt:data.UTCTimeStamp];
+        if (data.UTCTimeStamp.HasValue()) {
+            response.utcTimeStamp = [NSNumber numberWithUnsignedLongLong:data.UTCTimeStamp.Value()];
+        } else {
+            response.utcTimeStamp = nil;
+        }
     }
     {
-        response.timeSinceBoot = [NSNumber numberWithUnsignedInt:data.timeSinceBoot];
+        if (data.timeSinceBoot.HasValue()) {
+            response.timeSinceBoot = [NSNumber numberWithUnsignedLongLong:data.timeSinceBoot.Value()];
+        } else {
+            response.timeSinceBoot = nil;
+        }
     }
     DispatchSuccess(context, response);
 };

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
@@ -2837,9 +2837,9 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 
 @property (nonatomic, copy) NSData * _Nonnull logContent API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
 
-@property (nonatomic, copy) NSNumber * _Nonnull utcTimeStamp API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+@property (nonatomic, copy) NSNumber * _Nullable utcTimeStamp API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
 
-@property (nonatomic, copy) NSNumber * _Nonnull timeSinceBoot API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
+@property (nonatomic, copy) NSNumber * _Nullable timeSinceBoot API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2864,7 +2864,7 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @property (nonatomic, copy) NSData * _Nonnull content API_DEPRECATED(
     "Please use logContent", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 
-@property (nonatomic, copy) NSNumber * _Nonnull timeStamp API_DEPRECATED(
+@property (nonatomic, copy) NSNumber * _Nullable timeStamp API_DEPRECATED(
     "Please use utcTimeStamp", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
@@ -3484,9 +3484,9 @@ NS_ASSUME_NONNULL_BEGIN
 
         _logContent = [NSData data];
 
-        _utcTimeStamp = @(0);
+        _utcTimeStamp = nil;
 
-        _timeSinceBoot = @(0);
+        _timeSinceBoot = nil;
         _timedInvokeTimeoutMs = nil;
     }
     return self;
@@ -3527,12 +3527,12 @@ NS_ASSUME_NONNULL_BEGIN
     return self.logContent;
 }
 
-- (void)setTimeStamp:(NSNumber * _Nonnull)timeStamp
+- (void)setTimeStamp:(NSNumber * _Nullable)timeStamp
 {
     self.utcTimeStamp = timeStamp;
 }
 
-- (NSNumber * _Nonnull)timeStamp
+- (NSNumber * _Nullable)timeStamp
 {
     return self.utcTimeStamp;
 }

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -8042,8 +8042,8 @@ bool emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(
  * @brief Diagnostic Logs Cluster RetrieveLogsResponse Command callback (from server)
  */
 bool emberAfDiagnosticLogsClusterRetrieveLogsResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                              uint8_t Status, chip::ByteSpan LogContent, uint32_t UTCTimeStamp,
-                                                              uint32_t TimeSinceBoot);
+                                                              uint8_t Status, chip::ByteSpan LogContent, uint64_t UTCTimeStamp,
+                                                              uint64_t TimeSinceBoot);
 /**
  * @brief General Diagnostics Cluster TestEventTrigger Command callback (from client)
  */

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -7774,8 +7774,8 @@ public:
 
     LogsStatus status = static_cast<LogsStatus>(0);
     chip::ByteSpan logContent;
-    uint32_t UTCTimeStamp  = static_cast<uint32_t>(0);
-    uint32_t timeSinceBoot = static_cast<uint32_t>(0);
+    Optional<uint64_t> UTCTimeStamp;
+    Optional<uint64_t> timeSinceBoot;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -7792,8 +7792,8 @@ public:
 
     LogsStatus status = static_cast<LogsStatus>(0);
     chip::ByteSpan logContent;
-    uint32_t UTCTimeStamp  = static_cast<uint32_t>(0);
-    uint32_t timeSinceBoot = static_cast<uint32_t>(0);
+    Optional<uint64_t> UTCTimeStamp;
+    Optional<uint64_t> timeSinceBoot;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RetrieveLogsResponse


### PR DESCRIPTION
There were a few issues here:

1. We were using a monotonic timestamp, but setting the UTCTimeStamp in the response payload.

2. We were using a millisecond timestamp, whereas the spec has microsecond ones.

Switch to using "time since server init" for the timestamp, put it in the TimeSinceBoot field, and make sure it has the right units.

Also fixes the timestamps to actually be optional, per spec.

Fixes https://github.com/project-chip/connectedhomeip/issues/24265
