### PR TITLE
Light UI updates - add level and color control UI Information

### DIFF
--- a/examples/lighting-app/linux/ui.cpp
+++ b/examples/lighting-app/linux/ui.cpp
@@ -332,9 +332,9 @@ void UiInit(SDL_GLContext * gl_context, SDL_Window ** window)
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
-    SDL_WindowFlags window_flags = (SDL_WindowFlags) (SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+    SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
     *window     = SDL_CreateWindow("Dear ImGui SDL2+OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720,
-                                   window_flags);
+                               window_flags);
     *gl_context = SDL_GL_CreateContext(*window);
     SDL_GL_MakeCurrent(*window, *gl_context);
     SDL_GL_SetSwapInterval(1); // Enable vsync

--- a/examples/lighting-app/linux/ui.cpp
+++ b/examples/lighting-app/linux/ui.cpp
@@ -26,7 +26,6 @@
 #include <setup_payload/SetupPayload.h>
 
 #include <app-common/zap-generated/attributes/Accessors.h>
-#include <app/util/attribute-storage.h>
 
 #include <SDL.h>
 #include <SDL_opengl.h>

--- a/examples/lighting-app/linux/ui.cpp
+++ b/examples/lighting-app/linux/ui.cpp
@@ -74,8 +74,9 @@ private:
     uint8_t mQRData[kMaxQRBufferSize] = { 0 };
 
     // light data:
-    bool mLightIsOn       = false;
-    uint8_t mCurrentLevel = 0;
+    bool mLightIsOn                      = false;
+    uint8_t mCurrentLevel                = 0;
+    uint16_t mLevelRemainingTime10sOfSec = 0;
 
     // Updates the data (run in the chip event loop)
     void ChipLoopUpdate();
@@ -155,7 +156,8 @@ void DeviceState::ShowUi()
     }
 
     ImGui::Text("Level Control:");
-    ImGui::Text("    Current Level: %d", mCurrentLevel);
+    ImGui::Text("    Current Level:          %d", mCurrentLevel);
+    ImGui::Text("    Remaining Time (1/10s): %d", mLevelRemainingTime10sOfSec);
 
     ImGui::End();
 
@@ -246,6 +248,10 @@ void DeviceState::ChipLoopUpdate()
         emberAfReadServerAttribute(kLightEndpointId, chip::app::Clusters::LevelControl::Id,
                                    chip::app::Clusters::LevelControl::Attributes::CurrentLevel::Id, &mCurrentLevel,
                                    sizeof(mCurrentLevel));
+
+        emberAfReadServerAttribute(kLightEndpointId, chip::app::Clusters::LevelControl::Id,
+                                   chip::app::Clusters::LevelControl::Attributes::RemainingTime::Id,
+                                   reinterpret_cast<uint8_t *>(&mLevelRemainingTime10sOfSec), sizeof(mLevelRemainingTime10sOfSec));
     }
 }
 

--- a/examples/lighting-app/linux/ui.cpp
+++ b/examples/lighting-app/linux/ui.cpp
@@ -271,29 +271,15 @@ void DeviceState::ChipLoopUpdate()
 
         // Level Control
         LevelControl::Attributes::CurrentLevel::Get(kLightEndpointId, mCurrentLevel);
-
-        emberAfReadAttribute(kLightEndpointId, chip::app::Clusters::LevelControl::Id,
-                             chip::app::Clusters::LevelControl::Attributes::MinLevel::Id, &mMinLevel, sizeof(mMinLevel));
-
-        emberAfReadAttribute(kLightEndpointId, chip::app::Clusters::LevelControl::Id,
-                             chip::app::Clusters::LevelControl::Attributes::MaxLevel::Id, &mMaxLevel, sizeof(mMaxLevel));
-
-        emberAfReadAttribute(kLightEndpointId, chip::app::Clusters::LevelControl::Id,
-                             chip::app::Clusters::LevelControl::Attributes::RemainingTime::Id,
-                             reinterpret_cast<uint8_t *>(&mLevelRemainingTime10sOfSec), sizeof(mLevelRemainingTime10sOfSec));
+        LevelControl::Attributes::MinLevel::Get(kLightEndpointId, &mMinLevel);
+        LevelControl::Attributes::MaxLevel::Get(kLightEndpointId, &mMaxLevel);
+        LevelControl::Attributes::RemainingTime::Get(kLightEndpointId, &mLevelRemainingTime10sOfSec);
 
         // Color control
-        emberAfReadAttribute(kLightEndpointId, chip::app::Clusters::ColorControl::Id,
-                             chip::app::Clusters::ColorControl::Attributes::CurrentHue::Id, &mColorHue, sizeof(mColorHue));
-        emberAfReadAttribute(kLightEndpointId, chip::app::Clusters::ColorControl::Id,
-                             chip::app::Clusters::ColorControl::Attributes::CurrentSaturation::Id, &mColorSaturation,
-                             sizeof(mColorSaturation));
-        emberAfReadAttribute(kLightEndpointId, chip::app::Clusters::ColorControl::Id,
-                             chip::app::Clusters::ColorControl::Attributes::CurrentX::Id, reinterpret_cast<uint8_t *>(&mColorX),
-                             sizeof(mColorX));
-        emberAfReadAttribute(kLightEndpointId, chip::app::Clusters::ColorControl::Id,
-                             chip::app::Clusters::ColorControl::Attributes::CurrentY::Id, reinterpret_cast<uint8_t *>(&mColorY),
-                             sizeof(mColorY));
+        ColorControl::Attributes::CurrentHue::Get(kLightEndpointId, &mColorHue);
+        ColorControl::Attributes::CurrentSaturation::Get(kLightEndpointId, &mColorSaturation);
+        ColorControl::Attributes::CurrentX::Get(kLightEndpointId, &mColorX);
+        ColorControl::Attributes::CurrentY::Get(kLightEndpointId, &mColorY);
     }
 }
 

--- a/examples/lighting-app/linux/ui.cpp
+++ b/examples/lighting-app/linux/ui.cpp
@@ -321,9 +321,9 @@ void UiInit(SDL_GLContext * gl_context, SDL_Window ** window)
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
-    SDL_WindowFlags window_flags = (SDL_WindowFlags) (SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+    SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
     *window     = SDL_CreateWindow("Dear ImGui SDL2+OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720,
-                                   window_flags);
+                               window_flags);
     *gl_context = SDL_GL_CreateContext(*window);
     SDL_GL_MakeCurrent(*window, *gl_context);
     SDL_GL_SetSwapInterval(1); // Enable vsync

--- a/examples/lighting-app/linux/ui.cpp
+++ b/examples/lighting-app/linux/ui.cpp
@@ -26,8 +26,6 @@
 #include <setup_payload/SetupPayload.h>
 
 #include <app-common/zap-generated/attributes/Accessors.h>
-#include <app-common/zap-generated/ids/Attributes.h>
-#include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/attribute-storage.h>
 
 #include <SDL.h>

--- a/examples/lighting-app/linux/ui.cpp
+++ b/examples/lighting-app/linux/ui.cpp
@@ -74,7 +74,7 @@ private:
     uint8_t mQRData[kMaxQRBufferSize] = { 0 };
 
     // light data:
-    bool mOnOff = false;
+    bool mLightIsOn = false;
 
     // Updates the data (run in the chip event loop)
     void ChipLoopUpdate();
@@ -140,7 +140,16 @@ void DeviceState::ShowUi()
 {
     ImGui::Begin("Light app");
     ImGui::Text("Here is the current ember device state:");
-    ImGui::Checkbox("Light is ON", &mOnOff);
+
+    if (mLightIsOn)
+    {
+        ImGui::Text("Light is ON");
+    }
+    else
+    {
+        ImGui::Text("Light is OFF");
+    }
+
     ImGui::End();
 
     if (mHasQRCode)
@@ -218,7 +227,7 @@ void DeviceState::ChipLoopUpdate()
         uint8_t value;
         emberAfReadServerAttribute(kLightEndpointId, chip::app::Clusters::OnOff::Id,
                                    chip::app::Clusters::OnOff::Attributes::OnOff::Id, &value, sizeof(value));
-        mOnOff = (value != 0);
+        mLightIsOn = (value != 0);
     }
 }
 
@@ -263,9 +272,9 @@ void UiInit(SDL_GLContext * gl_context, SDL_Window ** window)
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
-    SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+    SDL_WindowFlags window_flags = (SDL_WindowFlags) (SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
     *window     = SDL_CreateWindow("Dear ImGui SDL2+OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720,
-                               window_flags);
+                                   window_flags);
     *gl_context = SDL_GL_CreateContext(*window);
     SDL_GL_MakeCurrent(*window, *gl_context);
     SDL_GL_SetSwapInterval(1); // Enable vsync

--- a/examples/lighting-app/linux/ui.cpp
+++ b/examples/lighting-app/linux/ui.cpp
@@ -74,7 +74,8 @@ private:
     uint8_t mQRData[kMaxQRBufferSize] = { 0 };
 
     // light data:
-    bool mLightIsOn = false;
+    bool mLightIsOn       = false;
+    uint8_t mCurrentLevel = 0;
 
     // Updates the data (run in the chip event loop)
     void ChipLoopUpdate();
@@ -141,17 +142,20 @@ inline ImVec2 operator+(const ImVec2 & a, const ImVec2 & b)
 
 void DeviceState::ShowUi()
 {
-    ImGui::Begin("Light app");
-    ImGui::Text("Here is the current ember device state:");
+    ImGui::Begin("Light app state");
+    ImGui::Text("On-Off:");
 
     if (mLightIsOn)
     {
-        ImGui::Text("Light is ON");
+        ImGui::Text("    Light is ON");
     }
     else
     {
-        ImGui::Text("Light is OFF");
+        ImGui::Text("    Light is OFF");
     }
+
+    ImGui::Text("Level Control:");
+    ImGui::Text("    Current Level: %d", mCurrentLevel);
 
     ImGui::End();
 
@@ -238,6 +242,10 @@ void DeviceState::ChipLoopUpdate()
         emberAfReadServerAttribute(kLightEndpointId, chip::app::Clusters::OnOff::Id,
                                    chip::app::Clusters::OnOff::Attributes::OnOff::Id, &value, sizeof(value));
         mLightIsOn = (value != 0);
+
+        emberAfReadServerAttribute(kLightEndpointId, chip::app::Clusters::LevelControl::Id,
+                                   chip::app::Clusters::LevelControl::Attributes::CurrentLevel::Id, &mCurrentLevel,
+                                   sizeof(mCurrentLevel));
     }
 }
 


### PR DESCRIPTION
Added UI for level control and some color control information.

Saw the values moving as timed interactions were triggered.
Also learned that hue-saturation vs x-y are completely independent (is this really expected?) and not persisted across reboots. Looks like a useful debug tool.

![image](https://user-images.githubusercontent.com/1832280/218584372-da4005cb-41ed-446b-96d6-19227c6ba26e.png)


