### PR TITLE
[chip-tool] Remove pairing ethernet command

### DIFF
--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -173,14 +173,6 @@ public:
     {}
 };
 
-class Ethernet : public PairingCommand
-{
-public:
-    Ethernet(CredentialIssuerCommands * credsIssuerConfig) :
-        PairingCommand("ethernet", PairingMode::Ethernet, PairingNetworkType::Ethernet, credsIssuerConfig)
-    {}
-};
-
 class StartUdcServerCommand : public CHIPCommand
 {
 public:
@@ -207,7 +199,6 @@ void registerCommandsPairing(Commands & commands, CredentialIssuerCommands * cre
         make_unique<PairBleWiFi>(credsIssuerConfig),
         make_unique<PairBleThread>(credsIssuerConfig),
         make_unique<PairSoftAP>(credsIssuerConfig),
-        make_unique<Ethernet>(credsIssuerConfig),
         make_unique<PairOnNetwork>(credsIssuerConfig),
         make_unique<PairOnNetworkShort>(credsIssuerConfig),
         make_unique<PairOnNetworkLong>(credsIssuerConfig),

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -75,9 +75,6 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
     case PairingMode::SoftAP:
         err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort, mRemoteAddr.interfaceId));
         break;
-    case PairingMode::Ethernet:
-        err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort, mRemoteAddr.interfaceId));
-        break;
     }
 
     return err;
@@ -100,7 +97,6 @@ CommissioningParameters PairingCommand::GetCommissioningParameters()
     case PairingNetworkType::Thread:
         params.SetThreadOperationalDataset(mOperationalDataset);
         break;
-    case PairingNetworkType::Ethernet:
     case PairingNetworkType::None:
         break;
     }

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -34,7 +34,6 @@ enum class PairingMode
     CodePaseOnly,
     Ble,
     SoftAP,
-    Ethernet,
     OnNetwork,
 };
 
@@ -43,7 +42,6 @@ enum class PairingNetworkType
     None,
     WiFi,
     Thread,
-    Ethernet,
 };
 
 class PairingCommand : public CHIPCommand,
@@ -69,7 +67,6 @@ public:
         switch (networkType)
         {
         case PairingNetworkType::None:
-        case PairingNetworkType::Ethernet:
             break;
         case PairingNetworkType::WiFi:
             AddArgument("ssid", &mSSID);
@@ -102,14 +99,6 @@ public:
             AddArgument("pase-only", 0, 1, &mPaseOnly);
             break;
         case PairingMode::SoftAP:
-            AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
-            AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
-            AddArgument("discriminator", 0, 4096, &mDiscriminator);
-            AddArgument("device-remote-ip", &mRemoteAddr);
-            AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
-            AddArgument("pase-only", 0, 1, &mPaseOnly);
-            break;
-        case PairingMode::Ethernet:
             AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
             AddArgument("discriminator", 0, 4096, &mDiscriminator);


### PR DESCRIPTION
CHIP spec generally does not allow direct IP address specification or port, per discussion, 'pairing ethernet' command should be disabled in chip-tool to force address and port are discovered via MDNS.

