### PR TITLE
Resolve unsafe memory accesses in ExchangeContext (#25023)

### DIFF
--- a/src/messaging/tests/TestMessagingLayer.cpp
+++ b/src/messaging/tests/TestMessagingLayer.cpp
@@ -142,6 +142,26 @@ void CheckExchangeOutgoingMessagesFail(nlTestSuite * inSuite, void * inContext)
     ec->Close();
 }
 
+/**
+ * Tests that the Exchange Context APIs do not crash if delayed calls are made after the Exchange Context is
+ * closed.
+ */
+void CheckExchangeContextDoesNotCrashWhenDelayedCallsOccurAfterClose(nlTestSuite * inSuite, void * inContext)
+{
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+
+    // Create an Exchange Context.
+    ExchangeContext * ec = ctx.NewExchangeToAlice(&mockSolicitedAppDelegate);
+
+    // Close the Exchange Context.
+    ec->Close();
+
+    // Call public APIs to verify that they do not crash or fail the test.
+    NL_TEST_ASSERT(inSuite, ec->StartResponseTimer() == CHIP_ERROR_INTERNAL);
+    ec->CancelResponseTimer();
+    ec->AbortAllOtherCommunicationOnFabric();
+}
+
 // Test Suite
 
 /**


### PR DESCRIPTION
Fixes #25023

### Problem

When an `ExchangeMgr` is shut down (`ShutDown()`), the `SessionManager` is set to `nullptr` and resources are released. However, if a child `ExchangeContext` is still in use on another thread (e.g. in the middle of `SendMessage(...)`), the `ExchangeContext` uses `mExchangeManager->GetSessionManager()` without any `null` safety checks. This can cause segmentation faults when the `null` `SessionManager` is dereferenced.

### Solution

Add `null` checks on all usages of the `SessionManager`. Return error codes where appropriate / applicable, and fail gracefully / silently where it is safe to do so.