### PR TITLE
[matter_yamltests] Add an optional definition property to pseudo clus…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/delay_commands.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/delay_commands.py
@@ -19,9 +19,36 @@ import time
 from ..pseudo_cluster import PseudoCluster
 from .accessory_server_bridge import AccessoryServerBridge
 
+_DEFINITION = '''<?xml version="1.0"?>
+<configurator>
+<cluster>
+    <name>DelayCommands</name>
+    <code>0xFFF1FD02</code>
+
+    <command source="client" code="0" name="WaitForCommissioning">
+    </command>
+
+    <command source="client" code="1" name="WaitForCommissionee">
+      <arg name="nodeId" type="node_id"/>
+      <arg name="expireExistingSession" type="bool" optional="true"/>
+    </command>
+
+    <command source="client" code="2" name="WaitForMs">
+      <arg name="ms" type="int16u"/>
+    </command>
+
+    <command source="client" code="3" name="WaitForMessage">
+      <arg name="registerKey" type="char_string"/>
+      <arg name="message" type="char_string"/>
+    </command>
+</cluster>
+</configurator>
+'''
+
 
 class DelayCommands(PseudoCluster):
     name = 'DelayCommands'
+    definition = _DEFINITION
 
     async def WaitForMs(self, request):
         duration_in_ms = 0

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/log_commands.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/log_commands.py
@@ -15,9 +15,28 @@
 
 from ..pseudo_cluster import PseudoCluster
 
+_DEFINITION = '''<?xml version="1.0"?>
+<configurator>
+<cluster>
+    <name>LogCommands</name>
+    <code>0xFFF1FD01</code>
+
+    <command source="client" code="0" name="Log">
+      <arg name="message" type="char_string"/>
+    </command>
+
+    <command source="client" code="1" name="UserPrompt">
+      <arg name="message" type="char_string"/>
+      <arg name="expectedValue" type="char_string" optional="true"/>
+    </command>
+</cluster>
+</configurator>
+'''
+
 
 class LogCommands(PseudoCluster):
     name = 'LogCommands'
+    definition = _DEFINITION
 
     async def UserPrompt(self, request):
         pass

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/system_commands.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/system_commands.py
@@ -16,9 +16,53 @@
 from ..pseudo_cluster import PseudoCluster
 from .accessory_server_bridge import AccessoryServerBridge
 
+_DEFINITION = '''<?xml version="1.0"?>
+<configurator>
+<cluster>
+    <name>SystemCommands</name>
+    <code>0xFFF1FD03</code>
+
+    <command source="client" code="0" name="Start">
+      <arg name="registerKey" type="char_string" optional="true"/>
+      <arg name="discriminator" type="int16u" optional="true"/>
+      <arg name="port" type="int16u" optional="true"/>
+      <arg name="minCommissioningTimeout" type="int16u" optional="true"/>
+      <arg name="kvs" type="char_string" optional="true"/>
+      <arg name="filepath" type="char_string" optional="true"/>
+      <arg name="otaDownloadPath" type="char_string" optional="true"/>
+    </command>
+
+    <command source="client" code="1" name="Stop">
+      <arg name="registerKey" type="char_string" optional="true"/>
+    </command>
+
+    <command source="client" code="2" name="Reboot">
+      <arg name="registerKey" type="char_string" optional="true"/>
+    </command>
+
+    <command source="client" code="3" name="FactoryReset">
+      <arg name="registerKey" type="char_string" optional="true"/>
+    </command>
+
+    <command source="client" code="4" name="CreateOtaImage">
+      <arg name="otaImageFilePath" type="char_string"/>
+      <arg name="rawImageFilePath" type="char_string"/>
+      <arg name="rawImageContent" type="char_string"/>
+    </command>
+
+    <command source="client" code="5" name="CompareFiles">
+      <arg name="file1" type="char_string"/>
+      <arg name="file2" type="char_string"/>
+    </command>
+
+</cluster>
+</configurator>
+'''
+
 
 class SystemCommands(PseudoCluster):
     name = 'SystemCommands'
+    definition = _DEFINITION
 
     async def Start(self, request):
         AccessoryServerBridge.start(request)

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_cluster.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_cluster.py
@@ -44,7 +44,7 @@ class PseudoCluster(ABC):
               - name: "MyCustomParameter"
                 value: "this_is_a_custom_value"
 
-    A pseudo cluster can optionally declare a definition in order to benefits
+    A pseudo cluster can optionally declare a definition in order to benefit
     from automatic command names checking and argument names validation.
 
     For example, the 'CustomCommands' pseudo cluster can be implemented as:

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_cluster.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_cluster.py
@@ -34,9 +34,6 @@ class PseudoCluster(ABC):
         async def MyCustomMethod(self, request):
             pass
 
-        async def MyCustomMethod(self, request):
-            pass
-
     It can then be called from any test step as:
 
     - label: "Call a custom method"
@@ -46,8 +43,37 @@ class PseudoCluster(ABC):
           values:
               - name: "MyCustomParameter"
                 value: "this_is_a_custom_value"
+
+    A pseudo cluster can optionally declare a definition in order to benefits
+    from automatic command names checking and argument names validation.
+
+    For example, the 'CustomCommands' pseudo cluster can be implemented as:
+
+        _DEFINITION = '''<?xml version="1.0"?>
+        <configurator>
+          <cluster>
+            <name>CustomCommands</name>
+            <code>0xFFF1FD00</code>
+
+            <command source="client" code="0" name="MyCustomMethod">
+                <arg name="MyCustomParameter" type="char_string"/>
+            </command>
+          </cluster>
+        </configurator>
+        '''
+
+    class CustomCommand(PseudoCluster):
+        name = 'CustomCommands'
+        definition = _DEFINITION
+
+        async def MyCustomMethod(self, request):
+            pass
     """
 
     @abstractproperty
     def name(self):
         pass
+
+    @property
+    def definition(self):
+        return None

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_clusters.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_clusters.py
@@ -20,7 +20,7 @@ from .pseudo_cluster import PseudoCluster
 
 class PseudoClusters:
     def __init__(self, clusters: list[PseudoCluster]):
-        self.__clusters = clusters
+        self.clusters = clusters
 
     def supports(self, request) -> bool:
         return False if self.__get_command(request) is None else True
@@ -38,7 +38,7 @@ class PseudoClusters:
         return status, []
 
     def __get_command(self, request):
-        for cluster in self.__clusters:
+        for cluster in self.clusters:
             if request.cluster == cluster.name and getattr(cluster, request.command, None):
                 return getattr(cluster, request.command)
         return None


### PR DESCRIPTION
…ter in order to benefits from the built-in error reporting

#### Problem

The pseudo-clusters does not benefits from the built in error reporting and those can fails at runtime instead of parse time.

This PR adds an optional definition property to the pseudo cluster base class such that one can register a definition with the expected commands/arguments/responses.
With this is someone mistyped a command or an argument name it will fails at parsing not runtime. It also offers some guarantees to the pseudo clusters implementation where you don't have to validates the input.

