### PR TITLE
[codegen] Add ability to define CustomGenerator plugin.

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -326,6 +326,7 @@ CurrentHue
 CurrentLevel
 CurrentSaturation
 customAcl
+CustomGenerator
 customizations
 cvfJ
 cxx
@@ -1164,6 +1165,8 @@ saveAs
 sbin
 scalability
 scalable
+schema
+schemas
 scm
 sco
 scp

--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -326,7 +326,6 @@ CurrentHue
 CurrentLevel
 CurrentSaturation
 customAcl
-CustomGenerator
 customizations
 cvfJ
 cxx

--- a/scripts/codegen.py
+++ b/scripts/codegen.py
@@ -71,9 +71,9 @@ __LOG_LEVELS__ = {
     '--generator',
     default='JAVA',
     help='What code generator to run.  The choices are: '+'|'.join(GENERATORS.keys())+'. ' +
-         'When using custom, provide the plugin path using ' +
-         '`--generator custom:<path_to_plugin>` syntax. The plugin path shall contain a package ' +
-         'named `matter_idl_plugin/__init.py__` that defines a subclass of CodeGenerator named CustomGenerator.')
+         'When using custom, provide the plugin path using `--generator custom:<path_to_plugin>:<plugin_module_name>` syntax. ' +
+    'For example, `--generator custom:./my_plugin:my_plugin_module` will load `./my_plugin/my_plugin_module/__init.py__` ' +
+         'that defines a subclass of CodeGenerator named CustomGenerator.')
 @click.option(
     '--output-dir',
     type=click.Path(exists=False),

--- a/scripts/codegen.py
+++ b/scripts/codegen.py
@@ -92,10 +92,15 @@ __LOG_LEVELS__ = {
     type=click.Path(exists=True),
     default=None,
     help='A file containing all expected outputs. Script will fail if outputs do not match')
+@click.option(
+    '--plugin',
+    type=click.Path(exists=True),
+    default='.',
+    help='A path to a directory containing matter_idl_plagin/__init__.py that defines CustomGenerator. Will auto-set --generator to CUSTOM.')
 @click.argument(
     'idl_path',
     type=click.Path(exists=True))
-def main(log_level, generator, output_dir, dry_run, name_only, expected_outputs, idl_path):
+def main(log_level, generator, output_dir, dry_run, name_only, expected_outputs, plugin, idl_path):
     """
     Parses MATTER IDL files (.matter) and performs SDK code generation
     as set up by the program arguments.
@@ -109,6 +114,14 @@ def main(log_level, generator, output_dir, dry_run, name_only, expected_outputs,
             format='%(asctime)s %(levelname)-7s %(message)s',
             datefmt='%Y-%m-%d %H:%M:%S'
         )
+
+    if plugin:
+        if generator != 'custom':
+            print('GENERATOR = '+generator)
+            logging.warning("Overriding --generator to 'custom' to support --plugin.")
+
+        sys.path.append(plugin)
+        generator = 'CUSTOM'
 
     logging.info("Parsing idl from %s" % idl_path)
     idl_tree = CreateParser().parse(open(idl_path, "rt").read())

--- a/scripts/codegen.py
+++ b/scripts/codegen.py
@@ -120,6 +120,7 @@ def main(log_level, generator, output_dir, dry_run, name_only, expected_outputs,
     logging.info("Parsing idl from %s" % idl_path)
     idl_tree = CreateParser().parse(open(idl_path, "rt").read())
 
+    plugin_module = None
     if generator.startswith('custom'):
         # check that the plugin path is provided
         if ':' not in generator:

--- a/scripts/py_matter_idl/examples/README.md
+++ b/scripts/py_matter_idl/examples/README.md
@@ -11,9 +11,9 @@ scripts/py_matter_idl/examples/matter_idl_plugin:
 3. Have CustomGenerator load jinja templates, also under the "matter_idl_plugin"
    subdirectory.
 4. Execute the `codegen.py` script passing the path to the parent directory of
-   "matter_idl_plugin" via `--plugin` argument.
+   "matter_idl_plugin" via `--generator custom:<plugin_path>` argument.
 
 ```
-cd scripts/py_matter_idl/examples
-../../codegen.py --plugin ./scripts/py_matter_idl/examples ./src/controller/data_model/controller-clusters.matter
+# From top-of-tree in this example
+./scripts/codegen.py --generator custom:./scripts/py_matter_idl/examples ./src/controller/data_model/controller-clusters.matter
 ```

--- a/scripts/py_matter_idl/examples/README.md
+++ b/scripts/py_matter_idl/examples/README.md
@@ -1,0 +1,19 @@
+## Creating a custom matter_idl generator
+
+The matter_idl tool can be used to generate arbitrary code based on the Matter
+data model schemas. To create a custom generator that lives outside of the
+Matter SDK tree, follow the design pattern of
+scripts/py_matter_idl/examples/matter_idl_plugin:
+
+1. Create a directory exactly named "matter_idl_plugin".
+2. Add an `__init__.py` under "matter_idl_plugin" implementing a subclass of
+   `CodeGenerator` named `CustomGenerator`.
+3. Have CustomGenerator load jinja templates, also under the "matter_idl_plugin"
+   subdirectory.
+4. Execute the `codegen.py` script from the parent directory of
+   "matter_idl_plugin".
+
+```
+cd scripts/py_matter_idl/examples
+../../codegen.py --generator custom ../../../src/controller/data_model/controller-clusters.matter
+```

--- a/scripts/py_matter_idl/examples/README.md
+++ b/scripts/py_matter_idl/examples/README.md
@@ -5,15 +5,17 @@ data model schemas. To create a custom generator that lives outside of the
 Matter SDK tree, follow the design pattern of
 scripts/py_matter_idl/examples/matter_idl_plugin:
 
-1. Create a directory exactly named "matter_idl_plugin".
+1. Create a directory for your python generator module, for example
+   "matter_idl_plugin".
 2. Add an `__init__.py` under "matter_idl_plugin" implementing a subclass of
    `CodeGenerator` named `CustomGenerator`.
 3. Have `CustomGenerator` load jinja templates, also under the
    "matter_idl_plugin" subdirectory.
 4. Execute the `codegen.py` script passing the path to the parent directory of
-   "matter_idl_plugin" via `--generator custom:<plugin_path>` argument.
+   "matter_idl_plugin" via
+   `--generator custom:<plugin_path>:<plugin_module_name>` argument.
 
 ```
 # From top-of-tree in this example
-./scripts/codegen.py --generator custom:./scripts/py_matter_idl/examples ./src/controller/data_model/controller-clusters.matter
+./scripts/codegen.py --generator custom:./scripts/py_matter_idl/examples:matter_idl_plugin ./src/controller/data_model/controller-clusters.matter
 ```

--- a/scripts/py_matter_idl/examples/README.md
+++ b/scripts/py_matter_idl/examples/README.md
@@ -10,10 +10,10 @@ scripts/py_matter_idl/examples/matter_idl_plugin:
    `CodeGenerator` named `CustomGenerator`.
 3. Have CustomGenerator load jinja templates, also under the "matter_idl_plugin"
    subdirectory.
-4. Execute the `codegen.py` script from the parent directory of
-   "matter_idl_plugin".
+4. Execute the `codegen.py` script passing the path to the parent directory of
+   "matter_idl_plugin" via `--plugin` argument.
 
 ```
 cd scripts/py_matter_idl/examples
-../../codegen.py --generator custom ../../../src/controller/data_model/controller-clusters.matter
+../../codegen.py --plugin ./scripts/py_matter_idl/examples ./src/controller/data_model/controller-clusters.matter
 ```

--- a/scripts/py_matter_idl/examples/README.md
+++ b/scripts/py_matter_idl/examples/README.md
@@ -8,8 +8,8 @@ scripts/py_matter_idl/examples/matter_idl_plugin:
 1. Create a directory exactly named "matter_idl_plugin".
 2. Add an `__init__.py` under "matter_idl_plugin" implementing a subclass of
    `CodeGenerator` named `CustomGenerator`.
-3. Have CustomGenerator load jinja templates, also under the "matter_idl_plugin"
-   subdirectory.
+3. Have `CustomGenerator` load jinja templates, also under the
+   "matter_idl_plugin" subdirectory.
 4. Execute the `codegen.py` script passing the path to the parent directory of
    "matter_idl_plugin" via `--generator custom:<plugin_path>` argument.
 

--- a/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
@@ -104,15 +104,24 @@ class EncodingDataType:
 
     @staticmethod
     def fromType(protobufType: str):
-        if protobufType == "uint32": return EncodingDataType.UINT
-        if protobufType == "uint64": return EncodingDataType.UINT
-        if protobufType == "int32": return EncodingDataType.INT
-        if protobufType == "int64": return EncodingDataType.INT
-        if protobufType == "bool": return EncodingDataType.BOOL
-        if protobufType == "string": return EncodingDataType.CHAR_STRING
-        if protobufType == "bytes": return EncodingDataType.OCT_STRING
-        if protobufType == "float": return EncodingDataType.FLOAT
-        if protobufType == "double": return EncodingDataType.DOUBLE
+        if protobufType == "uint32":
+            return EncodingDataType.UINT
+        if protobufType == "uint64":
+            return EncodingDataType.UINT
+        if protobufType == "int32":
+            return EncodingDataType.INT
+        if protobufType == "int64":
+            return EncodingDataType.INT
+        if protobufType == "bool":
+            return EncodingDataType.BOOL
+        if protobufType == "string":
+            return EncodingDataType.CHAR_STRING
+        if protobufType == "bytes":
+            return EncodingDataType.OCT_STRING
+        if protobufType == "float":
+            return EncodingDataType.FLOAT
+        if protobufType == "double":
+            return EncodingDataType.DOUBLE
 
         # If not a primitive type, it is a named type; assume it is a Struct.
         # NOTE: the actual type may be an Enum or Bitmap.

--- a/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
@@ -177,7 +177,7 @@ class CustomGenerator(CodeGenerator):
     Example of a custom generator.  Outputs protobuf representation of Matter clusters.
     """
 
-    def __init__(self, storage: GeneratorStorage, idl: Idl):
+    def __init__(self, storage: GeneratorStorage, idl: Idl, **kargs):
         """
         Inintialization is specific for java generation and will add
         filters as required by the java .jinja templates to function.

--- a/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
@@ -77,17 +77,14 @@ def toProtobufType(zapType: str) -> str:
         return "int64"
     if zapTypeLower in floatTypes:
         return "float"
+    if zapTypeLower == "double":
+        return "double"
+    if zapTypeLower == "boolean":
+        return "bool"
     if zapTypeLower in stringTypes:
         return "string"
     if zapTypeLower in bytesTypes:
         return "bytes"
-
-    match(zapTypeLower):
-        case "boolean":
-            return "bool"
-
-        case "double":
-            return "double"
 
     # If no match, return the original type name for the Struct, Enum, or Bitmap.
     return zapType
@@ -107,16 +104,15 @@ class EncodingDataType:
 
     @staticmethod
     def fromType(protobufType: str):
-        match(protobufType):
-            case "uint32": return EncodingDataType.UINT
-            case "uint64": return EncodingDataType.UINT
-            case "int32": return EncodingDataType.INT
-            case "int64": return EncodingDataType.INT
-            case "bool": return EncodingDataType.BOOL
-            case "string": return EncodingDataType.CHAR_STRING
-            case "bytes": return EncodingDataType.OCT_STRING
-            case "float": return EncodingDataType.FLOAT
-            case "double": return EncodingDataType.DOUBLE
+        if protobufType == "uint32": return EncodingDataType.UINT
+        if protobufType == "uint64": return EncodingDataType.UINT
+        if protobufType == "int32": return EncodingDataType.INT
+        if protobufType == "int64": return EncodingDataType.INT
+        if protobufType == "bool": return EncodingDataType.BOOL
+        if protobufType == "string": return EncodingDataType.CHAR_STRING
+        if protobufType == "bytes": return EncodingDataType.OCT_STRING
+        if protobufType == "float": return EncodingDataType.FLOAT
+        if protobufType == "double": return EncodingDataType.DOUBLE
 
         # If not a primitive type, it is a named type; assume it is a Struct.
         # NOTE: the actual type may be an Enum or Bitmap.
@@ -129,6 +125,7 @@ def commandArgs(command: Command, cluster: Cluster):
         if struct.name == command.input_param:
             return struct.fields
 
+    # If the command has no input parameters, just return an empty list.
     return []
 
 

--- a/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
@@ -1,0 +1,326 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import List
+
+import jinja2
+from matter_idl import matter_idl_types
+from matter_idl.generators import CodeGenerator, GeneratorStorage
+from matter_idl.matter_idl_types import Attribute, Cluster, ClusterSide, Command, DataType, Field, Idl
+
+
+def toUpperSnakeCase(s):
+    """ Convert camelCaseString to UPPER_SNAKE_CASE """
+    lastLower = False
+    letters = []
+    for c in s:
+        #if c == '_': next
+        if c.isupper():
+            if lastLower:
+                letters.append('_')
+            letters.append(c)
+            lastLower = False
+        else:
+            letters.append(c.upper())
+            lastLower = True
+
+    return ''.join(letters)
+
+
+def toLowerSnakeCase(s):
+    """ Convert camelCaseString to lower_snake_case whenever a transition from lower to upper case is detected """
+    return toUpperSnakeCase(s).lower()
+
+
+def toUpperAcronym(s):
+    """ Remove lower case letters and numbers from the given string"""
+    return ''.join([i for i in s if i.isupper() or i.isnumeric()]).upper()
+
+
+def toEnumConstant(enumEntry, enumName):
+    """ Create enum entry name by prepending that acronym of the enum name and converting to upper snake case """
+    prefix = toUpperAcronym(enumName)
+    if (enumEntry[0] == 'k'):
+        enumEntry = enumEntry[1:]
+    return prefix + '_' + toUpperSnakeCase(enumEntry)
+
+
+def toEnumName(s):
+    """ Add En umto the end of the string if it is not already there """
+    return s + "Enum" if not s.endswith("Enum") else s
+
+
+def toStructName(s):
+    """ Add Struct to the end of the string if it is not already there """
+    return s + "Struct" if not s.endswith("Struct") else s
+
+
+def toEventName(s):
+    """ Add Event to the end of the string if it is not already there """
+    return s + "Event" if not s.endswith("Event") else s
+
+
+def toProtobufType(s):
+    """ Convert zap type to protobuf type """
+
+    match(s.lower()):
+        case "boolean":
+            return "bool"
+
+        case "enum8":
+            return "uint32"
+        case "enum16":
+            return "uint32"
+        case "enum32":
+            return "uint32"
+        case "bitmap8":
+            return "uint32"
+        case "bitmap16":
+            return "uint32"
+        case "bitmap32":
+            return "uint32"
+        case "cluster_id":
+            return "uint32"
+        case "attrib_id":
+            return "uint32"
+        case "event_id":
+            return "uint32"
+        case "command_id":
+            return "uint32"
+        case "endpoint_no":
+            return "uint32"
+        case "group_id":
+            return "uint32"
+        case "devtype_id":
+            return "uint32"
+        case "fabric_idx":
+            return "uint32"
+        case "vendor_id":
+            return "uint32"
+        case "status_code":
+            return "uint32"
+        case "faulttype":
+            return "uint32"
+        case 'epoch_s':
+            return "uint32"
+        case "levelcontroloptions":
+            return "uint32"
+        case "percent100ths":
+            return "uint32"
+        case "percent":
+            return "uint32"
+
+        case "int8u":
+            return "uint32"
+        case "int16u":
+            return "uint32"
+        case "int24u":
+            return "uint32"
+        case "int32u":
+            return "uint32"
+
+        case "enum64":
+            return "uint64"
+        case "bitmap64":
+            return "uint64"
+        case "node_id":
+            return "uint64"
+        case "fabric_id":
+            return "uint64"
+        case "epoch_us":
+            return "uint64"
+        case "int40u":
+            return "uint64"
+        case "int48u":
+            return "uint64"
+        case "int56u":
+            return "uint64"
+        case "int64u":
+            return "uint64"
+
+        case "int8s":
+            return "int32"
+        case "int16s":
+            return "int32"
+        case "int24s":
+            return "int32"
+        case "int32s":
+            return "int32"
+
+        case "int40s":
+            return "int64"
+        case "int48s":
+            return "int64"
+        case "int56s":
+            return "int64"
+        case "int64s":
+            return "int64"
+
+        case "long_char_string":
+            return "string"
+        case "char_string":
+            return "string"
+
+        case "long_octet_string":
+            return "bytes"
+        case "octet_string":
+            return "bytes"
+
+        case "single":
+            return "float"
+        case "float":
+            return "float"
+        case "double":
+            return "double"
+
+    return s
+
+
+# Python enum of types
+class DataType:
+    UINT = 1
+    INT = 2
+    BOOL = 3
+    CHAR_STRING = 4
+    OCT_STRING = 5
+    STRUCT = 6
+    FLOAT = 7
+    DOUBLE = 8
+
+
+def typeToTypeNum(s):
+    match(s):
+        case "uint32": return DataType.UINT
+        case "uint64": return DataType.UINT
+        case "int32": return DataType.INT
+        case "int64": return DataType.INT
+        case "bool": return DataType.BOOL
+        case "string": return DataType.CHAR_STRING
+        case "bytes": return DataType.OCT_STRING
+        case "float": return DataType.FLOAT
+        case "double": return DataType.DOUBLE
+
+    return DataType.STRUCT
+
+
+def commandArgs(command: Command, cluster: Cluster):
+    # Find command.input_arg in cluster.structs
+    for struct in cluster.structs:
+        if struct.name == command.input_param:
+            return struct.fields
+
+    return []
+
+
+def commandResponseArgs(command: Command, cluster: Cluster):
+    # Find command.input_arg in cluster.structs
+    for struct in cluster.structs:
+        if struct.name == command.output_param:
+            return struct.fields
+
+    return []
+
+
+def toTypeEncodedTag(tag, typeNum):
+    tag = (int(typeNum) << 19) | int(tag)
+    #tag = tag + 1
+    return tag
+
+
+def toFieldType(field: Field):
+    prefix = ""
+    protobufType = toProtobufType(field.data_type.name)
+    if field.is_list:
+        prefix = "repeated " + prefix
+    elif field.is_optional:
+        prefix = "optional " + prefix
+    return prefix + protobufType
+
+
+def toFieldTag(field: Field):
+    protobufType = toProtobufType(field.data_type.name)
+    typeNum = typeToTypeNum(protobufType)
+    tag = toTypeEncodedTag(field.code, typeNum)
+    return tag
+
+
+def toFieldComment(field: Field):
+    protobufType = toProtobufType(field.data_type.name)
+    typeNum = typeToTypeNum(protobufType)
+    tagComment = "/** %s Type: %d IsList: %d FieldId: %d */" % (
+        field.data_type.name, typeNum, field.is_list, field.code)
+    return tagComment
+
+
+class CustomGenerator(CodeGenerator):
+    """
+    Generation of cpp code for application implementation for matter.
+    """
+
+    def __init__(self, storage: GeneratorStorage, idl: Idl):
+        """
+        Inintialization is specific for java generation and will add
+        filters as required by the java .jinja templates to function.
+        """
+        super().__init__(storage, idl)
+
+        # Override the template path to use local templates within this plugin directory
+        self.jinja_env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(
+                searchpath=os.path.dirname(__file__)),
+            keep_trailing_newline=True)
+
+        # String helpers
+        self.jinja_env.filters['toLowerSnakeCase'] = toLowerSnakeCase
+        self.jinja_env.filters['toUpperSnakeCase'] = toUpperSnakeCase
+
+        # Type helpers
+        self.jinja_env.filters['toStructName'] = toStructName
+        self.jinja_env.filters['toEventName'] = toEventName
+        self.jinja_env.filters['toEnumName'] = toEnumName
+        self.jinja_env.filters['toEnumConstant'] = toEnumConstant
+        self.jinja_env.filters['toProtobufType'] = toProtobufType
+        self.jinja_env.filters['toTypeEncodedTag'] = toTypeEncodedTag
+
+        # Tag helpers
+        self.jinja_env.filters['toFieldTag'] = toFieldTag
+        self.jinja_env.filters['toFieldType'] = toFieldType
+        self.jinja_env.filters['toFieldComment'] = toFieldComment
+
+        # Command helpers
+        self.jinja_env.filters['commandArgs'] = commandArgs
+        self.jinja_env.filters['commandResponseArgs'] = commandResponseArgs
+
+    def internal_render_all(self):
+        """
+        Renders the given custom template to the given output filename.
+        """
+
+        # Every cluster has its own impl, to avoid
+        # very large compilations (running out of RAM)
+        for cluster in self.idl.clusters:
+            if cluster.side != ClusterSide.CLIENT:
+                continue
+
+            filename = "proto/%s_trait.proto" % toLowerSnakeCase(cluster.name)
+
+            # Header containing a macro to initialize all cluster plugins
+            self.internal_render_one_output(
+                template_path="./matter_cluster_proto.jinja",
+                output_file_name=filename,
+                vars={
+                    'cluster': cluster,
+                }
+            )

--- a/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
@@ -54,9 +54,11 @@ def toEnumEntryName(enumEntry, enumName):
         enumEntry = enumEntry[1:]
     return prefix + '_' + toUpperSnakeCase(enumEntry)
 
+
 def toProtobufType(zapType: str) -> str:
     """ Convert zap type to protobuf type """
-    u32Types = ["uint32", "enum8", "enum16", "enum32", "bitmap8", "bitmap16", "bitmap32", "cluster_id", "attrib_id", "event_id", "command_id", "endpoint_no", "group_id", "devtype_id", "fabric_idx", "vendor_id", "status_code", "faulttype", "levelcontroloptions", "percent100ths", "percent"]
+    u32Types = ["uint32", "enum8", "enum16", "enum32", "bitmap8", "bitmap16", "bitmap32", "cluster_id", "attrib_id", "event_id", "command_id",
+                "endpoint_no", "group_id", "devtype_id", "fabric_idx", "vendor_id", "status_code", "faulttype", "levelcontroloptions", "percent100ths", "percent"]
     u64Types = ["uint64", "enum64", "bitmap64", "node_id", "fabric_id", "int40u", "int48u", "int56u", "int64u"]
     i32Types = ["int32", "int8s", "int16s", "int24s", "int32s"]
     i64Types = ["int64", "int40s", "int48s", "int56s", "int64s"]
@@ -84,7 +86,6 @@ def toProtobufType(zapType: str) -> str:
         case "boolean":
             return "bool"
 
-
         case "double":
             return "double"
 
@@ -105,7 +106,7 @@ class EncodingDataType:
     DOUBLE = 8
 
     @staticmethod
-    def fromType(protobufType : str):
+    def fromType(protobufType: str):
         match(protobufType):
             case "uint32": return EncodingDataType.UINT
             case "uint64": return EncodingDataType.UINT
@@ -138,7 +139,7 @@ def commandResponseArgs(command: Command, cluster: Cluster):
     return []
 
 
-def toEncodedTag(tag, typeNum : EncodingDataType):
+def toEncodedTag(tag, typeNum: EncodingDataType):
     """ Return the final encoded tag from the given field number and field encoded data type.
         The Matter field type information is encoded into the upper range of the protobuf field 
         tag for stateless translation to Matter TLV. """

--- a/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
@@ -118,11 +118,13 @@ class EncodingDataType:
             case "float": return EncodingDataType.FLOAT
             case "double": return EncodingDataType.DOUBLE
 
+        # If not a primitive type, it is a named type; assume it is a Struct.
+        # NOTE: the actual type may be an Enum or Bitmap.
         return EncodingDataType.STRUCT
 
 
 def commandArgs(command: Command, cluster: Cluster):
-    # Find command.input_arg in cluster.structs
+    """Return the list of fields for the command request for the given command and cluster."""
     for struct in cluster.structs:
         if struct.name == command.input_param:
             return struct.fields
@@ -131,7 +133,7 @@ def commandArgs(command: Command, cluster: Cluster):
 
 
 def commandResponseArgs(command: Command, cluster: Cluster):
-    # Find command.input_arg in cluster.structs
+    """Return the list of fields for the command response for the given command and cluster."""
     for struct in cluster.structs:
         if struct.name == command.output_param:
             return struct.fields
@@ -147,7 +149,8 @@ def toEncodedTag(tag, typeNum: EncodingDataType):
     return tag
 
 
-def toFieldType(field: Field):
+def toProtobufFullType(field: Field):
+    """Return the full protobuf type for the given field, including repeated and optional specifiers."""
     prefix = ""
     protobufType = toProtobufType(field.data_type.name)
     if field.is_list:
@@ -174,7 +177,7 @@ def toFieldComment(field: Field):
 
 class CustomGenerator(CodeGenerator):
     """
-    Example of a custom generator.  Outputs protobuf representation of MAtter clusters.
+    Example of a custom generator.  Outputs protobuf representation of Matter clusters.
     """
 
     def __init__(self, storage: GeneratorStorage, idl: Idl):
@@ -201,7 +204,7 @@ class CustomGenerator(CodeGenerator):
 
         # Tag helpers
         self.jinja_env.filters['toFieldTag'] = toFieldTag
-        self.jinja_env.filters['toFieldType'] = toFieldType
+        self.jinja_env.filters['toProtobufFullType'] = toProtobufFullType
         self.jinja_env.filters['toFieldComment'] = toFieldComment
 
         # Command helpers

--- a/scripts/py_matter_idl/examples/matter_idl_plugin/matter_cluster_proto.jinja
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/matter_cluster_proto.jinja
@@ -14,8 +14,9 @@ message {{cluster.name}}Cluster {
     CLUSTER_ID_UNSUPPORTED = 0;
     CLUSTER_ID = {{cluster.code}};
   }
+{%- if cluster.enums %}
 
-{% if cluster.enums %}  // Enums{% endif -%}
+  // Enums
 {%-   for entry in cluster.enums %}
   enum {{entry.name}} {
     {%- if (entry.entries[0].code != 0) %}
@@ -23,47 +24,53 @@ message {{cluster.name}}Cluster {
     {%-  for field in entry.entries %}
     {{field.name | toEnumEntryName(entry.name)}} = {{field.code}};{%   endfor %}
   }
-{%   endfor %}
+{%   endfor %}{% endif -%}
+{%- if cluster.bitmaps %}
 
-{% if cluster.bitmaps %}  // Bitmaps{% endif -%}
+  // Bitmaps
 {%-   for entry in cluster.bitmaps %}
   enum {{entry.name}} {
     {{"unsupported" | toEnumEntryName(entry.name)}} = 0;
     {%-  for field in entry.entries %}
     {{field.name | toEnumEntryName(entry.name)}} = {{field.code}};{%   endfor %}
   }
-{%   endfor %}
+{%   endfor %}{% endif -%}
+{%- if cluster.structs %}
 
-{% if cluster.structs %}  // Structs{% endif -%}
+  // Structs
 {%-   for entry in cluster.structs %}{% if not entry.tag %}
   message {{entry.name}} {
     {%-  for field in entry.fields %}
     {{field | toFieldComment}}
     {{field | toProtobufFullType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}
   }
-{% endif %}{%   endfor %}
+{% endif %}{%   endfor %}{% endif -%}
+{%- if cluster.attributes %}
 
-{% if cluster.attributes %}  // Attributes{% endif -%}
+  // Attributes
 {%-   for attr in cluster.attributes %}
   {{attr.definition | toFieldComment}}
   {{attr.definition.data_type.name | toProtobufType}} {{attr.definition.name | toLowerSnakeCase}} = {{attr.definition | toFieldTag()}};
-    // [(attribute) = {
+    /*
+    [(attribute) = {
 {%- if attr.is_writable %}
-      // is_writable : true,{% endif %}
+      is_writable : true,{% endif %}
 {%- if attr.is_subscribable %}
-      // is_subscribable: true,{% endif %}
-    // }];
+      is_subscribable: true,{% endif %}
+    }];
+    */
 
-{%   endfor -%}
+{%   endfor %}{% endif -%}
+{%- if cluster.commands %}
 
-{%- if cluster.commands %}  // Commands{% endif %}
+  // Commands
 {%-   for cmd in cluster.commands %}
   message {{cmd.name}}Command {
     // option (message_type) = MATTER_COMMAND;
     {% if cmd.input_param %}{%-  for field in cmd | commandArgs(cluster) %}
     {{field | toFieldComment}}
     {{field | toProtobufFullType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}{% endif %}
-}{% if cmd.output_param != "DefaultSuccess" %}
+  }{% if cmd.output_param != "DefaultSuccess" %}
   
   message {{cmd.name}}CommandResponse {
     // option (message_type) = MATTER_COMMAND_RESPONSE;
@@ -71,9 +78,10 @@ message {{cluster.name}}Cluster {
     {{field | toFieldComment}}
     {{field | toProtobufFullType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}{% endif %}
   }{% endif %}
-{%   endfor %}
+{%   endfor %}{% endif %}
 
-{% if cluster.events %}  // Events{% endif %}
+{%- if cluster.events %}
+  // Events
 {%-   for entry in cluster.events %}
   message {{entry.name}} {
     // option (message_type) = MATTER_EVENT;
@@ -82,5 +90,5 @@ message {{cluster.name}}Cluster {
     {{field | toProtobufFullType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}
   }
 
-{%   endfor %}
-}
+{%   endfor %}{% endif %}
+} // {{cluster.name}}Cluster

--- a/scripts/py_matter_idl/examples/matter_idl_plugin/matter_cluster_proto.jinja
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/matter_cluster_proto.jinja
@@ -15,16 +15,17 @@ message {{cluster.name}}Cluster {
     CLUSTER_ID = {{cluster.code}};
   }
 
-  // Enums
+{% if cluster.enums %}  // Enums{% endif -%}
 {%-   for entry in cluster.enums %}
   enum {{entry.name}} {
-    {% if (entry.entries[0].code != 0) %}{{"unsupported" | toEnumEntryName(entry.name)}} = 0;{% endif %}
+    {%- if (entry.entries[0].code != 0) %}
+    {{"unsupported" | toEnumEntryName(entry.name)}} = 0;{% endif -%}
     {%-  for field in entry.entries %}
     {{field.name | toEnumEntryName(entry.name)}} = {{field.code}};{%   endfor %}
   }
 {%   endfor %}
 
-  // Bitmaps
+{% if cluster.bitmaps %}  // Bitmaps{% endif -%}
 {%-   for entry in cluster.bitmaps %}
   enum {{entry.name}} {
     {{"unsupported" | toEnumEntryName(entry.name)}} = 0;
@@ -33,7 +34,7 @@ message {{cluster.name}}Cluster {
   }
 {%   endfor %}
 
-  // Structs
+{% if cluster.structs %}  // Structs{% endif -%}
 {%-   for entry in cluster.structs %}{% if not entry.tag %}
   message {{entry.name}} {
     {%-  for field in entry.fields %}
@@ -42,7 +43,7 @@ message {{cluster.name}}Cluster {
   }
 {% endif %}{%   endfor %}
 
-  // Attributes
+{% if cluster.attributes %}  // Attributes{% endif -%}
 {%-   for attr in cluster.attributes %}
   {{attr.definition | toFieldComment}}
   {{attr.definition.data_type.name | toProtobufType}} {{attr.definition.name | toLowerSnakeCase}} = {{attr.definition | toFieldTag()}};
@@ -53,9 +54,9 @@ message {{cluster.name}}Cluster {
       // is_subscribable: true,{% endif %}
     // }];
 
-{%   endfor %}
+{%   endfor -%}
 
-  // Commands
+{%- if cluster.commands %}  // Commands{% endif %}
 {%-   for cmd in cluster.commands %}
   message {{cmd.name}}Command {
     // option (message_type) = MATTER_COMMAND;
@@ -72,7 +73,7 @@ message {{cluster.name}}Cluster {
   }{% endif %}
 {%   endfor %}
 
-  // Events
+{% if cluster.events %}  // Events{% endif %}
 {%-   for entry in cluster.events %}
   message {{entry.name}} {
     // option (message_type) = MATTER_EVENT;

--- a/scripts/py_matter_idl/examples/matter_idl_plugin/matter_cluster_proto.jinja
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/matter_cluster_proto.jinja
@@ -7,7 +7,7 @@ package com.chip.proto;
 
 option java_multiple_files = true;
 
-message {{cluster.name}}Trait {
+message {{cluster.name}}Cluster {
   // option (message_type) = MATTER_TRAIT;
 
   enum ClusterId {
@@ -18,18 +18,18 @@ message {{cluster.name}}Trait {
   // Enums
 {%-   for entry in cluster.enums %}
   enum {{entry.name}} {
-    {% if (entry.entries[0].code != 0) %}{{"unsupported" | toEnumConstant(entry.name)}} = 0;{% endif %}
+    {% if (entry.entries[0].code != 0) %}{{"unsupported" | toEnumEntryName(entry.name)}} = 0;{% endif %}
     {%-  for field in entry.entries %}
-    {{field.name | toEnumConstant(entry.name)}} = {{field.code}};{%   endfor %}
+    {{field.name | toEnumEntryName(entry.name)}} = {{field.code}};{%   endfor %}
   }
 {%   endfor %}
 
   // Bitmaps
 {%-   for entry in cluster.bitmaps %}
   enum {{entry.name}} {
-    {{"unsupported" | toEnumConstant(entry.name)}} = 0;
+    {{"unsupported" | toEnumEntryName(entry.name)}} = 0;
     {%-  for field in entry.entries %}
-    {{field.name | toEnumConstant(entry.name)}} = {{field.code}};{%   endfor %}
+    {{field.name | toEnumEntryName(entry.name)}} = {{field.code}};{%   endfor %}
   }
 {%   endfor %}
 
@@ -74,7 +74,7 @@ message {{cluster.name}}Trait {
 
   // Events
 {%-   for entry in cluster.events %}
-  message {{entry.name | toEventName}} {
+  message {{entry.name}} {
     // option (message_type) = MATTER_EVENT;
     {%  for field in entry.fields %}
     {{field | toFieldComment}}

--- a/scripts/py_matter_idl/examples/matter_idl_plugin/matter_cluster_proto.jinja
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/matter_cluster_proto.jinja
@@ -1,0 +1,85 @@
+
+/// AUTO-GENERATED with matter_idl.
+
+syntax = "proto3";
+
+package com.chip.proto;
+
+option java_multiple_files = true;
+
+message {{cluster.name}}Trait {
+  // option (message_type) = MATTER_TRAIT;
+
+  enum ClusterId {
+    CLUSTER_ID_UNSUPPORTED = 0;
+    CLUSTER_ID = {{cluster.code}};
+  }
+
+  // Enums
+{%-   for entry in cluster.enums %}
+  enum {{entry.name}} {
+    {% if (entry.entries[0].code != 0) %}{{"unsupported" | toEnumConstant(entry.name)}} = 0;{% endif %}
+    {%-  for field in entry.entries %}
+    {{field.name | toEnumConstant(entry.name)}} = {{field.code}};{%   endfor %}
+  }
+{%   endfor %}
+
+  // Bitmaps
+{%-   for entry in cluster.bitmaps %}
+  enum {{entry.name}} {
+    {{"unsupported" | toEnumConstant(entry.name)}} = 0;
+    {%-  for field in entry.entries %}
+    {{field.name | toEnumConstant(entry.name)}} = {{field.code}};{%   endfor %}
+  }
+{%   endfor %}
+
+  // Structs
+{%-   for entry in cluster.structs %}{% if not entry.tag %}
+  message {{entry.name}} {
+    {%-  for field in entry.fields %}
+    {{field | toFieldComment}}
+    {{field | toFieldType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}
+  }
+{% endif %}{%   endfor %}
+
+  // Attributes
+{%-   for attr in cluster.attributes %}
+  {{attr.definition | toFieldComment}}
+  {{attr.definition.data_type.name | toProtobufType}} {{attr.definition.name | toLowerSnakeCase}} = {{attr.definition | toFieldTag()}};
+    // [(attribute) = {
+{%- if attr.is_writable %}
+      // is_writable : true,{% endif %}
+{%- if attr.is_subscribable %}
+      // is_subscribable: true,{% endif %}
+    // }];
+
+{%   endfor %}
+
+  // Commands
+{%-   for cmd in cluster.commands %}
+  message {{cmd.name}}Command {
+    // option (message_type) = MATTER_COMMAND;
+    {% if cmd.input_param %}{%-  for field in cmd | commandArgs(cluster) %}
+    {{field | toFieldComment}}
+    {{field | toFieldType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}{% endif %}
+}{% if cmd.output_param != "DefaultSuccess" %}
+  
+  message {{cmd.name}}CommandResponse {
+    // option (message_type) = MATTER_COMMAND_RESPONSE;
+    {% if cmd.output_param %}{%-  for field in cmd | commandResponseArgs(cluster) %}
+    {{field | toFieldComment}}
+    {{field | toFieldType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}{% endif %}
+  }{% endif %}
+{%   endfor %}
+
+  // Events
+{%-   for entry in cluster.events %}
+  message {{entry.name | toEventName}} {
+    // option (message_type) = MATTER_EVENT;
+    {%  for field in entry.fields %}
+    {{field | toFieldComment}}
+    {{field | toFieldType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}
+  }
+
+{%   endfor %}
+}

--- a/scripts/py_matter_idl/examples/matter_idl_plugin/matter_cluster_proto.jinja
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/matter_cluster_proto.jinja
@@ -38,7 +38,7 @@ message {{cluster.name}}Cluster {
   message {{entry.name}} {
     {%-  for field in entry.fields %}
     {{field | toFieldComment}}
-    {{field | toFieldType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}
+    {{field | toProtobufFullType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}
   }
 {% endif %}{%   endfor %}
 
@@ -61,14 +61,14 @@ message {{cluster.name}}Cluster {
     // option (message_type) = MATTER_COMMAND;
     {% if cmd.input_param %}{%-  for field in cmd | commandArgs(cluster) %}
     {{field | toFieldComment}}
-    {{field | toFieldType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}{% endif %}
+    {{field | toProtobufFullType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}{% endif %}
 }{% if cmd.output_param != "DefaultSuccess" %}
   
   message {{cmd.name}}CommandResponse {
     // option (message_type) = MATTER_COMMAND_RESPONSE;
     {% if cmd.output_param %}{%-  for field in cmd | commandResponseArgs(cluster) %}
     {{field | toFieldComment}}
-    {{field | toFieldType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}{% endif %}
+    {{field | toProtobufFullType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}{% endif %}
   }{% endif %}
 {%   endfor %}
 
@@ -78,7 +78,7 @@ message {{cluster.name}}Cluster {
     // option (message_type) = MATTER_EVENT;
     {%  for field in entry.fields %}
     {{field | toFieldComment}}
-    {{field | toFieldType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}
+    {{field | toProtobufFullType}} {{field.name | toLowerSnakeCase}} = {{field | toFieldTag}};{%   endfor %}
   }
 
 {%   endfor %}

--- a/scripts/py_matter_idl/examples/matter_idl_plugin/matter_cluster_proto.jinja
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/matter_cluster_proto.jinja
@@ -3,7 +3,7 @@
 
 syntax = "proto3";
 
-package com.chip.proto;
+package com.matter.example.proto;
 
 option java_multiple_files = true;
 

--- a/scripts/py_matter_idl/matter_idl/generators/bridge/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/bridge/__init__.py
@@ -16,13 +16,13 @@
 import enum
 import logging
 import re
+from typing import List, Set, Union
 
-from matter_idl.generators import CodeGenerator, GeneratorStorage
-from matter_idl.matter_idl_types import Idl, Field, Attribute, Cluster, ClusterSide
 from matter_idl import matter_idl_types
-from matter_idl.generators.types import (ParseDataType, BasicString, BasicInteger, FundamentalType,
-                                         IdlType, IdlEnumType, IdlBitmapType, TypeLookupContext)
-from typing import Union, List, Set
+from matter_idl.generators import CodeGenerator, GeneratorStorage
+from matter_idl.generators.types import (BasicInteger, BasicString, FundamentalType, IdlBitmapType, IdlEnumType, IdlType,
+                                         ParseDataType, TypeLookupContext)
+from matter_idl.matter_idl_types import Attribute, Cluster, ClusterSide, Field, Idl
 
 
 def camel_to_const(s):

--- a/scripts/py_matter_idl/matter_idl/generators/bridge/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/bridge/__init__.py
@@ -135,7 +135,7 @@ class BridgeGenerator(CodeGenerator):
     Generation of bridge cpp code for matter.
     """
 
-    def __init__(self, storage: GeneratorStorage, idl: Idl):
+    def __init__(self, storage: GeneratorStorage, idl: Idl, **kargs):
         """
         Inintialization is specific for cpp generation and will add
         filters as required by the cpp .jinja templates to function.

--- a/scripts/py_matter_idl/matter_idl/generators/cpp/application/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/cpp/application/__init__.py
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from matter_idl.generators import CodeGenerator, GeneratorStorage
-from matter_idl.matter_idl_types import Idl, ClusterSide, Field, Attribute, Cluster, FieldQuality, Command, DataType
-from matter_idl import matter_idl_types
-from matter_idl.generators.types import ParseDataType, BasicString, BasicInteger, FundamentalType, IdlType, IdlEnumType, IdlBitmapType, TypeLookupContext
-from typing import Union, List, Set
-from stringcase import capitalcase
-
 import enum
 import logging
+from typing import List, Set, Union
+
+from matter_idl import matter_idl_types
+from matter_idl.generators import CodeGenerator, GeneratorStorage
+from matter_idl.generators.types import (BasicInteger, BasicString, FundamentalType, IdlBitmapType, IdlEnumType, IdlType,
+                                         ParseDataType, TypeLookupContext)
+from matter_idl.matter_idl_types import Attribute, Cluster, ClusterSide, Command, DataType, Field, FieldQuality, Idl
+from stringcase import capitalcase
 
 
 def serverClustersOnly(clusters: List[Cluster]) -> List[Cluster]:

--- a/scripts/py_matter_idl/matter_idl/generators/cpp/application/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/cpp/application/__init__.py
@@ -32,7 +32,7 @@ class CppApplicationGenerator(CodeGenerator):
     Generation of cpp code for application implementation for matter.
     """
 
-    def __init__(self, storage: GeneratorStorage, idl: Idl):
+    def __init__(self, storage: GeneratorStorage, idl: Idl, **kargs):
         """
         Inintialization is specific for java generation and will add
         filters as required by the java .jinja templates to function.

--- a/scripts/py_matter_idl/matter_idl/generators/java/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/java/__init__.py
@@ -13,15 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from matter_idl.generators import CodeGenerator, GeneratorStorage
-from matter_idl.matter_idl_types import Idl, ClusterSide, Field, Attribute, Cluster, FieldQuality, Command, DataType
-from matter_idl import matter_idl_types
-from matter_idl.generators.types import ParseDataType, BasicString, BasicInteger, FundamentalType, IdlType, IdlEnumType, IdlBitmapType, TypeLookupContext
-from typing import Union, List, Set
-from stringcase import capitalcase
-
 import enum
 import logging
+from typing import List, Set, Union
+
+from matter_idl import matter_idl_types
+from matter_idl.generators import CodeGenerator, GeneratorStorage
+from matter_idl.generators.types import (BasicInteger, BasicString, FundamentalType, IdlBitmapType, IdlEnumType, IdlType,
+                                         ParseDataType, TypeLookupContext)
+from matter_idl.matter_idl_types import Attribute, Cluster, ClusterSide, Command, DataType, Field, FieldQuality, Idl
+from stringcase import capitalcase
 
 
 def FieldToGlobalName(field: Field, context: TypeLookupContext) -> Union[str, None]:

--- a/scripts/py_matter_idl/matter_idl/generators/java/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/java/__init__.py
@@ -348,7 +348,7 @@ class JavaGenerator(CodeGenerator):
     Generation of java code for matter.
     """
 
-    def __init__(self, storage: GeneratorStorage, idl: Idl):
+    def __init__(self, storage: GeneratorStorage, idl: Idl, **kargs):
         """
         Inintialization is specific for java generation and will add
         filters as required by the java .jinja templates to function.

--- a/scripts/py_matter_idl/matter_idl/generators/registry.py
+++ b/scripts/py_matter_idl/matter_idl/generators/registry.py
@@ -40,8 +40,7 @@ class CodeGenerator(enum.Enum):
         elif self == CodeGenerator.CUSTOM:
             # Use a package naming convention to find the custom generator:
             # ./matter_idl_plugin/__init__.py defines a subclass of CodeGenerator named CustomGenerator.
-            # The current working directory is added to the python path so that the custom generator
-            # can be found.
+        ``` # The plugin is expected to be in the path provided via the `--plugin <path>` cli argument.
             from matter_idl_plugin import CustomGenerator
             return CustomGenerator(*args, **kargs)
         else:

--- a/scripts/py_matter_idl/matter_idl/generators/registry.py
+++ b/scripts/py_matter_idl/matter_idl/generators/registry.py
@@ -40,7 +40,7 @@ class CodeGenerator(enum.Enum):
         elif self == CodeGenerator.CUSTOM:
             # Use a package naming convention to find the custom generator:
             # ./matter_idl_plugin/__init__.py defines a subclass of CodeGenerator named CustomGenerator.
-        ``` # The plugin is expected to be in the path provided via the `--plugin <path>` cli argument.
+            # The plugin is expected to be in the path provided via the `--plugin <path>` cli argument.
             from matter_idl_plugin import CustomGenerator
             return CustomGenerator(*args, **kargs)
         else:

--- a/scripts/py_matter_idl/matter_idl/generators/registry.py
+++ b/scripts/py_matter_idl/matter_idl/generators/registry.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import enum
+import importlib
 
 from matter_idl.generators.bridge import BridgeGenerator
 from matter_idl.generators.cpp.application import CppApplicationGenerator
@@ -42,7 +43,7 @@ class CodeGenerator(enum.Enum):
             # ./matter_idl_plugin/__init__.py defines a subclass of CodeGenerator named CustomGenerator.
             # The plugin is expected to be in the path provided via the `--plugin <path>` cli argument.
             # Replaces `from plugin_module import CustomGenerator``
-            plugin_module = __import__(kargs['plugin_module'])
+            plugin_module = importlib.import_module(kargs['plugin_module'])
             CustomGenerator = plugin_module.CustomGenerator
             return CustomGenerator(*args, **kargs)
         else:

--- a/scripts/py_matter_idl/matter_idl/generators/registry.py
+++ b/scripts/py_matter_idl/matter_idl/generators/registry.py
@@ -28,6 +28,7 @@ class CodeGenerator(enum.Enum):
     JAVA = enum.auto()
     BRIDGE = enum.auto()
     CPP_APPLICATION = enum.auto()
+    CUSTOM = enum.auto()
 
     def Create(self, *args, **kargs):
         if self == CodeGenerator.JAVA:
@@ -36,6 +37,16 @@ class CodeGenerator(enum.Enum):
             return BridgeGenerator(*args, **kargs)
         elif self == CodeGenerator.CPP_APPLICATION:
             return CppApplicationGenerator(*args, **kargs)
+        elif self == CodeGenerator.CUSTOM:
+            # Use a package naming convention to find the custom generator:
+            # ./matter_idl_plugin/__init__.py defines a subclass of CodeGenerator named CustomGenerator.
+            # The current working directory is added to the python path so that the custom generator
+            # can be found.
+            import os
+            import sys
+            sys.path.append(os.getcwd())
+            from matter_idl_plugin import CustomGenerator
+            return CustomGenerator(*args, **kargs)
         else:
             raise NameError("Unknown code generator type")
 
@@ -56,4 +67,5 @@ GENERATORS = {
     'java': CodeGenerator.JAVA,
     'bridge': CodeGenerator.BRIDGE,
     'cpp-app': CodeGenerator.CPP_APPLICATION,
+    'custom': CodeGenerator.CUSTOM,
 }

--- a/scripts/py_matter_idl/matter_idl/generators/registry.py
+++ b/scripts/py_matter_idl/matter_idl/generators/registry.py
@@ -41,7 +41,9 @@ class CodeGenerator(enum.Enum):
             # Use a package naming convention to find the custom generator:
             # ./matter_idl_plugin/__init__.py defines a subclass of CodeGenerator named CustomGenerator.
             # The plugin is expected to be in the path provided via the `--plugin <path>` cli argument.
-            from matter_idl_plugin import CustomGenerator
+            # Replaces `from plugin_module import CustomGenerator``
+            plugin_module = __import__(kargs['plugin_module'])
+            CustomGenerator = plugin_module.CustomGenerator
             return CustomGenerator(*args, **kargs)
         else:
             raise NameError("Unknown code generator type")

--- a/scripts/py_matter_idl/matter_idl/generators/registry.py
+++ b/scripts/py_matter_idl/matter_idl/generators/registry.py
@@ -42,9 +42,6 @@ class CodeGenerator(enum.Enum):
             # ./matter_idl_plugin/__init__.py defines a subclass of CodeGenerator named CustomGenerator.
             # The current working directory is added to the python path so that the custom generator
             # can be found.
-            import os
-            import sys
-            sys.path.append(os.getcwd())
             from matter_idl_plugin import CustomGenerator
             return CustomGenerator(*args, **kargs)
         else:

--- a/scripts/py_matter_idl/matter_idl/test_generators.py
+++ b/scripts/py_matter_idl/matter_idl/test_generators.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import os
+import sys
 import unittest
 from dataclasses import dataclass, field
 from typing import List
@@ -123,7 +124,8 @@ class GeneratorTest:
         if self.generator_name.lower() == 'cpp-app':
             return CppApplicationGenerator(storage, idl)
         if self.generator_name.lower() == 'custom':
-            sys.path.append('../examples')
+            sys.path.append(os.path.abspath(
+                os.path.join(os.path.dirname(__file__), '../examples')))
             from matter_idl_plugin import CustomGenerator
             return CustomGenerator(storage, idl)
         else:

--- a/scripts/py_matter_idl/matter_idl/test_generators.py
+++ b/scripts/py_matter_idl/matter_idl/test_generators.py
@@ -122,6 +122,10 @@ class GeneratorTest:
             return BridgeGenerator(storage, idl)
         if self.generator_name.lower() == 'cpp-app':
             return CppApplicationGenerator(storage, idl)
+        if self.generator_name.lower() == 'custom':
+            sys.path.append('../examples')
+            from matter_idl_plugin import CustomGenerator
+            return CustomGenerator(storage, idl)
         else:
             raise Exception("Unknown generator for testing: %s",
                             self.generator_name.lower())

--- a/scripts/py_matter_idl/matter_idl/test_generators.py
+++ b/scripts/py_matter_idl/matter_idl/test_generators.py
@@ -123,7 +123,7 @@ class GeneratorTest:
             return BridgeGenerator(storage, idl)
         if self.generator_name.lower() == 'cpp-app':
             return CppApplicationGenerator(storage, idl)
-        if self.generator_name.lower() == 'custom':
+        if self.generator_name.lower() == 'custom-example-proto':
             sys.path.append(os.path.abspath(
                 os.path.join(os.path.dirname(__file__), '../examples')))
             from matter_idl_plugin import CustomGenerator

--- a/scripts/py_matter_idl/matter_idl/tests/available_tests.yaml
+++ b/scripts/py_matter_idl/matter_idl/tests/available_tests.yaml
@@ -76,3 +76,12 @@ cpp-app:
     inputs/large_lighting_app.matter:
         app/PluginApplicationCallbacks.h: outputs/large_lighting_app/cpp-app/PluginApplicationCallbacks.h
         app/callback-stub.cpp: outputs/large_lighting_app/cpp-app/callback-stub.cpp
+
+custom:
+    inputs/several_clusters.matter:
+        proto/first_cluster.proto: outputs/proto/first_cluster.proto
+        proto/second_cluster.proto: outputs/proto/second_cluster.proto
+        proto/third_cluster.proto: outputs/proto/third_cluster.proto
+
+    inputs/large_all_clusters_app.matter:
+        proto/ota_software_update_provider_cluster.proto: outputs/proto/ota_software_update_provider_cluster.proto

--- a/scripts/py_matter_idl/matter_idl/tests/available_tests.yaml
+++ b/scripts/py_matter_idl/matter_idl/tests/available_tests.yaml
@@ -77,7 +77,7 @@ cpp-app:
         app/PluginApplicationCallbacks.h: outputs/large_lighting_app/cpp-app/PluginApplicationCallbacks.h
         app/callback-stub.cpp: outputs/large_lighting_app/cpp-app/callback-stub.cpp
 
-custom:
+custom-example-proto:
     inputs/several_clusters.matter:
         proto/first_cluster.proto: outputs/proto/first_cluster.proto
         proto/second_cluster.proto: outputs/proto/second_cluster.proto

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/first_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/first_cluster.proto
@@ -1,0 +1,37 @@
+
+/// AUTO-GENERATED with matter_idl.
+
+syntax = "proto3";
+
+package com.chip.proto;
+
+option java_multiple_files = true;
+
+message FirstCluster {
+  // option (message_type) = MATTER_TRAIT;
+
+  enum ClusterId {
+    CLUSTER_ID_UNSUPPORTED = 0;
+    CLUSTER_ID = 1;
+  }
+
+  // Enums
+
+  // Bitmaps
+
+  // Structs
+
+  // Attributes
+  /** int16u Type: 6 IsList: 0 FieldId: 1 */
+  int16u some_integer = 3145729;
+    // [(attribute) = {
+      // is_writable : true,
+      // is_subscribable: true,
+    // }];
+
+
+
+  // Commands
+
+  // Events
+}

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/first_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/first_cluster.proto
@@ -3,7 +3,7 @@
 
 syntax = "proto3";
 
-package com.chip.proto;
+package com.matter.example.proto;
 
 option java_multiple_files = true;
 

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/first_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/first_cluster.proto
@@ -15,11 +15,11 @@ message FirstCluster {
     CLUSTER_ID = 1;
   }
 
-  // Enums
 
-  // Bitmaps
 
-  // Structs
+
+
+
 
   // Attributes
   /** int16u Type: 6 IsList: 0 FieldId: 1 */
@@ -31,7 +31,5 @@ message FirstCluster {
 
 
 
-  // Commands
 
-  // Events
 }

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/first_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/first_cluster.proto
@@ -15,21 +15,15 @@ message FirstCluster {
     CLUSTER_ID = 1;
   }
 
-
-
-
-
-
-
   // Attributes
   /** int16u Type: 6 IsList: 0 FieldId: 1 */
   int16u some_integer = 3145729;
-    // [(attribute) = {
-      // is_writable : true,
-      // is_subscribable: true,
-    // }];
+    /*
+    [(attribute) = {
+      is_writable : true,
+      is_subscribable: true,
+    }];
+    */
 
 
-
-
-}
+} // FirstCluster

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/ota_software_update_provider_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/ota_software_update_provider_cluster.proto
@@ -37,16 +37,18 @@ message OtaSoftwareUpdateProviderCluster {
   }
 
 
-
-
   // Structs
 
   // Attributes
   /** int16u Type: 6 IsList: 0 FieldId: 65533 */
   int16u cluster_revision = 3211261;
-    // [(attribute) = {
-      // is_subscribable: true,
-    // }];
+    /*
+    [(attribute) = {
+      is_subscribable: true,
+    }];
+    */
+
+
 
   // Commands
   message QueryImageCommand {
@@ -68,7 +70,7 @@ message OtaSoftwareUpdateProviderCluster {
     optional bool requestor_can_consent = 1572870;
     /** OCTET_STRING Type: 5 IsList: 0 FieldId: 7 */
     optional bytes metadata_for_provider = 2621447;
-}
+  }
   
   message QueryImageCommandResponse {
     // option (message_type) = MATTER_COMMAND_RESPONSE;
@@ -82,7 +84,7 @@ message OtaSoftwareUpdateProviderCluster {
     bytes update_token = 2621440;
     /** INT32U Type: 6 IsList: 0 FieldId: 1 */
     INT32U new_version = 3145729;
-}
+  }
   
   message ApplyUpdateRequestCommandResponse {
     // option (message_type) = MATTER_COMMAND_RESPONSE;
@@ -100,8 +102,6 @@ message OtaSoftwareUpdateProviderCluster {
     bytes update_token = 2621440;
     /** INT32U Type: 6 IsList: 0 FieldId: 1 */
     INT32U software_version = 3145729;
-}
+  }
 
-
-
-}
+} // OtaSoftwareUpdateProviderCluster

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/ota_software_update_provider_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/ota_software_update_provider_cluster.proto
@@ -1,0 +1,112 @@
+
+/// AUTO-GENERATED with matter_idl.
+
+syntax = "proto3";
+
+package com.chip.proto;
+
+option java_multiple_files = true;
+
+message OtaSoftwareUpdateProviderCluster {
+  // option (message_type) = MATTER_TRAIT;
+
+  enum ClusterId {
+    CLUSTER_ID_UNSUPPORTED = 0;
+    CLUSTER_ID = 41;
+  }
+
+  // Enums
+  enum OTAApplyUpdateAction {
+    
+    OTAAUA_PROCEED = 0;
+    OTAAUA_AWAIT_NEXT_ACTION = 1;
+    OTAAUA_DISCONTINUE = 2;
+  }
+
+  enum OTADownloadProtocol {
+    
+    OTADP_BDXSYNCHRONOUS = 0;
+    OTADP_BDXASYNCHRONOUS = 1;
+    OTADP_HTTPS = 2;
+    OTADP_VENDOR_SPECIFIC = 3;
+  }
+
+  enum OTAQueryStatus {
+    
+    OTAQS_UPDATE_AVAILABLE = 0;
+    OTAQS_BUSY = 1;
+    OTAQS_NOT_AVAILABLE = 2;
+    OTAQS_DOWNLOAD_PROTOCOL_NOT_SUPPORTED = 3;
+  }
+
+
+  // Bitmaps
+
+  // Structs
+
+  // Attributes
+  /** int16u Type: 6 IsList: 0 FieldId: 65533 */
+  int16u cluster_revision = 3211261;
+    // [(attribute) = {
+      // is_subscribable: true,
+    // }];
+
+
+
+  // Commands
+  message QueryImageCommand {
+    // option (message_type) = MATTER_COMMAND;
+    
+    /** vendor_id Type: 1 IsList: 0 FieldId: 0 */
+    uint32 vendor_id = 524288;
+    /** INT16U Type: 6 IsList: 0 FieldId: 1 */
+    INT16U product_id = 3145729;
+    /** INT32U Type: 6 IsList: 0 FieldId: 2 */
+    INT32U software_version = 3145730;
+    /** OTADownloadProtocol Type: 6 IsList: 1 FieldId: 3 */
+    repeated OTADownloadProtocol protocols_supported = 3145731;
+    /** INT16U Type: 6 IsList: 0 FieldId: 4 */
+    optional INT16U hardware_version = 3145732;
+    /** CHAR_STRING Type: 6 IsList: 0 FieldId: 5 */
+    optional CHAR_STRING location = 3145733;
+    /** BOOLEAN Type: 3 IsList: 0 FieldId: 6 */
+    optional bool requestor_can_consent = 1572870;
+    /** OCTET_STRING Type: 6 IsList: 0 FieldId: 7 */
+    optional OCTET_STRING metadata_for_provider = 3145735;
+}
+  
+  message QueryImageCommandResponse {
+    // option (message_type) = MATTER_COMMAND_RESPONSE;
+    
+  }
+
+  message ApplyUpdateRequestCommand {
+    // option (message_type) = MATTER_COMMAND;
+    
+    /** OCTET_STRING Type: 6 IsList: 0 FieldId: 0 */
+    OCTET_STRING update_token = 3145728;
+    /** INT32U Type: 6 IsList: 0 FieldId: 1 */
+    INT32U new_version = 3145729;
+}
+  
+  message ApplyUpdateRequestCommandResponse {
+    // option (message_type) = MATTER_COMMAND_RESPONSE;
+    
+    /** OTAApplyUpdateAction Type: 6 IsList: 0 FieldId: 0 */
+    OTAApplyUpdateAction action = 3145728;
+    /** INT32U Type: 6 IsList: 0 FieldId: 1 */
+    INT32U delayed_action_time = 3145729;
+  }
+
+  message NotifyUpdateAppliedCommand {
+    // option (message_type) = MATTER_COMMAND;
+    
+    /** OCTET_STRING Type: 6 IsList: 0 FieldId: 0 */
+    OCTET_STRING update_token = 3145728;
+    /** INT32U Type: 6 IsList: 0 FieldId: 1 */
+    INT32U software_version = 3145729;
+}
+
+
+  // Events
+}

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/ota_software_update_provider_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/ota_software_update_provider_cluster.proto
@@ -17,14 +17,12 @@ message OtaSoftwareUpdateProviderCluster {
 
   // Enums
   enum OTAApplyUpdateAction {
-    
     OTAAUA_PROCEED = 0;
     OTAAUA_AWAIT_NEXT_ACTION = 1;
     OTAAUA_DISCONTINUE = 2;
   }
 
   enum OTADownloadProtocol {
-    
     OTADP_BDXSYNCHRONOUS = 0;
     OTADP_BDXASYNCHRONOUS = 1;
     OTADP_HTTPS = 2;
@@ -32,7 +30,6 @@ message OtaSoftwareUpdateProviderCluster {
   }
 
   enum OTAQueryStatus {
-    
     OTAQS_UPDATE_AVAILABLE = 0;
     OTAQS_BUSY = 1;
     OTAQS_NOT_AVAILABLE = 2;
@@ -40,7 +37,7 @@ message OtaSoftwareUpdateProviderCluster {
   }
 
 
-  // Bitmaps
+
 
   // Structs
 
@@ -50,8 +47,6 @@ message OtaSoftwareUpdateProviderCluster {
     // [(attribute) = {
       // is_subscribable: true,
     // }];
-
-
 
   // Commands
   message QueryImageCommand {
@@ -108,5 +103,5 @@ message OtaSoftwareUpdateProviderCluster {
 }
 
 
-  // Events
+
 }

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/ota_software_update_provider_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/ota_software_update_provider_cluster.proto
@@ -3,7 +3,7 @@
 
 syntax = "proto3";
 
-package com.chip.proto;
+package com.matter.example.proto;
 
 option java_multiple_files = true;
 
@@ -67,12 +67,12 @@ message OtaSoftwareUpdateProviderCluster {
     repeated OTADownloadProtocol protocols_supported = 3145731;
     /** INT16U Type: 6 IsList: 0 FieldId: 4 */
     optional INT16U hardware_version = 3145732;
-    /** CHAR_STRING Type: 6 IsList: 0 FieldId: 5 */
-    optional CHAR_STRING location = 3145733;
+    /** CHAR_STRING Type: 4 IsList: 0 FieldId: 5 */
+    optional string location = 2097157;
     /** BOOLEAN Type: 3 IsList: 0 FieldId: 6 */
     optional bool requestor_can_consent = 1572870;
-    /** OCTET_STRING Type: 6 IsList: 0 FieldId: 7 */
-    optional OCTET_STRING metadata_for_provider = 3145735;
+    /** OCTET_STRING Type: 5 IsList: 0 FieldId: 7 */
+    optional bytes metadata_for_provider = 2621447;
 }
   
   message QueryImageCommandResponse {
@@ -83,8 +83,8 @@ message OtaSoftwareUpdateProviderCluster {
   message ApplyUpdateRequestCommand {
     // option (message_type) = MATTER_COMMAND;
     
-    /** OCTET_STRING Type: 6 IsList: 0 FieldId: 0 */
-    OCTET_STRING update_token = 3145728;
+    /** OCTET_STRING Type: 5 IsList: 0 FieldId: 0 */
+    bytes update_token = 2621440;
     /** INT32U Type: 6 IsList: 0 FieldId: 1 */
     INT32U new_version = 3145729;
 }
@@ -101,8 +101,8 @@ message OtaSoftwareUpdateProviderCluster {
   message NotifyUpdateAppliedCommand {
     // option (message_type) = MATTER_COMMAND;
     
-    /** OCTET_STRING Type: 6 IsList: 0 FieldId: 0 */
-    OCTET_STRING update_token = 3145728;
+    /** OCTET_STRING Type: 5 IsList: 0 FieldId: 0 */
+    bytes update_token = 2621440;
     /** INT32U Type: 6 IsList: 0 FieldId: 1 */
     INT32U software_version = 3145729;
 }

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/second_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/second_cluster.proto
@@ -1,0 +1,36 @@
+
+/// AUTO-GENERATED with matter_idl.
+
+syntax = "proto3";
+
+package com.chip.proto;
+
+option java_multiple_files = true;
+
+message SecondCluster {
+  // option (message_type) = MATTER_TRAIT;
+
+  enum ClusterId {
+    CLUSTER_ID_UNSUPPORTED = 0;
+    CLUSTER_ID = 2;
+  }
+
+  // Enums
+
+  // Bitmaps
+
+  // Structs
+
+  // Attributes
+  /** octet_string Type: 6 IsList: 0 FieldId: 123 */
+  octet_string some_bytes = 3145851;
+    // [(attribute) = {
+      // is_subscribable: true,
+    // }];
+
+
+
+  // Commands
+
+  // Events
+}

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/second_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/second_cluster.proto
@@ -15,20 +15,14 @@ message SecondCluster {
     CLUSTER_ID = 2;
   }
 
-
-
-
-
-
-
   // Attributes
   /** octet_string Type: 5 IsList: 0 FieldId: 123 */
   bytes some_bytes = 2621563;
-    // [(attribute) = {
-      // is_subscribable: true,
-    // }];
+    /*
+    [(attribute) = {
+      is_subscribable: true,
+    }];
+    */
 
 
-
-
-}
+} // SecondCluster

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/second_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/second_cluster.proto
@@ -3,7 +3,7 @@
 
 syntax = "proto3";
 
-package com.chip.proto;
+package com.matter.example.proto;
 
 option java_multiple_files = true;
 
@@ -22,8 +22,8 @@ message SecondCluster {
   // Structs
 
   // Attributes
-  /** octet_string Type: 6 IsList: 0 FieldId: 123 */
-  octet_string some_bytes = 3145851;
+  /** octet_string Type: 5 IsList: 0 FieldId: 123 */
+  bytes some_bytes = 2621563;
     // [(attribute) = {
       // is_subscribable: true,
     // }];

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/second_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/second_cluster.proto
@@ -15,11 +15,11 @@ message SecondCluster {
     CLUSTER_ID = 2;
   }
 
-  // Enums
 
-  // Bitmaps
 
-  // Structs
+
+
+
 
   // Attributes
   /** octet_string Type: 5 IsList: 0 FieldId: 123 */
@@ -30,7 +30,5 @@ message SecondCluster {
 
 
 
-  // Commands
 
-  // Events
 }

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/third_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/third_cluster.proto
@@ -30,25 +30,25 @@ message ThirdCluster {
   }
 
 
-
-
   // Attributes
   /** MyEnum Type: 6 IsList: 0 FieldId: 10 */
   MyEnum some_enum = 3145738;
-    // [(attribute) = {
-      // is_writable : true,
-      // is_subscribable: true,
-    // }];
+    /*
+    [(attribute) = {
+      is_writable : true,
+      is_subscribable: true,
+    }];
+    */
 
 
   /** LevelControlOptions Type: 1 IsList: 0 FieldId: 20 */
   uint32 options = 524308;
-    // [(attribute) = {
-      // is_writable : true,
-      // is_subscribable: true,
-    // }];
+    /*
+    [(attribute) = {
+      is_writable : true,
+      is_subscribable: true,
+    }];
+    */
 
 
-
-
-}
+} // ThirdCluster

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/third_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/third_cluster.proto
@@ -17,7 +17,6 @@ message ThirdCluster {
 
   // Enums
   enum MyEnum {
-    
     ME_UNKNOWN = 0;
     ME_KNOWN = 100;
   }
@@ -31,7 +30,7 @@ message ThirdCluster {
   }
 
 
-  // Structs
+
 
   // Attributes
   /** MyEnum Type: 6 IsList: 0 FieldId: 10 */
@@ -51,7 +50,5 @@ message ThirdCluster {
 
 
 
-  // Commands
 
-  // Events
 }

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/third_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/third_cluster.proto
@@ -1,0 +1,57 @@
+
+/// AUTO-GENERATED with matter_idl.
+
+syntax = "proto3";
+
+package com.chip.proto;
+
+option java_multiple_files = true;
+
+message ThirdCluster {
+  // option (message_type) = MATTER_TRAIT;
+
+  enum ClusterId {
+    CLUSTER_ID_UNSUPPORTED = 0;
+    CLUSTER_ID = 3;
+  }
+
+  // Enums
+  enum MyEnum {
+    
+    ME_UNKNOWN = 0;
+    ME_KNOWN = 100;
+  }
+
+
+  // Bitmaps
+  enum LevelControlOptions {
+    LCO_UNSUPPORTED = 0;
+    LCO_EXECUTE_IF_OFF = 1;
+    LCO_COUPLE_COLOR_TEMP_TO_LEVEL = 2;
+  }
+
+
+  // Structs
+
+  // Attributes
+  /** MyEnum Type: 6 IsList: 0 FieldId: 10 */
+  MyEnum some_enum = 3145738;
+    // [(attribute) = {
+      // is_writable : true,
+      // is_subscribable: true,
+    // }];
+
+
+  /** LevelControlOptions Type: 1 IsList: 0 FieldId: 20 */
+  uint32 options = 524308;
+    // [(attribute) = {
+      // is_writable : true,
+      // is_subscribable: true,
+    // }];
+
+
+
+  // Commands
+
+  // Events
+}

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/proto/third_cluster.proto
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/proto/third_cluster.proto
@@ -3,7 +3,7 @@
 
 syntax = "proto3";
 
-package com.chip.proto;
+package com.matter.example.proto;
 
 option java_multiple_files = true;
 


### PR DESCRIPTION
Adds the ability to run the codegen.py tool with an externally defined custom generator. Provides an example that generates a protobuf representation of the Matter schema and instructions on how to run that example.

Example usage as provided in README:

1. Create a directory for your python generator module, for example
   "matter_idl_plugin".
2. Add an `__init__.py` under "matter_idl_plugin" implementing a subclass of
   `CodeGenerator` named `CustomGenerator`.
3. Have `CustomGenerator` load jinja templates, also under the
   "matter_idl_plugin" subdirectory.
4. Execute the `codegen.py` script passing the path to the parent directory of
   "matter_idl_plugin" via
   `--generator custom:<plugin_path>:<plugin_module_name>` argument.

```
# From top-of-tree in this example
./scripts/codegen.py --generator custom:./scripts/py_matter_idl/examples:matter_idl_plugin ./src/controller/data_model/controller-clusters.matter
```
