### PR TITLE
Updating documentation for installing Zap

### DIFF
--- a/docs/VSCODE_DEVELOPMENT.md
+++ b/docs/VSCODE_DEVELOPMENT.md
@@ -29,7 +29,7 @@ Tested on:
    `git config --global core.autocrlf false`
 1. Git clone the main Matter repository here:
    <https://github.com/project-chip/connectedhomeip>
-1. Launch Visual Studio Code, and open the cloned folder from
+1. Launch Visual Studio Code, and open the cloned folder from above
 1. Install the
    [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
    extension for Visual Studio Code, this extension allows you to use docker

--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -130,20 +130,9 @@ Finally, reboot your RPi.
 
 ## Installing ZAP
 
-`zap-cli` is already installed in pre-built docker images for chip-build, such
-as
-[chip-build-vscode](https://hub.docker.com/r/connectedhomeip/chip-build-vscode).
-
-Zap generation and tooling relies on `zap-cli` being available on the current
-system. You can install it from the zap project
-[Releases](https://github.com/project-chip/zap/releases).
-
-You should install a compatible release version, generally checking against the
-release set in
-[integrations/docker/images/chip-build/Dockerfile](../../integrations/docker/images/chip-build/Dockerfile).
-
-On linux, installation from `zap-linux.zip` is recommended as it pulls fewer
-dependencies than the `.deb` package.
+`bootstrap.sh` will download a compatible zap version and set it up in `$PATH`.
+If you want to install/use a different version, you may download one from the
+zap project [Releases](https://github.com/project-chip/zap/releases)
 
 ### Which ZAP to use
 


### PR DESCRIPTION
Zap no longer needs to be manually installed.

Fixing a minor typo as well.