### PR TITLE
Simplify and future-proof enum range checks in door locks.

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -380,7 +380,7 @@ void DoorLockServer::setUserCommandHandler(chip::app::CommandHandler * commandOb
         return;
     }
 
-    if (!userType.IsNull() && userType.Value() == UserTypeEnum::kUnknownEnumValue)
+    if (userType == UserTypeEnum::kUnknownEnumValue)
     {
         emberAfDoorLockClusterPrintln(
             "[SetUser] Unable to set the user: user type is unknown [endpointId=%d,userIndex=%d,userType=%u]",
@@ -693,7 +693,7 @@ void DoorLockServer::setCredentialCommandHandler(
         return;
     }
 
-    if (!userType.IsNull() && userType.Value() == UserTypeEnum::kUnknownEnumValue)
+    if (userType == UserTypeEnum::kUnknownEnumValue)
     {
         emberAfDoorLockClusterPrintln("[SetCredential] Unable to set the credential: user type is unknown "
                                       "[endpointId=%d,credentialIndex=%d,userType=%u]",

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -380,11 +380,10 @@ void DoorLockServer::setUserCommandHandler(chip::app::CommandHandler * commandOb
         return;
     }
 
-    if (!userType.IsNull() &&
-        (userType.Value() < UserTypeEnum::kUnrestrictedUser || userType.Value() > UserTypeEnum::kRemoteOnlyUser))
+    if (!userType.IsNull() && userType.Value() == UserTypeEnum::kUnknownEnumValue)
     {
         emberAfDoorLockClusterPrintln(
-            "[SetUser] Unable to set the user: user type is out of range [endpointId=%d,userIndex=%d,userType=%u]",
+            "[SetUser] Unable to set the user: user type is unknown [endpointId=%d,userIndex=%d,userType=%u]",
             commandPath.mEndpointId, userIndex, to_underlying(userType.Value()));
 
         sendClusterResponse(commandObj, commandPath, EMBER_ZCL_STATUS_INVALID_COMMAND);
@@ -694,10 +693,9 @@ void DoorLockServer::setCredentialCommandHandler(
         return;
     }
 
-    if (!userType.IsNull() &&
-        (userType.Value() < UserTypeEnum::kUnrestrictedUser || userType.Value() > UserTypeEnum::kRemoteOnlyUser))
+    if (!userType.IsNull() && userType.Value() == UserTypeEnum::kUnknownEnumValue)
     {
-        emberAfDoorLockClusterPrintln("[SetCredential] Unable to set the credential: user type is out of range "
+        emberAfDoorLockClusterPrintln("[SetCredential] Unable to set the credential: user type is unknown "
                                       "[endpointId=%d,credentialIndex=%d,userType=%u]",
                                       commandPath.mEndpointId, credentialIndex, to_underlying(userType.Value()));
         sendSetCredentialResponse(commandObj, commandPath, DlStatus::kInvalidField, 0, nextAvailableCredentialSlot);
@@ -3113,9 +3111,9 @@ void DoorLockServer::setHolidayScheduleCommandHandler(chip::app::CommandHandler 
         return;
     }
 
-    if (operatingMode > OperatingModeEnum::kPassage || operatingMode < OperatingModeEnum::kNormal)
+    if (operatingMode == OperatingModeEnum::kUnknownEnumValue)
     {
-        emberAfDoorLockClusterPrintln("[SetHolidaySchedule] Unable to add schedule - operating mode is out of range"
+        emberAfDoorLockClusterPrintln("[SetHolidaySchedule] Unable to add schedule - operating mode is unknown"
                                       "[endpointId=%d,scheduleIndex=%d,localStarTime=%" PRIu32 ",localEndTime=%" PRIu32
                                       ", operatingMode=%d]",
                                       endpointId, holidayIndex, localStartTime, localEndTime, to_underlying(operatingMode));

--- a/src/app/data-model/Nullable.h
+++ b/src/app/data-model/Nullable.h
@@ -84,6 +84,8 @@ struct Nullable : protected Optional<T>
 
     bool operator==(const Nullable & other) const { return Optional<T>::operator==(other); }
     bool operator!=(const Nullable & other) const { return !(*this == other); }
+    bool operator==(const T & other) const { return !IsNull() && Value() == other; }
+    bool operator!=(const T & other) const { return IsNull() || Value() != other; }
 };
 
 template <class T>

--- a/src/app/data-model/Nullable.h
+++ b/src/app/data-model/Nullable.h
@@ -83,9 +83,9 @@ struct Nullable : protected Optional<T>
     static constexpr bool kIsFabricScoped = false;
 
     bool operator==(const Nullable & other) const { return Optional<T>::operator==(other); }
-    bool operator!=(const Nullable & other) const { return !(*this == other); }
-    bool operator==(const T & other) const { return !IsNull() && Value() == other; }
-    bool operator!=(const T & other) const { return IsNull() || Value() != other; }
+    bool operator!=(const Nullable & other) const { return Optional<T>::operator!=(other); }
+    bool operator==(const T & other) const { return Optional<T>::operator==(other); }
+    bool operator!=(const T & other) const { return Optional<T>::operator!=(other); }
 };
 
 template <class T>

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -184,6 +184,8 @@ public:
         return (mHasValue == other.mHasValue) && (!other.mHasValue || (mValue.mData == other.mValue.mData));
     }
     bool operator!=(const Optional & other) const { return !(*this == other); }
+    bool operator==(const T & other) const { return HasValue() && Value() == other; }
+    bool operator!=(const T & other) const { return !(*this == other); }
 
     /** Convenience method to create an optional without a valid value. */
     static Optional<T> Missing() { return Optional<T>(); }


### PR DESCRIPTION
Instead of explicitly checking for the min/max values, check for the "unknown value" value that decoding will decode to if the value is out of range.

Fixes https://github.com/project-chip/connectedhomeip/issues/20936


