### PR TITLE
[yaml] Add discoverOnce as an optional argument to CommissionerCommands::PairWithCode

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -7,7 +7,7 @@ ARG COMMITHASH=7b99e6399c6069037c613782d78132c69b9dcabb
 # ZAP Development install, so that it runs on both x64 and arm64
 # Generally this should match with the ZAP version that is used for codegen within the
 # specified SHA
-ARG ZAP_VERSION=v2023.02.09-nightly
+ARG ZAP_VERSION=v2023.02.16-nightly
 
 # Ensure TARGETPLATFORM is set
 RUN case ${TARGETPLATFORM} in \

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -8,7 +8,7 @@
                 "mac-arm64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2023.02.09-nightly.1"]
+            "tags": ["version:2@v2023.02.16-nightly.1"]
         }
     ]
 }

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2023.2.9'
+MIN_ZAP_VERSION = '2023.2.16'
 
 
 class ZapTool:

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -68,3 +68,5 @@ ClustersWithPreAttributeChangeFunctions:
     - Mode Select
     - Fan Control
     - Thermostat
+
+ClustersWithShutdownFunctions: []

--- a/src/app/tests/suites/commands/commissioner/CommissionerCommands.cpp
+++ b/src/app/tests/suites/commands/commissioner/CommissionerCommands.cpp
@@ -33,6 +33,8 @@ CommissionerCommands::PairWithCode(const char * identity,
     memcpy(code, value.payload.data(), value.payload.size());
     ChipLogError(chipTool, "Pairing Code is %s", code);
 
+    mDiscoverOnce = value.discoverOnce;
+
     // To reduce the scanning latency in some setups, and since the primary use for PairWithCode is to commission a device to
     // another commissioner, assume that the commissionable device is available on the network.
     chip::Controller::DiscoveryType discoveryType = chip::Controller::DiscoveryType::kDiscoveryNetworkOnly;
@@ -128,6 +130,11 @@ void CommissionerCommands::OnStatusUpdate(DevicePairingDelegate::Status status)
         OnResponse(ConvertToStatusIB(CHIP_ERROR_INCORRECT_STATE), nullptr);
         break;
     case DevicePairingDelegate::Status::SecurePairingDiscoveringMoreDevices:
+        if (mDiscoverOnce.ValueOr(false))
+        {
+            ChipLogError(chipTool, "Secure Pairing Failed");
+            OnResponse(ConvertToStatusIB(CHIP_ERROR_INCORRECT_STATE), nullptr);
+        }
         break;
     }
 }

--- a/src/app/tests/suites/commands/commissioner/CommissionerCommands.h
+++ b/src/app/tests/suites/commands/commissioner/CommissionerCommands.h
@@ -45,4 +45,7 @@ public:
     void OnPairingComplete(CHIP_ERROR error) override;
     void OnPairingDeleted(CHIP_ERROR error) override;
     void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR error) override;
+
+private:
+    chip::Optional<bool> mDiscoverOnce;
 };

--- a/zzz_generated/app-common/app-common/zap-generated/tests/simulated-cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/tests/simulated-cluster-objects.h
@@ -28,6 +28,7 @@ struct PairWithCodeCommand
 {
     chip::NodeId nodeId;
     chip::CharSpan payload;
+    Optional<bool> discoverOnce;
 
     CHIP_ERROR Encode(chip::TLV::TLVWriter & writer, chip::TLV::Tag tag) const
     {
@@ -35,6 +36,7 @@ struct PairWithCodeCommand
         ReturnErrorOnFailure(writer.StartContainer(tag, chip::TLV::kTLVType_Structure, outer));
         ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(0), nodeId));
         ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(1), payload));
+        ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(2), discoverOnce));
         ReturnErrorOnFailure(writer.EndContainer(outer));
         return CHIP_NO_ERROR;
     }
@@ -56,6 +58,9 @@ struct PairWithCodeCommand
                 break;
             case 1:
                 ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, payload));
+                break;
+            case 2:
+                ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, discoverOnce));
                 break;
             default:
                 break;


### PR DESCRIPTION
#### Problem

This PR adds `discoverOnce` optional argument supports to `CommissionerCommands::PairWithCode`.

 It depends on https://github.com/project-chip/zap/pull/928 for the generation bits. So I expect the `zap` CI task to failed here until the SDK got the update.