### PR TITLE
[ESP32] Fixed compilation with Bluedroid related errors for all-clusters-app.

### DIFF
--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -34,6 +34,7 @@
 #include <app/util/basic-types.h>
 #include <app/util/util.h>
 #include <common/CHIPDeviceManager.h>
+#include <esp_log.h>
 #include <lib/dnssd/Advertiser.h>
 
 #if CONFIG_DEVICE_TYPE_ESP32_C3_DEVKITM

--- a/examples/platform/esp32/lock/BoltLockManager.cpp
+++ b/examples/platform/esp32/lock/BoltLockManager.cpp
@@ -21,6 +21,7 @@
 #include "AppTask.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <cstring>
+#include <esp_log.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 BoltLockManager BoltLockManager::sLock;


### PR DESCRIPTION
This PR aims to fix the compilation errors in compilation of all-clusters-app with Bluedroid.
**Problem:**
The compilation of all-clusters-app was failing when compiled with Bluedroid as the option set in the menuconfig for Bluetooth host on ESP32 platform.

**Change Overview:**
Included the log library <esp_log.h> to fix the log related errors encountered  in examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp and examples/platform/esp32/lock/BoltLockManager.cpp.

**Testing**
Successfully compiled the all-clusters-app for esp32c3 with Bluedroid as the option set in the menuconfig for Bluetooth host.