### PR TITLE
[ESP32] ESP-IDF v5.0 support in reamining apps

### DIFF
--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -92,8 +92,7 @@ Identify gIdentify1 = {
 void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId,
                                                      uint8_t type, uint16_t size, uint8_t * value)
 {
-    ESP_LOGI(TAG,
-             "PostAttributeChangeCallback - Cluster ID: '0x%04" PRIx32 "', EndPoint ID: '0x%02x' , Attribute ID: '0x%04" PRIx32 "'",
+    ESP_LOGI(TAG, "PostAttributeChangeCallback - Cluster ID: '0x%" PRIx32 "', EndPoint ID: '0x%x' , Attribute ID: '0x%" PRIx32 "'",
              clusterId, endpointId, attributeId);
 
     switch (clusterId)
@@ -125,7 +124,7 @@ void AppDeviceCallbacks::OnOnOffPostAttributeChangeCallback(EndpointId endpointI
 {
     using namespace app::Clusters::OnOff::Attributes;
 
-    VerifyOrExit(attributeId == OnOff::Id, ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%04" PRIx32 "'", attributeId));
+    VerifyOrExit(attributeId == OnOff::Id, ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%" PRIx32 "'", attributeId));
     VerifyOrExit(endpointId == 1 || endpointId == 2, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
 
     // At this point we can assume that value points to a bool value.
@@ -143,7 +142,7 @@ void AppDeviceCallbacks::OnLevelControlAttributeChangeCallback(EndpointId endpoi
     bool onOffState    = mEndpointOnOffState[endpointId - 1];
     uint8_t brightness = onOffState ? *value : 0;
 
-    VerifyOrExit(attributeId == CurrentLevel::Id, ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%04" PRIx32 "'", attributeId));
+    VerifyOrExit(attributeId == CurrentLevel::Id, ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%" PRIx32 "'", attributeId));
     VerifyOrExit(endpointId == 1 || endpointId == 2, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
 
     // At this point we can assume that value points to a bool value.
@@ -161,7 +160,7 @@ void AppDeviceCallbacks::OnColorControlAttributeChangeCallback(EndpointId endpoi
     using namespace app::Clusters::ColorControl::Attributes;
 
     VerifyOrExit(attributeId == CurrentHue::Id || attributeId == CurrentSaturation::Id,
-                 ESP_LOGI(TAG, "Unhandled AttributeId ID: '0x%04" PRIx32 "'", attributeId));
+                 ESP_LOGI(TAG, "Unhandled AttributeId ID: '0x%" PRIx32 "'", attributeId));
     VerifyOrExit(endpointId == 1 || endpointId == 2, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
     if (endpointId == 1)
     {

--- a/examples/all-clusters-minimal-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-minimal-app/esp32/main/DeviceCallbacks.cpp
@@ -91,8 +91,7 @@ Identify gIdentify1 = {
 void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId,
                                                      uint8_t type, uint16_t size, uint8_t * value)
 {
-    ESP_LOGI(TAG,
-             "PostAttributeChangeCallback - Cluster ID: '0x%04" PRIx32 "', EndPoint ID: '0x%02x' , Attribute ID: '0x%04" PRIx32 "'",
+    ESP_LOGI(TAG, "PostAttributeChangeCallback - Cluster ID: '0x%" PRIx32 "', EndPoint ID: '0x%x' , Attribute ID: '0x%" PRIx32 "'",
              clusterId, endpointId, attributeId);
 
     switch (clusterId)
@@ -123,7 +122,7 @@ void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Clus
 void AppDeviceCallbacks::OnOnOffPostAttributeChangeCallback(EndpointId endpointId, AttributeId attributeId, uint8_t * value)
 {
     VerifyOrExit(attributeId == Clusters::OnOff::Attributes::OnOff::Id,
-                 ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%04" PRIx32 "'", attributeId));
+                 ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%" PRIx32 "'", attributeId));
     VerifyOrExit(endpointId == 1 || endpointId == 2, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
 
     // At this point we can assume that value points to a bool value.
@@ -140,7 +139,7 @@ void AppDeviceCallbacks::OnLevelControlAttributeChangeCallback(EndpointId endpoi
     uint8_t brightness = onOffState ? *value : 0;
 
     VerifyOrExit(attributeId == Clusters::LevelControl::Attributes::CurrentLevel::Id,
-                 ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%04" PRIx32 "'", attributeId));
+                 ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%" PRIx32 "'", attributeId));
     VerifyOrExit(endpointId == 1 || endpointId == 2, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
 
     // At this point we can assume that value points to a bool value.
@@ -158,7 +157,7 @@ void AppDeviceCallbacks::OnColorControlAttributeChangeCallback(EndpointId endpoi
     using namespace Clusters::ColorControl::Attributes;
 
     VerifyOrExit(attributeId == CurrentHue::Id || attributeId == CurrentSaturation::Id,
-                 ESP_LOGI(TAG, "Unhandled AttributeId ID: '0x%04" PRIx32 "'", attributeId));
+                 ESP_LOGI(TAG, "Unhandled AttributeId ID: '0x%" PRIx32 "'", attributeId));
     VerifyOrExit(endpointId == 1 || endpointId == 2, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
     if (endpointId == 1)
     {

--- a/examples/bridge-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/bridge-app/esp32/main/DeviceCallbacks.cpp
@@ -39,8 +39,7 @@ using namespace ::chip::System;
 void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId,
                                                      uint8_t type, uint16_t size, uint8_t * value)
 {
-    ESP_LOGI(TAG,
-             "PostAttributeChangeCallback - Cluster ID: '0x%04" PRIx32 "', EndPoint ID: '0x%02x', Attribute ID: '0x%04" PRIx32 "'",
+    ESP_LOGI(TAG, "PostAttributeChangeCallback - Cluster ID: '0x%" PRIx32 "', EndPoint ID: '0x%x', Attribute ID: '0x%" PRIx32 "'",
              clusterId, endpointId, attributeId);
     ESP_LOGI(TAG, "Current free heap: %d\n", heap_caps_get_free_size(MALLOC_CAP_8BIT));
 }

--- a/examples/chef/esp32/CMakeLists.txt
+++ b/examples/chef/esp32/CMakeLists.txt
@@ -27,7 +27,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
     "${CMAKE_CURRENT_LIST_DIR}/../../common/QRCode"
-    "${IDF_PATH}/examples/common_components/led_strip"
 )
 
 if(${IDF_TARGET} STREQUAL "esp32")

--- a/examples/chef/esp32/main/CMakeLists.txt
+++ b/examples/chef/esp32/main/CMakeLists.txt
@@ -87,8 +87,14 @@ set(PRIV_INCLUDE_DIRS_LIST  "${PRIV_INCLUDE_DIRS_LIST}"
                      "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
                      "${CMAKE_SOURCE_DIR}/../../common/screen-framework/include/"
                      "${CMAKE_SOURCE_DIR}/../../../src/lib/support"
-                     "${IDF_PATH}/components/freertos/include/freertos"
 )
+
+if (${IDF_VERSION_MAJOR} LESS 5)
+    list(APPEND PRIV_INCLUDE_DIRS_LIST "${IDF_PATH}/components/freertos/include/freertos")
+else()
+    list(APPEND PRIV_INCLUDE_DIRS_LIST "${IDF_PATH}/components/freertos/FreeRTOS-Kernel/include/freertos")
+endif()
+
 set(SRC_DIRS_LIST  "${SRC_DIRS_LIST}"
                      "${CMAKE_SOURCE_DIR}/../../platform/esp32"
                      "${CMAKE_SOURCE_DIR}/../../common/pigweed"

--- a/examples/chef/esp32/main/idf_component.yml
+++ b/examples/chef/esp32/main/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+    espressif/led_strip: "^1.0.0-alpha"

--- a/examples/light-switch-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/light-switch-app/esp32/main/DeviceCallbacks.cpp
@@ -36,8 +36,7 @@ using namespace chip::app::Clusters;
 void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId,
                                                      uint8_t mask, uint8_t type, uint16_t size, uint8_t * value)
 {
-    ESP_LOGI(TAG,
-             "PostAttributeChangeCallback - Cluster ID: '0x%04" PRIx32 "', EndPoint ID: '0x%02x', Attribute ID: '0x%04" PRIx32 "'",
+    ESP_LOGI(TAG, "PostAttributeChangeCallback - Cluster ID: '0x%" PRIx32 "', EndPoint ID: '0x%x', Attribute ID: '0x%" PRIx32 "'",
              clusterId, endpointId, attributeId);
 
     switch (clusterId)

--- a/examples/lighting-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/lighting-app/esp32/main/DeviceCallbacks.cpp
@@ -47,8 +47,7 @@ using namespace chip::app::Clusters;
 void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId,
                                                      uint8_t type, uint16_t size, uint8_t * value)
 {
-    ESP_LOGI(TAG,
-             "PostAttributeChangeCallback - Cluster ID: '0x%04" PRIx32 "', EndPoint ID: '0x%02x', Attribute ID: '0x%04" PRIx32 "'",
+    ESP_LOGI(TAG, "PostAttributeChangeCallback - Cluster ID: '0x%" PRIx32 "', EndPoint ID: '0x%x', Attribute ID: '0x%" PRIx32 "'",
              clusterId, endpointId, attributeId);
 
     switch (clusterId)
@@ -78,7 +77,7 @@ void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Clus
 void AppDeviceCallbacks::OnOnOffPostAttributeChangeCallback(EndpointId endpointId, AttributeId attributeId, uint8_t * value)
 {
     VerifyOrExit(attributeId == OnOff::Attributes::OnOff::Id,
-                 ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%04" PRIx32 "'", attributeId));
+                 ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%" PRIx32 "'", attributeId));
     VerifyOrExit(endpointId == 1, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
 
     AppLED.Set(*value);
@@ -90,7 +89,7 @@ exit:
 void AppDeviceCallbacks::OnLevelControlAttributeChangeCallback(EndpointId endpointId, AttributeId attributeId, uint8_t * value)
 {
     VerifyOrExit(attributeId == LevelControl::Attributes::CurrentLevel::Id,
-                 ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%04" PRIx32 "'", attributeId));
+                 ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%" PRIx32 "'", attributeId));
     VerifyOrExit(endpointId == 1, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
 
     AppLED.SetBrightness(*value);
@@ -107,7 +106,7 @@ void AppDeviceCallbacks::OnColorControlAttributeChangeCallback(EndpointId endpoi
 
     VerifyOrExit(attributeId == ColorControl::Attributes::CurrentHue::Id ||
                      attributeId == ColorControl::Attributes::CurrentSaturation::Id,
-                 ESP_LOGI(TAG, "Unhandled AttributeId ID: '0x%04" PRIx32 "'", attributeId));
+                 ESP_LOGI(TAG, "Unhandled AttributeId ID: '0x%" PRIx32 "'", attributeId));
     VerifyOrExit(endpointId == 1, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
 
     if (attributeId == ColorControl::Attributes::CurrentHue::Id)

--- a/examples/lock-app/esp32/main/CMakeLists.txt
+++ b/examples/lock-app/esp32/main/CMakeLists.txt
@@ -68,7 +68,7 @@ idf_component_register(INCLUDE_DIRS
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/door-lock-server"
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/identify-server"
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/groups-server"
-                     PRIV_REQUIRES bt chip QRCode)
+                     PRIV_REQUIRES bt chip QRCode nvs_flash driver)
 add_dependencies(${COMPONENT_LIB} app-codegen)
 
 set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
@@ -185,7 +185,7 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/identify-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/groups-server"
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/lock"
-                      PRIV_REQUIRES chip QRCode bt)
+                      PRIV_REQUIRES chip QRCode bt nvs_flash driver)
 
 add_dependencies(${COMPONENT_LIB} app-codegen)
 

--- a/examples/lock-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/lock-app/esp32/main/DeviceCallbacks.cpp
@@ -39,8 +39,9 @@ using namespace ::chip::DeviceLayer;
 void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId,
                                                      uint8_t type, uint16_t size, uint8_t * value)
 {
-    ESP_LOGI(TAG, "PostAttributeChangeCallback - Cluster ID: '0x%04x', EndPoint ID: '0x%02x', Attribute ID: '0x%04x'", clusterId,
-             endpointId, attributeId);
+    ESP_LOGI(TAG,
+             "PostAttributeChangeCallback - Cluster ID: '0x%04" PRIx32 "', EndPoint ID: '0x%02x', Attribute ID: '0x%04" PRIx32 "'",
+             clusterId, endpointId, attributeId);
 
     switch (clusterId)
     {
@@ -49,7 +50,7 @@ void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Clus
         break;
 
     default:
-        ESP_LOGI(TAG, "Unhandled cluster ID: %d", clusterId);
+        ESP_LOGI(TAG, "Unhandled cluster ID: %" PRIu32, clusterId);
         break;
     }
 
@@ -59,7 +60,7 @@ void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Clus
 void AppDeviceCallbacks::OnOnOffPostAttributeChangeCallback(EndpointId endpointId, AttributeId attributeId, uint8_t * value)
 {
     VerifyOrExit(attributeId == app::Clusters::OnOff::Attributes::OnOff::Id,
-                 ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%04x", attributeId));
+                 ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%04" PRIx32, attributeId));
     VerifyOrExit(endpointId == 1 || endpointId == 2, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
     if (*value)
     {

--- a/examples/lock-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/lock-app/esp32/main/DeviceCallbacks.cpp
@@ -39,8 +39,7 @@ using namespace ::chip::DeviceLayer;
 void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId,
                                                      uint8_t type, uint16_t size, uint8_t * value)
 {
-    ESP_LOGI(TAG,
-             "PostAttributeChangeCallback - Cluster ID: '0x%04" PRIx32 "', EndPoint ID: '0x%02x', Attribute ID: '0x%04" PRIx32 "'",
+    ESP_LOGI(TAG, "PostAttributeChangeCallback - Cluster ID: '0x%" PRIx32 "', EndPoint ID: '0x%x', Attribute ID: '0x%" PRIx32 "'",
              clusterId, endpointId, attributeId);
 
     switch (clusterId)
@@ -60,7 +59,7 @@ void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Clus
 void AppDeviceCallbacks::OnOnOffPostAttributeChangeCallback(EndpointId endpointId, AttributeId attributeId, uint8_t * value)
 {
     VerifyOrExit(attributeId == app::Clusters::OnOff::Attributes::OnOff::Id,
-                 ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%04" PRIx32, attributeId));
+                 ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%" PRIx32, attributeId));
     VerifyOrExit(endpointId == 1 || endpointId == 2, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
     if (*value)
     {

--- a/examples/lock-app/esp32/main/main.cpp
+++ b/examples/lock-app/esp32/main/main.cpp
@@ -20,7 +20,6 @@
 #include "esp_heap_caps_init.h"
 #include "esp_log.h"
 #include "esp_netif.h"
-#include "esp_spi_flash.h"
 #include "esp_system.h"
 #include "esp_wifi.h"
 #include "freertos/FreeRTOS.h"
@@ -36,8 +35,6 @@
 #include <cstdio>
 #include <string>
 #include <vector>
-
-#include <lib/support/ErrorStr.h>
 
 #if CONFIG_ENABLE_PW_RPC
 #include "PigweedLogger.h"
@@ -82,7 +79,7 @@ static void InitServer(intptr_t context)
     CHIP_ERROR error = GetAppTask().StartAppTask();
     if (error != CHIP_NO_ERROR)
     {
-        ESP_LOGE(TAG, "GetAppTask().StartAppTask() failed: %s", ErrorStr(error));
+        ESP_LOGE(TAG, "GetAppTask().StartAppTask() failed: %" CHIP_ERROR_FORMAT, error.Format());
     }
 }
 
@@ -114,7 +111,7 @@ extern "C" void app_main()
     CHIP_ERROR error              = deviceMgr.Init(&EchoCallbacks);
     if (error != CHIP_NO_ERROR)
     {
-        ESP_LOGE(TAG, "device.Init() failed: %s", ErrorStr(error));
+        ESP_LOGE(TAG, "device.Init() failed: %" CHIP_ERROR_FORMAT, error.Format());
         return;
     }
 

--- a/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
@@ -110,12 +110,12 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
         acceptData.StartOffset  = mTransfer.GetStartOffset();
         acceptData.Length       = mTransfer.GetTransferLength();
         VerifyOrReturn(mTransfer.AcceptTransfer(acceptData) == CHIP_NO_ERROR,
-                       ChipLogError(BDX, "%s: %s", __FUNCTION__, chip::ErrorStr(err)));
+                       ChipLogError(BDX, "AcceptTransfter failed error:%" CHIP_ERROR_FORMAT, err.Format()));
 
         // Store the file designator, used during block query
         uint16_t fdl       = 0;
         const uint8_t * fd = mTransfer.GetFileDesignator(fdl);
-        VerifyOrReturn(fdl < sizeof(mFileDesignator), ChipLogError(BDX, "Cannot store file designator with length = %d", fdl));
+        VerifyOrReturn(fdl < sizeof(mFileDesignator), ChipLogError(BDX, "Cannot store file designator with length = %u", fdl));
         memcpy(mFileDesignator, fd, fdl);
         mFileDesignator[fdl] = 0;
 
@@ -157,7 +157,7 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
 
         if (CHIP_NO_ERROR != mTransfer.PrepareBlock(blockData))
         {
-            ChipLogError(BDX, "%s: PrepareBlock failed: %s", __FUNCTION__, chip::ErrorStr(err));
+            ChipLogError(BDX, "PrepareBlock failed: %" CHIP_ERROR_FORMAT, err.Format());
             mTransfer.AbortTransfer(StatusCode::kUnknown);
         }
         break;
@@ -215,7 +215,7 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
     case TransferSession::OutputEventType::kBlockReceived:
     default:
         // TransferSession should prevent this case from happening.
-        ChipLogError(BDX, "%s: unsupported event type", __FUNCTION__);
+        ChipLogError(BDX, "unsupported event type");
     }
 }
 

--- a/examples/ota-provider-app/esp32/main/CMakeLists.txt
+++ b/examples/ota-provider-app/esp32/main/CMakeLists.txt
@@ -55,7 +55,7 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/providers"
                       EXCLUDE_SRCS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp"
-                      PRIV_REQUIRES chip QRCode bt console spiffs)
+                      PRIV_REQUIRES chip QRCode bt console spiffs spi_flash nvs_flash)
 
 get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 include("${CHIP_ROOT}/build/chip/esp32/esp32_codegen.cmake")

--- a/examples/ota-provider-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/ota-provider-app/esp32/main/DeviceCallbacks.cpp
@@ -35,7 +35,7 @@ void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Clus
 {
     ESP_LOGI(TAG,
              "PostAttributeChangeCallback - Cluster ID: '" ChipLogFormatMEI
-             "', EndPoint ID: '0x%02x', Attribute ID: '" ChipLogFormatMEI "'",
+             "', EndPoint ID: '0x%x', Attribute ID: '" ChipLogFormatMEI "'",
              ChipLogValueMEI(clusterId), endpointId, ChipLogValueMEI(attributeId));
 
     // TODO handle this callback in switch statement

--- a/examples/ota-provider-app/esp32/main/main.cpp
+++ b/examples/ota-provider-app/esp32/main/main.cpp
@@ -26,7 +26,6 @@
 #include <common/Esp32AppServer.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
-#include <lib/support/ErrorStr.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 #include <OTAProviderCommands.h>
@@ -89,7 +88,7 @@ static void InitServer(intptr_t context)
         chip::Protocols::BDX::Id, bdxOtaSender);
     if (error != CHIP_NO_ERROR)
     {
-        ESP_LOGE(TAG, "RegisterUnsolicitedMessageHandler failed: %s", chip::ErrorStr(error));
+        ESP_LOGE(TAG, "RegisterUnsolicitedMessageHandler failed: %" CHIP_ERROR_FORMAT, error.Format());
         return;
     }
 
@@ -114,7 +113,7 @@ static void InitServer(intptr_t context)
     }
     size_t total = 0, used = 0;
     err = esp_spiffs_info(NULL, &total, &used);
-    ESP_LOGI(TAG, "Partition size: total: %d, used: %d", total, used);
+    ESP_LOGI(TAG, "Partition size: total: %u, used: %u", total, used);
     char otaImagePath[kMaxImagePathlen];
     memset(otaImagePath, 0, sizeof(otaImagePath));
     snprintf(otaImagePath, sizeof(otaImagePath), "/fs/%s", otaFilename);
@@ -129,7 +128,7 @@ static void InitServer(intptr_t context)
     fseek(otaImageFile, 0, SEEK_END);
     otaImageLen = ftell(otaImageFile);
     rewind(otaImageFile);
-    ESP_LOGI(TAG, "The OTA image size: %d", otaImageLen);
+    ESP_LOGI(TAG, "The OTA image size: %" PRIu32, otaImageLen);
     if (otaImageLen > 0)
     {
         otaProvider.SetQueryImageStatus(OTAQueryStatus::kUpdateAvailable);
@@ -203,12 +202,12 @@ CHIP_ERROR OnBlockQuery(void * context, chip::System::PacketBufferHandle & block
     size_t size_read = fread(blockBuf->Start(), 1, size, otaImageFile);
     if (size_read != size)
     {
-        ESP_LOGE(TAG, "Failed to read %d bytes from %s", size, otaFilename);
+        ESP_LOGE(TAG, "Failed to read %u bytes from %s", size, otaFilename);
         size  = 0;
         isEof = false;
         return CHIP_ERROR_READ_FAILED;
     }
-    ESP_LOGI(TAG, "Read %d bytes from %s", size, otaFilename);
+    ESP_LOGI(TAG, "Read %u bytes from %s", size, otaFilename);
     return CHIP_NO_ERROR;
 }
 
@@ -253,7 +252,7 @@ extern "C" void app_main()
     CHIP_ERROR error = deviceMgr.Init(&EchoCallbacks);
     if (error != CHIP_NO_ERROR)
     {
-        ESP_LOGE(TAG, "device.Init() failed: %s", ErrorStr(error));
+        ESP_LOGE(TAG, "device.Init() failed: %" CHIP_ERROR_FORMAT, error.Format());
         return;
     }
 

--- a/examples/ota-provider-app/esp32/partitions.csv
+++ b/examples/ota-provider-app/esp32/partitions.csv
@@ -2,7 +2,7 @@
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
 nvs,      data, nvs,     ,        0x6000,
 phy_init, data, phy,     ,        0x1000,
-# Factory partition size about 1.5MB
-factory,  app,  factory, ,        1500K,
-# spiffs partition to storage the image file size about 1.5MB
-img_storage,  data, spiffs,     ,     1500K,
+# Factory partition size about 1.6MB
+factory,  app,  factory, ,        1600K,
+# spiffs partition to storage the image file size about 1.6MB
+img_storage,  data, spiffs,     ,     1600K,

--- a/examples/ota-requestor-app/esp32/main/CMakeLists.txt
+++ b/examples/ota-requestor-app/esp32/main/CMakeLists.txt
@@ -63,7 +63,7 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/providers"
 )
 
-set(PRIV_REQUIRES_LIST chip QRCode bt console app_update)
+set(PRIV_REQUIRES_LIST chip QRCode bt console app_update nvs_flash)
 
 if (CONFIG_ENABLE_PW_RPC)
 # Append additional directories for RPC build

--- a/examples/ota-requestor-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/ota-requestor-app/esp32/main/DeviceCallbacks.cpp
@@ -35,7 +35,7 @@ void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Clus
 {
     ESP_LOGI(TAG,
              "PostAttributeChangeCallback - Cluster ID: '" ChipLogFormatMEI
-             "', EndPoint ID: '0x%02x', Attribute ID: '" ChipLogFormatMEI "'",
+             "', EndPoint ID: '0x%x', Attribute ID: '" ChipLogFormatMEI "'",
              ChipLogValueMEI(clusterId), endpointId, ChipLogValueMEI(attributeId));
 
     // TODO handle this callback in switch statement

--- a/examples/ota-requestor-app/esp32/main/main.cpp
+++ b/examples/ota-requestor-app/esp32/main/main.cpp
@@ -21,7 +21,6 @@
 #include "esp_heap_caps_init.h"
 #include "esp_log.h"
 #include "esp_netif.h"
-#include "esp_spi_flash.h"
 #include "esp_system.h"
 #include "esp_wifi.h"
 #include "freertos/FreeRTOS.h"
@@ -32,7 +31,6 @@
 #include <common/Esp32AppServer.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
-#include <lib/support/ErrorStr.h>
 #include <ota/OTAHelper.h>
 #include <shell_extension/launch.h>
 
@@ -128,17 +126,6 @@ extern "C" void app_main()
 
     ESP_LOGI(TAG, "OTA Requester!");
 
-    /* Print chip information */
-    esp_chip_info_t chip_info;
-    esp_chip_info(&chip_info);
-    ESP_LOGI(TAG, "This is ESP32 chip with %d CPU cores, WiFi%s%s, ", chip_info.cores,
-             (chip_info.features & CHIP_FEATURE_BT) ? "/BT" : "", (chip_info.features & CHIP_FEATURE_BLE) ? "/BLE" : "");
-
-    ESP_LOGI(TAG, "silicon revision %d, ", chip_info.revision);
-
-    ESP_LOGI(TAG, "%dMB %s flash\n", spi_flash_get_chip_size() / (1024 * 1024),
-             (chip_info.features & CHIP_FEATURE_EMB_FLASH) ? "embedded" : "external");
-
     // Initialize the ESP NVS layer.
     esp_err_t err = nvs_flash_init();
     if (err != ESP_OK)
@@ -159,7 +146,7 @@ extern "C" void app_main()
     CHIP_ERROR error = deviceMgr.Init(&EchoCallbacks);
     if (error != CHIP_NO_ERROR)
     {
-        ESP_LOGE(TAG, "device.Init() failed: %s", ErrorStr(error));
+        ESP_LOGE(TAG, "device.Init() failed: %" CHIP_ERROR_FORMAT, error.Format());
         return;
     }
 

--- a/examples/temperature-measurement-app/esp32/main/CMakeLists.txt
+++ b/examples/temperature-measurement-app/esp32/main/CMakeLists.txt
@@ -55,7 +55,7 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/providers"
 )
 
-set(PRIV_REQUIRES_LIST chip QRCode bt)
+set(PRIV_REQUIRES_LIST chip QRCode bt nvs_flash)
 
 if (CONFIG_ENABLE_PW_RPC)
 # Append additional directories for RPC build

--- a/examples/temperature-measurement-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/temperature-measurement-app/esp32/main/DeviceCallbacks.cpp
@@ -33,8 +33,7 @@ using namespace ::chip::System;
 void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId,
                                                      uint8_t type, uint16_t size, uint8_t * value)
 {
-    ESP_LOGI(TAG,
-             "PostAttributeChangeCallback - Cluster ID: '0x%04" PRIx32 "', EndPoint ID: '0x%02x', Attribute ID: '0x%04" PRIx32 "'",
+    ESP_LOGI(TAG, "PostAttributeChangeCallback - Cluster ID: '0x%" PRIx32 "', EndPoint ID: '0x%x', Attribute ID: '0x%" PRIx32 "'",
              clusterId, endpointId, attributeId);
 
     // TODO handle this callback in switch statement

--- a/examples/temperature-measurement-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/temperature-measurement-app/esp32/main/DeviceCallbacks.cpp
@@ -33,11 +33,12 @@ using namespace ::chip::System;
 void AppDeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId,
                                                      uint8_t type, uint16_t size, uint8_t * value)
 {
-    ESP_LOGI(TAG, "PostAttributeChangeCallback - Cluster ID: '0x%04x', EndPoint ID: '0x%02x', Attribute ID: '0x%04x'", clusterId,
-             endpointId, attributeId);
+    ESP_LOGI(TAG,
+             "PostAttributeChangeCallback - Cluster ID: '0x%04" PRIx32 "', EndPoint ID: '0x%02x', Attribute ID: '0x%04" PRIx32 "'",
+             clusterId, endpointId, attributeId);
 
     // TODO handle this callback in switch statement
-    ESP_LOGI(TAG, "Unhandled cluster ID: %d", clusterId);
+    ESP_LOGI(TAG, "Unhandled cluster ID: %" PRIu32, clusterId);
 
     ESP_LOGI(TAG, "Current free heap: %d\n", heap_caps_get_free_size(MALLOC_CAP_8BIT));
 }

--- a/examples/temperature-measurement-app/esp32/main/main.cpp
+++ b/examples/temperature-measurement-app/esp32/main/main.cpp
@@ -19,7 +19,6 @@
 #include "esp_heap_caps_init.h"
 #include "esp_log.h"
 #include "esp_netif.h"
-#include "esp_spi_flash.h"
 #include "esp_system.h"
 #include "esp_wifi.h"
 #include "freertos/FreeRTOS.h"
@@ -35,8 +34,6 @@
 #include <cstdio>
 #include <string>
 #include <vector>
-
-#include <lib/support/ErrorStr.h>
 
 #if CONFIG_ENABLE_PW_RPC
 #include "Rpc.h"
@@ -85,18 +82,6 @@ extern "C" void app_main()
 
     ESP_LOGI(TAG, "Temperature sensor!");
 
-    /* Print chip information */
-    esp_chip_info_t chip_info;
-    esp_chip_info(&chip_info);
-
-    ESP_LOGI(TAG, "This is ESP32 chip with %d CPU cores, WiFi%s%s, ", chip_info.cores,
-             (chip_info.features & CHIP_FEATURE_BT) ? "/BT" : "", (chip_info.features & CHIP_FEATURE_BLE) ? "/BLE" : "");
-
-    ESP_LOGI(TAG, "silicon revision %d, ", chip_info.revision);
-
-    ESP_LOGI(TAG, "%dMB %s flash\n", spi_flash_get_chip_size() / (1024 * 1024),
-             (chip_info.features & CHIP_FEATURE_EMB_FLASH) ? "embedded" : "external");
-
     // Initialize the ESP NVS layer.
     esp_err_t err = nvs_flash_init();
     if (err != ESP_OK)
@@ -112,7 +97,7 @@ extern "C" void app_main()
     CHIP_ERROR error = deviceMgr.Init(&EchoCallbacks);
     if (error != CHIP_NO_ERROR)
     {
-        ESP_LOGE(TAG, "device.Init() failed: %s", ErrorStr(error));
+        ESP_LOGE(TAG, "device.Init() failed: %" CHIP_ERROR_FORMAT, error.Format());
         return;
     }
 


### PR DESCRIPTION
####  Problem
Fixes https://github.com/project-chip/connectedhomeip/issues/24576

#### Change Overview
Added support for esp-idf v5.0 in ota-requestor-app, ota-provider-app, temperature-measurement-app, lock-app, and chef-app.

In a nutshell:

- Fixed few format specifier
- Changed ErrorStr to err.Format()
- Added components to required list. In v4.4.4 these made it to list somehow through some other component's global requirement list but, those are not made private and hence needed to be added explicitly.

#### Testing
Successfully compiled above apps for esp32c3 on idf v5.0 and v4.4.3