### PR TITLE
[matter_yamltests] Add a config_override property to the TestParser i…

### DIFF
--- a/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
+++ b/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
@@ -33,7 +33,7 @@ import click
 from chip.ChipStack import *
 from chip.yaml.runner import ReplTestRunner
 from matter_yamltests.definitions import SpecDefinitionsFromPaths
-from matter_yamltests.parser import PostProcessCheckStatus, TestParser
+from matter_yamltests.parser import PostProcessCheckStatus, TestParser, TestParserConfig
 
 _DEFAULT_CHIP_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", ".."))
@@ -100,7 +100,8 @@ def main(setup_code, yaml_path, node_id, pics_file):
             ])
 
             # Parsing YAML test and setting up chip-repl yamltests runner.
-            yaml = TestParser(yaml_path, pics_file, clusters_definitions)
+            parser_config = TestParserConfig(pics_file, clusters_definitions)
+            yaml = TestParser(yaml_path, parser_config)
             runner = ReplTestRunner(
                 clusters_definitions, certificate_authority_manager, dev_ctrl)
 


### PR DESCRIPTION
…n order to modify the test parameters

#### Problem

There is no mechanism to override the test configuration. The current `TestParser.update_config method does not provide the right abstraction since it appears that `YamlTests` does a deep copy of the config at init, so changing them after does not works.

