### PR TITLE
[Silabs] Add option to remove all logs

### DIFF
--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -112,6 +112,9 @@ if [ "$#" == "0" ]; then
         --no-version
             Skip the silabs formating for the Matter software version string
             Currently : v1.0-<branchName>-<ShortCommitSha>
+        --release
+            Remove all logs and debugs features (including the LCD). Yield the smallest image size possible
+
     "
 elif [ "$#" -lt "2" ]; then
     echo "Invalid number of arguments
@@ -178,6 +181,10 @@ else
             #    ;;
             --no-version)
                 USE_GIT_SHA_FOR_VERSION=false
+                shift
+                ;;
+            --release)
+                optArgs+="is_debug=false disable_lcd=true chip_build_libshell=false enable_openthread_cli=false use_external_flash=false chip_logging=false silabs_log_enabled=false "
                 shift
                 ;;
             *)

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -56,7 +56,6 @@ efr32_sdk("sdk") {
   ]
 
   defines = [
-    "SILABS_LOG_ENABLED=1",
     "PW_RPC_ENABLED",
 
     # Thread is built but test driver do not have the NETWORK_COMMISSIONING cluster or zap config.

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -40,6 +40,8 @@ declare_args() {
 
   sleep_time_ms = 3300000  # 55 mins sleep
 
+  silabs_log_enabled = true
+
   # Enable Sleepy end device
   enable_sleepy_device = false
 }
@@ -165,7 +167,7 @@ template("efr32_sdk") {
       "__STARTUP_CLEAR_BSS",
       "HARD_FAULT_LOG_ENABLE",
       "CORTEXM3_EFM32_MICRO",
-      "SILABS_LOG_ENABLED=1",
+      "SILABS_LOG_ENABLED=${silabs_log_enabled}",
       "NVM3_DEFAULT_NVM_SIZE=40960",
       "NVM3_DEFAULT_MAX_OBJECT_SIZE=4092",
       "KVS_MAX_ENTRIES=${kvs_max_entries}",


### PR DESCRIPTION
Add a release flag for Silicon Labs platform, removing all logs and debug options to have the smallest footprint possible.

