### PR TITLE
Stop sending status responses from inside findUserIndexByCredential.

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -1662,7 +1662,6 @@ bool DoorLockServer::findUserIndexByCredential(chip::EndpointId endpointId, Cred
         if (!emberAfPluginDoorLockGetUser(endpointId, i, user))
         {
             ChipLogError(Zcl, "[GetCredentialStatus] Unable to get user: app error [userIndex=%d]", i);
-            emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
             return false;
         }
 
@@ -1701,7 +1700,6 @@ bool DoorLockServer::findUserIndexByCredential(chip::EndpointId endpointId, Cred
         if (!emberAfPluginDoorLockGetUser(endpointId, i, user))
         {
             ChipLogError(Zcl, "[findUserIndexByCredential] Unable to get user: app error [userIndex=%d]", i);
-            emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
             return false;
         }
 
@@ -1725,7 +1723,6 @@ bool DoorLockServer::findUserIndexByCredential(chip::EndpointId endpointId, Cred
                              "[findUserIndexByCredential] Unable to get credential: app error "
                              "[userIndex=%d,credentialIndex=%d,credentialType=%u]",
                              i, credential.CredentialIndex, to_underlying(credentialType));
-                emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
                 return false;
             }
 
@@ -1736,7 +1733,6 @@ bool DoorLockServer::findUserIndexByCredential(chip::EndpointId endpointId, Cred
                              "not occupied "
                              "[userIndex=%d,credentialIndex=%d,credentialType=%u]",
                              i, credential.CredentialIndex, to_underlying(credentialType));
-                emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
                 return false;
             }
 


### PR DESCRIPTION
A utility function to look up information shoud not be sending status responses that would override what its callers might want to do with that information.

findUserIndexByCredential has the following callers:

* getCredentialStatusCommandHandler: this sends an error response if findUserIndexByCredential returns false.
* modifyProgrammingPIN: this returns a failure status if findUserIndexByCredential returns false, and its only callsite in DoorLockServer::setCredentialCommandHandler then sends a status response.
* DoorLockServer::clearCredential: this returns a failure status if findUserIndexByCredential returns false, and its callers in DoorLockServer::clearCredentialCommandHandler then send a status response.
* DoorLockServer::HandleRemoteLockOperation: this sends an error response if findUserIndexByCredential returns false.
