### PR TITLE
Fixed Bridge App ZAP File

### DIFF
--- a/examples/bridge-app/bridge-common/bridge-app.zap
+++ b/examples/bridge-app/bridge-common/bridge-app.zap
@@ -2371,27 +2371,6 @@
           ],
           "events": [
             {
-              "name": "HardwareFaultChange",
-              "code": 0,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "RadioFaultChange",
-              "code": 1,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "NetworkFaultChange",
-              "code": 2,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
               "name": "BootReason",
               "code": 3,
               "mfgCode": null,
@@ -3598,22 +3577,6 @@
               "minInterval": 0,
               "maxInterval": 65344,
               "reportableChange": 0
-            }
-          ],
-          "events": [
-            {
-              "name": "ConnectionStatus",
-              "code": 0,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "NetworkFaultChange",
-              "code": 1,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
             }
           ]
         },
@@ -5779,13 +5742,6 @@
             {
               "name": "StateChanged",
               "code": 0,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "ActionFailed",
-              "code": 1,
               "mfgCode": null,
               "side": "server",
               "included": 1


### PR DESCRIPTION
  - Removed events from General Diagnostics Cluster, which are not implemented for this app.
  - Removed all Thread Network Diagnostics Cluster events, which are currently not implemented in the SDK at all.
  - Removed ActionFailed event from the Actions Cluster, which is not implemented in the SDK. 

NOTE: ActionFailed is marked as Mandatory in the spec. Need either to update the spec to mark it optional or to open SDK ticket to request implementation.

These more detailed cleanup are following changes in PR #24862