### PR TITLE
Stop forcing a blanket dependency on mbedtls.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -163,7 +163,6 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
       "${chip_root}/src/setup_payload",
       "${chip_root}/src/system",
       "${chip_root}/src/transport",
-      "${mbedtls_root}:mbedtls",
       "${nlassert_root}:nlassert",
       "${nlio_root}:nlio",
       "${nlunit_test_root}:nlunit-test",


### PR DESCRIPTION
The things that actually depend on it should declare that dependency, as needed (as src/crypto does).

This stops builds that never actually use mbedtls from needing to check out the submodule.


