### PR TITLE
Remove AttributeWritePermission from types-silabs.xml and makes it a …

### DIFF
--- a/src/app/common/templates/weak-enum-list.yaml
+++ b/src/app/common/templates/weak-enum-list.yaml
@@ -1,6 +1,5 @@
 # Allow-list of enums that we generate as enums, not enum classes.  The goal is
 # to drive this down to 0.
-- AttributeWritePermission
 - BarrierControlBarrierPosition
 - BarrierControlMovingState
 - ColorControlOptions

--- a/src/app/util/attribute-metadata.h
+++ b/src/app/util/attribute-metadata.h
@@ -105,6 +105,17 @@ union EmberAfDefaultOrMinMaxAttributeValue
     const EmberAfAttributeMinMaxValue * ptrToMinMaxValue;
 };
 
+enum class EmberAfAttributeWritePermission
+{
+    DenyWrite            = 0,
+    AllowWriteNormal     = 1,
+    AllowWriteOfReadOnly = 2,
+    UnsupportedAttribute = 0x86, // Protocols::InteractionModel::Status::UnsupportedAttribute
+    InvalidValue         = 0x87, // Protocols::InteractionModel::Status::ConstraintError
+    ReadOnly             = 0x88, // Protocols::InteractionModel::Status::UnsupportedWrite
+    InvalidDataType      = 0x8d, // Protocols::InteractionModel::Status::InvalidDataType
+};
+
 // Attribute masks modify how attributes are used by the framework
 //
 // Attribute that has this mask is NOT read-only

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -48,12 +48,12 @@ EmberAfStatus emberAfWriteAttributeExternal(EndpointId endpoint, ClusterId clust
         emberAfAllowNetworkWriteAttributeCallback(endpoint, cluster, attributeID, dataPtr, dataType);
     switch (extWritePermission)
     {
-    case EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_DENY_WRITE:
+    case EmberAfAttributeWritePermission::DenyWrite:
         return EMBER_ZCL_STATUS_FAILURE;
-    case EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL:
-    case EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_OF_READ_ONLY:
+    case EmberAfAttributeWritePermission::AllowWriteNormal:
+    case EmberAfAttributeWritePermission::AllowWriteOfReadOnly:
         return emAfWriteAttribute(endpoint, cluster, attributeID, dataPtr, dataType,
-                                  (extWritePermission == EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_OF_READ_ONLY), false);
+                                  (extWritePermission == EmberAfAttributeWritePermission::AllowWriteOfReadOnly), false);
     default:
         return (EmberAfStatus) extWritePermission;
     }

--- a/src/app/util/generic-callback-stubs.cpp
+++ b/src/app/util/generic-callback-stubs.cpp
@@ -28,7 +28,7 @@ EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t * value,
                                           uint8_t type)
 {
-    return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
+    return EmberAfAttributeWritePermission::AllowWriteNormal; // Default
 }
 
 bool __attribute__((weak)) emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId)

--- a/src/app/zap-templates/zcl/data-model/silabs/types-silabs.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/types-silabs.xml
@@ -23,15 +23,6 @@ limitations under the License.
     <item name="NoSourceFound" value="0x0"/>
     <item name="SourceFound" value="0x1"/>
   </enum>
-  <enum name="AttributeWritePermission" type="ENUM8">
-    <item name="DenyWrite" value="0x00"/>
-    <item name="AllowWriteNormal" value="0x01"/>
-    <item name="AllowWriteOfReadOnly" value="0x02"/>
-    <item name="UnsupportedAttribute" value="0x86"/>
-    <item name="InvalidValue" value="0x87"/>
-    <item name="ReadOnly" value="0x88"/>
-    <item name="InvalidDataType" value="0x8D"/>
-  </enum>
   <struct name="Notification">
     <item name="contentId" type="INT16U"/>
     <item name="statusFeedback" type="ENUM8"/>

--- a/zzz_generated/app-common/app-common/zap-generated/enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/enums.h
@@ -24,18 +24,6 @@
 
 // ZCL enums
 
-// Enum for AttributeWritePermission
-enum EmberAfAttributeWritePermission : uint8_t
-{
-    EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_DENY_WRITE               = 0,
-    EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL       = 1,
-    EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_OF_READ_ONLY = 2,
-    EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_UNSUPPORTED_ATTRIBUTE    = 134,
-    EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_INVALID_VALUE            = 135,
-    EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_READ_ONLY                = 136,
-    EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_INVALID_DATA_TYPE        = 141,
-};
-
 // Enum for BarrierControlBarrierPosition
 enum EmberAfBarrierControlBarrierPosition : uint8_t
 {


### PR DESCRIPTION
…not generated enum

#### Problem

This PR remove `AttributeWritePermission` from the list of generated enums and makes it a non generated enum class instead.

