### PR TITLE
[Android] Fix navigation issue within Android CHIPTool (phase I)

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -28,7 +28,6 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import com.google.chip.chiptool.NetworkCredentialsParcelable
 import chip.setuppayload.SetupPayload
 import chip.setuppayload.SetupPayloadParser
 import chip.setuppayload.SetupPayloadParser.UnrecognizedQrCodeException
@@ -71,7 +70,7 @@ class CHIPToolActivity :
       val fragment = SelectActionFragment.newInstance()
       supportFragmentManager
           .beginTransaction()
-          .add(R.id.fragment_container, fragment, fragment.javaClass.simpleName)
+          .add(R.id.nav_host_fragment, fragment, fragment.javaClass.simpleName)
           .commit()
     } else {
       networkType =
@@ -116,26 +115,16 @@ class CHIPToolActivity :
     showFragment(SelectActionFragment.newInstance(), false)
   }
 
-  override fun handleScanQrCodeClicked() {
-    showFragment(BarcodeFragment.newInstance())
-  }
-
-  override fun onProvisionWiFiCredentialsClicked() {
-    networkType = ProvisionNetworkType.WIFI
-    showFragment(BarcodeFragment.newInstance(), false)
-  }
-
-  override fun onProvisionThreadCredentialsClicked() {
-    networkType = ProvisionNetworkType.THREAD
-    showFragment(BarcodeFragment.newInstance(), false)
-  }
-
   override fun onShowDeviceAddressInput() {
     showFragment(AddressCommissioningFragment.newInstance(), false)
   }
 
   override fun onNetworkCredentialsEntered(networkCredentials: NetworkCredentialsParcelable) {
     showFragment(DeviceProvisioningFragment.newInstance(deviceInfo!!, networkCredentials))
+  }
+
+  override fun handleScanQrCodeClicked() {
+    showFragment(BarcodeFragment.newInstance(), false)
   }
 
   override fun handleClusterInteractionClicked() {
@@ -179,17 +168,18 @@ class CHIPToolActivity :
     startActivity(redirectIntent)
   }
 
-  override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-    super.onActivityResult(requestCode, resultCode, data)
-
-    if (requestCode == REQUEST_CODE_COMMISSIONING) {
-      // Simply ignore the commissioning result.
-      // TODO: tracking commissioned devices.
-    }
+  override fun handleProvisionWiFiCredentialsClicked() {
+    networkType = ProvisionNetworkType.WIFI
+    showFragment(BarcodeFragment.newInstance(), false)
   }
 
-  override fun handleCustomFlowClicked() {
-    showFragment(BarcodeFragment.newInstance())
+  override fun handleProvisionThreadCredentialsClicked() {
+    networkType = ProvisionNetworkType.THREAD
+    showFragment(BarcodeFragment.newInstance(), false)
+  }
+
+  override fun handleProvisionCustomFlowClicked() {
+    showFragment(BarcodeFragment.newInstance(), false)
   }
 
   override fun handleUnpairDeviceClicked() {
@@ -199,7 +189,7 @@ class CHIPToolActivity :
   private fun showFragment(fragment: Fragment, showOnBack: Boolean = true) {
     val fragmentTransaction = supportFragmentManager
         .beginTransaction()
-        .replace(R.id.fragment_container, fragment, fragment.javaClass.simpleName)
+        .replace(R.id.nav_host_fragment, fragment, fragment.javaClass.simpleName)
 
     if (showOnBack) {
       fragmentTransaction.addToBackStack(null)

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/SelectActionFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/SelectActionFragment.kt
@@ -45,11 +45,11 @@ class SelectActionFragment : Fragment() {
       scanQrBtn.setOnClickListener { getCallback()?.handleScanQrCodeClicked() }
       provisionWiFiCredentialsBtn.apply {
         isEnabled = hasLocationPermission()
-        setOnClickListener { getCallback()?.onProvisionWiFiCredentialsClicked() }
+        setOnClickListener { getCallback()?.handleProvisionWiFiCredentialsClicked() }
       }
       provisionThreadCredentialsBtn.apply {
         isEnabled = hasLocationPermission()
-        setOnClickListener { getCallback()?.onProvisionThreadCredentialsClicked() }
+        setOnClickListener { getCallback()?.handleProvisionThreadCredentialsClicked() }
       }
       onOffClusterBtn.setOnClickListener { getCallback()?.handleOnOffClicked() }
       sensorClustersBtn.setOnClickListener { getCallback()?.handleSensorClicked() }
@@ -58,7 +58,7 @@ class SelectActionFragment : Fragment() {
       basicClusterBtn.setOnClickListener { getCallback()?.handleBasicClicked() }
       attestationTestBtn.setOnClickListener { getCallback()?.handleAttestationTestClicked() }
       clusterInteractionBtn.setOnClickListener { getCallback()?.handleClusterInteractionClicked() }
-      provisionCustomFlowBtn.setOnClickListener{  getCallback()?.handleCustomFlowClicked() }
+      provisionCustomFlowBtn.setOnClickListener{  getCallback()?.handleProvisionCustomFlowClicked() }
       wildcardBtn.setOnClickListener { getCallback()?.handleWildcardClicked() }
       unpairDeviceBtn.setOnClickListener{ getCallback()?.handleUnpairDeviceClicked() }
     }
@@ -134,10 +134,6 @@ class SelectActionFragment : Fragment() {
   interface Callback {
     /** Notifies listener of Scan QR code button click. */
     fun handleScanQrCodeClicked()
-    /** Notifies listener of provision-WiFi-credentials button click. */
-    fun onProvisionWiFiCredentialsClicked()
-    /** Notifies listener of provision-Thread-credentials button click. */
-    fun onProvisionThreadCredentialsClicked()
     /** Notifies listener of Light On/Off & Level Cluster button click. */
     fun handleOnOffClicked()
     /** Notifies listener of Sensor Clusters button click. */
@@ -156,8 +152,12 @@ class SelectActionFragment : Fragment() {
     fun handleClusterInteractionClicked()
     /** Notifies listener of wildcard button click. */
     fun handleWildcardClicked()
+    /** Notifies listener of provision-WiFi-credentials button click. */
+    fun handleProvisionWiFiCredentialsClicked()
+    /** Notifies listener of provision-Thread-credentials button click. */
+    fun handleProvisionThreadCredentialsClicked()
     /** Notifies listener of provision-custom-flow button click. */
-    fun handleCustomFlowClicked()
+    fun handleProvisionCustomFlowClicked()
     /** Notifies listener of unpair button click. */
     fun handleUnpairDeviceClicked()
   }

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
@@ -45,7 +45,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Runnable
 import kotlinx.coroutines.launch
-import java.lang.IllegalArgumentException
 
 @ExperimentalCoroutinesApi
 class DeviceProvisioningFragment : Fragment() {
@@ -74,7 +73,7 @@ class DeviceProvisioningFragment : Fragment() {
     scope = viewLifecycleOwner.lifecycleScope
     deviceInfo = checkNotNull(requireArguments().getParcelable(ARG_DEVICE_INFO))
     
-    return inflater.inflate(R.layout.single_fragment_container, container, false).apply {
+    return inflater.inflate(R.layout.barcode_fragment, container, false).apply {
       if (savedInstanceState == null) {
         if (deviceInfo.ipAddress != null) {
           pairDeviceWithAddress()

--- a/examples/android/CHIPTool/app/src/main/res/layout/single_fragment_container.xml
+++ b/examples/android/CHIPTool/app/src/main/res/layout/single_fragment_container.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    android:id="@+id/fragment_container"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"/>

--- a/examples/android/CHIPTool/app/src/main/res/layout/top_activity.xml
+++ b/examples/android/CHIPTool/app/src/main/res/layout/top_activity.xml
@@ -1,4 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/fragment_container"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"/>
+    android:layout_height="match_parent"
+    tools:context=".CHIPToolActivity">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>


### PR DESCRIPTION
**Problem**

1. Click "SCAN QR CODE" -> "INPUT DEVICE ADDRESS"
2. Click back button w/o commission
Expected: The app should go back to 'SCAN QR CODE' screen
Actual: The app go back to 'SELECT ACTION' screen and with "INPUT DEVICE ADDRESS" screen overlapping on it

All other similar user cases has the same problem, the navigation behavior of Android CHIPTool is broken.
 
**Solution**

Currently, Android CHIPTool programmatically add all fragments to an FrameLayout, and then load the FrameLayout to CHIPToolActivity, it does not have any logic to properly handle the navigation.

From https://developer.android.com/guide/fragments/create

We should always use a FragmentContainerView as the container for fragments, as FragmentContainerView includes fixes specific to fragments that other view groups such as FrameLayout do not provide, and using the [Navigation library](https://developer.android.com/guide/navigation) to manage your app's navigation. 

This PR contains the first part of this solution, using FragmentContainerView as the container to manage fragments. The follow-up PR will use [Navigation library] to manage the Android CHIPTool's navigation. 

