### PR TITLE
Make sure to generate events when we clear credentials.

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -2903,19 +2903,24 @@ EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip
     bool clearedCredential = false;
     for (uint16_t i = 1; i < maxNumberOfCredentials; ++i)
     {
-        status = clearCredential(endpointId, modifier, sourceNodeId, credentialType, i, false);
-        if (EMBER_ZCL_STATUS_SUCCESS != status)
+        EmberAfStatus clearStatus = clearCredential(endpointId, modifier, sourceNodeId, credentialType, i, false);
+        if (EMBER_ZCL_STATUS_SUCCESS != clearStatus)
         {
             ChipLogError(Zcl,
                          "[clearCredentials] Unable to clear the credential - internal error "
                          "[endpointId=%d,credentialType=%u,credentialIndex=%d,status=%d]",
                          endpointId, to_underlying(credentialType), i, status);
-            goto exit;
+            if (status == EMBER_ZCL_STATUS_SUCCESS)
+            {
+                status = clearStatus;
+            }
         }
-        clearedCredential = true;
+        else
+        {
+            clearedCredential = true;
+        }
     }
 
-exit:
     // Generate the event if we cleared any credentials, even if we then had errors
     // clearing other ones, so we don't have credentials silently disappearing.
     if (clearedCredential)

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -2899,23 +2899,32 @@ EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip
         return EMBER_ZCL_STATUS_FAILURE;
     }
 
+    EmberAfStatus status   = EMBER_ZCL_STATUS_SUCCESS;
+    bool clearedCredential = false;
     for (uint16_t i = 1; i < maxNumberOfCredentials; ++i)
     {
-        auto status = clearCredential(endpointId, modifier, sourceNodeId, credentialType, i, false);
+        status = clearCredential(endpointId, modifier, sourceNodeId, credentialType, i, false);
         if (EMBER_ZCL_STATUS_SUCCESS != status)
         {
             ChipLogError(Zcl,
                          "[clearCredentials] Unable to clear the credential - internal error "
                          "[endpointId=%d,credentialType=%u,credentialIndex=%d,status=%d]",
                          endpointId, to_underlying(credentialType), i, status);
-            return status;
+            goto exit;
         }
+        clearedCredential = true;
     }
 
-    sendRemoteLockUserChange(endpointId, credentialTypeToLockDataType(credentialType), DataOperationTypeEnum::kClear, sourceNodeId,
-                             modifier, 0xFFFE, 0xFFFE);
+exit:
+    // Generate the event if we cleared any credentials, even if we then had errors
+    // clearing other ones, so we don't have credentials silently disappearing.
+    if (clearedCredential)
+    {
+        sendRemoteLockUserChange(endpointId, credentialTypeToLockDataType(credentialType), DataOperationTypeEnum::kClear,
+                                 sourceNodeId, modifier, 0xFFFE, 0xFFFE);
+    }
 
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return status;
 }
 
 bool DoorLockServer::clearFabricFromCredentials(chip::EndpointId endpointId, CredentialTypeEnum credentialType,


### PR DESCRIPTION
We could end up in a situation where we cleared some credentials, then hit an error, and never generated the event for the credentials we had cleared.


