### PR TITLE
[Silabs] Small miscellaneous fixes: 

### DIFF
--- a/examples/chef/efr32/BUILD.gn
+++ b/examples/chef/efr32/BUILD.gn
@@ -83,7 +83,6 @@ efr32_sdk("sdk") {
 
 efr32_executable("chef_app") {
   output_name = "chip-efr32-chef-example.out"
-  public_configs = [ "${efr32_sdk_build_root}:silabs_config" ]
   include_dirs = [ "include" ]
   defines = []
 

--- a/examples/light-switch-app/silabs/efr32/BUILD.gn
+++ b/examples/light-switch-app/silabs/efr32/BUILD.gn
@@ -73,7 +73,6 @@ efr32_sdk("sdk") {
 
 efr32_executable("light_switch_app") {
   output_name = "chip-efr32-light-switch-example.out"
-  public_configs = [ "${efr32_sdk_build_root}:silabs_config" ]
   include_dirs = [ "include" ]
   defines = []
 

--- a/examples/lighting-app/silabs/efr32/BUILD.gn
+++ b/examples/lighting-app/silabs/efr32/BUILD.gn
@@ -72,7 +72,6 @@ efr32_sdk("sdk") {
 
 efr32_executable("lighting_app") {
   output_name = "chip-efr32-lighting-example.out"
-  public_configs = [ "${efr32_sdk_build_root}:silabs_config" ]
   include_dirs = [ "include" ]
   defines = []
 

--- a/examples/lock-app/silabs/efr32/BUILD.gn
+++ b/examples/lock-app/silabs/efr32/BUILD.gn
@@ -72,7 +72,6 @@ efr32_sdk("sdk") {
 
 efr32_executable("lock_app") {
   output_name = "chip-efr32-lock-example.out"
-  public_configs = [ "${efr32_sdk_build_root}:silabs_config" ]
   include_dirs = [ "include" ]
   defines = []
 

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -233,7 +233,10 @@ config("silabs-wifi-config") {
 source_set("efr32-common") {
   deps = []
   public_deps = []
-  public_configs = [ ":efr32-common-config" ]
+  public_configs = [
+    ":efr32-common-config",
+    "${efr32_sdk_build_root}:silabs_config",
+  ]
 
   include_dirs = [ "." ]
 

--- a/examples/thermostat/silabs/efr32/BUILD.gn
+++ b/examples/thermostat/silabs/efr32/BUILD.gn
@@ -89,7 +89,6 @@ efr32_sdk("sdk") {
 
 efr32_executable("thermostat_app") {
   output_name = "chip-efr32-thermostat-example.out"
-  public_configs = [ "${efr32_sdk_build_root}:silabs_config" ]
   include_dirs = [ "include" ]
   defines = []
 

--- a/examples/window-app/silabs/efr32/BUILD.gn
+++ b/examples/window-app/silabs/efr32/BUILD.gn
@@ -58,7 +58,6 @@ efr32_sdk("sdk") {
 
 efr32_executable("window_app") {
   output_name = "chip-efr32-window-example.out"
-  public_configs = [ "${efr32_sdk_build_root}:silabs_config" ]
   output_dir = root_out_dir
   include_dirs = [
     "include",

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -201,7 +201,8 @@ class Efr32Builder(GnBuilder):
                 'use_silabs_thread_lib=true chip_openthread_target="../silabs:ot-efr32-cert" use_thread_coap_lib=true openthread_external_platform=""')
 
         if not no_version:
-            shortCommitSha = subprocess.check_output(['git', 'describe', '--always', '--dirty', '--exclude', '*']).decode('ascii').strip()
+            shortCommitSha = subprocess.check_output(
+                ['git', 'describe', '--always', '--dirty', '--exclude', '*']).decode('ascii').strip()
             branchName = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).decode('ascii').strip()
             self.extra_gn_options.append(
                 'sl_matter_version_str="v1.0-%s-%s"' % (branchName, shortCommitSha))

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -201,7 +201,7 @@ class Efr32Builder(GnBuilder):
                 'use_silabs_thread_lib=true chip_openthread_target="../silabs:ot-efr32-cert" use_thread_coap_lib=true openthread_external_platform=""')
 
         if not no_version:
-            shortCommitSha = subprocess.check_output(['git', 'describe', '--always', '--dirty']).decode('ascii').strip()
+            shortCommitSha = subprocess.check_output(['git', 'describe', '--always', '--dirty', '--exclude', '*']).decode('ascii').strip()
             branchName = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).decode('ascii').strip()
             self.extra_gn_options.append(
                 'sl_matter_version_str="v1.0-%s-%s"' % (branchName, shortCommitSha))

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -205,7 +205,7 @@ else
 
     if [ "$USE_GIT_SHA_FOR_VERSION" == true ]; then
         {
-            ShortCommitSha=$(git describe --always --dirty)
+            ShortCommitSha=$(git describe --always --dirty --exclude '*')
             branchName=$(git rev-parse --abbrev-ref HEAD)
             optArgs+="sl_matter_version_str=\"v1.0-$branchName-$ShortCommitSha\" "
         } &>/dev/null

--- a/scripts/tools/silabs/FactoryDataProvider.py
+++ b/scripts/tools/silabs/FactoryDataProvider.py
@@ -40,8 +40,8 @@ class FactoryDataWriter:
     VERIFIER_NVM3_KEY = "0x8720A:"
     PRODUCT_ID_NVM3_KEY = "0x8720B:"
     VENDOR_ID_NVM3_KEY = "0x8720C:"
-    PRODUCT_NAME_NVM3_KEY = "0x8720D:"
-    VENDOR_NAME_NVM3_KEY = "0x8720E:"
+    VENDOR_NAME_NVM3_KEY = "0x8720D:"
+    PRODUCT_NAME_NVM3_KEY = "0x8720E:"
     HW_VER_STR_NVM3_KEY = "0x8720F:"
     UNIQUE_ID_NVM3_KEY = "0x8721F:"
     HW_VER_NVM3_KEY = "0x87308:"
@@ -147,8 +147,8 @@ class FactoryDataWriter:
 
         self._args = arguments
 
-        if self._args.rotating_id:
-            assert (len(bytearray.fromhex(self._args.rotating_id)) == kUniqueIDLength), "Provide a 16 bytes rotating id"
+        if self._args.unique_id:
+            assert (len(bytearray.fromhex(self._args.unique_id)) == kUniqueIDLength), "Provide a 16 bytes unique id"
         if self._args.product_name:
             assert (len(self._args.product_name) <= kMaxProductNameLength), "Product name exceeds the size limit"
         if self._args.vendor_name:
@@ -262,8 +262,8 @@ class FactoryDataWriter:
             hwVersionByteArray = bytes(self._args.hw_version_str, 'utf-8').hex()
             cmd.extend(["--object", self.HW_VER_STR_NVM3_KEY + str(hwVersionByteArray)])
 
-        if self._args.rotating_id:
-            cmd.extend(["--object", self.UNIQUE_ID_NVM3_KEY + self._args.rotating_id])
+        if self._args.unique_id:
+            cmd.extend(["--object", self.UNIQUE_ID_NVM3_KEY + self._args.unique_id])
 
         if self._args.manufacturing_date:
             dateByteArray = bytes(self._args.manufacturing_date, 'utf-8').hex()
@@ -338,7 +338,7 @@ def main():
                         help="[string] Provide the product label [optional]")
     parser.add_argument("--product_url", type=str,
                         help="[string] Provide the product url [optional]")
-    parser.add_argument("--rotating_id", type=str,
+    parser.add_argument("--unique_id", type=str,
                         help="[hex_string] A 128 bits hex string unique id (without 0x) [optional]")
     parser.add_argument("--serial_number", type=str,
                         help="[string] Provide serial number of the device")

--- a/scripts/tools/silabs/README.md
+++ b/scripts/tools/silabs/README.md
@@ -60,7 +60,7 @@ number to ensure you are writing to the right device.
 | --vendor_name        | optional             | string             | Provide the vendor name (Max 32 char).                                                  |
 | --hw_version         | optional             | dec/hex            | Provide the hardware version value (Max 2 bytes).                                       |
 | --hw_version_str     | optional             | string             | Provide the hardware version string (Max 64 char).                                      |
-| --rotating_id        | optional             | Hex string         | A 128 bits hex string unique id (without 0x).                                           |
+| --unique_id          | optional             | Hex string         | A 128 bits hex string unique id (without 0x).                                           |
 | --serial_number      | optional             | string             | Provide serial number of the device (Max 32 char).                                      |
 | --commissioning_flow | optional             | dec/hex            | Provide Commissioning Flow 0=Standard, 1=User Action, 2=Custom.                         |
 | --rendezvous_flag    | optional             | dec/hex            | Provide Rendez-vous flag: 1=SoftAP, 2=BLE 4=OnNetwork (Can be combined).                |


### PR DESCRIPTION
**Silabs build version**
- exclude the tag from the build version string as it makes quite a long string and the last tag is not really relevant to the current state
- move the silabs_config wich contains the version str to the silabs common source_set instead of calling it in each example.

**Silabs FactoryDataProvider.py**
- fix key mismatch in the factoryProvider script for the VendorName and Productname. 
- Correctly rename the argument rotating_id to unique_id ¯\_(ツ)_/¯


