### PR TITLE
Fixed All Clusters App ZAP Example File

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -4449,8 +4449,6 @@ endpoint 0 {
   }
 
   server cluster ThreadNetworkDiagnostics {
-    emits event ConnectionStatus;
-    emits event NetworkFaultChange;
     callback attribute channel;
     callback attribute routingRole;
     callback attribute networkName;
@@ -4708,8 +4706,6 @@ endpoint 1 {
   }
 
   server cluster Actions {
-    emits event StateChanged;
-    emits event ActionFailed;
     callback attribute actionList;
     callback attribute endpointLists;
     callback attribute setupURL;
@@ -4751,7 +4747,6 @@ endpoint 1 {
   }
 
   server cluster BooleanState {
-    emits event StateChange;
     ram      attribute stateValue;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
@@ -4852,18 +4847,6 @@ endpoint 1 {
   }
 
   server cluster PumpConfigurationAndControl {
-    emits event SupplyVoltageLow;
-    emits event SupplyVoltageHigh;
-    emits event PowerMissingPhase;
-    emits event SystemPressureLow;
-    emits event SystemPressureHigh;
-    emits event DryRunning;
-    emits event MotorTemperatureHigh;
-    emits event PumpMotorFatalFailure;
-    emits event ElectronicTemperatureHigh;
-    emits event PumpBlocked;
-    emits event SensorFailure;
-    emits event ElectronicNonFatalFailure;
     ram      attribute maxPressure;
     ram      attribute maxSpeed;
     ram      attribute maxFlow;

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -4885,22 +4885,6 @@
               "maxInterval": 65344,
               "reportableChange": 0
             }
-          ],
-          "events": [
-            {
-              "name": "ConnectionStatus",
-              "code": 0,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "NetworkFaultChange",
-              "code": 1,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            }
           ]
         },
         {
@@ -10746,22 +10730,6 @@
               "maxInterval": 65344,
               "reportableChange": 0
             }
-          ],
-          "events": [
-            {
-              "name": "StateChanged",
-              "code": 0,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "ActionFailed",
-              "code": 1,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            }
           ]
         },
         {
@@ -12737,15 +12705,6 @@
               "minInterval": 1,
               "maxInterval": 65534,
               "reportableChange": 0
-            }
-          ],
-          "events": [
-            {
-              "name": "StateChange",
-              "code": 0,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
             }
           ]
         },
@@ -14958,92 +14917,6 @@
               "minInterval": 0,
               "maxInterval": 65344,
               "reportableChange": 0
-            }
-          ],
-          "events": [
-            {
-              "name": "SupplyVoltageLow",
-              "code": 0,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "SupplyVoltageHigh",
-              "code": 1,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "PowerMissingPhase",
-              "code": 2,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "SystemPressureLow",
-              "code": 3,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "SystemPressureHigh",
-              "code": 4,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "DryRunning",
-              "code": 5,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "MotorTemperatureHigh",
-              "code": 6,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "PumpMotorFatalFailure",
-              "code": 7,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "ElectronicTemperatureHigh",
-              "code": 8,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "PumpBlocked",
-              "code": 9,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "SensorFailure",
-              "code": 10,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "ElectronicNonFatalFailure",
-              "code": 11,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
             }
           ]
         },


### PR DESCRIPTION
  - Removed all Thread Network Diagnostics Cluster events, which are currently not implemented in the SDK at all.
  - Removed all Actions Cluster events, which are currently not implemented in the SDK.
  - Removed StateChange event of the Boolean State Cluster, which is not implemented for the All Clusters App.
  - Removed all events of the Pump Configuration and Control Cluster, which are currently not implemented in the SDK.

