### PR TITLE
Add a cache for the FindBinary method of scripts/tests/run_test_suite…

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -81,3 +81,6 @@ colorama
 
 # update tornado for pw_watch
 tornado
+
+# YAML test harness
+diskcache


### PR DESCRIPTION
….py in order to not wait for too long each time it is runned manually

#### Problem

Running `./scripts/tests/run_test_suite.py` search the disks for binaries every time. On my laptop it takes something like 30 seconds every time. This PR adds a cache such that it instantaneous the next time.
Entries are evicted from the cache if the file does not exists anymore.