### PR TITLE
tv-casting-app: Handle uncaught exceptions before JNI crashes app and make iOS discoverCommissioners API callback based

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CertTestFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CertTestFragment.java
@@ -81,8 +81,12 @@ public class CertTestFragment extends Fragment {
   private void runCertTests(Activity activity) {
     CertTestMatterSuccessFailureCallback successFailureCallback =
         new CertTestMatterSuccessFailureCallback(activity);
-    CertTestMatterSuccessFailureCallbackInteger successFailureCallbackInteger =
-        new CertTestMatterSuccessFailureCallbackInteger(successFailureCallback);
+    CertTestMatterSuccessCallback successCallback =
+        new CertTestMatterSuccessCallback(successFailureCallback);
+    CertTestMatterFailureCallback failureCallback =
+        new CertTestMatterFailureCallback(successFailureCallback);
+    CertTestMatterSuccessCallbackInteger successCallbackInteger =
+        new CertTestMatterSuccessCallbackInteger(successFailureCallback);
     CertTestMatterCallbackHandler callback =
         new CertTestMatterCallbackHandler(successFailureCallback);
 
@@ -269,7 +273,7 @@ public class CertTestFragment extends Fragment {
         successFailureCallback,
         () -> {
           tvCastingApp.applicationBasic_readApplicationVersion(
-              kContentApp, successFailureCallback, successFailureCallback);
+              kContentApp, successCallback, failureCallback);
         });
 
     runAndWait(
@@ -277,7 +281,7 @@ public class CertTestFragment extends Fragment {
         successFailureCallback,
         () -> {
           tvCastingApp.applicationBasic_readVendorName(
-              kContentApp, successFailureCallback, successFailureCallback);
+              kContentApp, successCallback, failureCallback);
         });
 
     runAndWait(
@@ -285,7 +289,7 @@ public class CertTestFragment extends Fragment {
         successFailureCallback,
         () -> {
           tvCastingApp.applicationBasic_readApplicationName(
-              kContentApp, successFailureCallback, successFailureCallback);
+              kContentApp, successCallback, failureCallback);
         });
 
     runAndWait(
@@ -293,7 +297,7 @@ public class CertTestFragment extends Fragment {
         successFailureCallback,
         () -> {
           tvCastingApp.applicationBasic_readVendorID(
-              kContentApp, successFailureCallbackInteger, successFailureCallbackInteger);
+              kContentApp, successCallbackInteger, failureCallback);
         });
 
     runAndWait(
@@ -301,7 +305,7 @@ public class CertTestFragment extends Fragment {
         successFailureCallback,
         () -> {
           tvCastingApp.applicationBasic_readProductID(
-              kContentApp, successFailureCallbackInteger, successFailureCallbackInteger);
+              kContentApp, successCallbackInteger, failureCallback);
         });
 
     runAndWait(
@@ -320,7 +324,7 @@ public class CertTestFragment extends Fragment {
                       activity, MatterError.NO_ERROR, "mediaPlayback_subscribeToCurrentState");
                 }
               },
-              successFailureCallback,
+              failureCallback,
               0,
               20,
               new SubscriptionEstablishedCallback() {
@@ -415,8 +419,7 @@ public class CertTestFragment extends Fragment {
     }
   }
 
-  class CertTestMatterSuccessFailureCallback extends FailureCallback
-      implements SuccessCallback<String> {
+  class CertTestMatterSuccessFailureCallback {
     private Activity activity;
     private String testMethod;
     private CountDownLatch cdl;
@@ -433,7 +436,6 @@ public class CertTestFragment extends Fragment {
       this.cdl = cdl;
     }
 
-    @Override
     public void handle(MatterError error) {
       try {
         cdl.countDown();
@@ -446,7 +448,6 @@ public class CertTestFragment extends Fragment {
       }
     }
 
-    @Override
     public void handle(String response) {
       try {
         cdl.countDown();
@@ -460,18 +461,38 @@ public class CertTestFragment extends Fragment {
     }
   }
 
-  class CertTestMatterSuccessFailureCallbackInteger extends FailureCallback
-      implements SuccessCallback<Integer> {
-
+  class CertTestMatterSuccessCallback extends SuccessCallback<String> {
     private CertTestMatterSuccessFailureCallback delegate;
 
-    CertTestMatterSuccessFailureCallbackInteger(CertTestMatterSuccessFailureCallback delegate) {
+    CertTestMatterSuccessCallback(CertTestMatterSuccessFailureCallback delegate) {
       this.delegate = delegate;
     }
 
     @Override
-    public void handle(MatterError error) {
-      delegate.handle(error);
+    public void handle(String response) {
+      delegate.handle(response);
+    }
+  }
+
+  class CertTestMatterFailureCallback extends FailureCallback {
+    private CertTestMatterSuccessFailureCallback delegate;
+
+    CertTestMatterFailureCallback(CertTestMatterSuccessFailureCallback delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void handle(MatterError err) {
+      delegate.handle(err);
+    }
+  }
+
+  class CertTestMatterSuccessCallbackInteger extends SuccessCallback<Integer> {
+
+    private CertTestMatterSuccessFailureCallback delegate;
+
+    CertTestMatterSuccessCallbackInteger(CertTestMatterSuccessFailureCallback delegate) {
+      this.delegate = delegate;
     }
 
     @Override

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MediaPlaybackFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MediaPlaybackFragment.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 import com.chip.casting.ContentApp;
 import com.chip.casting.FailureCallback;
 import com.chip.casting.MatterError;
@@ -63,13 +64,16 @@ public class MediaPlaybackFragment extends Fragment {
             TextView currentStateValue = getView().findViewById(R.id.currentStateValue);
 
             SuccessCallback<MediaPlaybackTypes.PlaybackStateEnum> successCallback =
-                playbackStateEnum -> {
-                  Log.d(
-                      TAG,
-                      "handle() called on SuccessCallback<MediaPlaybackResponseTypes.PlaybackStateEnum> with "
-                          + playbackStateEnum);
-                  getActivity()
-                      .runOnUiThread(
+                new SuccessCallback<MediaPlaybackTypes.PlaybackStateEnum>() {
+                  @Override
+                  public void handle(MediaPlaybackTypes.PlaybackStateEnum playbackStateEnum) {
+                    Log.d(
+                        TAG,
+                        "handle() called on SuccessCallback<MediaPlaybackResponseTypes.PlaybackStateEnum> with "
+                            + playbackStateEnum);
+                    FragmentActivity fragmentActivity = getActivity();
+                    if (fragmentActivity != null) {
+                      fragmentActivity.runOnUiThread(
                           new Runnable() {
                             @Override
                             public void run() {
@@ -78,6 +82,8 @@ public class MediaPlaybackFragment extends Fragment {
                               }
                             }
                           });
+                    }
+                  }
                 };
 
             FailureCallback failureCallback =
@@ -97,18 +103,22 @@ public class MediaPlaybackFragment extends Fragment {
                 };
 
             SubscriptionEstablishedCallback subscriptionEstablishedCallback =
-                (SubscriptionEstablishedCallback)
-                    () -> {
-                      Log.d(TAG, "handle() called on SubscriptionEstablishedCallback");
-                      getActivity()
-                          .runOnUiThread(
-                              new Runnable() {
-                                @Override
-                                public void run() {
-                                  subscriptionStatus.setText("Subscription established!");
-                                }
-                              });
-                    };
+                new SubscriptionEstablishedCallback() {
+                  @Override
+                  public void handle() {
+                    Log.d(TAG, "handle() called on SubscriptionEstablishedCallback");
+                    FragmentActivity fragmentActivity = getActivity();
+                    if (fragmentActivity != null) {
+                      fragmentActivity.runOnUiThread(
+                          new Runnable() {
+                            @Override
+                            public void run() {
+                              subscriptionStatus.setText("Subscription established!");
+                            }
+                          });
+                    }
+                  }
+                };
 
             boolean retVal =
                 tvCastingApp.mediaPlayback_subscribeToCurrentState(

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/FailureCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/FailureCallback.java
@@ -27,8 +27,8 @@ public abstract class FailureCallback {
   private final void handleInternal(int errorCode, String errorMessage) {
     try {
       handle(new MatterError(errorCode, errorMessage));
-    } catch (Exception e) {
-      Log.e(TAG, "FailureCallback::Caught an unhandled exception from the client: " + e);
+    } catch (Throwable t) {
+      Log.e(TAG, "FailureCallback::Caught an unhandled Throwable from the client: " + t);
     }
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/FailureCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/FailureCallback.java
@@ -17,10 +17,18 @@
  */
 package com.chip.casting;
 
+import android.util.Log;
+
 public abstract class FailureCallback {
+  private static final String TAG = FailureCallback.class.getSimpleName();
+
   public abstract void handle(MatterError err);
 
-  public final void handle(int errorCode, String errorMessage) {
-    handle(new MatterError(errorCode, errorMessage));
+  private final void handleInternal(int errorCode, String errorMessage) {
+    try {
+      handle(new MatterError(errorCode, errorMessage));
+    } catch (Exception e) {
+      Log.e(TAG, "FailureCallback::Caught an unhandled exception from the client: " + e);
+    }
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MatterCallbackHandler.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MatterCallbackHandler.java
@@ -17,10 +17,18 @@
  */
 package com.chip.casting;
 
+import android.util.Log;
+
 public abstract class MatterCallbackHandler {
+  private static final String TAG = MatterCallbackHandler.class.getSimpleName();
+
   public abstract void handle(MatterError err);
 
-  public final void handle(int errorCode, String errorMessage) {
-    handle(new MatterError(errorCode, errorMessage));
+  private final void handleInternal(int errorCode, String errorMessage) {
+    try {
+      handle(new MatterError(errorCode, errorMessage));
+    } catch (Exception e) {
+      Log.e(TAG, "MatterCallbackHandler::Caught an unhandled exception from the client: " + e);
+    }
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MatterCallbackHandler.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MatterCallbackHandler.java
@@ -27,8 +27,8 @@ public abstract class MatterCallbackHandler {
   private final void handleInternal(int errorCode, String errorMessage) {
     try {
       handle(new MatterError(errorCode, errorMessage));
-    } catch (Exception e) {
-      Log.e(TAG, "MatterCallbackHandler::Caught an unhandled exception from the client: " + e);
+    } catch (Throwable t) {
+      Log.e(TAG, "MatterCallbackHandler::Caught an unhandled Throwable from the client: " + t);
     }
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SubscriptionEstablishedCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SubscriptionEstablishedCallback.java
@@ -17,6 +17,20 @@
  */
 package com.chip.casting;
 
-public interface SubscriptionEstablishedCallback {
-  void handle();
+import android.util.Log;
+
+public abstract class SubscriptionEstablishedCallback {
+  private static final String TAG = SubscriptionEstablishedCallback.class.getSimpleName();
+
+  public abstract void handle();
+
+  private void handleInternal() {
+    try {
+      handle();
+    } catch (Exception e) {
+      Log.e(
+          TAG,
+          "SubscriptionEstablishedCallback::Caught an unhandled exception from the client: " + e);
+    }
+  }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SubscriptionEstablishedCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SubscriptionEstablishedCallback.java
@@ -27,10 +27,10 @@ public abstract class SubscriptionEstablishedCallback {
   private void handleInternal() {
     try {
       handle();
-    } catch (Exception e) {
+    } catch (Throwable t) {
       Log.e(
           TAG,
-          "SubscriptionEstablishedCallback::Caught an unhandled exception from the client: " + e);
+          "SubscriptionEstablishedCallback::Caught an unhandled Throwable from the client: " + t);
     }
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SuccessCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SuccessCallback.java
@@ -17,6 +17,18 @@
  */
 package com.chip.casting;
 
-public interface SuccessCallback<R> {
-  void handle(R response);
+import android.util.Log;
+
+public abstract class SuccessCallback<R> {
+  private static final String TAG = SuccessCallback.class.getSimpleName();
+
+  public abstract void handle(R response);
+
+  public void handleInternal(R response) {
+    try {
+      handle(response);
+    } catch (Exception e) {
+      Log.e(TAG, "SuccessCallback::Caught an unhandled exception from the client: " + e);
+    }
+  }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SuccessCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SuccessCallback.java
@@ -27,8 +27,8 @@ public abstract class SuccessCallback<R> {
   public void handleInternal(R response) {
     try {
       handle(response);
-    } catch (Exception e) {
-      Log.e(TAG, "SuccessCallback::Caught an unhandled exception from the client: " + e);
+    } catch (Throwable t) {
+      Log.e(TAG, "SuccessCallback::Caught an unhandled Throwable from the client: " + t);
     }
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
@@ -61,6 +61,7 @@ CHIP_ERROR convertJAppParametersToCppAppParams(jobject appParameters, AppParams 
 CHIP_ERROR convertJContentAppToTargetEndpointInfo(jobject contentApp, TargetEndpointInfo & outTargetEndpointInfo)
 {
     ChipLogProgress(AppServer, "convertJContentAppToTargetEndpointInfo called");
+    VerifyOrReturnError(contentApp != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
 
     jclass jContentAppClass;
@@ -124,6 +125,7 @@ CHIP_ERROR convertTargetEndpointInfoToJContentApp(TargetEndpointInfo * targetEnd
 CHIP_ERROR convertJVideoPlayerToTargetVideoPlayerInfo(jobject videoPlayer, TargetVideoPlayerInfo & outTargetVideoPlayerInfo)
 {
     ChipLogProgress(AppServer, "convertJVideoPlayerToTargetVideoPlayerInfo called");
+    VerifyOrReturnError(videoPlayer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
 
     jclass jVideoPlayerClass;
@@ -241,6 +243,7 @@ CHIP_ERROR convertJDiscoveredNodeDataToCppDiscoveredNodeData(jobject jDiscovered
                                                              chip::Dnssd::DiscoveredNodeData & outCppDiscoveredNodeData)
 {
     ChipLogProgress(AppServer, "convertJDiscoveredNodeDataToCppDiscoveredNodeData called");
+    VerifyOrReturnError(jDiscoveredNodeData != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
@@ -31,10 +31,10 @@ CHIP_ERROR CallbackBaseJNI::SetUp(JNIEnv * env, jobject inHandler)
     mClazz = env->GetObjectClass(mObject);
     VerifyOrExit(mClazz != nullptr, ChipLogError(AppServer, "Failed to get handler Java class"));
 
-    mMethod = env->GetMethodID(mClazz, "handle", mMethodSignature);
+    mMethod = env->GetMethodID(mClazz, "handleInternal", mMethodSignature);
     if (mMethod == nullptr)
     {
-        ChipLogError(AppServer, "Failed to access 'handle' method with signature %s", mMethodSignature);
+        ChipLogError(AppServer, "Failed to access 'handleInternal' method with signature %s", mMethodSignature);
         env->ExceptionClear();
     }
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		3CCB8742286A593700771BAD /* ConversionUtils.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3CCB873C286A593700771BAD /* ConversionUtils.hpp */; };
 		3CCB8743286A593700771BAD /* CastingServerBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3CCB873D286A593700771BAD /* CastingServerBridge.mm */; };
 		3CCB8744286A593700771BAD /* ConversionUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3CCB873E286A593700771BAD /* ConversionUtils.mm */; };
+		3CD6D01A298CDA2100D7569A /* CommissionerDiscoveryDelegateImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CD6D019298CDA2100D7569A /* CommissionerDiscoveryDelegateImpl.h */; };
 		3CE868F42946D76200FCB92B /* CommissionableDataProviderImpl.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3CE868F32946D76200FCB92B /* CommissionableDataProviderImpl.mm */; };
 		3CF8532728E37F1000F07B9F /* MatterError.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3CF8532628E37F1000F07B9F /* MatterError.mm */; };
 /* End PBXBuildFile section */
@@ -60,6 +61,7 @@
 		3CCB873C286A593700771BAD /* ConversionUtils.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ConversionUtils.hpp; sourceTree = "<group>"; };
 		3CCB873D286A593700771BAD /* CastingServerBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CastingServerBridge.mm; sourceTree = "<group>"; };
 		3CCB873E286A593700771BAD /* ConversionUtils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ConversionUtils.mm; sourceTree = "<group>"; };
+		3CD6D019298CDA2100D7569A /* CommissionerDiscoveryDelegateImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CommissionerDiscoveryDelegateImpl.h; sourceTree = "<group>"; };
 		3CE868F32946D76200FCB92B /* CommissionableDataProviderImpl.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CommissionableDataProviderImpl.mm; sourceTree = "<group>"; };
 		3CF8532528E37ED800F07B9F /* MatterError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MatterError.h; sourceTree = "<group>"; };
 		3CF8532628E37F1000F07B9F /* MatterError.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MatterError.mm; sourceTree = "<group>"; };
@@ -128,6 +130,7 @@
 				3C26AC8F2927008900BA6881 /* DeviceAttestationCredentialsProviderImpl.mm */,
 				3C0D9CDF2920A30C00D3332B /* CommissionableDataProviderImpl.hpp */,
 				3CE868F32946D76200FCB92B /* CommissionableDataProviderImpl.mm */,
+				3CD6D019298CDA2100D7569A /* CommissionerDiscoveryDelegateImpl.h */,
 			);
 			path = MatterTvCastingBridge;
 			sourceTree = "<group>";
@@ -139,6 +142,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3CD6D01A298CDA2100D7569A /* CommissionerDiscoveryDelegateImpl.h in Headers */,
 				3C26AC8C2926FE0C00BA6881 /* DeviceAttestationCredentialsProviderImpl.hpp in Headers */,
 				3CCB8740286A593700771BAD /* CastingServerBridge.h in Headers */,
 				3CCB8742286A593700771BAD /* ConversionUtils.hpp in Headers */,

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
@@ -45,7 +45,8 @@
  @param discoveryRequestSentHandler Handler to call after the Commissioner discovery request has been sent
  */
 - (void)discoverCommissioners:(dispatch_queue_t _Nonnull)clientQueue
-    discoveryRequestSentHandler:(nullable void (^)(bool))discoveryRequestSentHandler;
+      discoveryRequestSentHandler:(nullable void (^)(bool))discoveryRequestSentHandler
+    discoveredCommissionerHandler:(nullable void (^)(DiscoveredNodeData * _Nonnull))discoveredCommissionerHandler;
 
 /*!
  @brief Retrieve a discovered commissioner TV

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CommissionerDiscoveryDelegateImpl.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CommissionerDiscoveryDelegateImpl.h
@@ -1,0 +1,65 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef CommissionerDiscoveryDelegateImpl_h
+#define CommissionerDiscoveryDelegateImpl_h
+
+#import "ConversionUtils.hpp"
+#include <controller/DeviceDiscoveryDelegate.h>
+
+class CommissionerDiscoveryDelegateImpl : public chip::Controller::DeviceDiscoveryDelegate {
+public:
+    void SetUp(dispatch_queue_t _Nonnull clientQueue,
+        void (^_Nonnull objCDiscoveredCommissionerHandler)(DiscoveredNodeData * _Nonnull),
+        TargetVideoPlayerInfo * cachedTargetVideoPlayerInfos)
+    {
+        mClientQueue = clientQueue;
+        mObjCDiscoveredCommissionerHandler = objCDiscoveredCommissionerHandler;
+        mCachedTargetVideoPlayerInfos = cachedTargetVideoPlayerInfos;
+    }
+
+    void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)
+    {
+        ChipLogProgress(AppServer, "CommissionerDiscoveryDelegateImpl().OnDiscoveredDevice() called");
+        __block const chip::Dnssd::DiscoveredNodeData cppNodeData = nodeData;
+        dispatch_async(mClientQueue, ^{
+            DiscoveredNodeData * objCDiscoveredNodeData = [ConversionUtils convertToObjCDiscoveredNodeDataFrom:&cppNodeData];
+
+            // set associated connectable video player from cache, if any
+            if (mCachedTargetVideoPlayerInfos != nullptr) {
+                for (size_t i = 0; i < kMaxCachedVideoPlayers && mCachedTargetVideoPlayerInfos[i].IsInitialized(); i++) {
+                    if (mCachedTargetVideoPlayerInfos[i].IsSameAs(&cppNodeData)) {
+                        VideoPlayer * connectableVideoPlayer =
+                            [ConversionUtils convertToObjCVideoPlayerFrom:&mCachedTargetVideoPlayerInfos[i]];
+                        [objCDiscoveredNodeData setConnectableVideoPlayer:connectableVideoPlayer];
+                    }
+                }
+            }
+
+            // make the callback
+            mObjCDiscoveredCommissionerHandler(objCDiscoveredNodeData);
+        });
+    }
+
+private:
+    void (^_Nonnull mObjCDiscoveredCommissionerHandler)(DiscoveredNodeData * _Nonnull);
+    dispatch_queue_t _Nonnull mClientQueue;
+    TargetVideoPlayerInfo * mCachedTargetVideoPlayerInfos;
+};
+
+#endif /* CommissionerDiscoveryDelegateImpl_h */

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissionerDiscoveryViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissionerDiscoveryViewModel.swift
@@ -29,15 +29,33 @@ class CommissionerDiscoveryViewModel: ObservableObject {
     func discoverAndUpdate() {
         if let castingServerBridge = CastingServerBridge.getSharedInstance()
         {
-            castingServerBridge.discoverCommissioners(DispatchQueue.main, discoveryRequestSentHandler:  { (result: Bool) -> () in
-                self.discoveryRequestStatus = result
-            })
+            castingServerBridge.discoverCommissioners(DispatchQueue.main,
+                discoveryRequestSentHandler:  { (result: Bool) -> () in
+                    self.discoveryRequestStatus = result
+                },
+                discoveredCommissionerHandler: { (commissioner: DiscoveredNodeData) -> () in
+                    self.Log.info("discoveredCommissionerHandler called with \(commissioner)")
+                    if(self.commissioners.contains(commissioner))
+                    {
+                        self.Log.info("Skipping previously discovered commissioner \(commissioner.description)")
+                    }
+                    else if(commissioner.numIPs == 0)
+                    {
+                        self.Log.info("Skipping commissioner because it does not have any resolved IP addresses \(commissioner.description)")
+                    }
+                    else
+                    {
+                        self.commissioners.append(commissioner)
+                    }
+                }
+            )
         }
         
-        Task {
+        /* Deprecated usage
+         Task {
             try? await Task.sleep(nanoseconds: 5_000_000_000)  // Wait for commissioners to respond
             updateCommissioners()
-        }
+        }*/
     }
     
     private func updateCommissioners() {

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -57,7 +57,7 @@ public:
     CHIP_ERROR Init(AppParams * AppParams = nullptr);
     CHIP_ERROR InitBindingHandlers();
 
-    CHIP_ERROR DiscoverCommissioners();
+    CHIP_ERROR DiscoverCommissioners(chip::Controller::DeviceDiscoveryDelegate * deviceDiscoveryDelegate = nullptr);
     const chip::Dnssd::DiscoveredNodeData *
     GetDiscoveredCommissioner(int index, chip::Optional<TargetVideoPlayerInfo *> & outAssociatedConnectableVideoPlayer);
     CHIP_ERROR OpenBasicCommissioningWindow(std::function<void(CHIP_ERROR)> commissioningCompleteCallback,

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -112,13 +112,15 @@ CHIP_ERROR CastingServer::TargetVideoPlayerInfoInit(NodeId nodeId, FabricIndex f
                                                    mOnConnectionFailureClientCallback);
 }
 
-CHIP_ERROR CastingServer::DiscoverCommissioners()
+CHIP_ERROR CastingServer::DiscoverCommissioners(DeviceDiscoveryDelegate * deviceDiscoveryDelegate)
 {
     TargetVideoPlayerInfo * connectableVideoPlayerList = ReadCachedTargetVideoPlayerInfos();
     if (connectableVideoPlayerList == nullptr || !connectableVideoPlayerList[0].IsInitialized())
     {
         ChipLogProgress(AppServer, "No cached video players found during discovery");
     }
+
+    mCommissionableNodeController.RegisterDeviceDiscoveryDelegate(deviceDiscoveryDelegate);
 
     // Send discover commissioners request
     return mCommissionableNodeController.DiscoverCommissioners(

--- a/src/controller/CHIPCommissionableNodeController.h
+++ b/src/controller/CHIPCommissionableNodeController.h
@@ -39,6 +39,7 @@ public:
     CommissionableNodeController(chip::Dnssd::Resolver * resolver = nullptr) : mResolver(resolver) {}
     ~CommissionableNodeController() override;
 
+    void RegisterDeviceDiscoveryDelegate(DeviceDiscoveryDelegate * delegate) { mDeviceDiscoveryDelegate = delegate; }
     CHIP_ERROR DiscoverCommissioners(Dnssd::DiscoveryFilter discoveryFilter = Dnssd::DiscoveryFilter());
 
     /**


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/24895 and https://github.com/project-chip/connectedhomeip/issues/24894

### Problems fixed
1. If one of the handlers in the tv-casting app for android, throws an exception that it does not handle, it leads to the exception being passed to JNI which crashes the application. This can be tested y temporarily adding a throw new RuntimeException(dummy exc) call in one of the handlers.
2. In the darwin tv-casting-app, the discoverCommissioners API call must be followed by a getDiscoveredCommissioners call after a certain period of time. This is not ideal because the wait time is non-deterministic and leads to the implementation of polling behaviour on the client side. Change the API to be callback based so that the client is called whenever a new commissioner is discovered.

### Testing
Tested with the android and iOS tv-casting-apps