### PR TITLE
[java-matter-controller] Add pairing already-discovered command

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -523,7 +523,7 @@ jobs:
                      --tool-args "commissionables" \
                      --factoryreset \
                   '
-            - name: Run Pairing over Onnetwork Test
+            - name: Run Pairing Onnetwork Test
               timeout-minutes: 10
               run: |
                   scripts/run_in_build_env.sh \
@@ -535,6 +535,18 @@ jobs:
                      --tool-args "onnetwork-long --nodeid 1 --setup-payload 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
                   '
+            - name: Run Pairing AlreadyDiscovered Test
+              timeout-minutes: 10
+              run: |
+                  scripts/run_in_build_env.sh \
+                  './scripts/tests/run_java_test.py \
+                     --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
+                     --app-args "--discriminator 3840 --interface-id -1" \
+                     --tool-path out/linux-x64-java-matter-controller \
+                     --tool-cluster "pairing" \
+                     --tool-args "already-discovered --nodeid 1 --setup-payload 20202021 --discriminator 3840 --address ::1 --port 5540 -t 1000" \
+                     --factoryreset \
+                  '                  
             - name: Uploading core files
               uses: actions/upload-artifact@v3
               if: ${{ failure() && !env.ACT }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -532,7 +532,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
-                     --tool-args "onnetwork-long --nodeid 1 --setup-payload 20202021 --discriminator 3840 -t 1000" \
+                     --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
                   '
             - name: Run Pairing AlreadyDiscovered Test
@@ -544,7 +544,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
-                     --tool-args "already-discovered --nodeid 1 --setup-payload 20202021 --discriminator 3840 --address ::1 --port 5540 -t 1000" \
+                     --tool-args "already-discovered --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 1000" \
                      --factoryreset \
                   '                  
             - name: Uploading core files

--- a/examples/java-matter-controller/BUILD.gn
+++ b/examples/java-matter-controller/BUILD.gn
@@ -42,6 +42,7 @@ java_binary("java-matter-controller") {
     "java/src/com/matter/controller/commands/discover/DiscoverCommissionersCommand.java",
     "java/src/com/matter/controller/commands/pairing/CloseSessionCommand.java",
     "java/src/com/matter/controller/commands/pairing/DiscoveryFilterType.java",
+    "java/src/com/matter/controller/commands/pairing/PairAlreadyDiscoveredCommand.java",
     "java/src/com/matter/controller/commands/pairing/PairCodeCommand.java",
     "java/src/com/matter/controller/commands/pairing/PairCodePaseCommand.java",
     "java/src/com/matter/controller/commands/pairing/PairCodeThreadCommand.java",

--- a/examples/java-matter-controller/java/src/com/matter/controller/Main.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/Main.java
@@ -60,6 +60,8 @@ public class Main {
         new PairCodeWifiCommand(controller, credentialsIssuer);
     PairCodeThreadCommand pairCodeThreadCommand =
         new PairCodeThreadCommand(controller, credentialsIssuer);
+    PairAlreadyDiscoveredCommand pairAlreadyDiscoveredCommand =
+        new PairAlreadyDiscoveredCommand(controller, credentialsIssuer);
     PairOnNetworkCommand pairOnNetworkCommand =
         new PairOnNetworkCommand(controller, credentialsIssuer);
     PairOnNetworkShortCommand pairOnNetworkShortCommand =
@@ -81,6 +83,7 @@ public class Main {
     clusterCommands.add(pairCodePaseCommand);
     clusterCommands.add(pairCodeWifiCommand);
     clusterCommands.add(pairCodeThreadCommand);
+    clusterCommands.add(pairAlreadyDiscoveredCommand);
     clusterCommands.add(pairOnNetworkCommand);
     clusterCommands.add(pairOnNetworkShortCommand);
     clusterCommands.add(pairOnNetworkLongCommand);

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairAlreadyDiscoveredCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairAlreadyDiscoveredCommand.java
@@ -10,7 +10,7 @@ public final class PairAlreadyDiscoveredCommand extends PairingCommand {
         controller,
         "already-discovered",
         PairingModeType.ALREADY_DISCOVERED,
-        PairingNetworkType.ETHERNET,
+        PairingNetworkType.NONE,
         credsIssue);
   }
 

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairAlreadyDiscoveredCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairAlreadyDiscoveredCommand.java
@@ -1,0 +1,30 @@
+package com.matter.controller.commands.pairing;
+
+import chip.devicecontroller.ChipDeviceController;
+import com.matter.controller.commands.common.CredentialsIssuer;
+
+public final class PairAlreadyDiscoveredCommand extends PairingCommand {
+  public PairAlreadyDiscoveredCommand(
+      ChipDeviceController controller, CredentialsIssuer credsIssue) {
+    super(
+        controller,
+        "already-discovered",
+        PairingModeType.ALREADY_DISCOVERED,
+        PairingNetworkType.ETHERNET,
+        credsIssue);
+  }
+
+  @Override
+  protected void runCommand() {
+    currentCommissioner()
+        .pairDeviceWithAddress(
+            getNodeId(),
+            getRemoteAddr().getHostAddress(),
+            getRemotePort(),
+            getDiscriminator(),
+            getSetupPINCode(),
+            null);
+    currentCommissioner().setCompletionListener(this);
+    waitCompleteMs(getTimeoutMillis());
+  }
+}

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.java
@@ -51,22 +51,6 @@ public abstract class PairingCommand extends MatterCommand
   private final StringBuffer mDiscoveryFilterInstanceName = new StringBuffer();
   private static Logger logger = Logger.getLogger(PairingCommand.class.getName());
 
-  public long getNodeId() {
-    return mNodeId.get();
-  }
-
-  public int getSetupPINCode() {
-    return mSetupPINCode.get();
-  }
-
-  public int getDiscriminator() {
-    return mDiscriminator.get();
-  }
-
-  public long getTimeoutMillis() {
-    return mTimeoutMillis.get();
-  }
-
   @Override
   public void onConnectDeviceComplete() {
     logger.log(Level.INFO, "onConnectDeviceComplete");
@@ -135,8 +119,28 @@ public abstract class PairingCommand extends MatterCommand
     }
   }
 
+  public long getNodeId() {
+    return mNodeId.get();
+  }
+
   public IPAddress getRemoteAddr() {
     return mRemoteAddr;
+  }
+
+  public int getRemotePort() {
+    return mRemotePort.get();
+  }
+
+  public int getSetupPINCode() {
+    return mSetupPINCode.get();
+  }
+
+  public int getDiscriminator() {
+    return mDiscriminator.get();
+  }
+
+  public long getTimeoutMillis() {
+    return mTimeoutMillis.get();
   }
 
   public PairingCommand(
@@ -200,6 +204,12 @@ public abstract class PairingCommand extends MatterCommand
         break;
       case SOFT_AP:
         AP:
+        addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null, false);
+        addArgument("discriminator", (short) 0, (short) 4096, mDiscriminator, null, false);
+        addArgument("device-remote-ip", mRemoteAddr, false);
+        addArgument("device-remote-port", (short) 0, Short.MAX_VALUE, mRemotePort, null, false);
+        break;
+      case ALREADY_DISCOVERED:
         addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null, false);
         addArgument("discriminator", (short) 0, (short) 4096, mDiscriminator, null, false);
         addArgument("device-remote-ip", mRemoteAddr, false);

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.java
@@ -174,7 +174,6 @@ public abstract class PairingCommand extends MatterCommand
 
     switch (networkType) {
       case NONE:
-      case ETHERNET:
         break;
       case WIFI:
         addArgument("ssid", mSSID, null, false);
@@ -211,7 +210,6 @@ public abstract class PairingCommand extends MatterCommand
         break;
       case ALREADY_DISCOVERED:
         addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null, false);
-        addArgument("discriminator", (short) 0, (short) 4096, mDiscriminator, null, false);
         addArgument("device-remote-ip", mRemoteAddr, false);
         addArgument("device-remote-port", (short) 0, Short.MAX_VALUE, mRemotePort, null, false);
         break;

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingModeType.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingModeType.java
@@ -24,5 +24,6 @@ public enum PairingModeType {
   CODE_PASE_ONLY,
   BLE,
   SOFT_AP,
+  ALREADY_DISCOVERED,
   ON_NETWORK;
 }

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingNetworkType.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingNetworkType.java
@@ -22,5 +22,4 @@ public enum PairingNetworkType {
   NONE,
   WIFI,
   THREAD,
-  ETHERNET;
 }

--- a/scripts/tests/java/commissioning_test.py
+++ b/scripts/tests/java/commissioning_test.py
@@ -42,17 +42,20 @@ class CommissioningTest:
         parser.add_argument('command', help="Command name")
         parser.add_argument('-t', '--timeout', help="The program will return with timeout after specified seconds", default='200')
         parser.add_argument('-a', '--address', help="Address of the device")
+        parser.add_argument('-p', '--port', help="Port of the remote device", default='5540')
         parser.add_argument('-s', '--setup-payload', dest='setup_payload',
                             help="Setup Payload (manual pairing code or QR code content)")
         parser.add_argument('-n', '--nodeid', help="The Node ID issued to the device", default='1')
         parser.add_argument('-d', '--discriminator', help="Discriminator of the device", default='3840')
-        parser.add_argument('-p', '--paa-trust-store-path', dest='paa_trust_store_path',
+        parser.add_argument('-c', '--paa-trust-store-path', dest='paa_trust_store_path',
                             help="Path that contains valid and trusted PAA Root Certificates")
 
         args = parser.parse_args(args.split())
 
         self.command_name = args.command
         self.nodeid = args.nodeid
+        self.address = args.address
+        self.port = args.port
         self.setup_payload = args.setup_payload
         self.discriminator = args.discriminator
         self.timeout = args.timeout
@@ -67,11 +70,25 @@ class CommissioningTest:
         DumpProgramOutputToQueue(self.thread_list, Fore.GREEN + "JAVA " + Style.RESET_ALL, java_process, self.queue)
         return java_process.wait()
 
+    def TestCmdAlreadyDiscovered(self, nodeid, setuppin, discriminator, address, port, timeout):
+        java_command = self.command + ['pairing', 'already-discovered', nodeid, setuppin, discriminator, address, port, timeout]
+        logging.info(f"Execute: {java_command}")
+        java_process = subprocess.Popen(
+            java_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        DumpProgramOutputToQueue(self.thread_list, Fore.GREEN + "JAVA " + Style.RESET_ALL, java_process, self.queue)
+        return java_process.wait()
+
     def RunTest(self):
         if self.command_name == 'onnetwork-long':
-            logging.info("Testing pairing over onnetwork-long")
+            logging.info("Testing pairing onnetwork-long")
             code = self.TestCmdOnnetworkLong(self.nodeid, self.setup_payload, self.discriminator, self.timeout)
             if code != 0:
-                raise Exception(f"Testing onnetwork-long pairing failed with error {code}")
+                raise Exception(f"Testing pairing onnetwork-long failed with error {code}")
+        elif self.command_name == 'already-discovered':
+            logging.info("Testing pairing already-discovered")
+            code = self.TestCmdAlreadyDiscovered(self.nodeid, self.setup_payload,
+                                                 self.discriminator, self.address, self.port, self.timeout)
+            if code != 0:
+                raise Exception(f"Testing pairing already-discovered failed with error {code}")
         else:
             raise Exception(f"Unsupported command {self.command_name}")

--- a/scripts/tests/java/commissioning_test.py
+++ b/scripts/tests/java/commissioning_test.py
@@ -45,9 +45,11 @@ class CommissioningTest:
         parser.add_argument('-p', '--port', help="Port of the remote device", default='5540')
         parser.add_argument('-s', '--setup-payload', dest='setup_payload',
                             help="Setup Payload (manual pairing code or QR code content)")
+        parser.add_argument('-c', '--setup-pin-code', dest='setup_pin_code',
+                            help="Setup Payload (manual pairing code or QR code content)")
         parser.add_argument('-n', '--nodeid', help="The Node ID issued to the device", default='1')
         parser.add_argument('-d', '--discriminator', help="Discriminator of the device", default='3840')
-        parser.add_argument('-c', '--paa-trust-store-path', dest='paa_trust_store_path',
+        parser.add_argument('-u', '--paa-trust-store-path', dest='paa_trust_store_path',
                             help="Path that contains valid and trusted PAA Root Certificates")
 
         args = parser.parse_args(args.split())
@@ -57,6 +59,7 @@ class CommissioningTest:
         self.address = args.address
         self.port = args.port
         self.setup_payload = args.setup_payload
+        self.setup_pin_code = args.setup_pin_code
         self.discriminator = args.discriminator
         self.timeout = args.timeout
 
@@ -70,8 +73,8 @@ class CommissioningTest:
         DumpProgramOutputToQueue(self.thread_list, Fore.GREEN + "JAVA " + Style.RESET_ALL, java_process, self.queue)
         return java_process.wait()
 
-    def TestCmdAlreadyDiscovered(self, nodeid, setuppin, discriminator, address, port, timeout):
-        java_command = self.command + ['pairing', 'already-discovered', nodeid, setuppin, discriminator, address, port, timeout]
+    def TestCmdAlreadyDiscovered(self, nodeid, setuppin, address, port, timeout):
+        java_command = self.command + ['pairing', 'already-discovered', nodeid, setuppin, address, port, timeout]
         logging.info(f"Execute: {java_command}")
         java_process = subprocess.Popen(
             java_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -81,13 +84,12 @@ class CommissioningTest:
     def RunTest(self):
         if self.command_name == 'onnetwork-long':
             logging.info("Testing pairing onnetwork-long")
-            code = self.TestCmdOnnetworkLong(self.nodeid, self.setup_payload, self.discriminator, self.timeout)
+            code = self.TestCmdOnnetworkLong(self.nodeid, self.setup_pin_code, self.discriminator, self.timeout)
             if code != 0:
                 raise Exception(f"Testing pairing onnetwork-long failed with error {code}")
         elif self.command_name == 'already-discovered':
             logging.info("Testing pairing already-discovered")
-            code = self.TestCmdAlreadyDiscovered(self.nodeid, self.setup_payload,
-                                                 self.discriminator, self.address, self.port, self.timeout)
+            code = self.TestCmdAlreadyDiscovered(self.nodeid, self.setup_pin_code, self.address, self.port, self.timeout)
             if code != 0:
                 raise Exception(f"Testing pairing already-discovered failed with error {code}")
         else:

--- a/scripts/tests/java/commissioning_test.py
+++ b/scripts/tests/java/commissioning_test.py
@@ -46,7 +46,7 @@ class CommissioningTest:
         parser.add_argument('-s', '--setup-payload', dest='setup_payload',
                             help="Setup Payload (manual pairing code or QR code content)")
         parser.add_argument('-c', '--setup-pin-code', dest='setup_pin_code',
-                            help="Setup Payload (manual pairing code or QR code content)")
+                            help="Setup PIN code which can be used for password-authenticated session establishment (PASE) with the Commissionee")
         parser.add_argument('-n', '--nodeid', help="The Node ID issued to the device", default='1')
         parser.add_argument('-d', '--discriminator', help="Discriminator of the device", default='3840')
         parser.add_argument('-u', '--paa-trust-store-path', dest='paa_trust_store_path',


### PR DESCRIPTION
Since we need to keep the pair by ip address  API in SDK to support Java JNI implementation and already shipped Darwin software, we should have some way to exercise this API. 

1. Add 'pairing already-discoverred' command in java-chip-tool
2. Add 'Pairing AlreadyDiscovered Test' in CI
