### PR TITLE
[Tizen] Fix QEMU runner return code processing

### DIFF
--- a/integrations/docker/images/chip-build-tizen-qemu/Dockerfile
+++ b/integrations/docker/images/chip-build-tizen-qemu/Dockerfile
@@ -158,7 +158,7 @@ RUN set -x \
     "if [[ -x /mnt/chip/runner.sh ]]; then\n" \
     "  echo '### RUNNER START ###'\n" \
     "  /mnt/chip/runner.sh\n" \
-    "  echo '### RUNNER STOP:' $?\n" \
+    "  echo '### RUNNER STOP:' \$?\n" \
     "else\n" \
     "  read -r -t 5 -p 'Press ENTER to access root shell...' && exit || echo ' timeout.'\n" \
     "fi\n" \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.38 Version bump reason: [Tizen] Add QEMU docker image for running tests
+0.6.39 Version bump reason: [Tizen] Fixup for QEMU docker image


### PR DESCRIPTION
Fixup for #24813 

### Problem

If not escaped, the dollar character is processed by the shell which creates Docker image. Issue spotted when checking negative test case.