### PR TITLE
Darwin: Pass event timestamp to MTRDeviceDelegate

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -429,11 +429,21 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @property (nonatomic, readonly, copy, nullable) NSError * error;
 @end
 
+typedef NS_ENUM(NSUInteger, MTREventTimeType) { MTREventTimeTypeSystemUpTime = 0, MTREventTimeTypeTimestampDate };
+
 @interface MTREventReport : NSObject
 @property (nonatomic, readonly, copy) MTREventPath * path;
 @property (nonatomic, readonly, copy) NSNumber * eventNumber; // EventNumber type (uint64_t)
 @property (nonatomic, readonly, copy) NSNumber * priority; // PriorityLevel type (uint8_t)
-@property (nonatomic, readonly, copy) NSNumber * timestamp; // Timestamp type (uint64_t)
+
+// Either systemUpTime or timestampDate will be valid depending on eventTimeType
+@property (nonatomic, readonly) MTREventTimeType eventTimeType;
+MTR_NEWLY_AVAILABLE;
+@property (nonatomic, readonly) NSTimeInterval systemUpTime;
+MTR_NEWLY_AVAILABLE;
+@property (nonatomic, readonly, copy, nullable) NSDate * timestampDate;
+MTR_NEWLY_AVAILABLE;
+
 // An instance of one of the event payload interfaces.
 @property (nonatomic, readonly, copy) id value;
 
@@ -541,6 +551,11 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
     API_DEPRECATED("Please use commandPathWithEndpointID:clusterID:commandID:", ios(16.1, 16.4), macos(13.0, 13.3),
         watchos(9.1, 9.4), tvos(16.1, 16.4));
 
+@end
+
+@interface MTREventReport (Deprecated)
+@property (nonatomic, readonly, copy) NSNumber * timestamp;
+MTR_NEWLY_DEPRECATED("Please use timestampDate and systemUpTime")
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -429,20 +429,26 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @property (nonatomic, readonly, copy, nullable) NSError * error;
 @end
 
-typedef NS_ENUM(NSUInteger, MTREventTimeType) { MTREventTimeTypeSystemUpTime = 0, MTREventTimeTypeTimestampDate };
+typedef NS_ENUM(NSUInteger, MTREventTimeType) {
+    MTREventTimeTypeSystemUpTime = 0,
+    MTREventTimeTypeTimestampDate
+} MTR_NEWLY_AVAILABLE;
+
+typedef NS_ENUM(NSUInteger, MTREventPriority) {
+    MTREventPriorityDebug = 0,
+    MTREventPriorityInfo = 1,
+    MTREventPriorityCritical = 2
+} MTR_NEWLY_AVAILABLE;
 
 @interface MTREventReport : NSObject
 @property (nonatomic, readonly, copy) MTREventPath * path;
 @property (nonatomic, readonly, copy) NSNumber * eventNumber; // EventNumber type (uint64_t)
-@property (nonatomic, readonly, copy) NSNumber * priority; // PriorityLevel type (uint8_t)
+@property (nonatomic, readonly, copy) NSNumber * priority; // PriorityLevel type (MTREventPriority)
 
 // Either systemUpTime or timestampDate will be valid depending on eventTimeType
-@property (nonatomic, readonly) MTREventTimeType eventTimeType;
-MTR_NEWLY_AVAILABLE;
-@property (nonatomic, readonly) NSTimeInterval systemUpTime;
-MTR_NEWLY_AVAILABLE;
-@property (nonatomic, readonly, copy, nullable) NSDate * timestampDate;
-MTR_NEWLY_AVAILABLE;
+@property (nonatomic, readonly) MTREventTimeType eventTimeType MTR_NEWLY_AVAILABLE;
+@property (nonatomic, readonly) NSTimeInterval systemUpTime MTR_NEWLY_AVAILABLE;
+@property (nonatomic, readonly, copy, nullable) NSDate * timestampDate MTR_NEWLY_AVAILABLE;
 
 // An instance of one of the event payload interfaces.
 @property (nonatomic, readonly, copy) id value;
@@ -554,8 +560,7 @@ MTR_NEWLY_AVAILABLE;
 @end
 
 @interface MTREventReport (Deprecated)
-@property (nonatomic, readonly, copy) NSNumber * timestamp;
-MTR_NEWLY_DEPRECATED("Please use timestampDate and systemUpTime")
+@property (nonatomic, readonly, copy) NSNumber * timestamp MTR_NEWLY_DEPRECATED("Please use timestampDate and systemUpTime");
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -2042,23 +2042,46 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
 }
 @end
 
+@interface MTREventReport () {
+    NSNumber * _timestampValue;
+}
+@end
+
 @implementation MTREventReport
-- (instancetype)initWithPath:(const ConcreteEventPath &)path
+- (instancetype)initWithPath:(const chip::app::ConcreteEventPath &)path
                  eventNumber:(NSNumber *)eventNumber
                     priority:(NSNumber *)priority
-                   timestamp:(NSNumber *)timestamp
+               timestampType:(NSNumber *)timestampType
+              timestampValue:(NSNumber *)timestampValue
                        value:(id _Nullable)value
-                       error:(NSError * _Nullable)error
+                       error:(NSError * _Nullable)error;
 {
     if (self = [super init]) {
         _path = [[MTREventPath alloc] initWithPath:path];
         _eventNumber = eventNumber;
         _priority = priority;
-        _timestamp = timestamp;
+        _timestampValue = timestampValue;
+        if ((Timestamp::Type) timestampType.unsignedIntegerValue == Timestamp::Type::kSystem) {
+            _eventTimeType = MTREventTimeTypeSystemUpTime;
+            _systemUpTime = MTRTimeIntervalForEventTimestampValue(timestampValue.unsignedLongLongValue);
+        } else if ((Timestamp::Type) timestampType.unsignedIntegerValue == Timestamp::Type::kSystem) {
+            _eventTimeType = MTREventTimeTypeTimestampDate;
+            _timestampDate =
+                [NSDate dateWithTimeIntervalSince1970:MTRTimeIntervalForEventTimestampValue(timestampValue.unsignedLongLongValue)];
+        } else {
+            return nil;
+        }
         _value = value;
         _error = error;
     }
     return self;
+}
+@end
+
+@implementation MTREventReport (Deprecated)
+- (NSNumber *)timestamp
+{
+    return _timestampValue;
 }
 @end
 
@@ -2094,7 +2117,8 @@ void SubscriptionCallback::OnEventData(const EventHeader & aEventHeader, TLV::TL
     [mEventReports addObject:[[MTREventReport alloc] initWithPath:aEventHeader.mPath
                                                       eventNumber:@(aEventHeader.mEventNumber)
                                                          priority:@((uint8_t) aEventHeader.mPriorityLevel)
-                                                        timestamp:@(aEventHeader.mTimestamp.mValue)
+                                                    timestampType:@((NSUInteger) aEventHeader.mTimestamp.mType)
+                                                   timestampValue:@(aEventHeader.mTimestamp.mValue)
                                                             value:value
                                                             error:error]];
 }

--- a/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
@@ -22,6 +22,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/ConcreteEventPath.h>
 #include <app/DeviceProxy.h>
+#include <app/EventLoggingTypes.h>
 
 @class MTRDeviceController;
 
@@ -99,9 +100,8 @@ static inline MTRTransportType MTRMakeTransportType(chip::Transport::Type type)
 @interface MTREventReport ()
 - (instancetype)initWithPath:(const chip::app::ConcreteEventPath &)path
                  eventNumber:(NSNumber *)eventNumber
-                    priority:(NSNumber *)priority
-               timestampType:(NSNumber *)timestampType
-              timestampValue:(NSNumber *)timestampValue
+                    priority:(chip::app::PriorityLevel)priority
+                   timestamp:(const chip::app::Timestamp &)timestamp
                        value:(id _Nullable)value
                        error:(NSError * _Nullable)error;
 @end

--- a/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
@@ -100,7 +100,8 @@ static inline MTRTransportType MTRMakeTransportType(chip::Transport::Type type)
 - (instancetype)initWithPath:(const chip::app::ConcreteEventPath &)path
                  eventNumber:(NSNumber *)eventNumber
                     priority:(NSNumber *)priority
-                   timestamp:(NSNumber *)timestamp
+               timestampType:(NSNumber *)timestampType
+              timestampValue:(NSNumber *)timestampValue
                        value:(id _Nullable)value
                        error:(NSError * _Nullable)error;
 @end

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -211,9 +211,11 @@ extern NSString * const MTREventTimestampDateKey MTR_NEWLY_AVAILABLE;
  * these keys:
  *
  *                MTREventNumberKey : NSNumber-wrapped uint64_t value. Monotonically increasing, but consecutive events may not have
- * consecutive numbers. MTREventPriorityKey : NSNumber-wrapped MTREventPriority value. MTREventTimeTypeKey : NSNumber-wrapped
- * MTREventTimeType value. MTREventSystemUpTimeKey : NSNumber-wrapped NSTimeInterval value. MTREventTimestampDateKey : NSDate
- * object.
+ * consecutive numbers.
+ *                MTREventPriorityKey : NSNumber-wrapped MTREventPriority value.
+ *                MTREventTimeTypeKey : NSNumber-wrapped MTREventTimeType value.
+ *                MTREventSystemUpTimeKey : NSNumber-wrapped NSTimeInterval value.
+ *                MTREventTimestampDateKey : NSDate object.
  *
  *                Only one of MTREventTimestampDateKey and MTREventSystemUpTimeKey will be present, depending on the value for
  * MTREventTimeTypeKey.

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -208,17 +208,17 @@ extern NSString * const MTREventTimestampDateKey MTR_NEWLY_AVAILABLE;
  * @param eventReport  An array of response-value objects as described in MTRDeviceResponseHandler
  *
  *                In addition to the MTREventPathKey and MTRDataKey containing the path and event values, eventReport also contains
- * these keys:
+ *                these keys:
  *
- *                MTREventNumberKey : NSNumber-wrapped uint64_t value. Monotonically increasing, but consecutive events may not have
- * consecutive numbers.
+ *                MTREventNumberKey : NSNumber-wrapped uint64_t value. Monotonically increasing, but consecutive events may not
+ *                                    have consecutive numbers.
  *                MTREventPriorityKey : NSNumber-wrapped MTREventPriority value.
  *                MTREventTimeTypeKey : NSNumber-wrapped MTREventTimeType value.
  *                MTREventSystemUpTimeKey : NSNumber-wrapped NSTimeInterval value.
  *                MTREventTimestampDateKey : NSDate object.
  *
  *                Only one of MTREventTimestampDateKey and MTREventSystemUpTimeKey will be present, depending on the value for
- * MTREventTimeTypeKey.
+ *                MTREventTimeTypeKey.
  */
 - (void)device:(MTRDevice *)device receivedEventReport:(NSArray<NSDictionary<NSString *, id> *> *)eventReport;
 

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -63,6 +63,18 @@ typedef NS_ENUM(NSUInteger, MTRDeviceState) {
 @property (nonatomic, readonly) MTRDeviceState state;
 
 /**
+ * The estimated device system start time.
+ *
+ * A device can reports its events with either calendar time or time since system start time. When events are reported with time
+ * since system start time, this property will return an estimation of the device system start time. Because a device may report
+ * timestamp this way due to the lack of a wall clock, system start time can only be estimated based on event receive time and the
+ * timestamp value, and this estimation may change over time, but only toward an earlier date.
+ *
+ * If events are always reported with calendar time, then this property will return nil.
+ */
+@property (nonatomic, readonly, nullable) NSDate * estimatedStartTime MTR_NEWLY_AVAILABLE;
+
+/**
  * Set the delegate to receive asynchronous callbacks about the device.
  *
  * The delegate will be called on the provided queue, for attribute reports, event reports, and device state changes.
@@ -168,6 +180,12 @@ typedef NS_ENUM(NSUInteger, MTRDeviceState) {
 
 @end
 
+extern NSString * const MTREventNumberKey MTR_NEWLY_AVAILABLE;
+extern NSString * const MTREventPriorityKey MTR_NEWLY_AVAILABLE;
+extern NSString * const MTREventTimeTypeKey MTR_NEWLY_AVAILABLE;
+extern NSString * const MTREventSystemUpTimeKey MTR_NEWLY_AVAILABLE;
+extern NSString * const MTREventTimestampDateKey MTR_NEWLY_AVAILABLE;
+
 @protocol MTRDeviceDelegate <NSObject>
 @required
 /**
@@ -186,6 +204,18 @@ typedef NS_ENUM(NSUInteger, MTRDeviceState) {
  * Notifies delegate of event reports from the MTRDevice
  *
  * @param eventReport  An array of response-value objects as described in MTRDeviceResponseHandler
+ *
+ *                In addition to the MTREventPathKey and MTRDataKey containing the path and event values, eventReport also contains
+ * these keys:
+ *
+ *                MTREventNumberKey : NSNumber-wrapped uint64_t value.
+ *                MTREventPriorityKey : NSNumber-wrapped uint8_t value.
+ *                MTREventTimeTypeKey : NSNumber-wrapped MTREventTimeType value.
+ *                MTREventSystemUpTimeKey : NSNumber-wrapped NSTimeInterval value.
+ *                MTREventTimestampDateKey : NSDate object.
+ *
+ *                Only one of MTREventTimestampDateKey and MTREventSystemUpTimeKey will be present, depending on the value for
+ * MTREvenTimeTypeKey.
  */
 - (void)device:(MTRDevice *)device receivedEventReport:(NSArray<NSDictionary<NSString *, id> *> *)eventReport;
 

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -65,10 +65,12 @@ typedef NS_ENUM(NSUInteger, MTRDeviceState) {
 /**
  * The estimated device system start time.
  *
- * A device can reports its events with either calendar time or time since system start time. When events are reported with time
+ * A device can report its events with either calendar time or time since system start time. When events are reported with time
  * since system start time, this property will return an estimation of the device system start time. Because a device may report
- * timestamp this way due to the lack of a wall clock, system start time can only be estimated based on event receive time and the
- * timestamp value, and this estimation may change over time, but only toward an earlier date.
+ * timestamps this way due to the lack of a wall clock, system start time can only be estimated based on event receive time and the
+ * timestamp value, and this estimation may change over time.
+ *
+ * Device reboots may also cause the estimated device start time to jump forward.
  *
  * If events are always reported with calendar time, then this property will return nil.
  */
@@ -208,14 +210,13 @@ extern NSString * const MTREventTimestampDateKey MTR_NEWLY_AVAILABLE;
  *                In addition to the MTREventPathKey and MTRDataKey containing the path and event values, eventReport also contains
  * these keys:
  *
- *                MTREventNumberKey : NSNumber-wrapped uint64_t value.
- *                MTREventPriorityKey : NSNumber-wrapped uint8_t value.
- *                MTREventTimeTypeKey : NSNumber-wrapped MTREventTimeType value.
- *                MTREventSystemUpTimeKey : NSNumber-wrapped NSTimeInterval value.
- *                MTREventTimestampDateKey : NSDate object.
+ *                MTREventNumberKey : NSNumber-wrapped uint64_t value. Monotonically increasing, but consecutive events may not have
+ * consecutive numbers. MTREventPriorityKey : NSNumber-wrapped MTREventPriority value. MTREventTimeTypeKey : NSNumber-wrapped
+ * MTREventTimeType value. MTREventSystemUpTimeKey : NSNumber-wrapped NSTimeInterval value. MTREventTimestampDateKey : NSDate
+ * object.
  *
  *                Only one of MTREventTimestampDateKey and MTREventSystemUpTimeKey will be present, depending on the value for
- * MTREvenTimeTypeKey.
+ * MTREventTimeTypeKey.
  */
 - (void)device:(MTRDevice *)device receivedEventReport:(NSArray<NSDictionary<NSString *, id> *> *)eventReport;
 

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -210,8 +210,8 @@ extern NSString * const MTREventTimestampDateKey MTR_NEWLY_AVAILABLE;
  *                In addition to the MTREventPathKey and MTRDataKey containing the path and event values, eventReport also contains
  *                these keys:
  *
- *                MTREventNumberKey : NSNumber-wrapped uint64_t value. Monotonically increasing, but consecutive events may not
- *                                    have consecutive numbers.
+ *                MTREventNumberKey : NSNumber-wrapped uint64_t value. Monotonically increasing, and consecutive event reports
+ *                                    should have consecutive numbers unless device reboots, or if events are lost.
  *                MTREventPriorityKey : NSNumber-wrapped MTREventPriority value.
  *                MTREventTimeTypeKey : NSNumber-wrapped MTREventTimeType value.
  *                MTREventSystemUpTimeKey : NSNumber-wrapped NSTimeInterval value.

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -394,7 +394,7 @@ private:
         // Whenever a StartUp event is received, reset the estimated start time
         MTREventPath * eventPath = eventDict[MTREventPathKey];
         BOOL isStartUpEvent = (eventPath.cluster.unsignedLongValue == MTRClusterIDTypeBasicInformationID)
-            && (eventPath.event.unsignedLongValue == MTRClusterBasicEventStartUpID);
+            && (eventPath.event.unsignedLongValue == MTREventIDTypeClusterBasicInformationEventStartUpID);
         if (isStartUpEvent) {
             _estimatedStartTime = nil;
         }

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -118,7 +118,7 @@ NSTimeInterval MTRTimeIntervalForEventTimestampValue(uint64_t timeValue)
 
     // First convert the event timestamp value (in milliseconds) to NSTimeInterval - to minimize potential loss of precision
     // of uint64 => NSTimeInterval (double), convert whole seconds and remainder separately and then combine
-    NSTimeInterval eventTimestampValueSeconds = (NSTimeInterval)(timeValue / chip::kMillisecondsPerSecond);
+    NSTimeInterval eventTimestampValueSeconds = timeValue / chip::kMillisecondsPerSecond;
     NSTimeInterval eventTimestampValueRemainder
         = ((NSTimeInterval)(timeValue % chip::kMillisecondsPerSecond)) / chip::kMillisecondsPerSecond;
     NSTimeInterval eventTimestampValue = eventTimestampValueSeconds + eventTimestampValueRemainder;

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -259,11 +259,16 @@ private:
 {
     MTRDeviceState lastState = _state;
     _state = state;
-    id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-    if (delegate && (lastState != state)) {
-        dispatch_async(_delegateQueue, ^{
-            [delegate device:self stateChanged:state];
-        });
+    if (lastState != state) {
+        if (state != MTRDeviceStateReachable) {
+            _estimatedStartTime = nil;
+        }
+        id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
+        if (delegate) {
+            dispatch_async(_delegateQueue, ^{
+                [delegate device:self stateChanged:state];
+            });
+        }
     }
 }
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -118,9 +118,10 @@ NSTimeInterval MTRTimeIntervalForEventTimestampValue(uint64_t timeValue)
 
     // First convert the event timestamp value (in milliseconds) to NSTimeInterval - to minimize potential loss of precision
     // of uint64 => NSTimeInterval (double), convert whole seconds and remainder separately and then combine
-    NSTimeInterval eventTimestampValueSeconds = timeValue / chip::kMillisecondsPerSecond;
+    uint64_t eventTimestampValueSeconds = timeValue / chip::kMillisecondsPerSecond;
+    uint64_t eventTimestampValueRemainderMilliseconds = timeValue % chip::kMillisecondsPerSecond;
     NSTimeInterval eventTimestampValueRemainder
-        = ((NSTimeInterval)(timeValue % chip::kMillisecondsPerSecond)) / chip::kMillisecondsPerSecond;
+        = NSTimeInterval(eventTimestampValueRemainderMilliseconds) / chip::kMillisecondsPerSecond;
     NSTimeInterval eventTimestampValue = eventTimestampValueSeconds + eventTimestampValueRemainder;
 
     return eventTimestampValue;

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -51,4 +51,7 @@ typedef void (^MTRDevicePerformAsyncBlock)(MTRBaseDevice * baseDevice);
 // Returns min or max, if it is below or above, respectively.
 NSNumber * MTRClampedNumber(NSNumber * aNumber, NSNumber * min, NSNumber * max);
 
+#pragma mark - Utility for time conversion
+NSTimeInterval MTRTimeIntervalForEventTimestampValue(uint64_t timeValue);
+
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -54,4 +54,8 @@ NSNumber * MTRClampedNumber(NSNumber * aNumber, NSNumber * min, NSNumber * max);
 #pragma mark - Utility for time conversion
 NSTimeInterval MTRTimeIntervalForEventTimestampValue(uint64_t timeValue);
 
+#pragma mark - Utility for event priority conversion
+BOOL MTRPriorityLevelIsValid(chip::app::PriorityLevel priorityLevel);
+MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel);
+
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -1388,8 +1388,21 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     };
 
     __block unsigned eventReportsReceived = 0;
-    delegate.onEventDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * data) {
-        eventReportsReceived += data.count;
+    delegate.onEventDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * eventReport) {
+        eventReportsReceived += eventReport.count;
+
+        for (NSDictionary<NSString *, id> * eventDict in eventReport) {
+            NSNumber * eventTimeTypeNumber = eventDict[MTREventTimeTypeKey];
+            XCTAssertNotNil(eventTimeTypeNumber);
+            MTREventTimeType eventTimeType = (MTREventTimeType) eventTimeTypeNumber.unsignedIntegerValue;
+            XCTAssert((eventTimeType == MTREventTimeTypeSystemUpTime) || (eventTimeType == MTREventTimeTypeTimestampDate));
+            if (eventTimeType == MTREventTimeTypeSystemUpTime) {
+                XCTAssertNotNil(eventDict[MTREventSystemUpTimeKey]);
+                XCTAssertNotNil(device.estimatedStartTime);
+            } else if (eventTimeType == MTREventTimeTypeTimestampDate) {
+                XCTAssertNotNil(eventDict[MTREventTimestampDateKey]);
+            }
+        }
     };
 
     [device setDelegate:delegate queue:queue];

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -1457,6 +1457,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // with data versions) during the resubscribe.
     XCTAssertEqual(attributeReportsReceived, 0);
     XCTAssertEqual(eventReportsReceived, 0);
+
+    // Check that device resets start time on subscription drop
+    XCTAssertNil(device.estimatedStartTime);
 }
 
 - (void)test018_SubscriptionErrorWhenNotResubscribing


### PR DESCRIPTION
This change adds event number, event priority, and event time to event reports with MTRDevice.

Fixes #24711