### PR TITLE
[chip-tool] Add pairing already-discovered command

### DIFF
--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -173,6 +173,14 @@ public:
     {}
 };
 
+class PairAlreadyDiscovered : public PairingCommand
+{
+public:
+    PairAlreadyDiscovered(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("already-discovered", PairingMode::AlreadyDiscovered, PairingNetworkType::Ethernet, credsIssuerConfig)
+    {}
+};
+
 class StartUdcServerCommand : public CHIPCommand
 {
 public:
@@ -199,6 +207,7 @@ void registerCommandsPairing(Commands & commands, CredentialIssuerCommands * cre
         make_unique<PairBleWiFi>(credsIssuerConfig),
         make_unique<PairBleThread>(credsIssuerConfig),
         make_unique<PairSoftAP>(credsIssuerConfig),
+        make_unique<PairAlreadyDiscovered>(credsIssuerConfig),
         make_unique<PairOnNetwork>(credsIssuerConfig),
         make_unique<PairOnNetworkShort>(credsIssuerConfig),
         make_unique<PairOnNetworkLong>(credsIssuerConfig),

--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -177,7 +177,7 @@ class PairAlreadyDiscovered : public PairingCommand
 {
 public:
     PairAlreadyDiscovered(CredentialIssuerCommands * credsIssuerConfig) :
-        PairingCommand("already-discovered", PairingMode::AlreadyDiscovered, PairingNetworkType::Ethernet, credsIssuerConfig)
+        PairingCommand("already-discovered", PairingMode::AlreadyDiscovered, PairingNetworkType::Network, credsIssuerConfig)
     {}
 };
 

--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -177,7 +177,7 @@ class PairAlreadyDiscovered : public PairingCommand
 {
 public:
     PairAlreadyDiscovered(CredentialIssuerCommands * credsIssuerConfig) :
-        PairingCommand("already-discovered", PairingMode::AlreadyDiscovered, PairingNetworkType::Network, credsIssuerConfig)
+        PairingCommand("already-discovered", PairingMode::AlreadyDiscovered, PairingNetworkType::None, credsIssuerConfig)
     {}
 };
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -100,7 +100,7 @@ CommissioningParameters PairingCommand::GetCommissioningParameters()
     case PairingNetworkType::Thread:
         params.SetThreadOperationalDataset(mOperationalDataset);
         break;
-    case PairingNetworkType::Ethernet:
+    case PairingNetworkType::Network:
     case PairingNetworkType::None:
         break;
     }

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -75,6 +75,9 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
     case PairingMode::SoftAP:
         err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort, mRemoteAddr.interfaceId));
         break;
+    case PairingMode::AlreadyDiscovered:
+        err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort, mRemoteAddr.interfaceId));
+        break;
     }
 
     return err;
@@ -97,6 +100,7 @@ CommissioningParameters PairingCommand::GetCommissioningParameters()
     case PairingNetworkType::Thread:
         params.SetThreadOperationalDataset(mOperationalDataset);
         break;
+    case PairingNetworkType::Ethernet:
     case PairingNetworkType::None:
         break;
     }

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -100,7 +100,6 @@ CommissioningParameters PairingCommand::GetCommissioningParameters()
     case PairingNetworkType::Thread:
         params.SetThreadOperationalDataset(mOperationalDataset);
         break;
-    case PairingNetworkType::Network:
     case PairingNetworkType::None:
         break;
     }

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -43,7 +43,6 @@ enum class PairingNetworkType
     None,
     WiFi,
     Thread,
-    Network,
 };
 
 class PairingCommand : public CHIPCommand,
@@ -69,7 +68,6 @@ public:
         switch (networkType)
         {
         case PairingNetworkType::None:
-        case PairingNetworkType::Network:
             break;
         case PairingNetworkType::WiFi:
             AddArgument("ssid", &mSSID);

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -43,7 +43,7 @@ enum class PairingNetworkType
     None,
     WiFi,
     Thread,
-    Ethernet,
+    Network,
 };
 
 class PairingCommand : public CHIPCommand,
@@ -69,7 +69,7 @@ public:
         switch (networkType)
         {
         case PairingNetworkType::None:
-        case PairingNetworkType::Ethernet:
+        case PairingNetworkType::Network:
             break;
         case PairingNetworkType::WiFi:
             AddArgument("ssid", &mSSID);
@@ -112,7 +112,6 @@ public:
         case PairingMode::AlreadyDiscovered:
             AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
-            AddArgument("discriminator", 0, 4096, &mDiscriminator);
             AddArgument("device-remote-ip", &mRemoteAddr);
             AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
             AddArgument("pase-only", 0, 1, &mPaseOnly);

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -34,6 +34,7 @@ enum class PairingMode
     CodePaseOnly,
     Ble,
     SoftAP,
+    AlreadyDiscovered,
     OnNetwork,
 };
 
@@ -42,6 +43,7 @@ enum class PairingNetworkType
     None,
     WiFi,
     Thread,
+    Ethernet,
 };
 
 class PairingCommand : public CHIPCommand,
@@ -67,6 +69,7 @@ public:
         switch (networkType)
         {
         case PairingNetworkType::None:
+        case PairingNetworkType::Ethernet:
             break;
         case PairingNetworkType::WiFi:
             AddArgument("ssid", &mSSID);
@@ -99,6 +102,14 @@ public:
             AddArgument("pase-only", 0, 1, &mPaseOnly);
             break;
         case PairingMode::SoftAP:
+            AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
+            AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
+            AddArgument("discriminator", 0, 4096, &mDiscriminator);
+            AddArgument("device-remote-ip", &mRemoteAddr);
+            AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
+            AddArgument("pase-only", 0, 1, &mPaseOnly);
+            break;
+        case PairingMode::AlreadyDiscovered:
             AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
             AddArgument("discriminator", 0, 4096, &mDiscriminator);


### PR DESCRIPTION
Since we need to keep the pair by ip address API in SDK to support Java JNI implementation and already shipped Darwin software, we should have some way to exercise this API.

Add 'pairing already-discoverred' command in chip-tool


