### PR TITLE
Do not install matter yamltests in env (this has sideffects and cause…

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -120,10 +120,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
   }
 
   pw_python_pip_install("pip_install_matter_packages") {
-    packages = [
-      "//examples/common/pigweed/rpc_console:chip_rpc_distribution",
-      "//scripts:matter_yamltests_distribution",
-    ]
+    packages = [ "//examples/common/pigweed/rpc_console:chip_rpc_distribution" ]
   }
 
   # Python packages installed during bootstrap.

--- a/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
+++ b/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
@@ -27,6 +27,19 @@ import chip.FabricAdmin  # Needed before chip.CertificateAuthority
 
 # isort: on
 
+# ensure matter IDL is availale for import, otherwise set relative paths
+try:
+    from matter_idl import matter_idl_types
+except:
+    SCRIPT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
+    import sys
+
+    sys.path.append(os.path.join(SCRIPT_PATH, 'py_matter_idl'))
+    sys.path.append(os.path.join(SCRIPT_PATH, 'py_matter_yamltests'))
+
+    from matter_idl import matter_idl_types
+
+
 import chip.CertificateAuthority
 import chip.native
 import click


### PR DESCRIPTION
…s codegen.py confusion)


Errors like:

```
2023-02-13 13:20:35 INFO    Parsing idl from ../../../examples/all-clusters-app/linux/third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
2023-02-13 13:20:36 INFO    Running code generator cpp-app
Traceback (most recent call last):
  File "/Users/bzbarsky/connectedhomeip/out/debug/standalone/../../../examples/all-clusters-app/linux/third_party/connectedhomeip/scripts/codegen.py", line 165, in <module>
    main(auto_envvar_prefix='CHIP')
  File "/Users/bzbarsky/connectedhomeip/.environment/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/bzbarsky/connectedhomeip/.environment/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/bzbarsky/connectedhomeip/.environment/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/bzbarsky/connectedhomeip/.environment/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/bzbarsky/connectedhomeip/out/debug/standalone/../../../examples/all-clusters-app/linux/third_party/connectedhomeip/scripts/codegen.py", line 136, in main
    generator = CodeGenerator.FromString(generator).Create(storage, idl=idl_tree, plugin_module=plugin_module)
  File "/Users/bzbarsky/connectedhomeip/.environment/pigweed-venv/lib/python3.9/site-packages/matter_idl/generators/registry.py", line 38, in Create
    return CppApplicationGenerator(*args, **kargs)
TypeError: __init__() got an unexpected keyword argument 'plugin_module'
[18/713] ACTION //third_party/connectedhomeip/examples/all-clusters-app/all-...zap_pregen(//third_party/connectedhomeip/build/toolchain/host:mac_arm64_gcc)
ninja: build stopped: subcommand failed.
```

are not obviously "old matter idl in build env".
In GN we could add a dependency on codegen.py to require install of deps in the env first, however I am unsure if this problem is easily solvable in cmake ... so I would rather not pollute the env in the first place.

I am also skeptic on the rpc_console install ... but for now keeping that.
