### PR TITLE
[CI] Add pairing test with a remote server by IP address

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -489,7 +489,7 @@ jobs:
                       --target linux-x64-java-matter-controller \
                       build \
                    "
-            - name: Run Discover Tests
+            - name: Run Discover Commissionables Test
               timeout-minutes: 10
               run: |
                   scripts/run_in_build_env.sh \
@@ -501,7 +501,7 @@ jobs:
                      --tool-args "commissionables" \
                      --factoryreset \
                   '
-            - name: Run Pairing Tests
+            - name: Run Pairing over Onnetwork Test
               timeout-minutes: 10
               run: |
                   scripts/run_in_build_env.sh \
@@ -513,6 +513,18 @@ jobs:
                      --tool-args "onnetwork-long --nodeid 1 --setup-payload 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
                   '
+            - name: Run Pairing over Ethernet Test
+              timeout-minutes: 10
+              run: |
+                  scripts/run_in_build_env.sh \
+                  './scripts/tests/run_java_test.py \
+                     --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
+                     --app-args "--discriminator 3840 --interface-id -1" \
+                     --tool-path out/linux-x64-java-matter-controller \
+                     --tool-cluster "pairing" \
+                     --tool-args "ethernet --nodeid 1 --setup-payload 20202021 --discriminator 3840 --address ::1 --port 5540 -t 1000" \
+                     --factoryreset \
+                  '                  
             - name: Uploading core files
               uses: actions/upload-artifact@v3
               if: ${{ failure() && !env.ACT }}

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/common/Argument.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/common/Argument.java
@@ -150,8 +150,9 @@ public final class Argument {
         try {
           IPAddress ipAddress = (IPAddress) mValue;
           ipAddress.setAddress(InetAddress.getByName(value));
-        } catch (UnknownHostException e) {
           isValidArgument = true;
+        } catch (UnknownHostException e) {
+          isValidArgument = false;
         }
         break;
     }

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairEthernetCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairEthernetCommand.java
@@ -10,5 +10,16 @@ public final class PairEthernetCommand extends PairingCommand {
   }
 
   @Override
-  protected void runCommand() {}
+  protected void runCommand() {
+    currentCommissioner()
+        .pairDeviceWithAddress(
+            getNodeId(),
+            getRemoteAddr().getHostAddress(),
+            getRemotePort(),
+            getDiscriminator(),
+            getSetupPINCode(),
+            null);
+    currentCommissioner().setCompletionListener(this);
+    waitCompleteMs(getTimeoutMillis());
+  }
 }

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.java
@@ -49,96 +49,7 @@ public abstract class PairingCommand extends MatterCommand
   private final StringBuffer mPassword = new StringBuffer();
   private final StringBuffer mOnboardingPayload = new StringBuffer();
   private final StringBuffer mDiscoveryFilterInstanceName = new StringBuffer();
-
   private static Logger logger = Logger.getLogger(PairingCommand.class.getName());
-
-  public long getNodeId() {
-    return mNodeId.get();
-  }
-
-  public int getSetupPINCode() {
-    return mSetupPINCode.get();
-  }
-
-  public int getDiscriminator() {
-    return mDiscriminator.get();
-  }
-
-  public long getTimeoutMillis() {
-    return mTimeoutMillis.get();
-  }
-
-  @Override
-  public void onConnectDeviceComplete() {
-    logger.log(Level.INFO, "onConnectDeviceComplete");
-  }
-
-  @Override
-  public void onStatusUpdate(int status) {
-    logger.log(Level.INFO, "onStatusUpdate with status: " + status);
-  }
-
-  @Override
-  public void onPairingComplete(int errorCode) {
-    logger.log(Level.INFO, "onPairingComplete with error code: " + errorCode);
-    if (errorCode != 0) {
-      setFailure("onPairingComplete failure");
-    }
-  }
-
-  @Override
-  public void onPairingDeleted(int errorCode) {
-    logger.log(Level.INFO, "onPairingDeleted with error code: " + errorCode);
-  }
-
-  @Override
-  public void onCommissioningComplete(long nodeId, int errorCode) {
-    logger.log(Level.INFO, "onCommissioningComplete with error code: " + errorCode);
-    if (errorCode == 0) {
-      setSuccess();
-    } else {
-      setFailure("onCommissioningComplete failure");
-    }
-  }
-
-  @Override
-  public void onReadCommissioningInfo(
-      int vendorId, int productId, int wifiEndpointId, int threadEndpointId) {
-    logger.log(Level.INFO, "onReadCommissioningInfo");
-  }
-
-  @Override
-  public void onCommissioningStatusUpdate(long nodeId, String stage, int errorCode) {
-    logger.log(Level.INFO, "onCommissioningStatusUpdate");
-  }
-
-  @Override
-  public void onNotifyChipConnectionClosed() {
-    logger.log(Level.INFO, "onNotifyChipConnectionClosed");
-  }
-
-  @Override
-  public void onCloseBleComplete() {
-    logger.log(Level.INFO, "onCloseBleComplete");
-  }
-
-  @Override
-  public void onError(Throwable error) {
-    setFailure(error.toString());
-    logger.log(Level.INFO, "onError with error: " + error.toString());
-  }
-
-  @Override
-  public void onOpCSRGenerationComplete(byte[] csr) {
-    logger.log(Level.INFO, "onOpCSRGenerationComplete");
-    for (int i = 0; i < csr.length; i++) {
-      System.out.print(csr[i] + " ");
-    }
-  }
-
-  public IPAddress getRemoteAddr() {
-    return mRemoteAddr;
-  }
 
   public PairingCommand(
       ChipDeviceController controller,
@@ -241,5 +152,97 @@ public abstract class PairingCommand extends MatterCommand
     }
 
     addArgument("timeout", (long) 0, Long.MAX_VALUE, mTimeoutMillis, null, false);
+  }
+
+  public long getNodeId() {
+    return mNodeId.get();
+  }
+
+  public int getSetupPINCode() {
+    return mSetupPINCode.get();
+  }
+
+  public int getDiscriminator() {
+    return mDiscriminator.get();
+  }
+
+  public int getRemotePort() {
+    return mRemotePort.get();
+  }
+
+  public long getTimeoutMillis() {
+    return mTimeoutMillis.get();
+  }
+
+  public IPAddress getRemoteAddr() {
+    return mRemoteAddr;
+  }
+
+  @Override
+  public void onConnectDeviceComplete() {
+    logger.log(Level.INFO, "onConnectDeviceComplete");
+  }
+
+  @Override
+  public void onStatusUpdate(int status) {
+    logger.log(Level.INFO, "onStatusUpdate with status: " + status);
+  }
+
+  @Override
+  public void onPairingComplete(int errorCode) {
+    logger.log(Level.INFO, "onPairingComplete with error code: " + errorCode);
+    if (errorCode != 0) {
+      setFailure("onPairingComplete failure");
+    }
+  }
+
+  @Override
+  public void onPairingDeleted(int errorCode) {
+    logger.log(Level.INFO, "onPairingDeleted with error code: " + errorCode);
+  }
+
+  @Override
+  public void onCommissioningComplete(long nodeId, int errorCode) {
+    logger.log(Level.INFO, "onCommissioningComplete with error code: " + errorCode);
+    if (errorCode == 0) {
+      setSuccess();
+    } else {
+      setFailure("onCommissioningComplete failure");
+    }
+  }
+
+  @Override
+  public void onReadCommissioningInfo(
+      int vendorId, int productId, int wifiEndpointId, int threadEndpointId) {
+    logger.log(Level.INFO, "onReadCommissioningInfo");
+  }
+
+  @Override
+  public void onCommissioningStatusUpdate(long nodeId, String stage, int errorCode) {
+    logger.log(Level.INFO, "onCommissioningStatusUpdate");
+  }
+
+  @Override
+  public void onNotifyChipConnectionClosed() {
+    logger.log(Level.INFO, "onNotifyChipConnectionClosed");
+  }
+
+  @Override
+  public void onCloseBleComplete() {
+    logger.log(Level.INFO, "onCloseBleComplete");
+  }
+
+  @Override
+  public void onError(Throwable error) {
+    setFailure(error.toString());
+    logger.log(Level.INFO, "onError with error: " + error.toString());
+  }
+
+  @Override
+  public void onOpCSRGenerationComplete(byte[] csr) {
+    logger.log(Level.INFO, "onOpCSRGenerationComplete");
+    for (int i = 0; i < csr.length; i++) {
+      System.out.print(csr[i] + " ");
+    }
   }
 }

--- a/scripts/tests/java/commissioning_test.py
+++ b/scripts/tests/java/commissioning_test.py
@@ -41,18 +41,21 @@ class CommissioningTest:
 
         parser.add_argument('command', help="Command name")
         parser.add_argument('-t', '--timeout', help="The program will return with timeout after specified seconds", default='200')
-        parser.add_argument('-a', '--address', help="Address of the device")
+        parser.add_argument('-a', '--address', help="Address of the remote device")
+        parser.add_argument('-p', '--port', help="Port of the remote device", default='5540')
         parser.add_argument('-s', '--setup-payload', dest='setup_payload',
                             help="Setup Payload (manual pairing code or QR code content)")
         parser.add_argument('-n', '--nodeid', help="The Node ID issued to the device", default='1')
         parser.add_argument('-d', '--discriminator', help="Discriminator of the device", default='3840')
-        parser.add_argument('-p', '--paa-trust-store-path', dest='paa_trust_store_path',
+        parser.add_argument('-o', '--paa-trust-store-path', dest='paa_trust_store_path',
                             help="Path that contains valid and trusted PAA Root Certificates")
 
         args = parser.parse_args(args.split())
 
         self.command_name = args.command
         self.nodeid = args.nodeid
+        self.address = args.address
+        self.port = args.port
         self.setup_payload = args.setup_payload
         self.discriminator = args.discriminator
         self.timeout = args.timeout
@@ -67,10 +70,23 @@ class CommissioningTest:
         DumpProgramOutputToQueue(self.thread_list, Fore.GREEN + "JAVA " + Style.RESET_ALL, java_process, self.queue)
         return java_process.wait()
 
+    def TestCmdEthernet(self, nodeid, setuppin, discriminator, address, port, timeout):
+        java_command = self.command + ['pairing', 'ethernet', nodeid, setuppin, discriminator, address, port, timeout]
+        logging.info(f"Execute: {java_command}")
+        java_process = subprocess.Popen(
+            java_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        DumpProgramOutputToQueue(self.thread_list, Fore.GREEN + "JAVA " + Style.RESET_ALL, java_process, self.queue)
+        return java_process.wait()
+
     def RunTest(self):
-        logging.info("Testing onnetwork-long pairing")
         if self.command_name == 'onnetwork-long':
+            logging.info("Testing pairing over onnetwork-long")
             code = self.TestCmdOnnetworkLong(self.nodeid, self.setup_payload, self.discriminator, self.timeout)
+            if code != 0:
+                raise Exception(f"Testing onnetwork-long pairing failed with error {code}")
+        elif self.command_name == 'ethernet':
+            logging.info("Testing pairing over ethernet")
+            code = self.TestCmdEthernet(self.nodeid, self.setup_payload, self.discriminator, self.address, self.port, self.timeout)
             if code != 0:
                 raise Exception(f"Testing onnetwork-long pairing failed with error {code}")
         else:


### PR DESCRIPTION
Currently, java-matter-controller only support on-network pairing command, which require the target device program running in the same machine within the same network name place.

We need to setup the test which running the controller and target device within their own container, even on different VMs.

This PR contains the following changes:
1. add pairing over ethernet command to java-matter-controller
2. add test pairing over ethernet in CI 


