### PR TITLE
Darwin: Fix some more ambiguous Swift symbols.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -18,6 +18,7 @@
 #import <Foundation/Foundation.h>
 
 #import <Matter/MTRCluster.h>
+#import <Matter/MTRDefines.h>
 
 @class MTRSetupPayload;
 @class MTRDeviceController;

--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
@@ -16,6 +16,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <Matter/MTRDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -83,10 +84,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRCommissioningParameters (Deprecated)
 
-@property (nonatomic, copy, nullable) NSData * CSRNonce API_DEPRECATED(
-    "Please use csrNonce", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
-@property (nonatomic, copy, nullable) NSNumber * failSafeExpiryTimeoutSecs API_DEPRECATED(
-    "Please use failSafeTimeout", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy, nullable) NSData * CSRNonce MTR_DEPRECATED_WITH_REPLACEMENT(
+    "csrNonce", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+
+@property (nonatomic, copy, nullable) NSNumber * failSafeExpiryTimeoutSecs MTR_DEPRECATED_WITH_REPLACEMENT(
+    "failSafeTimeout", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDefines.h
+++ b/src/darwin/Framework/CHIP/MTRDefines.h
@@ -17,6 +17,8 @@
 
 #import <Foundation/Foundation.h>
 
+#pragma mark - Attribute macros
+
 #define MTR_EXPORT __attribute__((visibility("default")))
 
 #ifdef __cplusplus
@@ -24,6 +26,32 @@
 #else
 #define MTR_EXTERN extern MTR_EXPORT
 #endif
+
+#if __has_attribute(__swift_attr__)
+#define MTR_SWIFT_DISFAVORED_OVERLOAD __attribute__((__swift_attr__("@_disfavoredOverload")))
+#else
+#define MTR_SWIFT_DISFAVORED_OVERLOAD
+#endif
+
+#pragma mark - Deprecation macros (can be overriden via build system)
+
+#ifndef MTR_DEPRECATED
+#define MTR_DEPRECATED(...) API_DEPRECATED(__VA_ARGS__) MTR_SWIFT_DISFAVORED_OVERLOAD
+#endif
+
+#ifndef MTR_DEPRECATED_WITH_REPLACEMENT
+#define MTR_DEPRECATED_WITH_REPLACEMENT(...) API_DEPRECATED_WITH_REPLACEMENT(__VA_ARGS__) MTR_SWIFT_DISFAVORED_OVERLOAD
+#endif
+
+#ifndef MTR_NEWLY_DEPRECATED
+#define MTR_NEWLY_DEPRECATED(message)
+#endif
+
+#ifndef MTR_NEWLY_AVAILABLE
+#define MTR_NEWLY_AVAILABLE
+#endif
+
+#pragma mark - Types
 
 typedef NSData * MTRTLVBytes;
 typedef NSData * MTRCSRDERBytes;

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -943,7 +943,8 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
 - (void)issueOperationalCertificateForRequest:(MTROperationalCSRInfo *)csrInfo
                               attestationInfo:(MTRDeviceAttestationInfo *)attestationInfo
                                    controller:(MTRDeviceController *)controller
-                                   completion:(MTROperationalCertificateIssuedHandler)completion
+                                   completion:(void (^)(MTROperationalCertificateChain * _Nullable info,
+                                                  NSError * _Nullable error))completion
 {
     CSRInfo * oldCSRInfo = [[CSRInfo alloc] initWithNonce:csrInfo.csrNonce
                                                  elements:csrInfo.csrElementsTLV

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegate.h
@@ -16,26 +16,13 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <Matter/Matter.h>
+#import <Matter/MTRCluster.h>
+#import <Matter/MTRCommandPayloadsObjc.h>
+#import <Matter/MTRDefines.h>
+
+@class MTRDeviceController;
 
 NS_ASSUME_NONNULL_BEGIN
-
-typedef void (^MTRQueryImageCompletionHandler)(
-    MTROTASoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data, NSError * _Nullable error);
-
-typedef void (^MTRApplyUpdateRequestCompletionHandler)(
-    MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data, NSError * _Nullable error);
-
-typedef void (^MTRBDXQueryCompletionHandler)(NSData * _Nullable data, BOOL isEOF);
-
-API_DEPRECATED("Please use MTRQueryImageCompletionHandler", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
-typedef void (^MTRQueryImageCompletionHandlerDeprecated)(
-    MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data, NSError * _Nullable error);
-
-API_DEPRECATED(
-    "Plase Use MTRApplyUpdateRequestCompletionHandler", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
-typedef void (^MTRApplyUpdateRequestCompletionHandlerDeprecated)(
-    MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data, NSError * _Nullable error);
 
 /**
  * The protocol definition for the MTROTAProviderDelegate
@@ -62,14 +49,17 @@ typedef void (^MTRApplyUpdateRequestCompletionHandlerDeprecated)(
 - (void)handleQueryImageForNodeID:(NSNumber *)nodeID
                        controller:(MTRDeviceController *)controller
                            params:(MTROTASoftwareUpdateProviderClusterQueryImageParams *)params
-                       completion:(MTRQueryImageCompletionHandler)completion
+                       completion:(void (^)(MTROTASoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
+                                      NSError * _Nullable error))completion
     API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+
 - (void)handleQueryImageForNodeID:(NSNumber *)nodeID
                        controller:(MTRDeviceController *)controller
                            params:(MTROtaSoftwareUpdateProviderClusterQueryImageParams *)params
-                completionHandler:(MTRQueryImageCompletionHandlerDeprecated)completionHandler
-    API_DEPRECATED(
-        "Please use the selector ending in completion:", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+                completionHandler:(void (^)(MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
+                                      NSError * _Nullable error))completionHandler
+    MTR_DEPRECATED_WITH_REPLACEMENT("handleQueryImageForNodeID:controller:params:completion:", ios(16.1, 16.4), macos(13.0, 13.3),
+        watchos(9.1, 9.4), tvos(16.1, 16.4));
 
 /**
  * Notify the delegate when the apply update request command is received from
@@ -83,14 +73,17 @@ typedef void (^MTRApplyUpdateRequestCompletionHandlerDeprecated)(
 - (void)handleApplyUpdateRequestForNodeID:(NSNumber *)nodeID
                                controller:(MTRDeviceController *)controller
                                    params:(MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
-                               completion:(MTRApplyUpdateRequestCompletionHandler)completion
+                               completion:(void (^)(MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
+                                              NSError * _Nullable error))completion
     API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+
 - (void)handleApplyUpdateRequestForNodeID:(NSNumber *)nodeID
                                controller:(MTRDeviceController *)controller
                                    params:(MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
-                        completionHandler:(MTRApplyUpdateRequestCompletionHandlerDeprecated)completionHandler
-    API_DEPRECATED(
-        "Please use the selector ending in completion:", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+                        completionHandler:(void (^)(MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
+                                              NSError * _Nullable error))completionHandler
+    MTR_DEPRECATED_WITH_REPLACEMENT("handleApplyUpdateRequestForNodeID:controller:params:completion:", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 
 /**
  * Notify the delegate when the notify update applied command is received from
@@ -105,12 +98,13 @@ typedef void (^MTRApplyUpdateRequestCompletionHandlerDeprecated)(
                                     params:(MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
                                 completion:(MTRStatusCompletion)completion
     API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+
 - (void)handleNotifyUpdateAppliedForNodeID:(NSNumber *)nodeID
                                 controller:(MTRDeviceController *)controller
                                     params:(MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
                          completionHandler:(StatusCompletion)completionHandler
-    API_DEPRECATED(
-        "Please use the selector ending in completion:", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+    MTR_DEPRECATED_WITH_REPLACEMENT("handleNotifyUpdateAppliedForNodeID:controller:params:completion:", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 
 /**
  * Notify the delegate when a BDX Session starts for some node.  The controller
@@ -123,13 +117,14 @@ typedef void (^MTRApplyUpdateRequestCompletionHandlerDeprecated)(
                                         offset:(NSNumber *)offset
                                     completion:(MTRStatusCompletion)completion
     API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+
 - (void)handleBDXTransferSessionBeginForNodeID:(NSNumber *)nodeID
                                     controller:(MTRDeviceController *)controller
                                 fileDesignator:(NSString *)fileDesignator
                                         offset:(NSNumber *)offset
                              completionHandler:(StatusCompletion)completionHandler
-    API_DEPRECATED(
-        "Please use the selector ending in completion:", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+    MTR_DEPRECATED_WITH_REPLACEMENT("handleBDXTransferSessionBeginForNodeID:controller:fileDesignator:offset:completion:",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 
 /**
  * Notify the delegate when a BDX Session ends for some node.  The controller
@@ -150,16 +145,17 @@ typedef void (^MTRApplyUpdateRequestCompletionHandlerDeprecated)(
                       blockSize:(NSNumber *)blockSize
                      blockIndex:(NSNumber *)blockIndex
                     bytesToSkip:(NSNumber *)bytesToSkip
-                     completion:(MTRBDXQueryCompletionHandler)completion
+                     completion:(void (^)(NSData * _Nullable data, BOOL isEOF))completion
     API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+
 - (void)handleBDXQueryForNodeID:(NSNumber *)nodeID
                      controller:(MTRDeviceController *)controller
                       blockSize:(NSNumber *)blockSize
                      blockIndex:(NSNumber *)blockIndex
                     bytesToSkip:(NSNumber *)bytesToSkip
-              completionHandler:(MTRBDXQueryCompletionHandler)completionHandler
-    API_DEPRECATED(
-        "Please use the selector ending in completion:", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+              completionHandler:(void (^)(NSData * _Nullable data, BOOL isEOF))completionHandler
+    MTR_DEPRECATED_WITH_REPLACEMENT("handleBDXQueryForNodeID:controller:blockSize:blockIndex:bytesToSkip:completion:",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.h
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-#import "MTROTAProviderDelegate.h"
+#import <Matter/MTROTAProviderDelegate.h>
 
 #include <app/clusters/ota-provider/ota-provider-delegate.h>
 

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -16,6 +16,8 @@
  */
 
 #import "MTROTAProviderDelegateBridge.h"
+#import "MTRBaseClusters.h"
+#import "MTRCommandPayloadsObjC.h"
 #import "MTRDeviceControllerFactory_Internal.h"
 #import "MTRDeviceController_Internal.h"
 #import "NSDataSpanConversion.h"

--- a/src/darwin/Framework/CHIP/MTROperationalCertificateIssuer.h
+++ b/src/darwin/Framework/CHIP/MTROperationalCertificateIssuer.h
@@ -57,8 +57,6 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 
 @end
 
-typedef void (^MTROperationalCertificateIssuedHandler)(MTROperationalCertificateChain * _Nullable info, NSError * _Nullable error);
-
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @protocol MTROperationalCertificateIssuer
 @required
@@ -80,7 +78,8 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 - (void)issueOperationalCertificateForRequest:(MTROperationalCSRInfo *)csrInfo
                               attestationInfo:(MTRDeviceAttestationInfo *)attestationInfo
                                    controller:(MTRDeviceController *)controller
-                                   completion:(MTROperationalCertificateIssuedHandler)completion;
+                                   completion:(void (^)(MTROperationalCertificateChain * _Nullable info,
+                                                  NSError * _Nullable error))completion;
 
 /**
  * A way for MTROperationalCertificateIssuer to control whether it wants the
@@ -111,8 +110,7 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 
 @end
 
-API_DEPRECATED(
-    "Please use MTROperationalCertificateIssuedHandler", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
+API_DEPRECATED("MTRNOCChainIssuer is deprecated", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 typedef void (^MTRNOCChainGenerationCompleteHandler)(NSData * operationalCertificate, NSData * intermediateCertificate,
     NSData * rootCertificate, NSData * _Nullable ipk, NSNumber * _Nullable adminSubject, NSError * __autoreleasing * error);
 

--- a/src/darwin/Framework/CHIP/Matter.h
+++ b/src/darwin/Framework/CHIP/Matter.h
@@ -17,14 +17,6 @@
 
 #import <Foundation/Foundation.h>
 
-#ifndef MTR_NEWLY_DEPRECATED
-#define MTR_NEWLY_DEPRECATED(message)
-#endif
-
-#ifndef MTR_NEWLY_AVAILABLE
-#define MTR_NEWLY_AVAILABLE
-#endif
-
 #import <Matter/MTRAsyncCallbackWorkQueue.h>
 #import <Matter/MTRBaseClusters.h>
 #import <Matter/MTRBaseDevice.h>

--- a/src/darwin/Framework/CHIPTests/MTROperationalCertificateIssuerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTROperationalCertificateIssuerTests.m
@@ -91,7 +91,8 @@ static MTRTestKeys * sTestKeys = nil;
 - (void)issueOperationalCertificateForRequest:(MTROperationalCSRInfo *)csrInfo
                               attestationInfo:(MTRDeviceAttestationInfo *)attestationInfo
                                    controller:(MTRDeviceController *)controller
-                                   completion:(MTROperationalCertificateIssuedHandler)completion
+                                   completion:(void (^)(MTROperationalCertificateChain * _Nullable info,
+                                                  NSError * _Nullable error))completion
 {
     XCTAssertNotNil(csrInfo);
     XCTAssertNotNil(attestationInfo);

--- a/src/darwin/Framework/CHIPTests/MTRTestOTAProvider.m
+++ b/src/darwin/Framework/CHIPTests/MTRTestOTAProvider.m
@@ -16,21 +16,20 @@
 
 #import "MTRTestOTAProvider.h"
 
-@interface MTRTestOTAProvider ()
-@end
-
 @implementation MTRTestOTAProvider
 - (void)handleQueryImageForNodeID:(NSNumber *)nodeID
                        controller:(MTRDeviceController *)controller
                            params:(MTROTASoftwareUpdateProviderClusterQueryImageParams *)params
-                       completion:(MTRQueryImageCompletionHandler)completion
+                       completion:(void (^)(MTROTASoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
+                                      NSError * _Nullable error))completion
 {
 }
 
 - (void)handleApplyUpdateRequestForNodeID:(NSNumber *)nodeID
                                controller:(MTRDeviceController *)controller
                                    params:(MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
-                               completion:(MTRApplyUpdateRequestCompletionHandler)completion
+                               completion:(void (^)(MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
+                                              NSError * _Nullable error))completion
 {
 }
 
@@ -60,7 +59,7 @@
                       blockSize:(NSNumber * _Nonnull)blockSize
                      blockIndex:(NSNumber * _Nonnull)blockIndex
                     bytesToSkip:(NSNumber * _Nonnull)bytesToSkip
-                     completion:(MTRBDXQueryCompletionHandler)completion
+                     completion:(void (^)(NSData * _Nullable data, BOOL isEOF))completion
 {
 }
 


### PR DESCRIPTION
The following were still ambiguous in Swift:
- MTRCommissioningParameters.csrNonce
- MTROTAProviderDelegate.handleBDXTransferSessionBegin
- MTROTAProviderDelegate.handleBDXQuery

Use MTR_SWIFT_DISFAVORED_OVERLOAD instead of NS_UNAVAILABLE_FOR_SWIFT and introduce MTR_DEPRECATED that makes use of it to make Swift prefer non-deprecated symbols where there is ambiguity due to the old and new ObcJ name being imported as the same name in Swift.

Also avoid some typedefs for single-use completion block types since they add little value but carry a cost in terms of maintaining source compatibility going forward.