### PR TITLE
Fix implementation of OnChipScanComplete and OnScanComplete - second PR

### DIFF
--- a/src/controller/python/chip/ble/darwin/Scanning.mm
+++ b/src/controller/python/chip/ble/darwin/Scanning.mm
@@ -105,7 +105,7 @@ using ScanErrorCallback = void (*)(PyObject * context, uint32_t error);
     ChipLogProgress(Ble, "Scan timeout reached.");
 
     _completeCallback(_context);
-    _errorCallback(_context, CHIP_ERROR_TIMEOUT);
+    _errorCallback(_context, CHIP_ERROR_TIMEOUT.AsInteger());
 
     dispatch_source_cancel(_timer);
     [self.centralManager stopScan];

--- a/src/controller/python/chip/ble/darwin/Scanning.mm
+++ b/src/controller/python/chip/ble/darwin/Scanning.mm
@@ -11,6 +11,7 @@ struct PyObject;
 using DeviceScannedCallback
     = void (*)(PyObject * context, const char * address, uint16_t discriminator, uint16_t vendorId, uint16_t productId);
 using ScanCompleteCallback = void (*)(PyObject * context);
+using ScanErrorCallback = void (*)(PyObject * context, uint32_t error);
 }
 
 @interface ChipDeviceBleScanner : NSObject <CBCentralManagerDelegate>
@@ -23,10 +24,12 @@ using ScanCompleteCallback = void (*)(PyObject * context);
 @property (assign, nonatomic) PyObject * context;
 @property (assign, nonatomic) DeviceScannedCallback scanCallback;
 @property (assign, nonatomic) ScanCompleteCallback completeCallback;
+@property (assign, nonatomic) ScanErrorCallback errorCallback;
 
 - (id)initWithContext:(PyObject *)context
          scanCallback:(DeviceScannedCallback)scanCallback
      completeCallback:(ScanCompleteCallback)completeCallback
+        errorCallback:(ScanErrorCallback)errorCallback
             timeoutMs:(uint32_t)timeout;
 
 - (void)stopTimeoutReached;
@@ -38,6 +41,7 @@ using ScanCompleteCallback = void (*)(PyObject * context);
 - (id)initWithContext:(PyObject *)context
          scanCallback:(DeviceScannedCallback)scanCallback
      completeCallback:(ScanCompleteCallback)completeCallback
+        errorCallback:(ScanErrorCallback)errorCallback
             timeoutMs:(uint32_t)timeout
 {
     self = [super init];
@@ -50,6 +54,7 @@ using ScanCompleteCallback = void (*)(PyObject * context);
         _context = context;
         _scanCallback = scanCallback;
         _completeCallback = completeCallback;
+        _errorCallback = errorCallback;
 
         dispatch_source_set_event_handler(_timer, ^{
             [self stopTimeoutReached];
@@ -125,14 +130,15 @@ using ScanCompleteCallback = void (*)(PyObject * context);
 
 @end
 
-extern "C" void * pychip_ble_start_scanning(
-    PyObject * context, void * adapter, uint32_t timeout, DeviceScannedCallback scanCallback, ScanCompleteCallback completeCallback)
+extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, uint32_t timeout,
+    DeviceScannedCallback scanCallback, ScanCompleteCallback completeCallback, ScanErrorCallback errorCallback)
 {
     // NOTE: adapter is ignored as it does not apply to mac
 
     ChipDeviceBleScanner * scanner = [[ChipDeviceBleScanner alloc] initWithContext:context
                                                                       scanCallback:scanCallback
                                                                   completeCallback:completeCallback
+                                                                     errorCallback:errorCallback
                                                                          timeoutMs:timeout];
 
     return (__bridge_retained void *) (scanner);

--- a/src/controller/python/chip/ble/darwin/Scanning.mm
+++ b/src/controller/python/chip/ble/darwin/Scanning.mm
@@ -105,6 +105,7 @@ using ScanErrorCallback = void (*)(PyObject * context, uint32_t error);
     ChipLogProgress(Ble, "Scan timeout reached.");
 
     _completeCallback(_context);
+    _errorCallback(_context, CHIP_ERROR_TIMEOUT);
 
     dispatch_source_cancel(_timer);
     [self.centralManager stopScan];

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -821,7 +821,7 @@ void BLEManagerImpl::OnScanComplete()
 
 void BLEManagerImpl::OnScanError(CHIP_ERROR err)
 {
-    ChipLogDetail(Ble, "BLE scan error: %" CHIP_ERROR_FORMAT, err.Format());
+    ChipLogError(Ble, "BLE scan error: %" CHIP_ERROR_FORMAT, err.Format());
 }
 
 } // namespace Internal

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -804,15 +804,26 @@ void BLEManagerImpl::OnDeviceScanned(BluezDevice1 * device, const chip::Ble::Chi
 
 void BLEManagerImpl::OnScanComplete()
 {
-    if (mBLEScanConfig.mBleScanState != BleScanState::kScanForDiscriminator &&
-        mBLEScanConfig.mBleScanState != BleScanState::kScanForAddress)
+    switch (mBLEScanConfig.mBleScanState)
     {
+    case BleScanState::kNotScanning:
         ChipLogProgress(Ble, "Scan complete notification without an active scan.");
-        return;
+        break;
+    case BleScanState::kScanForAddress:
+    case BleScanState::kScanForDiscriminator:
+        ChipLogProgress(Ble, "Scan complete. No matching device found.");
+        break;
+    case BleScanState::kConnecting:
+        mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
+        break;
     }
 
-    BleConnectionDelegate::OnConnectionError(mBLEScanConfig.mAppState, CHIP_ERROR_TIMEOUT);
     mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
+}
+
+void BLEManagerImpl::OnScanError(CHIP_ERROR err)
+{
+    ChipLogDetail(Ble, "BLE scan error: %" CHIP_ERROR_FORMAT, err.Format());
 }
 
 } // namespace Internal

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -790,7 +790,7 @@ void BLEManagerImpl::OnDeviceScanned(BluezDevice1 * device, const chip::Ble::Chi
     }
     else
     {
-        // Internal consistency eerror
+        // Internal consistency error
         ChipLogError(Ble, "Unknown discovery type. Ignoring scanned device.");
         return;
     }

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -811,13 +811,12 @@ void BLEManagerImpl::OnScanComplete()
         break;
     case BleScanState::kScanForAddress:
     case BleScanState::kScanForDiscriminator:
+        mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
         ChipLogProgress(Ble, "Scan complete. No matching device found.");
         break;
     case BleScanState::kConnecting:
         break;
     }
-
-    mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
 }
 
 void BLEManagerImpl::OnScanError(CHIP_ERROR err)

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -814,7 +814,6 @@ void BLEManagerImpl::OnScanComplete()
         ChipLogProgress(Ble, "Scan complete. No matching device found.");
         break;
     case BleScanState::kConnecting:
-        mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
         break;
     }
 

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -91,7 +91,7 @@ class BLEManagerImpl final : public BLEManager,
 
 public:
     CHIP_ERROR ConfigureBle(uint32_t aAdapterId, bool aIsCentral);
-    void OnScanError(ChipError error);
+    void OnScanError(CHIP_ERROR error) override;
 
     // Driven by BlueZ IO
     static void HandleNewConnection(BLE_CONNECTION_OBJECT conId);

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -91,6 +91,7 @@ class BLEManagerImpl final : public BLEManager,
 
 public:
     CHIP_ERROR ConfigureBle(uint32_t aAdapterId, bool aIsCentral);
+    void OnScanError(ChipError error);
 
     // Driven by BlueZ IO
     static void HandleNewConnection(BLE_CONNECTION_OBJECT conId);

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -150,7 +150,9 @@ CHIP_ERROR ChipDeviceScanner::StartScan(System::Clock::Timeout timeout)
 
 void ChipDeviceScanner::TimerExpiredCallback(chip::System::Layer * layer, void * appState)
 {
-    static_cast<ChipDeviceScanner *>(appState)->StopScan();
+    ChipDeviceScanner * chipDeviceScanner = static_cast<ChipDeviceScanner *>(appState);
+    chipDeviceScanner->mDelegate->OnScanError(CHIP_ERROR_TIMEOUT);
+    chipDeviceScanner->StopScan();
 }
 
 CHIP_ERROR ChipDeviceScanner::StopScan()

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -44,6 +44,9 @@ public:
 
     // Called when a scan was completed (stopped or timed out)
     virtual void OnScanComplete() = 0;
+
+    // Call on scan error
+    virtual void OnScanError(CHIP_ERROR) = 0;
 };
 
 /// Allows scanning for CHIP devices

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -138,7 +138,8 @@ private:
 
     //  ===== Members that implement virtual methods on ChipDeviceScannerDelegate
     void OnChipDeviceScanned(void * device, const Ble::ChipBLEDeviceIdentificationInfo & info) override;
-    void OnChipScanComplete() override;
+    void OnScanComplete() override;
+    void OnScanError(CHIP_ERROR err) override;
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -242,7 +242,7 @@ CHIP_ERROR ChipDeviceScanner::StopChipScan()
     UnRegisterScanFilter();
 
     // Report to Impl class
-    mDelegate->OnChipScanComplete();
+    mDelegate->OnScanComplete();
 
     mIsScanning = false;
 

--- a/src/platform/Tizen/ChipDeviceScanner.h
+++ b/src/platform/Tizen/ChipDeviceScanner.h
@@ -65,7 +65,10 @@ public:
     virtual void OnChipDeviceScanned(void * device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info) = 0;
 
     // Called when a scan was completed (stopped or timed out)
-    virtual void OnChipScanComplete(void) = 0;
+    virtual void OnScanComplete(void) = 0;
+
+    // Called on scan error
+    virtual void OnScanError(CHIP_ERROR err) = 0;
 };
 
 /// Allows scanning for CHIP devices

--- a/src/platform/webos/BLEManagerImpl.cpp
+++ b/src/platform/webos/BLEManagerImpl.cpp
@@ -500,7 +500,7 @@ bool BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const 
 {
     bool result = false;
     result      = SubscribeCharacteristicToWebOS(conId, static_cast<const uint8_t *>(svcId->bytes),
-                                                 static_cast<const uint8_t *>(charId->bytes));
+                                            static_cast<const uint8_t *>(charId->bytes));
     return result;
 }
 
@@ -598,7 +598,8 @@ bool BLEManagerImpl::SendWriteRequestToWebOS(void * bleConnObj, const uint8_t * 
         valueParam.put("string", value);
     }
     else
-    {}
+    {
+    }
     param.put("value", valueParam);
 
     ChipLogProgress(Ble, "SendWriteRequestToWebOS Param : param  %s", param.stringify().c_str());

--- a/src/platform/webos/BLEManagerImpl.cpp
+++ b/src/platform/webos/BLEManagerImpl.cpp
@@ -500,7 +500,7 @@ bool BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const 
 {
     bool result = false;
     result      = SubscribeCharacteristicToWebOS(conId, static_cast<const uint8_t *>(svcId->bytes),
-                                            static_cast<const uint8_t *>(charId->bytes));
+                                                 static_cast<const uint8_t *>(charId->bytes));
     return result;
 }
 
@@ -598,8 +598,7 @@ bool BLEManagerImpl::SendWriteRequestToWebOS(void * bleConnObj, const uint8_t * 
         valueParam.put("string", value);
     }
     else
-    {
-    }
+    {}
     param.put("value", valueParam);
 
     ChipLogProgress(Ble, "SendWriteRequestToWebOS Param : param  %s", param.stringify().c_str());
@@ -917,31 +916,26 @@ void BLEManagerImpl::NotifyBLEPeripheralAdvStopComplete(bool aIsSuccess, void * 
     PlatformMgr().PostEventOrDie(&event);
 }
 
-void BLEManagerImpl::OnChipScanComplete()
-{
-    if (mBLEScanConfig.mBleScanState != BleScanState::kScanForDiscriminator &&
-        mBLEScanConfig.mBleScanState != BleScanState::kScanForAddress)
-    {
-        ChipLogProgress(DeviceLayer, "Scan complete notification without an active scan.");
-        return;
-    }
-
-    ChipLogError(DeviceLayer, "Scan Completed with Timeout: Notify Upstream.");
-    BleConnectionDelegate::OnConnectionError(mBLEScanConfig.mAppState, CHIP_ERROR_TIMEOUT);
-    mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
-}
-
 void BLEManagerImpl::OnScanComplete()
 {
-    if (mBLEScanConfig.mBleScanState != BleScanState::kScanForDiscriminator &&
-        mBLEScanConfig.mBleScanState != BleScanState::kScanForAddress)
+    switch (mBLEScanConfig.mBleScanState)
     {
+    case BleScanState::kNotScanning:
         ChipLogProgress(Ble, "Scan complete notification without an active scan.");
-        return;
+        break;
+    case BleScanState::kScanForAddress:
+    case BleScanState::kScanForDiscriminator:
+        mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
+        ChipLogProgress(Ble, "Scan complete. No matching device found.");
+        break;
+    case BleScanState::kConnecting:
+        break;
     }
+}
 
-    BleConnectionDelegate::OnConnectionError(mBLEScanConfig.mAppState, CHIP_ERROR_TIMEOUT);
-    mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
+void BLEManagerImpl::OnScanError(CHIP_ERROR err)
+{
+    ChipLogDetail(Ble, "BLE scan error: %" CHIP_ERROR_FORMAT, err.Format());
 }
 
 bool BLEManagerImpl::gattGetServiceCb(LSHandle * sh, LSMessage * message, void * userData)

--- a/src/platform/webos/BLEManagerImpl.h
+++ b/src/platform/webos/BLEManagerImpl.h
@@ -135,10 +135,9 @@ private:
     CHIP_ERROR CancelConnection() override;
 
     // ===== Members that implement virtual methods on ChipDeviceScannerDelegate
-    void OnScanComplete() override;
     void OnChipDeviceScanned(char * address) override;
-    void OnChipScanComplete() override;
-
+    void OnScanComplete() override;
+    void OnScanError(CHIP_ERROR err) override;
     // ===== Members for internal use by the following friends.
 
     friend BLEManager & BLEMgr();

--- a/src/platform/webos/ChipDeviceScanner.cpp
+++ b/src/platform/webos/ChipDeviceScanner.cpp
@@ -336,7 +336,7 @@ CHIP_ERROR ChipDeviceScanner::StopChipScan()
     ChipLogProgress(DeviceLayer, "CHIP Scanner Async Thread Quit Done..Wait for Thread Windup...!");
 
     // Report to Impl class
-    mDelegate->OnChipScanComplete();
+    mDelegate->OnScanComplete();
 
     mIsScanning = false;
 

--- a/src/platform/webos/ChipDeviceScanner.h
+++ b/src/platform/webos/ChipDeviceScanner.h
@@ -43,8 +43,10 @@ public:
     virtual void OnChipDeviceScanned(char * address) = 0;
 
     // Called when a scan was completed (stopped or timed out)
-    virtual void OnScanComplete()     = 0;
-    virtual void OnChipScanComplete() = 0;
+    virtual void OnScanComplete() = 0;
+
+    // Called on scan error
+    virtual void OnScanError(CHIP_ERROR err) = 0;
 };
 
 /// Allows scanning for CHIP devices


### PR DESCRIPTION
I recreated PR #23612. In the original one there was a problem with CI "pullapprove — Given usernames could not be requested."


### Problem

When the chip-tool is shutting down because of timeout from [StartWaiting](https://github.com/jlatusek/connectedhomeip/blob/1e8a74435aff49ab5783f616a90b6fb99b3dea0e/examples/chip-tool/commands/common/CHIPCommand.cpp#L218) then [mBleLayer->mBleTransport](https://github.com/jlatusek/connectedhomeip/blob/1e8a74435aff49ab5783f616a90b6fb99b3dea0e/src/transport/raw/BLE.cpp#L50) is firstly set to nullptr and [OnBleConnectionError](https://github.com/jlatusek/connectedhomeip/blob/1e8a74435aff49ab5783f616a90b6fb99b3dea0e/src/ble/BleLayer.cpp#L773) is called on this pointer. 

### Fix

I've changed the implementation of [OnScanComplete](https://github.com/project-chip/connectedhomeip/blob/733afaabd512cbf396d3edf09805d1054a6ec5f8/src/platform/Linux/BLEManagerImpl.cpp#L805) to do not call `OnConnectionError` it seems that this isn't the right place to do it. I've created `OnScanError`, which is called when the error occurs during scanning. Now it is called from [TimerExpiredCallback](https://github.com/jlatusek/connectedhomeip/blob/1e8a74435aff49ab5783f616a90b6fb99b3dea0e/src/platform/Linux/bluez/ChipDeviceScanner.cpp#L151)  which is the callback for a timeout for scan task. For [kConnectTimeout](https://github.com/jlatusek/connectedhomeip/blob/1e8a74435aff49ab5783f616a90b6fb99b3dea0e/src/platform/Linux/BLEManagerImpl.cpp#L799) `OnConnectionError` is called [here](https://github.com/jlatusek/connectedhomeip/blob/1e8a74435aff49ab5783f616a90b6fb99b3dea0e/src/platform/Linux/BLEManagerImpl.cpp#L268) if an error occurred.


### Testing

Manually tested on the Linux platform on one device I've run:
``` sh
 ./out/linux-x64-light/chip-lighting-app --discriminator 42 --passcode 1234 --wifi 
 ```
and on the other Linux device I've run: 
``` sh
./out/linux-x64-chip-tool/chip-tool pairing ble-wifi 0x01 <wifi_name> <wifi_pass> 1234 42
```
