### PR TITLE
Default to boringssl when building on darwin.

### DIFF
--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -25,6 +25,8 @@ if (chip_crypto == "") {
       current_os == "zephyr" || current_os == "mbed" || current_os == "webos" ||
       current_os == "cmsis-rtos") {
     chip_crypto = "mbedtls"
+  } else if (current_os == "mac" || current_os == "ios") {
+    chip_crypto = "boringssl"
   } else {
     chip_crypto = "openssl"
   }

--- a/src/tools/chip-cert/BUILD.gn
+++ b/src/tools/chip-cert/BUILD.gn
@@ -37,7 +37,9 @@ executable("chip-cert") {
     "chip-cert.h",
   ]
 
-  public_configs = [ "${chip_root}/src/crypto:openssl_config" ]
+  if (chip_crypto == "openssl") {
+    public_configs = [ "${chip_root}/src/crypto:openssl_config" ]
+  }
 
   cflags = [ "-Wconversion" ]
 


### PR DESCRIPTION
This gets rid of the openssl dependency.

