### PR TITLE
[Silabs] EFR32+9117 NCP Modifications and Radio Board Modifications

### DIFF
--- a/examples/light-switch-app/silabs/SiWx917/BUILD.gn
+++ b/examples/light-switch-app/silabs/SiWx917/BUILD.gn
@@ -122,7 +122,6 @@ if (chip_enable_wifi) {
     efr32_lwip_defs += [ "LWIP_IPV6=0" ]
   }
 
-  wiseconnect_sdk_root = "${chip_root}/third_party/silabs/wisemcu-wifi-bt-sdk"
   import("${examples_plat_dir}/SiWx917/rs911x.gni")
 }
 

--- a/examples/lighting-app/silabs/SiWx917/BUILD.gn
+++ b/examples/lighting-app/silabs/SiWx917/BUILD.gn
@@ -128,7 +128,6 @@ if (chip_enable_wifi) {
     efr32_lwip_defs += [ "LWIP_IPV6=0" ]
   }
 
-  wiseconnect_sdk_root = "${chip_root}/third_party/silabs/wisemcu-wifi-bt-sdk"
   import("${examples_plat_dir}/SiWx917/rs911x.gni")
 }
 

--- a/examples/lock-app/silabs/SiWx917/BUILD.gn
+++ b/examples/lock-app/silabs/SiWx917/BUILD.gn
@@ -121,8 +121,6 @@ if (chip_enable_wifi) {
   } else {
     efr32_lwip_defs += [ "LWIP_IPV6=0" ]
   }
-
-  wiseconnect_sdk_root = "${chip_root}/third_party/silabs/wisemcu-wifi-bt-sdk"
   import("${examples_plat_dir}/SiWx917/rs911x.gni")
 }
 

--- a/examples/platform/silabs/SiWx917/SiWx917/rs911x.gni
+++ b/examples/platform/silabs/SiWx917/SiWx917/rs911x.gni
@@ -4,7 +4,7 @@ import("//build_overrides/pigweed.gni")
 
 examples_plat_dir = "${chip_root}/examples/platform/silabs/SiWx917"
 wifi_sdk_dir = "${chip_root}/src/platform/silabs/SiWx917/wifi"
-wiseconnect_sdk_root = "${chip_root}/third_party/silabs/wisemcu-wifi-bt-sdk"
+wisemcu_sdk_root = "${chip_root}/third_party/silabs/wisemcu-wifi-bt-sdk"
 rs911x_cflags = []
 
 rs911x_src_plat = [
@@ -15,60 +15,59 @@ rs911x_src_plat = [
   "${examples_plat_dir}/SiWx917/hal/rsi_hal_mcu_timer.c",
   "${examples_plat_dir}/SiWx917/hal/rsi_hal_mcu_platform_init.c",
 
-  "${wiseconnect_sdk_root}/platforms/si91x/hal/src/rsi_bootup_config.c",
-  "${wiseconnect_sdk_root}/platforms/si91x/hal/src/rsi_hal_mcu_m4.c",
-  "${wiseconnect_sdk_root}/platforms/si91x/hal/src/rsi_hal_mcu_m4_rom.c",
-  "${wiseconnect_sdk_root}/platforms/si91x/hal/src/rsi_hal_mcu_interrupt.c",
+  "${wisemcu_sdk_root}/platforms/si91x/hal/src/rsi_bootup_config.c",
+  "${wisemcu_sdk_root}/platforms/si91x/hal/src/rsi_hal_mcu_m4.c",
+  "${wisemcu_sdk_root}/platforms/si91x/hal/src/rsi_hal_mcu_m4_rom.c",
+  "${wisemcu_sdk_root}/platforms/si91x/hal/src/rsi_hal_mcu_interrupt.c",
 ]
 rs911x_plat_incs = [
   "${wifi_sdk_dir}",
   "${wifi_sdk_dir}/hal",
-  "${wiseconnect_sdk_root}/platforms/si91x/hal/inc",
+  "${wisemcu_sdk_root}/platforms/si91x/hal/inc",
 
-  #  "${wiseconnect_sdk_root}/sapi/include",
   "${chip_root}/src/platform/silabs/SiWx917",
   "${chip_root}/src/platform/silabs/SiWx917/bluetooth",
   "${examples_plat_dir}/SiWx917",
-  "${wiseconnect_sdk_root}/platforms/si91x/hal/inc",
+  "${wisemcu_sdk_root}/platforms/si91x/hal/inc",
 ]
 
 #
 # All the stuff from wiseconnect
 #
 rs911x_src_sapi = [
-  "${wiseconnect_sdk_root}/sapi/wlan/rsi_wlan_apis.c",
-  "${wiseconnect_sdk_root}/sapi/common/rsi_apis_non_rom.c",
-  "${wiseconnect_sdk_root}/sapi/common/rsi_apis_rom.c",
-  "${wiseconnect_sdk_root}/sapi/common/rsi_common_apis.c",
-  "${wiseconnect_sdk_root}/sapi/common/rsi_device_init_apis.c",
+  "${wisemcu_sdk_root}/sapi/wlan/rsi_wlan_apis.c",
+  "${wisemcu_sdk_root}/sapi/common/rsi_apis_non_rom.c",
+  "${wisemcu_sdk_root}/sapi/common/rsi_apis_rom.c",
+  "${wisemcu_sdk_root}/sapi/common/rsi_common_apis.c",
+  "${wisemcu_sdk_root}/sapi/common/rsi_device_init_apis.c",
 
-  #  "${wiseconnect_sdk_root}/sapi/common/rsi_wisemcu_hardware_setup.c",
-  "${wiseconnect_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_frame_rd_wr.c",
-  "${wiseconnect_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_functs.c",
-  "${wiseconnect_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_iface_init.c",
-  "${wiseconnect_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_mem_rd_wr.c",
-  "${wiseconnect_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_reg_rd_wr.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_common.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_device_init.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_driver_event_handlers.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_driver.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_events_rom.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_events.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_iap.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_nwk_rom.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_nwk.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_pkt_mgmt_rom.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_pkt_mgmt.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_queue_rom.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_queue.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_scheduler_rom.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_scheduler.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_setregion_countryinfo.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_timer.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_utils_rom.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_utils.c",
-  "${wiseconnect_sdk_root}/sapi/driver/rsi_wlan.c",
-  "${wiseconnect_sdk_root}/sapi/rtos/freertos_wrapper/rsi_os_wrapper.c",
+  #  "${wisemcu_sdk_root}/sapi/common/rsi_wisemcu_hardware_setup.c",
+  "${wisemcu_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_frame_rd_wr.c",
+  "${wisemcu_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_functs.c",
+  "${wisemcu_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_iface_init.c",
+  "${wisemcu_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_mem_rd_wr.c",
+  "${wisemcu_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_reg_rd_wr.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_common.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_device_init.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_driver_event_handlers.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_driver.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_events_rom.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_events.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_iap.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_nwk_rom.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_nwk.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_pkt_mgmt_rom.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_pkt_mgmt.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_queue_rom.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_queue.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_scheduler_rom.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_scheduler.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_setregion_countryinfo.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_timer.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_utils_rom.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_utils.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_wlan.c",
+  "${wisemcu_sdk_root}/sapi/rtos/freertos_wrapper/rsi_os_wrapper.c",
 ]
 
 foreach(src_file, rs911x_src_sapi) {
@@ -89,28 +88,28 @@ rs911x_inc_plat = [
   "${wifi_sdk_dir}",
   "${examples_plat_dir}/SiWx917",
   "${examples_plat_dir}/SiWx917/hal",
-  "${wiseconnect_sdk_root}/sapi/include",
+  "${wisemcu_sdk_root}/sapi/include",
 
   #CCP Platfrom
-  "${wiseconnect_sdk_root}/platforms/si91x/hal/inc",
-  "${wiseconnect_sdk_root}/platforms/si91x/boards/brd4325a/inc",
-  "${wiseconnect_sdk_root}/platforms/si91x/drivers/peripheral_drivers/inc",
-  "${wiseconnect_sdk_root}/platforms/si91x/drivers/systemlevel/inc",
-  "${wiseconnect_sdk_root}/platforms/si91x/core/chip/inc",
-  "${wiseconnect_sdk_root}/platforms/si91x/core/config",
-  "${wiseconnect_sdk_root}/platforms/si91x/drivers/cmsis_driver/config",
-  "${wiseconnect_sdk_root}/platforms/si91x/drivers/rom_driver/inc",
-  "${wiseconnect_sdk_root}/platforms/si91x/drivers/cmsis_driver",
-  "${wiseconnect_sdk_root}/platforms/si91x/drivers/cmsis_driver/CMSIS/Driver/Include",
+  "${wisemcu_sdk_root}/platforms/si91x/hal/inc",
+  "${wisemcu_sdk_root}/platforms/si91x/boards/brd4325a/inc",
+  "${wisemcu_sdk_root}/platforms/si91x/drivers/peripheral_drivers/inc",
+  "${wisemcu_sdk_root}/platforms/si91x/drivers/systemlevel/inc",
+  "${wisemcu_sdk_root}/platforms/si91x/core/chip/inc",
+  "${wisemcu_sdk_root}/platforms/si91x/core/config",
+  "${wisemcu_sdk_root}/platforms/si91x/drivers/cmsis_driver/config",
+  "${wisemcu_sdk_root}/platforms/si91x/drivers/rom_driver/inc",
+  "${wisemcu_sdk_root}/platforms/si91x/drivers/cmsis_driver",
+  "${wisemcu_sdk_root}/platforms/si91x/drivers/cmsis_driver/CMSIS/Driver/Include",
 
-  "${wiseconnect_sdk_root}/platforms/si91x/core/cmsis",
-  "${wiseconnect_sdk_root}/platforms/si91x/service/system/inc",
+  "${wisemcu_sdk_root}/platforms/si91x/core/cmsis",
+  "${wisemcu_sdk_root}/platforms/si91x/service/system/inc",
 ]
 
 # Apparently - the rsi library needs this
 rs911x_src_sock = [
-  "${wiseconnect_sdk_root}/sapi/network/socket/rsi_socket.c",
-  "${wiseconnect_sdk_root}/sapi/network/socket/rsi_socket_rom.c",
+  "${wisemcu_sdk_root}/sapi/network/socket/rsi_socket.c",
+  "${wisemcu_sdk_root}/sapi/network/socket/rsi_socket_rom.c",
 ]
 rs911x_sock_inc = [ "${wifi_sdk_dir}/rsi-sockets" ]
 

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -50,10 +50,11 @@ import("${silabs_common_plat_dir}/efr32/args.gni")
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))
 assert(!(use_rs911x && chip_enable_openthread))
+assert(!(use_rs9117 && chip_enable_openthread))
 assert(!(use_wf200 && chip_enable_openthread))
 
 if (chip_enable_wifi) {
-  assert(use_rs911x || use_wf200)
+  assert(use_rs911x || use_wf200 || use_rs9117)
   enable_openthread_cli = false
   import("${chip_root}/src/platform/silabs/EFR32/wifi_args.gni")
 
@@ -61,8 +62,11 @@ if (chip_enable_wifi) {
     wiseconnect_sdk_root =
         "${chip_root}/third_party/silabs/wiseconnect-wifi-bt-sdk"
     import("rs911x/rs911x.gni")
+  } else if (use_rs9117) {
+    wisemcu_sdk_root =
+        "${chip_root}/third_party/silabs/wisemcu-wifi-bt-sdk"
+    import("rs911x/rs9117.gni")
   }
-
   if (use_wf200) {
     import("wf200/wf200.gni")
   }
@@ -293,7 +297,17 @@ source_set("efr32-common") {
 
       #add compilation flags for rs991x build. This will be addressed directly in wiseconnect sdk in the next version release of that sdk
       cflags = rs911x_cflags
-    } else if (use_wf200) {
+    } else if (use_rs9117){
+      sources += rs911x_src_plat
+
+      # All the stuff from wiseconnect
+      sources += rs911x_src_sapi
+      include_dirs += rs911x_inc_plat
+
+      #add compilation flags for rs991x build. This will be addressed directly in wiseconnect sdk in the next version release of that sdk
+      cflags = rs911x_cflags
+    }
+    else if (use_wf200) {
       sources += wf200_plat_src
       include_dirs += wf200_plat_incs
     }

--- a/examples/platform/silabs/efr32/rs911x/rs9117.gni
+++ b/examples/platform/silabs/efr32/rs911x/rs9117.gni
@@ -1,0 +1,64 @@
+import("//build_overrides/chip.gni")
+
+examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
+wifi_sdk_dir = "${chip_root}/src/platform/silabs/EFR32/wifi"
+wisemcu_sdk_root = "${chip_root}/third_party/silabs/wisemcu-wifi-bt-sdk"
+
+rs911x_src_plat = [
+  "${examples_plat_dir}/rs911x/rsi_if.c",
+  "${examples_plat_dir}/rs911x/wfx_rsi_host.c",
+  "${examples_plat_dir}/rs911x/hal/rsi_hal_mcu_interrupt.c",
+  "${examples_plat_dir}/rs911x/hal/rsi_hal_mcu_ioports.c",
+  "${examples_plat_dir}/rs911x/hal/rsi_hal_mcu_timer.c",
+  "${examples_plat_dir}/rs911x/hal/efx_spi.c",
+  "${wifi_sdk_dir}/wfx_notify.cpp",
+]
+
+#
+# All the stuff from wiseconnect
+#
+rs911x_src_sapi = [
+  "${wisemcu_sdk_root}/sapi/wlan/rsi_wlan_apis.c",
+  "${wisemcu_sdk_root}/sapi/common/rsi_apis_non_rom.c",
+  "${wisemcu_sdk_root}/sapi/common/rsi_apis_rom.c",
+  "${wisemcu_sdk_root}/sapi/common/rsi_common_apis.c",
+  "${wisemcu_sdk_root}/sapi/common/rsi_device_init_apis.c",
+  "${wisemcu_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_frame_rd_wr.c",
+  "${wisemcu_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_functs.c",
+  "${wisemcu_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_iface_init.c",
+  "${wisemcu_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_mem_rd_wr.c",
+  "${wisemcu_sdk_root}/sapi/driver/device_interface/spi/rsi_spi_reg_rd_wr.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_common.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_device_init.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_driver_event_handlers.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_driver.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_events_rom.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_events.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_iap.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_nwk_rom.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_nwk.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_pkt_mgmt_rom.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_pkt_mgmt.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_queue_rom.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_queue.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_scheduler_rom.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_scheduler.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_setregion_countryinfo.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_timer.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_utils_rom.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_utils.c",
+  "${wisemcu_sdk_root}/sapi/driver/rsi_wlan.c",
+  "${wisemcu_sdk_root}/sapi/rtos/freertos_wrapper/rsi_os_wrapper.c",
+
+  # Apparently - the rsi library needs this (though we may not use use it)
+  "${wisemcu_sdk_root}/sapi/network/socket/rsi_socket.c",
+  "${wisemcu_sdk_root}/sapi/network/socket/rsi_socket_rom.c",
+]
+
+rs911x_cflags = [ "-Wno-empty-body" ]
+
+rs911x_inc_plat = [
+  "${examples_plat_dir}/rs911x",
+  "${examples_plat_dir}/rs911x/hal",
+  "${wisemcu_sdk_root}/sapi/include",
+]

--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -113,6 +113,10 @@ int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap)
  *********************************************************************/
 int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info)
 {
+#ifdef RS9117_WIFI
+    //TODO: for wisemcu
+    return 0;
+#else
     int32_t status;
     uint8_t buff[RSI_RESPONSE_MAX_SIZE] = { 0 };
     status                              = rsi_wlan_get(RSI_WLAN_EXT_STATS, buff, sizeof(buff));
@@ -132,6 +136,7 @@ int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info)
         extra_info->overrun_count     = test->overrun_count - temp_reset->overrun_count;
     }
     return status;
+#endif
 }
 
 /******************************************************************
@@ -144,6 +149,10 @@ int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info)
  *********************************************************************/
 int32_t wfx_rsi_reset_count()
 {
+#ifdef RS9117_WIFI
+    //TODO: for wisemcu
+    return 0;
+#else
     int32_t status;
     uint8_t buff[RSI_RESPONSE_MAX_SIZE] = { 0 };
     status                              = rsi_wlan_get(RSI_WLAN_EXT_STATS, buff, sizeof(buff));
@@ -163,6 +172,7 @@ int32_t wfx_rsi_reset_count()
         temp_reset->overrun_count     = test->overrun_count;
     }
     return status;
+#endif
 }
 
 /******************************************************************

--- a/examples/window-app/silabs/SiWx917/BUILD.gn
+++ b/examples/window-app/silabs/SiWx917/BUILD.gn
@@ -121,7 +121,6 @@ if (chip_enable_wifi) {
     efr32_lwip_defs += [ "LWIP_IPV6=0" ]
   }
 
-  wiseconnect_sdk_root = "${chip_root}/third_party/silabs/wisemcu-wifi-bt-sdk"
   import("${examples_plat_dir}/SiWx917/rs911x.gni")
 }
 

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -132,15 +132,17 @@ else
         case $1 in
             --wifi)
                 if [ -z "$2" ]; then
-                    echo "--wifi requires rs911x or wf200"
+                    echo "--wifi requires rs911x or rs9117 or wf200"
                     exit 1
                 fi
                 if [ "$2" = "rs911x" ]; then
                     optArgs+="use_rs911x=true "
+                elif [ "$2" = "rs9117" ]; then
+                    optArgs+="use_rs9117=true "
                 elif [ "$2" = "wf200" ]; then
                     optArgs+="use_wf200=true "
                 else
-                    echo "Wifi usage: --wifi rs911x|wf200"
+                    echo "Wifi usage: --wifi rs911x|rs9117|wf200"
                     exit 1
                 fi
                 USE_WIFI=true
@@ -176,7 +178,7 @@ else
                 shift
                 ;;
             *)
-                if [ "$1" =~ *"use_rs911x=true"* ] || [ "$1" =~ *"use_wf200=true"* ]; then
+                if [ "$1" =~ *"use_rs911x=true"* ] || [ "$1" =~ *"use_rs9117=true"* ] || [ "$1" =~ *"use_wf200=true"* ]; then
                     USE_WIFI=true
                 fi
 

--- a/third_party/silabs/BUILD.gn
+++ b/third_party/silabs/BUILD.gn
@@ -18,7 +18,7 @@ import("//build_overrides/jlink.gni")
 import("${chip_root}/src/platform/device.gni")
 import("${efr32_sdk_build_root}/silabs_board.gni")
 
-if (silabs_board == "BRD4325A") {  # CCP board
+if (silabs_board == "BRD4325B") {  # CCP board
   import("${efr32_sdk_build_root}/SiWx917_sdk.gni")
 } else {
   import("${efr32_sdk_build_root}/efr32_sdk.gni")

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -24,7 +24,7 @@ declare_args() {
   # Location of the efr32 SDK.
   efr32_sdk_root = "${chip_root}/third_party/silabs/gecko_sdk"
   sdk_support_root = "${chip_root}/third_party/silabs/matter_support"
-  wiseconnect_sdk_root =
+  wisemcu_sdk_root =
       "${chip_root}/third_party/silabs/wiseconnect-wifi-bt-sdk"
   wisemcu_sdk_root = "${chip_root}/third_party/silabs/wisemcu-wifi-bt-sdk"
   examples_plat_dir = "${chip_root}/examples/platform/silabs/SiWx917"
@@ -89,7 +89,7 @@ template("efr32_sdk") {
       "${wisemcu_sdk_root}/third_party/freertos/portable/GCC/ARM_CM4F",
       "${examples_plat_dir}/device/inc",
 
-      "${wiseconnect_sdk_root}/sapi/include",
+      "${wisemcu_sdk_root}/sapi/include",
 
       "${chip_root}/examples/platform/SiWx917/SiWx917",
       "${chip_root}/examples/platform/SiWx917/SiWx917/hal",
@@ -252,10 +252,10 @@ template("efr32_sdk") {
       "${wisemcu_sdk_root}/platforms/si91x/core/chip/src/system_RS1xxxx.c",
 
       # Bluetooth
-      "${wiseconnect_sdk_root}/sapi/bluetooth/rsi_ble_gap_apis.c",
-      "${wiseconnect_sdk_root}/sapi/bluetooth/rsi_ble_gatt_apis.c",
-      "${wiseconnect_sdk_root}/sapi/bluetooth/rsi_bt_common_apis.c",
-      "${wiseconnect_sdk_root}/sapi/driver/rsi_bt_ble.c",
+      "${wisemcu_sdk_root}/sapi/bluetooth/rsi_ble_gap_apis.c",
+      "${wisemcu_sdk_root}/sapi/bluetooth/rsi_ble_gatt_apis.c",
+      "${wisemcu_sdk_root}/sapi/bluetooth/rsi_bt_common_apis.c",
+      "${wisemcu_sdk_root}/sapi/driver/rsi_bt_ble.c",
       "${wisemcu_sdk_root}/platforms/si91x/drivers/peripheral_drivers/src/clock_update.c",
       "${wisemcu_sdk_root}/platforms/si91x/drivers/peripheral_drivers/src/rsi_comparator.c",
       "${wisemcu_sdk_root}/platforms/si91x/drivers/peripheral_drivers/src/rsi_egpio.c",

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -200,6 +200,18 @@ template("efr32_sdk") {
           "RSI_SPI_INTERFACE",
           "RSI_WITH_OS",
         ]
+      } else if (use_rs9117) {
+        defines += [
+          "SL_HEAP_SIZE=32768",
+          "SL_WIFI=1",
+          "SL_WFX_USE_SPI",
+          "EFX32_RS911X=1",
+          "RS911X_WIFI",
+          "RS9117_WIFI",
+          "RSI_WLAN_ENABLE",
+          "RSI_SPI_INTERFACE",
+          "RSI_WITH_OS",
+        ]
       } else if (use_wf200) {
         defines += [
           "SL_HEAP_SIZE=24576",

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -33,6 +33,7 @@ declare_args() {
   # WIFI rcp boards options for wifi apps.
   use_wf200 = false
   use_rs911x = false
+  use_rs9117 = false
   use_rs911x_sockets = false
 }
 

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -88,7 +88,7 @@ if (silabs_board == "BRD4304A") {
 } else if (silabs_board == "BRD4170A") {
   silabs_family = "efr32mg12"
   silabs_mcu = "EFR32MG12P433F1024GM68"
-} else if (silabs_board == "BRD4325A") {
+} else if (silabs_board == "BRD4325B") {
   silabs_family = "SiWx917"
   silabs_mcu = "EFR32MG12P432F1024GL125"
   disable_lcd = true


### PR DESCRIPTION
**This PR will consist of these changes**
1. EFR32 + 9117 NCP to use Wisemcu SDK Package.
3. Correction for BLE to be used Wisemcu for SiWx917 SOC.
4. Radio Board Name Correction.
5. Differentiating rs911x to rs9116 and rs9117.