### PR TITLE
Remove WriteHandler::Abort.

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -132,7 +132,10 @@ void InteractionModelEngine::Shutdown()
 
     for (auto & writeHandler : mWriteHandlers)
     {
-        writeHandler.Abort();
+        if (!writeHandler.IsFree())
+        {
+            writeHandler.Close();
+        }
     }
 
     mReportingEngine.Shutdown();

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -70,12 +70,6 @@ public:
     Protocols::InteractionModel::Status OnWriteRequest(Messaging::ExchangeContext * apExchangeContext,
                                                        System::PacketBufferHandle && aPayload, bool aIsTimedWrite);
 
-    /*
-     * This forcibly closes the exchange context if a valid one is pointed to and de-initializes the object. Such a situation does
-     * not arise during normal message processing flows that all normally call Close() below.
-     */
-    void Abort();
-
     /**
      *  Clean up state when we are done sending the write response.
      */
@@ -136,7 +130,6 @@ private:
     CHIP_ERROR SendWriteResponse(System::PacketBufferTLVWriter && aMessageWriter);
 
     void MoveToState(const State aTargetState);
-    void ClearState();
     const char * GetStateStr() const;
 
     void DeliverListWriteBegin(const ConcreteAttributePath & aPath);


### PR DESCRIPTION
It's basically just Close, except missing some state updates, and not doing the "is this actually in use" check that Close does.  We can guard on that check in the caller and call Close.

Fixes https://github.com/project-chip/connectedhomeip/issues/21740


