### PR TITLE
Add back the ability to choose a specific target when regenerating te…

### DIFF
--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -374,7 +374,7 @@ def getTargets(type, test_target):
     targets = []
 
     if type & TargetType.TESTS:
-        targets.extend(getTestsTemplatesTargets('all'))
+        targets.extend(getTestsTemplatesTargets(test_target))
 
     if type & TargetType.GLOBAL:
         targets.extend(getGlobalTemplatesTargets())


### PR DESCRIPTION
…sts using scripts/tools/zap_regen_all.py

#### Problem

This is a small followup to #24527 which broke the ability to choose which tests to regenerate with: `./scripts/tools/zap_regen_all.py --type tests --tests chip-tool` for example.