### PR TITLE
Stop requiring openssl to bootstrap.

### DIFF
--- a/scripts/environment.json
+++ b/scripts/environment.json
@@ -9,7 +9,8 @@
         "gn_root": ".",
         "gn_targets": [":python_packages.install"],
         "requirements": ["scripts/requirements.txt"],
-        "constraints": ["scripts/constraints.txt"]
+        "constraints": ["scripts/constraints.txt"],
+        "gn_args": ["chip_crypto=\"boringssl\""]
     },
     "required_submodules": ["third_party/pigweed/repo"],
     "rosetta": "never",

--- a/scripts/environment_no_cipd.json
+++ b/scripts/environment_no_cipd.json
@@ -3,7 +3,8 @@
         "gn_root": ".",
         "gn_targets": [":python_packages.install"],
         "requirements": ["scripts/requirements.txt"],
-        "constraints": ["scripts/constraints.txt"]
+        "constraints": ["scripts/constraints.txt"],
+        "gn_args": ["chip_crypto=\"boringssl\""]
     },
     "required_submodules": ["third_party/pigweed/repo"],
     "rosetta": "never",


### PR DESCRIPTION
Bootstrap seems to do something with chip_crypto as part ofthe bootstrap process.  Have it use the already-available boringssl for that instead of requiring an external openssl.

Fixes https://github.com/project-chip/connectedhomeip/issues/24897

