### PR TITLE
Adding required fields for Thermostat App

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,7 +66,6 @@ jobs:
                      #       Issues exist for most of them:
                      #       https://github.com/project-chip/connectedhomeip/issues/19180
                      #       https://github.com/project-chip/connectedhomeip/issues/19176
-                     #       https://github.com/project-chip/connectedhomeip/issues/19175
                      #       https://github.com/project-chip/connectedhomeip/issues/19173
                      #       https://github.com/project-chip/connectedhomeip/issues/19169
                      #       https://github.com/project-chip/connectedhomeip/issues/22640
@@ -94,7 +93,6 @@ jobs:
                      if [ "$idl_file" = './examples/log-source-app/log-source-common/log-source-app.matter' ]; then continue; fi
                      if [ "$idl_file" = './examples/placeholder/linux/apps/app1/config.matter' ]; then continue; fi
                      if [ "$idl_file" = './examples/placeholder/linux/apps/app2/config.matter' ]; then continue; fi
-                     if [ "$idl_file" = './examples/thermostat/thermostat-common/thermostat.matter' ]; then continue; fi
                      if [ "$idl_file" = './examples/window-app/common/window-app.matter' ]; then continue; fi
 
                      # Test files are intentionally small and not spec-compilant, just parse-compliant

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -1267,6 +1267,8 @@ server cluster EthernetNetworkDiagnostics = 55 {
   readonly attribute attrib_id attributeList[] = 65531;
   readonly attribute bitmap32 featureMap = 65532;
   readonly attribute int16u clusterRevision = 65533;
+
+  command ResetCounts(): DefaultSuccess = 0;
 }
 
 server cluster AdministratorCommissioning = 60 {
@@ -1626,6 +1628,7 @@ endpoint 0 {
 
   server cluster Identify {
     ram      attribute identifyTime;
+    ram      attribute identifyType;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 4;
   }

--- a/examples/thermostat/thermostat-common/thermostat.zap
+++ b/examples/thermostat/thermostat-common/thermostat.zap
@@ -83,6 +83,22 @@
           "enabled": 1,
           "attributes": [
             {
+              "name": "IdentifyType",
+              "code": 1,
+              "mfgCode": null,
+              "side": "server",
+              "type": "enum8",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0x0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "IdentifyTime",
               "code": 0,
               "mfgCode": null,
@@ -4293,7 +4309,7 @@
               "code": 0,
               "mfgCode": null,
               "source": "client",
-              "incoming": 0,
+              "incoming": 1,
               "outgoing": 1
             }
           ],


### PR DESCRIPTION
Fixes linting errors called out by:

`./scripts/idl_lint.py --log-level warn ./examples/thermostat/thermostat-common/thermostat.matter`

Errors:
```
2023-02-10 19:22:38 ERROR   ERROR: Required attributes: EP0:Identify does not expose IdentifyType(1) attribute at ./examples/thermostat/thermostat-common/thermostat.matter:1627:3
2023-02-10 19:22:38 ERROR   ERROR: Required commands: Cluster EthernetNetworkDiagnostics does not define mandatory command ResetCounts(0) at ./examples/thermostat/thermostat-common/thermostat.matter:1236:1
2023-02-10 19:22:38 ERROR   Found 2 lint errors
```

Closes #19175