### PR TITLE
[ESP32] Fix host setup failure on mac and some build docs

### DIFF
--- a/docs/guides/esp32/build_app_and_commission.md
+++ b/docs/guides/esp32/build_app_and_commission.md
@@ -53,9 +53,7 @@ functionality can still work fine.
 
 -   Matter
 
-    Before running any other build command, the scripts/activate.sh environment
-    setup script should be sourced at the top level. This script set up a Python
-    environment with libraries used to build and test.
+    Activate the Matter environment.
 
     ```
     $ cd path/to/connectedhomeip
@@ -82,7 +80,7 @@ functionality can still work fine.
 -   Set the Matter target to build
 
     ```
-    $ idf.py set-target (Matter)
+    $ idf.py set-target (target chip)
     ```
 
     All the example applications supports target chips: esp32, esp32s3, esp32c3

--- a/docs/guides/esp32/build_app_and_commission.md
+++ b/docs/guides/esp32/build_app_and_commission.md
@@ -53,7 +53,8 @@ functionality can still work fine.
 
 -   Matter
 
-    Activate the Matter environment.
+    Activate the Matter environment. Below command needs to be executed after
+    sourcing `esp-idf/export.sh`.
 
     ```
     $ cd path/to/connectedhomeip

--- a/docs/guides/esp32/factory_data.md
+++ b/docs/guides/esp32/factory_data.md
@@ -1,38 +1,15 @@
 ## Using ESP32 Factory Data Provider
 
 By default applications uses test-mode or default commissionable data provider,
-device attestation credentials provider, and device instance info provider.
+device attestation credentials provider, device instance info provider, and
+device info provider.
 
 To use different values for them you can use the ESP32 Factory Data Provider.
 
-### Configuration Options
+### Supported data
 
-Enable config option `CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER` to use ESP32
-specific implementation of CommissionableDataProvider and
-DeviceAttestationCredentialsProvider.
-
-[Component config → CHIP Device Layer → Commissioning options → Use ESP32
-Factory Data Provider]
-
-Enable config option `CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER` to use ESP32
-specific implementation of DeviceInstanceInfoProvider.
-
-[Component config → CHIP Device Layer → Commissioning options → Use ESP32 Device
-Instance Info Provider]
-
-ESP32 implementation reads factory data from nvs partition, chip-factory data
-must be flashed into the configured nvs partition. Factory partition can be
-configured using `CONFIG_CHIP_FACTORY_NAMESPACE_PARTITION_LABEL` option, default
-is "nvs".
-
-### Generate NVS Binary Image
-
-`scripts/tools/generate_esp32_chip_factory_bin.py` script generates the
-chip-factory NVS binary image `partition.bin`.
-
-#### Supported data
-
-Script supports adding following data to the NVS binary image:
+Following data can be added to the manufacturing partition using
+`scripts/tools/generate_esp32_chip_factory_bin.py` script.
 
 -   Commissionable data
 
@@ -46,40 +23,61 @@ Script supports adding following data to the NVS binary image:
     -   Certificate declaration
 
 -   Device instance information
+
     -   Vendor id and name
     -   Product id and name
     -   Hardware version and version string
     -   Serial Number
     -   Unique identifier
 
+-   Device information
+    -   Fixed Labels
+    -   Supported locales
+    -   Supported calendar types
+
+### Configuration Options
+
+Enable config option `CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER` to use ESP32
+specific implementation of `CommissionableDataProvider` and
+`DeviceAttestationCredentialsProvider`.
+
+[Component config → CHIP Device Layer → Commissioning options → Use ESP32
+Factory Data Provider]
+
+Enable config option `CONFIG_ENABLE_ESP32_DEVICE_INSTANCE_INFO_PROVIDER` to use
+ESP32 specific implementation of `DeviceInstanceInfoProvider`.
+
+[Component config → CHIP Device Layer → Commissioning options → Use ESP32 Device
+Instance Info Provider]
+
+Enable config option `CONFIG_ENABLE_ESP32_DEVICE_INFO_PROVIDER` to use ESP32
+specific implementation of `DeviceInfoProvider`.
+
+[Component config → CHIP Device Layer → Commissioning options → Use ESP32 Device
+Info Provider]
+
+ESP32 implementation reads factory data from nvs partition, chip-factory data
+must be flashed into the configured nvs partition. Factory partition can be
+configured using `CONFIG_CHIP_FACTORY_NAMESPACE_PARTITION_LABEL` option, default
+is "nvs".
+
+[Component config -> CHIP Device Layer -> Matter Manufacturing Options ->
+chip-factory namespace partition label]
+
+### Generate NVS Binary Image
+
+`scripts/tools/generate_esp32_chip_factory_bin.py` script generates the
+chip-factory NVS binary image `partition.bin`.
+
 Please check help for available options,
 `scripts/tools/generate_esp32_chip_factory_bin.py`
-
-#### Dependency
-
-Script has dependency on
-[spake2p](https://github.com/project-chip/connectedhomeip/tree/master/src/tools/spake2p)
-for generating spake2p parameters.
-
-Build spake2p:
-
-```
-cd path/to/connectedhomeip
-gn gen out/host
-ninja -C out/host
-cd -
-```
-
-Add spake2p to \$PATH environment variable
-
-```
-export PATH=$PATH:path/to/connectedhomeip/out/host
-```
 
 #### Usage
 
 Below mentioned command generates the nvs image with test DAC with VID:0xFFF2
 and PID:8000 and some examples values for other fields.
+
+For more help please check `./generate_esp32_chip_factory_bin.py -h`
 
 ```
 ./generate_esp32_chip_factory_bin.py -d 3434 -p 99663300 \
@@ -89,7 +87,7 @@ and PID:8000 and some examples values for other fields.
                                     --dac-cert path/to/connectedhomeip/credentials/test/attestation/Chip-Test-DAC-FFF2-8001-0008-Cert.der \
                                     --dac-key path/to/connectedhomeip/credentials/test/attestation/Chip-Test-DAC-FFF2-8001-0008-Key.der \
                                     --pai-cert path/to/connectedhomeip/credentials/test/attestation/Chip-Test-PAI-FFF2-8001-Cert.der \
-                                    --cd path/to/connectedhomeip/credentials/test/certification-declaration/Chip-Test-CD-FFF2-8001.der \
+                                    --cd path/to/connectedhomeip/credentials/test/certification-declaration/Chip-Test-CD-FFF2-8001.der
 ```
 
 #### Flashing the generated NVS image

--- a/docs/guides/esp32/setup_idf_chip.md
+++ b/docs/guides/esp32/setup_idf_chip.md
@@ -70,14 +70,16 @@ source scripts/bootstrap.sh
 Whenever Matter environment is out of date, it can be updated by running above
 command.
 
+
 For MacOS, `gdbgui` python package will not be installed using `bootstrap.sh`
 script as it is restricted only for x64 Linux platforms. It is restricted
 because, building wheels for `gevent` (dependency of `gdbgui`) fails on MacOS.
 
+Please run the below commands after every bootstrapping.
+
 Workaround is to install `gdbgui` wheels as binary:
 
 ```
-source scripts/activate.sh
 python3 -m pip install -c scripts/constraints.txt --no-cache --prefer-binary gdbgui==0.13.2.0
 deactivate
 ```

--- a/docs/guides/esp32/setup_idf_chip.md
+++ b/docs/guides/esp32/setup_idf_chip.md
@@ -70,7 +70,6 @@ source scripts/bootstrap.sh
 Whenever Matter environment is out of date, it can be updated by running above
 command.
 
-
 For MacOS, `gdbgui` python package will not be installed using `bootstrap.sh`
 script as it is restricted only for x64 Linux platforms. It is restricted
 because, building wheels for `gevent` (dependency of `gdbgui`) fails on MacOS.

--- a/docs/guides/esp32/setup_idf_chip.md
+++ b/docs/guides/esp32/setup_idf_chip.md
@@ -57,22 +57,29 @@ step.
 -   [Linux](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/BUILDING.md#installing-prerequisites-on-linux)
 -   [macOS](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/BUILDING.md#installing-prerequisites-on-macos)
 
-### Prepare for building
+### Bootstrap Matter environment
 
-Before running any other build command, the `scripts/activate.sh` environment
-setup script should be sourced at the top level. This script takes care of
-downloading GN, ninja, and setting up a Python environment with libraries used
-to build and test.
-
-```
-source scripts/activate.sh
-```
-
-If this script says the environment is out of date, it can be updated by
-running:
+Execute the below command to bootstrap Matter environment. This script takes
+care of downloading GN, ninja, and setting up a Python environment with
+libraries used to build and test.
 
 ```
 source scripts/bootstrap.sh
+```
+
+Whenever Matter environment is out of date, it can be updated by running above
+command.
+
+For MacOS, `gdbgui` python package will not be installed using `bootstrap.sh`
+script as it is restricted only for x64 Linux platforms. It is restricted
+because, building wheels for `gevent` (dependency of `gdbgui`) fails on MacOS.
+
+Workaround is to install `gdbgui` wheels as binary:
+
+```
+source scripts/activate.sh
+python3 -m pip install -c scripts/constraints.txt --no-cache --prefer-binary gdbgui==0.13.2.0
+deactivate
 ```
 
 ---

--- a/scripts/requirements.esp32.txt
+++ b/scripts/requirements.esp32.txt
@@ -1,12 +1,12 @@
-click>=7.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-future>=0.15.2 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-pyparsing>=2.0.3,<2.4.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-idf-component-manager>=0.2.99-beta ; platform_machine != 'aarch64' and sys_platform == 'linux'
+click>=7.0
+future>=0.15.2
+pyparsing>=2.0.3,<2.4.0
+idf-component-manager
+pygdbmi<=0.9.0.2
+reedsolo>=1.5.3,<=1.5.4
+bitstring>=3.1.6
+ecdsa>=0.16.0
+kconfiglib==13.7.1
+construct==2.10.54
+python-socketio<5
 gdbgui==0.13.2.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-pygdbmi<=0.9.0.2 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-reedsolo>=1.5.3,<=1.5.4 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-bitstring>=3.1.6 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-ecdsa>=0.16.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-kconfiglib==13.7.1 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-construct==2.10.54 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-python-socketio<5 ; platform_machine != 'aarch64' and sys_platform == 'linux'


### PR DESCRIPTION
#### Problem
Fixes https://github.com/project-chip/connectedhomeip/issues/24734#issuecomment-1413755055

This may also fix https://github.com/project-chip/connectedhomeip/issues/24816

#### Change Overview
https://github.com/project-chip/connectedhomeip/pull/22071 restricted `requirements.esp32.txt` to only linux platform and hence dependencies required to build the ESP32 examples are not installed on mac.

Restrictions were added because building wheels for `gevent` (dependency of `gdbgui`) failed.

Removed the platform restrictions for all the dependencies other than `gdbgui`. Added some documentation around how to install `gdbgui` on mac.

And some doc fixes. 

#### Testing
- Was able successfully bootstrap and build the esp32 application on mac and Ubuntu.