### PR TITLE
[chip-tool] Add missing commands to get TestDiscovery to work.

### DIFF
--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.h
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.h
@@ -22,6 +22,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/EventHeader.h>
 #include <app/MessageDef/StatusIB.h>
+#include <lib/dnssd/Resolver.h>
 
 class RemoteDataModelLoggerDelegate
 {
@@ -39,5 +40,6 @@ CHIP_ERROR LogEventAsJSON(const chip::app::EventHeader & header, chip::TLV::TLVR
 CHIP_ERROR LogErrorAsJSON(const chip::app::EventHeader & header, const chip::app::StatusIB & status);
 CHIP_ERROR LogErrorAsJSON(const CHIP_ERROR & error);
 CHIP_ERROR LogGetCommissionerNodeId(chip::NodeId value);
+CHIP_ERROR LogDiscoveredNodeData(const chip::Dnssd::DiscoveredNodeData & nodeData);
 void SetDelegate(RemoteDataModelLoggerDelegate * delegate);
 }; // namespace RemoteDataModelLogger

--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -74,6 +74,11 @@ void registerCommandsDiscover(Commands & commands, CredentialIssuerCommands * cr
     commands_list clusterCommands = {
         make_unique<Resolve>(credsIssuerConfig),
         make_unique<DiscoverCommissionablesCommand>(credsIssuerConfig),
+        make_unique<DiscoverCommissionableByShortDiscriminatorCommand>(credsIssuerConfig),
+        make_unique<DiscoverCommissionableByLongDiscriminatorCommand>(credsIssuerConfig),
+        make_unique<DiscoverCommissionableByCommissioningModeCommand>(credsIssuerConfig),
+        make_unique<DiscoverCommissionableByVendorIdCommand>(credsIssuerConfig),
+        make_unique<DiscoverCommissionableByDeviceTypeCommand>(credsIssuerConfig),
         make_unique<DiscoverCommissionersCommand>(credsIssuerConfig),
     };
 

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
@@ -17,9 +17,17 @@
  */
 
 #include "DiscoverCommissionablesCommand.h"
+#include <commands/common/RemoteDataModelLogger.h>
 #include <lib/support/BytesToHex.h>
 
 using namespace ::chip;
+
+void DiscoverCommissionablesCommandBase::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)
+{
+    nodeData.LogDetail();
+    LogErrorOnFailure(RemoteDataModelLogger::LogDiscoveredNodeData(nodeData));
+    SetCommandExitStatus(CHIP_NO_ERROR);
+}
 
 CHIP_ERROR DiscoverCommissionablesCommand::RunCommand()
 {
@@ -28,7 +36,37 @@ CHIP_ERROR DiscoverCommissionablesCommand::RunCommand()
     return CurrentCommissioner().DiscoverCommissionableNodes(filter);
 }
 
-void DiscoverCommissionablesCommand::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)
+CHIP_ERROR DiscoverCommissionableByShortDiscriminatorCommand::RunCommand()
 {
-    nodeData.LogDetail();
+    CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
+    chip::Dnssd::DiscoveryFilter filter(chip::Dnssd::DiscoveryFilterType::kShortDiscriminator, mDiscriminator);
+    return CurrentCommissioner().DiscoverCommissionableNodes(filter);
+}
+
+CHIP_ERROR DiscoverCommissionableByLongDiscriminatorCommand::RunCommand()
+{
+    CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
+    chip::Dnssd::DiscoveryFilter filter(chip::Dnssd::DiscoveryFilterType::kLongDiscriminator, mDiscriminator);
+    return CurrentCommissioner().DiscoverCommissionableNodes(filter);
+}
+
+CHIP_ERROR DiscoverCommissionableByCommissioningModeCommand::RunCommand()
+{
+    CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
+    chip::Dnssd::DiscoveryFilter filter(chip::Dnssd::DiscoveryFilterType::kCommissioningMode);
+    return CurrentCommissioner().DiscoverCommissionableNodes(filter);
+}
+
+CHIP_ERROR DiscoverCommissionableByVendorIdCommand::RunCommand()
+{
+    CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
+    chip::Dnssd::DiscoveryFilter filter(chip::Dnssd::DiscoveryFilterType::kVendorId, mVendorId);
+    return CurrentCommissioner().DiscoverCommissionableNodes(filter);
+}
+
+CHIP_ERROR DiscoverCommissionableByDeviceTypeCommand::RunCommand()
+{
+    CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
+    chip::Dnssd::DiscoveryFilter filter(chip::Dnssd::DiscoveryFilterType::kDeviceType, mDeviceType);
+    return CurrentCommissioner().DiscoverCommissionableNodes(filter);
 }

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
@@ -20,16 +20,103 @@
 
 #include "../common/CHIPCommand.h"
 
-class DiscoverCommissionablesCommand : public CHIPCommand, public chip::Controller::DeviceDiscoveryDelegate
+class DiscoverCommissionablesCommandBase : public CHIPCommand, public chip::Controller::DeviceDiscoveryDelegate
 {
 public:
-    DiscoverCommissionablesCommand(CredentialIssuerCommands * credsIssuerConfig) : CHIPCommand("commissionables", credsIssuerConfig)
+    DiscoverCommissionablesCommandBase(const char * name, CredentialIssuerCommands * credsIssuerConfig) :
+        CHIPCommand(name, credsIssuerConfig)
     {}
 
     /////////// DeviceDiscoveryDelegate Interface /////////
     void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
 
     /////////// CHIPCommand Interface /////////
-    CHIP_ERROR RunCommand() override;
     chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(30); }
+};
+
+class DiscoverCommissionablesCommand : public DiscoverCommissionablesCommandBase
+{
+public:
+    DiscoverCommissionablesCommand(CredentialIssuerCommands * credsIssuerConfig) :
+        DiscoverCommissionablesCommandBase("commissionables", credsIssuerConfig)
+    {}
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+};
+
+class DiscoverCommissionableByShortDiscriminatorCommand : public DiscoverCommissionablesCommandBase
+{
+public:
+    DiscoverCommissionableByShortDiscriminatorCommand(CredentialIssuerCommands * credsIssuerConfig) :
+        DiscoverCommissionablesCommandBase("find-commissionable-by-short-discriminator", credsIssuerConfig)
+    {
+        AddArgument("value", 0, UINT16_MAX, &mDiscriminator);
+    }
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+
+private:
+    uint16_t mDiscriminator;
+};
+
+class DiscoverCommissionableByLongDiscriminatorCommand : public DiscoverCommissionablesCommandBase
+{
+public:
+    DiscoverCommissionableByLongDiscriminatorCommand(CredentialIssuerCommands * credsIssuerConfig) :
+        DiscoverCommissionablesCommandBase("find-commissionable-by-long-discriminator", credsIssuerConfig)
+    {
+        AddArgument("value", 0, UINT16_MAX, &mDiscriminator);
+    }
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+
+private:
+    uint16_t mDiscriminator;
+};
+
+class DiscoverCommissionableByCommissioningModeCommand : public DiscoverCommissionablesCommandBase
+{
+public:
+    DiscoverCommissionableByCommissioningModeCommand(CredentialIssuerCommands * credsIssuerConfig) :
+        DiscoverCommissionablesCommandBase("find-commissionable-by-commissioning-mode", credsIssuerConfig)
+    {}
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+};
+
+class DiscoverCommissionableByVendorIdCommand : public DiscoverCommissionablesCommandBase
+{
+public:
+    DiscoverCommissionableByVendorIdCommand(CredentialIssuerCommands * credsIssuerConfig) :
+        DiscoverCommissionablesCommandBase("find-commissionable-by-vendor-id", credsIssuerConfig)
+    {
+        AddArgument("value", 0, UINT16_MAX, &mVendorId);
+    }
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+
+private:
+    uint16_t mVendorId;
+};
+
+class DiscoverCommissionableByDeviceTypeCommand : public DiscoverCommissionablesCommandBase
+{
+public:
+    DiscoverCommissionableByDeviceTypeCommand(CredentialIssuerCommands * credsIssuerConfig) :
+        DiscoverCommissionablesCommandBase("find-commissionable-by-device-type", credsIssuerConfig)
+    {
+        AddArgument("value", 0, UINT16_MAX, &mDeviceType);
+    }
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+
+private:
+    // TODO: possibly 32-bit - see spec issue #3226
+    uint16_t mDeviceType;
 };


### PR DESCRIPTION
…ests

#### Problem

`TestDiscovery` does not work with `chip-tool` adapter on top of `matter_yamltests`. This PR adds the missing commands.
