### PR TITLE
Fix path filter patterns for doxygen workflow

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -21,18 +21,18 @@ on:
             - "**.c[cs]?"
             - "**.cxx"
             - "**.cpp"
-            - "**.c++"
+            - "**.c\\+\\+"
             - "**.ii"
             - "**.ixx"
             - "**.ipp"
-            - "**.i++"
+            - "**.i\\+\\+"
             - "**.inl"
             - "**.[hH]"
             - "**.hh"
             - "**.HH"
             - "**.hxx"
             - "**.hpp"
-            - "**.h++"
+            - "**.h\\+\\+"
             - "**.mm"
             - "**.txt"
             - "**.[ido]dl"
@@ -48,18 +48,18 @@ on:
             - "**.c[cs]?"
             - "**.cxx"
             - "**.cpp"
-            - "**.c++"
+            - "**.c\\+\\+"
             - "**.ii"
             - "**.ixx"
             - "**.ipp"
-            - "**.i++"
+            - "**.i\\+\\+"
             - "**.inl"
             - "**.[hH]"
             - "**.hh"
             - "**.HH"
             - "**.hxx"
             - "**.hpp"
-            - "**.h++"
+            - "**.h\\+\\+"
             - "**.mm"
             - "**.txt"
             - "**.[ido]dl"
@@ -80,7 +80,7 @@ jobs:
         name: Build Doxygen
         timeout-minutes: 5
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         container:
             image: connectedhomeip/chip-build-doxygen:0.6.35
 

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -89,15 +89,8 @@ jobs:
         steps:
             - name: "Print Actor"
               run: echo ${{github.actor}}
-            - uses: Wandalen/wretry.action@v1.0.36
-              name: Checkout
-              with:
-                  action: actions/checkout@v3
-                  with: |
-                      submodules: true
-                      token: ${{ github.token }}
-                  attempt_limit: 3
-                  attempt_delay: 2000
+            - name: Checkout
+              uses: actions/checkout@v3
             - name: Generate
               run: scripts/helpers/doxygen.sh
             - name: Extract branch name


### PR DESCRIPTION
### Problem

Doxygen workflow uses incorrect filtering path syntax:

https://github.com/arkq/connectedhomeip/actions/runs/4134131824
```
[Error: .github#L1](https://github.com/arkq/connectedhomeip/commit/d3f33230343e59071ee6e02d0ed5b5834ed71249#annotation_8721928396)
push event contained invalid paths patterns: the following globs were invalid: **.c++, **.i++, **.h++, pull_request event contained invalid paths patterns: the following globs were invalid: **.c++, **.i++, **.h++
```

### Changes

- escape `+` characters in the path filters strings
- do not use wretry for checkout - the chip-build-doxygen image does not contain node binary (doxygen workflow is run manually, retry is not required)

### Testing

Tested on local fork - files like `foo.c++` correctly trigger this workflow now (such files are not available in the repo, though)
