### PR TITLE
[matter_idl] Always add global attributes to the cluster attributes list

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -108,11 +108,6 @@ jobs:
               # does not enforce that the content is understood (that part is covered by parser
               # unit tests)
               #
-              # Also note ordering: global attributes are parsed first because other XML files may
-              # reference these.
-              #
-              # TODO: some multipass/postprocess may be more appropriate to allow any ordering of
-              #       things.
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/py_matter_idl/matter_idl/xml_parser.py \

--- a/scripts/py_matter_idl/matter_idl/zapxml/handlers/context.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/handlers/context.py
@@ -110,6 +110,9 @@ class Context:
         raise Exception(
             'Global attribute 0x%X (%d) not found. You probably need to load global-attributes.xml' % (code, code))
 
+    def GetGlobalAttributes(self):
+        return [attribute for code, attribute in self._global_attributes.items()]
+
     def AddGlobalAttribute(self, attribute: Attribute):
         # NOTE: this may get added several times as both 'client' and 'server'
         #       however matter should not differentiate between the two
@@ -131,8 +134,11 @@ class Context:
             logging.warning(msg)
             self._not_handled.add(path)
 
-    def AddIdlPostProcessor(self, processor: IdlPostProcessor):
-        self._idl_post_processors.append(processor)
+    def AddIdlPostProcessor(self, processor: IdlPostProcessor, has_priority: bool = False):
+        if has_priority:
+            self._idl_post_processors.insert(0, processor)
+        else:
+            self._idl_post_processors.append(processor)
 
     def PostProcess(self, idl: Idl):
         for p in self._idl_post_processors:

--- a/scripts/py_matter_idl/matter_idl/zapxml/handlers/handlers.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/handlers/handlers.py
@@ -456,9 +456,18 @@ class ClusterGlobalAttributeHandler(BaseHandler):
         else:
             return BaseHandler(self.context)
 
-    def EndProcessing(self):
+    def FinalizeProcessing(self, idl: Idl):
+        for attribute in self._cluster.attributes:
+            if attribute.definition.code == self._code:
+                # NOTE: For now the value is ignored, but if needed it could
+                #       be updated here.
+                return
+
         self._cluster.attributes.append(
             self.context.GetGlobalAttribute(self._code))
+
+    def EndProcessing(self):
+        self.context.AddIdlPostProcessor(self)
 
 
 class ClusterHandler(BaseHandler):
@@ -581,6 +590,14 @@ class GlobalHandler(BaseHandler):
             return GlobalAttributeHandler(self.context, AttrsToAttribute(attrs))
         else:
             return BaseHandler(self.context)
+
+    def FinalizeProcessing(self, idl: Idl):
+        global_attributes = self.context.GetGlobalAttributes()
+        for cluster in idl.clusters:
+            cluster.attributes += global_attributes
+
+    def EndProcessing(self):
+        self.context.AddIdlPostProcessor(self, True)
 
 
 class ConfiguratorHandler(BaseHandler):

--- a/scripts/py_matter_yamltests/matter_yamltests/definitions.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/definitions.py
@@ -14,7 +14,6 @@
 #    limitations under the License.
 
 import enum
-import functools
 import glob
 import io
 from typing import List, Optional
@@ -244,18 +243,6 @@ class SpecDefinitions:
 
 
 def SpecDefinitionsFromPaths(paths: str, pseudo_clusters: Optional[PseudoClusters] = PseudoClusters([])):
-    def sort_with_global_attribute_first(a, b):
-        if a.endswith('global-attributes.xml'):
-            return -1
-        elif b.endswith('global-attributes.xml'):
-            return 1
-        elif a > b:
-            return 1
-        elif a == b:
-            return 0
-        elif a < b:
-            return -1
-
     filenames = []
     for path in paths:
         if '*' in path or '?' in path:
@@ -263,7 +250,6 @@ def SpecDefinitionsFromPaths(paths: str, pseudo_clusters: Optional[PseudoCluster
         else:
             filenames.append(path)
 
-    filenames.sort(key=functools.cmp_to_key(sort_with_global_attribute_first))
     sources = [ParseSource(source=name) for name in filenames]
 
     for pseudo_cluster in pseudo_clusters.clusters:


### PR DESCRIPTION
#### Problem

When using `ParseXmls` in https://github.com/project-chip/connectedhomeip/blob/e7528bce0c0a876f65fa76a90ed73c165c8aed13/scripts/py_matter_yamltests/matter_yamltests/definitions.py#L55 the global attributes are not part of the attribute list of the cluster by default.

Maybe it is on design and I have missed some facilities to get the global attributes list.