### PR TITLE
added User Key domain to valid keys for the NVM3 Silabs implemented API

### DIFF
--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -507,8 +507,8 @@ bool SILABSConfig::ValidConfigKey(Key key)
 {
     // Returns true if the key is in the Matter nvm3 reserved key range.
     // Additional check validates that the user consciously defined the expected key range
-    if ((key >= kMatterNvm3KeyLoLimit) && (key <= kMatterNvm3KeyHiLimit) && (key >= kMinConfigKey_MatterFactory) &&
-        (key <= kMaxConfigKey_MatterKvs))
+    if (((key >= kMatterNvm3KeyLoLimit) && (key <= kMatterNvm3KeyHiLimit) && (key >= kMinConfigKey_MatterFactory) &&
+        (key <= kMaxConfigKey_MatterKvs)) || ((key >= kUserNvm3KeyDomainLoLimit) && (key <= kUserNvm3KeyDomainHiLimit))
     {
         return true;
     }

--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -506,9 +506,10 @@ exit:;
 bool SILABSConfig::ValidConfigKey(Key key)
 {
     // Returns true if the key is in the Matter nvm3 reserved key range.
+    // or if the key is in the User Domain key range
     // Additional check validates that the user consciously defined the expected key range
     if (((key >= kMatterNvm3KeyLoLimit) && (key <= kMatterNvm3KeyHiLimit) && (key >= kMinConfigKey_MatterFactory) &&
-        (key <= kMaxConfigKey_MatterKvs)) || ((key >= kUserNvm3KeyDomainLoLimit) && (key <= kUserNvm3KeyDomainHiLimit))
+        (key <= kMaxConfigKey_MatterKvs)) || ((key >= kUserNvm3KeyDomainLoLimit) && (key <= kUserNvm3KeyDomainHiLimit)))
     {
         return true;
     }

--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -509,7 +509,8 @@ bool SILABSConfig::ValidConfigKey(Key key)
     // or if the key is in the User Domain key range
     // Additional check validates that the user consciously defined the expected key range
     if (((key >= kMatterNvm3KeyLoLimit) && (key <= kMatterNvm3KeyHiLimit) && (key >= kMinConfigKey_MatterFactory) &&
-        (key <= kMaxConfigKey_MatterKvs)) || ((key >= kUserNvm3KeyDomainLoLimit) && (key <= kUserNvm3KeyDomainHiLimit)))
+         (key <= kMaxConfigKey_MatterKvs)) ||
+        ((key >= kUserNvm3KeyDomainLoLimit) && (key <= kUserNvm3KeyDomainHiLimit)))
     {
         return true;
     }

--- a/src/platform/silabs/SilabsConfig.h
+++ b/src/platform/silabs/SilabsConfig.h
@@ -64,6 +64,9 @@ namespace Internal {
 // '08' = Matter nvm3 region
 // '72' = the sub region group base offset (Factory, Config, Counter or KVS)
 // '01' = the id offset inside the group.
+constexpr uint32_t kUserNvm3KeyDomainLoLimit    = 0x000000U;
+constexpr uint32_t kUserNvm3KeyDomainHiLimit    = 0x00FFFFU;
+constexpr uint32_t kUserNvm3KeyDomain           = 0x000000U;
 constexpr uint32_t kMatterNvm3KeyDomain  = 0x080000U;
 constexpr uint32_t kMatterNvm3KeyLoLimit = 0x087200U; // Do not modify without Silabs GSDK team approval
 constexpr uint32_t kMatterNvm3KeyHiLimit = 0x087FFFU; // Do not modify without Silabs GSDK team approval

--- a/src/platform/silabs/SilabsConfig.h
+++ b/src/platform/silabs/SilabsConfig.h
@@ -64,11 +64,11 @@ namespace Internal {
 // '08' = Matter nvm3 region
 // '72' = the sub region group base offset (Factory, Config, Counter or KVS)
 // '01' = the id offset inside the group.
-constexpr uint32_t kUserNvm3KeyDomainLoLimit    = 0x000000U; // User Domain NVM3 Key Range lower limit
-constexpr uint32_t kUserNvm3KeyDomainHiLimit    = 0x00FFFFU; // User Domain NVM3 Key Range Maximum limit
-constexpr uint32_t kMatterNvm3KeyDomain  = 0x080000U;
-constexpr uint32_t kMatterNvm3KeyLoLimit = 0x087200U; // Do not modify without Silabs GSDK team approval
-constexpr uint32_t kMatterNvm3KeyHiLimit = 0x087FFFU; // Do not modify without Silabs GSDK team approval
+constexpr uint32_t kUserNvm3KeyDomainLoLimit = 0x000000U; // User Domain NVM3 Key Range lower limit
+constexpr uint32_t kUserNvm3KeyDomainHiLimit = 0x00FFFFU; // User Domain NVM3 Key Range Maximum limit
+constexpr uint32_t kMatterNvm3KeyDomain      = 0x080000U;
+constexpr uint32_t kMatterNvm3KeyLoLimit     = 0x087200U; // Do not modify without Silabs GSDK team approval
+constexpr uint32_t kMatterNvm3KeyHiLimit     = 0x087FFFU; // Do not modify without Silabs GSDK team approval
 constexpr inline uint32_t SILABSConfigKey(uint8_t keyBaseOffset, uint8_t id)
 {
     return kMatterNvm3KeyDomain | static_cast<uint32_t>(keyBaseOffset) << 8 | id;

--- a/src/platform/silabs/SilabsConfig.h
+++ b/src/platform/silabs/SilabsConfig.h
@@ -64,9 +64,8 @@ namespace Internal {
 // '08' = Matter nvm3 region
 // '72' = the sub region group base offset (Factory, Config, Counter or KVS)
 // '01' = the id offset inside the group.
-constexpr uint32_t kUserNvm3KeyDomainLoLimit    = 0x000000U;
-constexpr uint32_t kUserNvm3KeyDomainHiLimit    = 0x00FFFFU;
-constexpr uint32_t kUserNvm3KeyDomain           = 0x000000U;
+constexpr uint32_t kUserNvm3KeyDomainLoLimit    = 0x000000U; // User Domain NVM3 Key Range lower limit
+constexpr uint32_t kUserNvm3KeyDomainHiLimit    = 0x00FFFFU; // User Domain NVM3 Key Range Maximum limit
 constexpr uint32_t kMatterNvm3KeyDomain  = 0x080000U;
 constexpr uint32_t kMatterNvm3KeyLoLimit = 0x087200U; // Do not modify without Silabs GSDK team approval
 constexpr uint32_t kMatterNvm3KeyHiLimit = 0x087FFFU; // Do not modify without Silabs GSDK team approval


### PR DESCRIPTION
added the User key domain to valid keys for the NVM3 Silabs implemented API to facilitate development experience for end user. 

