### PR TITLE
[matter_yamltests] Add events supports

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/definitions.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/definitions.py
@@ -141,11 +141,19 @@ class SpecDefinitions:
         if struct:
             return struct
 
+        event = self.get_event_by_name(cluster_name, target_name)
+        if event:
+            return event
+
         return None
 
     def is_fabric_scoped(self, target) -> bool:
-        if hasattr(target, 'qualities'):
+        if isinstance(target, Event):
+            return bool(target.is_fabric_sensitive)
+
+        if isinstance(target, Struct) and hasattr(target, 'qualities'):
             return bool(target.qualities & StructQuality.FABRIC_SCOPED)
+
         return False
 
     def is_nullable(self, target) -> bool:

--- a/scripts/py_matter_yamltests/matter_yamltests/fixes.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/fixes.py
@@ -130,10 +130,10 @@ def try_update_yaml_node_id_test_runner_state(tests, config):
 
         if test.cluster == 'CommissionerCommands' or test.cluster == 'DelayCommands':
             if test.command == 'PairWithCode' or test.command == 'WaitForCommissionee':
-                if test.response_with_placeholders:
+                if test.responses_with_placeholders:
                     # It the test expects an error, we should not update the
                     # nodeId of the identity.
-                    error = test.response_with_placeholders.get('error')
+                    error = test.responses_with_placeholders[0].get('error')
                     if error:
                         continue
 

--- a/scripts/py_matter_yamltests/test_spec_definitions.py
+++ b/scripts/py_matter_yamltests/test_spec_definitions.py
@@ -94,6 +94,8 @@ source_event = '''<?xml version="1.0"?>
 
       <event code="0x0" name="TestEvent" priority="info" side="server"></event>
 
+      <event code="0x1" name="TestEventFabricScoped" priority="info" side="server" isFabricSensitive="true"></event>
+
     </cluster>
   </configurator>
 '''
@@ -232,8 +234,10 @@ class TestSpecDefinitions(unittest.TestCase):
         definitions = SpecDefinitions(
             [ParseSource(source=io.StringIO(source_event), name='source_event')])
         self.assertIsNone(definitions.get_event_name(0x4321, 0x0))
-        self.assertIsNone(definitions.get_event_name(0x1234, 0x1))
+        self.assertIsNone(definitions.get_event_name(0x1234, 0x2))
         self.assertEqual(definitions.get_event_name(0x1234, 0x0), 'TestEvent')
+        self.assertEqual(definitions.get_event_name(
+            0x1234, 0x1), 'TestEventFabricScoped')
 
     def test_get_command_by_name(self):
         definitions = SpecDefinitions(
@@ -358,7 +362,8 @@ class TestSpecDefinitions(unittest.TestCase):
 
         definitions = SpecDefinitions(
             [ParseSource(source=io.StringIO(source_event), name='source_event')])
-        self.assertIsNone(definitions.get_type_by_name('Test', 'TestEvent'))
+        self.assertIsInstance(
+            definitions.get_type_by_name('Test', 'TestEvent'), Event)
 
         definitions = SpecDefinitions(
             [ParseSource(source=io.StringIO(source_bitmap), name='source_bitmap')])
@@ -375,7 +380,7 @@ class TestSpecDefinitions(unittest.TestCase):
         self.assertIsInstance(definitions.get_type_by_name(
             'Test', 'TestStruct'), Struct)
 
-    def test_is_fabric_scoped(self):
+    def test_struct_is_fabric_scoped(self):
         definitions = SpecDefinitions(
             [ParseSource(source=io.StringIO(source_struct), name='source_struct')])
 
@@ -385,6 +390,17 @@ class TestSpecDefinitions(unittest.TestCase):
         struct = definitions.get_struct_by_name(
             'Test', 'TestStructFabricScoped')
         self.assertTrue(definitions.is_fabric_scoped(struct))
+
+    def test_event_is_fabric_scoped(self):
+        definitions = SpecDefinitions(
+            [ParseSource(source=io.StringIO(source_event), name='source_event')])
+
+        event = definitions.get_event_by_name('Test', 'TestEvent')
+        self.assertFalse(definitions.is_fabric_scoped(event))
+
+        event = definitions.get_event_by_name(
+            'Test', 'TestEventFabricScoped')
+        self.assertTrue(definitions.is_fabric_scoped(event))
 
 
 if __name__ == '__main__':

--- a/src/app/tests/suites/TestEvents.yaml
+++ b/src/app/tests/suites/TestEvents.yaml
@@ -31,11 +31,13 @@ tests:
     - label: "Check there is no event on the target endpoint"
       command: "readEvent"
       event: "TestEvent"
+      response: []
 
     - label: "Check reading events from an invalid endpoint"
       command: "readEvent"
       event: "TestEvent"
       endpoint: 0
+      response: []
 
     - label: "Generate an event on the accessory"
       command: "TestEmitTestEventRequest"
@@ -69,6 +71,7 @@ tests:
       command: "readEvent"
       event: "TestEvent"
       eventNumber: eventNumber + 1
+      response: []
 
     - label: "Generate a second event on the accessory"
       command: "TestEmitTestEventRequest"


### PR DESCRIPTION
#### Problem

`matter_yamltests` does not support having multiple expected values as a response.
This is an issue for everything that is testing events in yaml, but more generally this is needed when we will add tests for commands that contains multiple paths (or wildcards).

A simple example would be reading multiple attributes...
As an example, this allow to write things such as:
```
    - label: "Read the global attribute: ClusterRevision"
      command: "readAttribute"
      attribute: "ClusterRevision"
      endpoint: "0xFFFF"
      response:
          - values:
            - name: "value"
              value: 4
          - values:
            - name: "value"
              constraints:
                minValue: 4
```

Using the `chip-tool` adapter I'm able to get `TestEvents` and all the `Test_ACL_*` that are using events to pass.
