### PR TITLE
Enables loopback mode where CMD is NULL

### DIFF
--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -344,7 +344,7 @@ EmberStatus emberAfSendImmediateDefaultResponse(EmberAfStatus status)
 EmberStatus emberAfSendDefaultResponse(const EmberAfClusterCommand * cmd, EmberAfStatus status)
 {
     // Default Response commands are only sent in response to unicast commands.
-    if (cmd->type != EMBER_INCOMING_UNICAST && cmd->type != EMBER_INCOMING_UNICAST_REPLY)
+    if ((cmd == NULL) || (cmd->type != EMBER_INCOMING_UNICAST && cmd->type != EMBER_INCOMING_UNICAST_REPLY))
     {
         return EMBER_SUCCESS;
     }


### PR DESCRIPTION
This change allows the emberAf... API to be directly called from the esp-matter code.  This is needed for the binding case where the command is send out to the bound device but also needs to be processed locally. If CHIP supported loopback then the command would come back over loopback and trigger the appropriate emberAf... call. But CHIP doesn't support loopback so you have to make the local emberAf... call yourself.  

