### PR TITLE
[crypto] Fix compile error in BufferWriter init

### DIFF
--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -682,7 +682,7 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
     psa_status_t status                   = PSA_SUCCESS;
     const PSAP256KeypairContext & context = toConstPSAContext(mKeypair);
     const size_t outputSize               = output.Length() == 0 ? output.Capacity() : output.Length();
-    Encoding::BufferWriter bbuf(output, outputSize);
+    Encoding::BufferWriter bbuf(output.Bytes(), outputSize);
     uint8_t privateKey[kP256_PrivateKey_Length];
     size_t privateKeyLength = 0;
 


### PR DESCRIPTION
Issue:
In [CHIPCryptoPALPSA.cpp](https://github.com/project-chip/connectedhomeip/compare/master...crypto/buffer_writer_init?quick_pull=1#diff-f24e8582942bc701f5148117fd80d328395f7738c586d9e1c36e76e7f30f0099)

BufferWriter class expects a (uint8_t*, size_t) as initialization. The given parameter `output` was a `P256SerializedKeypair` which throws a compiler error.

Output: used compiler - gcc-arm-none-eabi-9-2019-q4-major

```
In member function 'virtual CHIP_ERROR chip::Crypto::P256Keypair::Serialize(chip::Crypto::P256SerializedKeypair&) const': .../src/crypto/CHIPCryptoPALPSA.cpp:685:51: 
error: no matching function for call to 'chip::Encoding::BufferWriter::BufferWriter(chip::Crypto::P256SerializedKeypair&, const size_t&)'
  685 |     Encoding::BufferWriter bbuf(output, outputSize);
```
Fix:
Use the `Bytes` method to expose a uint8_t* for use of the BufferWriter.
