### PR TITLE
Add a default group to example apps build

### DIFF
--- a/examples/lock-app/linux/BUILD.gn
+++ b/examples/lock-app/linux/BUILD.gn
@@ -44,3 +44,7 @@ executable("chip-lock-app") {
 group("linux") {
   deps = [ ":chip-lock-app" ]
 }
+
+group("default") {
+  deps = [ ":linux" ]
+}

--- a/examples/log-source-app/linux/BUILD.gn
+++ b/examples/log-source-app/linux/BUILD.gn
@@ -34,3 +34,7 @@ executable("chip-log-source-app") {
 group("linux") {
   deps = [ ":chip-log-source-app" ]
 }
+
+group("default") {
+  deps = [ ":linux" ]
+}

--- a/examples/ota-provider-app/linux/BUILD.gn
+++ b/examples/ota-provider-app/linux/BUILD.gn
@@ -35,3 +35,7 @@ executable("chip-ota-provider-app") {
 group("linux") {
   deps = [ ":chip-ota-provider-app" ]
 }
+
+group("default") {
+  deps = [ ":linux" ]
+}

--- a/examples/ota-requestor-app/linux/BUILD.gn
+++ b/examples/ota-requestor-app/linux/BUILD.gn
@@ -33,3 +33,7 @@ executable("chip-ota-requestor-app") {
 group("linux") {
   deps = [ ":chip-ota-requestor-app" ]
 }
+
+group("default") {
+  deps = [ ":linux" ]
+}

--- a/examples/persistent-storage/linux/BUILD.gn
+++ b/examples/persistent-storage/linux/BUILD.gn
@@ -32,3 +32,7 @@ executable("persistent_storage") {
 group("linux") {
   deps = [ ":persistent_storage" ]
 }
+
+group("default") {
+  deps = [ ":linux" ]
+}

--- a/examples/placeholder/linux/BUILD.gn
+++ b/examples/placeholder/linux/BUILD.gn
@@ -70,3 +70,7 @@ executable("chip-${chip_tests_zap_config}") {
 group("linux") {
   deps = [ ":chip-${chip_tests_zap_config}" ]
 }
+
+group("default") {
+  deps = [ ":linux" ]
+}

--- a/examples/thermostat/linux/BUILD.gn
+++ b/examples/thermostat/linux/BUILD.gn
@@ -36,3 +36,7 @@ executable("thermostat-app") {
 group("linux") {
   deps = [ ":thermostat-app" ]
 }
+
+group("default") {
+  deps = [ ":linux" ]
+}

--- a/examples/tv-app/linux/BUILD.gn
+++ b/examples/tv-app/linux/BUILD.gn
@@ -94,3 +94,7 @@ executable("chip-tv-app") {
 group("linux") {
   deps = [ ":chip-tv-app" ]
 }
+
+group("default") {
+  deps = [ ":linux" ]
+}

--- a/examples/tv-casting-app/linux/BUILD.gn
+++ b/examples/tv-casting-app/linux/BUILD.gn
@@ -54,3 +54,7 @@ executable("chip-tv-casting-app") {
 group("linux") {
   deps = [ ":chip-tv-casting-app" ]
 }
+
+group("default") {
+  deps = [ ":linux" ]
+}


### PR DESCRIPTION
Without this, all top level apps are generally built when running ninja, which results in things like `address-resolve` and `trace-decode` and various python tests to be pulled in and compiled.

This should speed up compilation quite a bit and removes a python venv dependency (for python tests) from the build.