### PR TITLE
Rpc: Make DeviceInfo SerialNumber field optional

### DIFF
--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -372,7 +372,7 @@ public:
         if (DeviceLayer::GetDeviceInstanceInfoProvider()->GetSerialNumber(response.serial_number, sizeof(response.serial_number)) !=
             CHIP_NO_ERROR)
         {
-            return pw::Status::Internal();
+            response.serial_number[0] = '\0'; // optional serial field not set.
         }
 
         // Create buffer for QR code that can fit max size and null terminator.


### PR DESCRIPTION
Problem:
The Device.DeviceInfo RPC currently returns an error if the serial number is not available:
```
>>> rpcs.chip.rpc.Device.GetDeviceInfo()
(Status.INTERNAL, chip.rpc.DeviceInfo(vendor_id=65521, product_id=32774, software_version=1, pairing_info=chip.rpc.PairingInfo(discriminator=3840), software_version_string='1.0'))
```
After #24346 Efr32 lock app does not provide a serial number. 

Change:
SerialNumber field now just not set if it is not available and returns OK.

Test:
Tested on EFR32 lock rpc build:
```
>>> rpcs.chip.rpc.Device.GetDeviceInfo()
(Status.OK, chip.rpc.DeviceInfo(vendor_id=65521, product_id=32774, software_version=1, pairing_info=chip.rpc.PairingInfo(discriminator=3840, qr_code='MT:8IXS142C00KA0648G00', qr_code_url='https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A8IXS142C00KA0648G00'), software_version_string='1.0'))
```
