### PR TITLE
Update docker cert-bins image to 12.22.12

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -163,10 +163,10 @@ RUN case ${TARGETPLATFORM} in \
             set -x \
             && mkdir node_js \
             && cd node_js \
-            && wget https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-x64.tar.xz \
-            && tar xfvJ node-v12.19.0-linux-x64.tar.xz \
-            && mv node-v12.19.0-linux-x64 /opt/ \
-            && ln -s /opt/node-v12.19.0-linux-x64 /opt/node \
+            && wget https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-x64.tar.xz \
+            && tar xfvJ node-v12.22.12-linux-x64.tar.xz \
+            && mv node-v12.22.12-linux-x64 /opt/ \
+            && ln -s /opt/node-v12.22.12-linux-x64 /opt/node \
             && ln -s /opt/node/bin/* /usr/bin \
             && cd .. \
             && rm -rf node_js \
@@ -175,10 +175,10 @@ RUN case ${TARGETPLATFORM} in \
             set -x \
             && mkdir node_js \
             && cd node_js \
-            && wget https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-arm64.tar.xz \
-            && tar xfvJ node-v12.19.0-linux-arm64.tar.xz \
-            && mv node-v12.19.0-linux-arm64 /opt/ \
-            && ln -s /opt/node-v12.19.0-linux-arm64 /opt/node \
+            && wget https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-arm64.tar.xz \
+            && tar xfvJ node-v12.22.12-linux-arm64.tar.xz \
+            && mv node-v12.22.12-linux-arm64 /opt/ \
+            && ln -s /opt/node-v12.22.12-linux-arm64 /opt/node \
             && ln -s /opt/node/bin/* /usr/bin \
             && cd .. \
             && rm -rf node_js \


### PR DESCRIPTION
This seems to be the latest version and #24853 seems to say that an dependency on webpack requires a new minimal nodejs version.

Fixes #24853