### PR TITLE
[Silabs]fix minimal feature build

### DIFF
--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -296,7 +296,7 @@ template("efr32_sdk") {
     if ((defined(invoker.chip_enable_pw_rpc) && invoker.chip_enable_pw_rpc) ||
         chip_build_libshell || enable_openthread_cli ||
         (defined(invoker.chip_enable_wifi) && invoker.chip_enable_wifi) ||
-        show_qr_code || disable_lcd || use_external_flash) {
+        show_qr_code || !disable_lcd || use_external_flash) {
       defines += [ "CONFIG_ENABLE_UART" ]
 
       if (use_external_flash) {


### PR DESCRIPTION
Fix condition to remove uart/lcd components in the build.

Tested minmal build with the following build options
`is_debug=false disable_lcd=true chip_build_libshell=false enable_openthread_cli=false use_external_flash=false chip_logging=false
`