### PR TITLE
Stop using emberAfSendImmediateDefaultResponse.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/static-supported-modes-manager.h
+++ b/examples/all-clusters-app/all-clusters-common/include/static-supported-modes-manager.h
@@ -56,7 +56,8 @@ public:
 
     SupportedModesManager::ModeOptionsProvider getModeOptionsProvider(EndpointId endpointId) const override;
 
-    EmberAfStatus getModeOptionByMode(EndpointId endpointId, uint8_t mode, const ModeOptionStructType ** dataPtr) const override;
+    Protocols::InteractionModel::Status getModeOptionByMode(EndpointId endpointId, uint8_t mode,
+                                                            const ModeOptionStructType ** dataPtr) const override;
 
     ~StaticSupportedModesManager(){};
 

--- a/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
@@ -4,6 +4,7 @@ using namespace std;
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ModeSelect;
+using chip::Protocols::InteractionModel::Status;
 
 using ModeOptionStructType = Structs::ModeOptionStruct::Type;
 using SemanticTag          = Structs::SemanticTagStruct::Type;
@@ -51,13 +52,13 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
     return ModeOptionsProvider(nullptr, nullptr);
 }
 
-EmberAfStatus StaticSupportedModesManager::getModeOptionByMode(unsigned short endpointId, unsigned char mode,
-                                                               const ModeOptionStructType ** dataPtr) const
+Status StaticSupportedModesManager::getModeOptionByMode(unsigned short endpointId, unsigned char mode,
+                                                        const ModeOptionStructType ** dataPtr) const
 {
     auto modeOptionsProvider = this->getModeOptionsProvider(endpointId);
     if (modeOptionsProvider.begin() == nullptr)
     {
-        return EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER;
+        return Status::UnsupportedCluster;
     }
     auto * begin = this->getModeOptionsProvider(endpointId).begin();
     auto * end   = this->getModeOptionsProvider(endpointId).end();
@@ -68,11 +69,11 @@ EmberAfStatus StaticSupportedModesManager::getModeOptionByMode(unsigned short en
         if (modeOption.mode == mode)
         {
             *dataPtr = &modeOption;
-            return EMBER_ZCL_STATUS_SUCCESS;
+            return Status::Success;
         }
     }
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "Cannot find the mode %u", mode);
-    return EMBER_ZCL_STATUS_INVALID_COMMAND;
+    return Status::InvalidCommand;
 }
 
 const ModeSelect::SupportedModesManager * ModeSelect::getSupportedModesManager()

--- a/examples/placeholder/linux/include/static-supported-modes-manager.h
+++ b/examples/placeholder/linux/include/static-supported-modes-manager.h
@@ -56,7 +56,8 @@ public:
 
     SupportedModesManager::ModeOptionsProvider getModeOptionsProvider(EndpointId endpointId) const override;
 
-    EmberAfStatus getModeOptionByMode(EndpointId endpointId, uint8_t mode, const ModeOptionStructType ** dataPtr) const override;
+    Protocols::InteractionModel::Status getModeOptionByMode(EndpointId endpointId, uint8_t mode,
+                                                            const ModeOptionStructType ** dataPtr) const override;
 
     ~StaticSupportedModesManager(){};
 

--- a/examples/placeholder/linux/static-supported-modes-manager.cpp
+++ b/examples/placeholder/linux/static-supported-modes-manager.cpp
@@ -4,6 +4,7 @@ using namespace std;
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ModeSelect;
+using chip::Protocols::InteractionModel::Status;
 
 using ModeOptionStructType = Structs::ModeOptionStruct::Type;
 using SemanticTag          = Structs::SemanticTagStruct::Type;
@@ -51,13 +52,13 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
     return ModeOptionsProvider(nullptr, nullptr);
 }
 
-EmberAfStatus StaticSupportedModesManager::getModeOptionByMode(unsigned short endpointId, unsigned char mode,
-                                                               const ModeOptionStructType ** dataPtr) const
+Status StaticSupportedModesManager::getModeOptionByMode(unsigned short endpointId, unsigned char mode,
+                                                        const ModeOptionStructType ** dataPtr) const
 {
     auto modeOptionsProvider = this->getModeOptionsProvider(endpointId);
     if (modeOptionsProvider.begin() == nullptr)
     {
-        return EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER;
+        return Status::UnsupportedCluster;
     }
     auto * begin = this->getModeOptionsProvider(endpointId).begin();
     auto * end   = this->getModeOptionsProvider(endpointId).end();
@@ -68,11 +69,11 @@ EmberAfStatus StaticSupportedModesManager::getModeOptionByMode(unsigned short en
         if (modeOption.mode == mode)
         {
             *dataPtr = &modeOption;
-            return EMBER_ZCL_STATUS_SUCCESS;
+            return Status::Success;
         }
     }
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "Cannot find the mode %u", mode);
-    return EMBER_ZCL_STATUS_INVALID_COMMAND;
+    return Status::InvalidCommand;
 }
 
 const ModeSelect::SupportedModesManager * ModeSelect::getSupportedModesManager()

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -137,7 +137,7 @@ bool emberAfAccountLoginClusterLoginCallback(app::CommandHandler * command, cons
 {
     CHIP_ERROR err               = CHIP_NO_ERROR;
     EndpointId endpoint          = commandPath.mEndpointId;
-    EmberAfStatus status         = EMBER_ZCL_STATUS_SUCCESS;
+    Status status                = Status::Success;
     auto & tempAccountIdentifier = commandData.tempAccountIdentifier;
     auto & setupPin              = commandData.setupPIN;
 
@@ -146,42 +146,42 @@ bool emberAfAccountLoginClusterLoginCallback(app::CommandHandler * command, cons
 
     if (!delegate->HandleLogin(tempAccountIdentifier, setupPin))
     {
-        status = EMBER_ZCL_STATUS_UNSUPPORTED_ACCESS;
+        status = Status::UnsupportedAccess;
     }
 
 exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfAccountLoginClusterLoginCallback error: %s", err.AsString());
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
-    emberAfSendImmediateDefaultResponse(status);
+    command->AddStatus(commandPath, status);
     return true;
 }
 
 bool emberAfAccountLoginClusterLogoutCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                               const Commands::Logout::DecodableType & commandData)
 {
-    CHIP_ERROR err       = CHIP_NO_ERROR;
-    EndpointId endpoint  = commandPath.mEndpointId;
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    EndpointId endpoint = commandPath.mEndpointId;
+    Status status       = Status::Success;
 
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
 
     if (!delegate->HandleLogout())
     {
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
 
 exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfAccountLoginClusterLogoutCallback error: %s", err.AsString());
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
 
-    emberAfSendImmediateDefaultResponse(status);
+    commandObj->AddStatus(commandPath, status);
     return true;
 }
 

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -41,6 +41,7 @@ using namespace chip::app::Clusters::AccountLogin;
 using namespace chip::AppPlatform;
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 using chip::app::Clusters::AccountLogin::Delegate;
+using chip::Protocols::InteractionModel::Status;
 
 static constexpr size_t kAccountLoginDeletageTableSize =
     EMBER_AF_ACCOUNT_LOGIN_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
@@ -125,7 +126,7 @@ exit:
     {
         ChipLogError(Zcl, "emberAfAccountLoginClusterGetSetupPINCallback error: %s", err.AsString());
 
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -125,7 +125,7 @@ exit:
     {
         ChipLogError(Zcl, "emberAfAccountLoginClusterGetSetupPINCallback error: %s", err.AsString());
 
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;

--- a/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
+++ b/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
@@ -41,6 +41,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::AdministratorCommissioning;
 using namespace chip::Protocols;
+using chip::Protocols::InteractionModel::Status;
 
 class AdministratorCommissioningAttrAccess : public AttributeAccessInterface
 {

--- a/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
+++ b/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
@@ -199,7 +199,7 @@ bool emberAfAdministratorCommissioningClusterRevokeCommissioningCallback(
     {
         Server::GetInstance().GetCommissioningWindowManager().CloseCommissioningWindow();
         ChipLogProgress(Zcl, "Commissioning window is now closed");
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
     }
     return true;
 }

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -301,7 +301,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfApplicationLauncherClusterLaunchAppCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -390,7 +390,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfApplicationLauncherClusterStopAppCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -475,7 +475,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfApplicationLauncherClusterStopAppCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -55,6 +55,7 @@ static constexpr size_t kApplicationLauncherDelegateTableSize =
 using chip::app::Clusters::ApplicationBasic::CatalogVendorApp;
 using chip::app::Clusters::ApplicationLauncher::Delegate;
 using ApplicationStatusEnum = app::Clusters::ApplicationBasic::ApplicationStatusEnum;
+using chip::Protocols::InteractionModel::Status;
 
 namespace {
 
@@ -301,7 +302,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfApplicationLauncherClusterLaunchAppCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -390,7 +391,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfApplicationLauncherClusterStopAppCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -475,7 +476,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfApplicationLauncherClusterStopAppCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -35,6 +35,7 @@
 
 using namespace chip;
 using namespace chip::app::Clusters::AudioOutput;
+using chip::Protocols::InteractionModel::Status;
 
 static constexpr size_t kAudioOutputDelegateTableSize =
     EMBER_AF_AUDIO_OUTPUT_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
@@ -212,27 +213,27 @@ exit:
 bool emberAfAudioOutputClusterSelectOutputCallback(app::CommandHandler * command, const app::ConcreteCommandPath & commandPath,
                                                    const Commands::SelectOutput::DecodableType & commandData)
 {
-    CHIP_ERROR err       = CHIP_NO_ERROR;
-    EndpointId endpoint  = commandPath.mEndpointId;
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
-    auto & index         = commandData.index;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    EndpointId endpoint = commandPath.mEndpointId;
+    Status status       = Status::Success;
+    auto & index        = commandData.index;
 
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
 
     if (!delegate->HandleSelectOutput(index))
     {
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
 
 exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfAudioOutputClusterSelectOutputCallback error: %s", err.AsString());
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
 
-    emberAfSendImmediateDefaultResponse(status);
+    command->AddStatus(commandPath, status);
     return true;
 }
 

--- a/src/app/clusters/channel-server/channel-server.cpp
+++ b/src/app/clusters/channel-server/channel-server.cpp
@@ -223,7 +223,7 @@ exit:
     // If isDelegateNull, no one will call responder, so HasSentResponse will be false
     if (!responder.HasSentResponse())
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;

--- a/src/app/clusters/channel-server/channel-server.cpp
+++ b/src/app/clusters/channel-server/channel-server.cpp
@@ -34,6 +34,7 @@ using namespace chip::app::Clusters::Channel;
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 using namespace chip::AppPlatform;
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
+using chip::Protocols::InteractionModel::Status;
 
 static constexpr size_t kChannelDelegateTableSize =
     EMBER_AF_CHANNEL_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
@@ -223,7 +224,7 @@ exit:
     // If isDelegateNull, no one will call responder, so HasSentResponse will be false
     if (!responder.HasSentResponse())
     {
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;

--- a/src/app/clusters/channel-server/channel-server.cpp
+++ b/src/app/clusters/channel-server/channel-server.cpp
@@ -233,55 +233,55 @@ exit:
 bool emberAfChannelClusterChangeChannelByNumberCallback(app::CommandHandler * command, const app::ConcreteCommandPath & commandPath,
                                                         const Commands::ChangeChannelByNumber::DecodableType & commandData)
 {
-    CHIP_ERROR err       = CHIP_NO_ERROR;
-    EndpointId endpoint  = commandPath.mEndpointId;
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
-    auto & majorNumber   = commandData.majorNumber;
-    auto & minorNumber   = commandData.minorNumber;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    EndpointId endpoint = commandPath.mEndpointId;
+    Status status       = Status::Success;
+    auto & majorNumber  = commandData.majorNumber;
+    auto & minorNumber  = commandData.minorNumber;
 
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
 
     if (!delegate->HandleChangeChannelByNumber(majorNumber, minorNumber))
     {
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
 
 exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfChannelClusterChangeChannelByNumberCallback error: %s", err.AsString());
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
 
-    emberAfSendImmediateDefaultResponse(status);
+    command->AddStatus(commandPath, status);
     return true;
 }
 
 bool emberAfChannelClusterSkipChannelCallback(app::CommandHandler * command, const app::ConcreteCommandPath & commandPath,
                                               const Commands::SkipChannel::DecodableType & commandData)
 {
-    CHIP_ERROR err       = CHIP_NO_ERROR;
-    EndpointId endpoint  = commandPath.mEndpointId;
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
-    auto & count         = commandData.count;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    EndpointId endpoint = commandPath.mEndpointId;
+    Status status       = Status::Success;
+    auto & count        = commandData.count;
 
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
 
     if (!delegate->HandleSkipChannel(count))
     {
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
 
 exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfChannelClusterSkipChannelCallback error: %s", err.AsString());
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
 
-    emberAfSendImmediateDefaultResponse(status);
+    command->AddStatus(commandPath, status);
     return true;
 }
 

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -762,7 +762,7 @@ bool ColorControlServer::moveHueCommand(EndpointId endpoint, uint8_t moveMode, u
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -771,7 +771,7 @@ bool ColorControlServer::moveHueCommand(EndpointId endpoint, uint8_t moveMode, u
 
     if (moveMode == EMBER_ZCL_HUE_MOVE_MODE_STOP)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -830,7 +830,7 @@ bool ColorControlServer::moveHueCommand(EndpointId endpoint, uint8_t moveMode, u
     }
     else
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_MALFORMED_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidAction);
         return true;
     }
     colorHueTransitionState->stepsRemaining = TRANSITION_TIME_1S;
@@ -879,7 +879,7 @@ bool ColorControlServer::moveToHueCommand(EndpointId endpoint, uint16_t hue, uin
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -904,7 +904,7 @@ bool ColorControlServer::moveToHueCommand(EndpointId endpoint, uint16_t hue, uin
     // this and report a malformed packet.
     if (!isEnhanced && (hue > MAX_HUE_VALUE))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_MALFORMED_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidAction);
         return true;
     }
 
@@ -942,7 +942,7 @@ bool ColorControlServer::moveToHueCommand(EndpointId endpoint, uint16_t hue, uin
         direction = MOVE_MODE_DOWN;
         break;
     default:
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_MALFORMED_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidAction);
         return true;
     }
 
@@ -1045,13 +1045,13 @@ bool ColorControlServer::moveToHueAndSaturationCommand(EndpointId endpoint, uint
     // this and report a malformed packet.
     if ((!isEnhanced && hue > MAX_HUE_VALUE) || saturation > MAX_SATURATION_VALUE)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_MALFORMED_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidAction);
         return true;
     }
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -1147,7 +1147,7 @@ bool ColorControlServer::stepHueCommand(EndpointId endpoint, uint8_t stepMode, u
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -1161,7 +1161,7 @@ bool ColorControlServer::stepHueCommand(EndpointId endpoint, uint8_t stepMode, u
 
     if (stepMode == MOVE_MODE_STOP)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -1246,7 +1246,7 @@ bool ColorControlServer::moveSaturationCommand(const app::ConcreteCommandPath & 
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -1257,7 +1257,7 @@ bool ColorControlServer::moveSaturationCommand(const app::ConcreteCommandPath & 
 
     if (moveMode == EMBER_ZCL_SATURATION_MOVE_MODE_STOP || rate == 0)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -1326,7 +1326,7 @@ bool ColorControlServer::moveToSaturationCommand(const app::ConcreteCommandPath 
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -1339,7 +1339,7 @@ bool ColorControlServer::moveToSaturationCommand(const app::ConcreteCommandPath 
     // this and report a malformed packet.
     if (saturation > MAX_SATURATION_VALUE)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_MALFORMED_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidAction);
         return true;
     }
 
@@ -1393,7 +1393,7 @@ bool ColorControlServer::stepSaturationCommand(const app::ConcreteCommandPath & 
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -1409,7 +1409,7 @@ bool ColorControlServer::stepSaturationCommand(const app::ConcreteCommandPath & 
 
     if (stepMode == MOVE_MODE_STOP)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -1468,7 +1468,7 @@ bool ColorControlServer::colorLoopCommand(const app::ConcreteCommandPath & comma
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -1555,7 +1555,7 @@ bool ColorControlServer::colorLoopCommand(const app::ConcreteCommandPath & comma
         }
         else
         {
-            emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_MALFORMED_COMMAND);
+            commandObj->AddStatus(commandPath, Status::InvalidAction);
             return true;
         }
     }
@@ -1714,7 +1714,7 @@ bool ColorControlServer::moveToColorCommand(const app::ConcreteCommandPath & com
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -1776,7 +1776,7 @@ bool ColorControlServer::moveColorCommand(const app::ConcreteCommandPath & comma
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -1788,7 +1788,7 @@ bool ColorControlServer::moveColorCommand(const app::ConcreteCommandPath & comma
 
     if (rateX == 0 && rateY == 0)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -1875,7 +1875,7 @@ bool ColorControlServer::stepColorCommand(const app::ConcreteCommandPath & comma
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -2189,7 +2189,7 @@ bool ColorControlServer::moveColorTempCommand(const app::ConcreteCommandPath & c
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -2201,13 +2201,13 @@ bool ColorControlServer::moveColorTempCommand(const app::ConcreteCommandPath & c
 
     if (moveMode == MOVE_MODE_STOP)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
     if (rate == 0)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return true;
     }
 
@@ -2278,7 +2278,7 @@ bool ColorControlServer::moveToColorTempCommand(const app::ConcreteCommandPath &
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -2308,7 +2308,7 @@ bool ColorControlServer::stepColorTempCommand(const app::ConcreteCommandPath & c
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -2325,7 +2325,7 @@ bool ColorControlServer::stepColorTempCommand(const app::ConcreteCommandPath & c
 
     if (stepMode == MOVE_MODE_STOP)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -27,6 +27,7 @@
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ColorControl;
+using chip::Protocols::InteractionModel::Status;
 
 /**********************************************************
  * Attributes Definition
@@ -747,9 +748,12 @@ EmberEventControl * ColorControlServer::configureHSVEventControl(EndpointId endp
  * @return true Success
  * @return false Failed
  */
-bool ColorControlServer::moveHueCommand(EndpointId endpoint, uint8_t moveMode, uint16_t rate, uint8_t optionsMask,
-                                        uint8_t optionsOverride, bool isEnhanced)
+bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
+                                        uint8_t moveMode, uint16_t rate, uint8_t optionsMask, uint8_t optionsOverride,
+                                        bool isEnhanced)
 {
+    EndpointId endpoint = commandPath.mEndpointId;
+
     uint8_t currentHue          = 0;
     uint16_t currentEnhancedHue = 0;
     EmberAfStatus status        = EMBER_ZCL_STATUS_SUCCESS;
@@ -864,9 +868,12 @@ exit:
  * @return true Success
  * @return false Failed
  */
-bool ColorControlServer::moveToHueCommand(EndpointId endpoint, uint16_t hue, uint8_t hueMoveMode, uint16_t transitionTime,
-                                          uint8_t optionsMask, uint8_t optionsOverride, bool isEnhanced)
+bool ColorControlServer::moveToHueCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
+                                          uint16_t hue, uint8_t hueMoveMode, uint16_t transitionTime, uint8_t optionsMask,
+                                          uint8_t optionsOverride, bool isEnhanced)
 {
+    EndpointId endpoint = commandPath.mEndpointId;
+
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     uint16_t currentHue  = 0;
     uint8_t direction;
@@ -1009,10 +1016,13 @@ exit:
  * @return true Success
  * @return false Failed
  */
-bool ColorControlServer::moveToHueAndSaturationCommand(EndpointId endpoint, uint16_t hue, uint8_t saturation,
-                                                       uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride,
-                                                       bool isEnhanced)
+bool ColorControlServer::moveToHueAndSaturationCommand(app::CommandHandler * commandObj,
+                                                       const app::ConcreteCommandPath & commandPath, uint16_t hue,
+                                                       uint8_t saturation, uint16_t transitionTime, uint8_t optionsMask,
+                                                       uint8_t optionsOverride, bool isEnhanced)
 {
+    EndpointId endpoint = commandPath.mEndpointId;
+
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     uint16_t currentHue  = 0;
     uint16_t halfWay     = isEnhanced ? HALF_MAX_UINT16T : HALF_MAX_UINT8T;
@@ -1134,9 +1144,12 @@ exit:
  * @return true Success
  * @return false Failed
  */
-bool ColorControlServer::stepHueCommand(EndpointId endpoint, uint8_t stepMode, uint16_t stepSize, uint16_t transitionTime,
-                                        uint8_t optionsMask, uint8_t optionsOverride, bool isEnhanced)
+bool ColorControlServer::stepHueCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
+                                        uint8_t stepMode, uint16_t stepSize, uint16_t transitionTime, uint8_t optionsMask,
+                                        uint8_t optionsOverride, bool isEnhanced)
 {
+    EndpointId endpoint = commandPath.mEndpointId;
+
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
 
     ColorHueTransitionState * colorHueTransitionState        = getColorHueTransitionState(endpoint);
@@ -1228,7 +1241,7 @@ exit:
     return true;
 }
 
-bool ColorControlServer::moveSaturationCommand(const app::ConcreteCommandPath & commandPath,
+bool ColorControlServer::moveSaturationCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                const Commands::MoveSaturation::DecodableType & commandData)
 {
     auto & moveMode        = commandData.moveMode;
@@ -1308,7 +1321,7 @@ exit:
  * @return true
  * @return false
  */
-bool ColorControlServer::moveToSaturationCommand(const app::ConcreteCommandPath & commandPath,
+bool ColorControlServer::moveToSaturationCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                  const Commands::MoveToSaturation::DecodableType & commandData)
 {
     uint8_t saturation      = commandData.saturation;
@@ -1373,7 +1386,7 @@ exit:
     return true;
 }
 
-bool ColorControlServer::stepSaturationCommand(const app::ConcreteCommandPath & commandPath,
+bool ColorControlServer::stepSaturationCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                const Commands::StepSaturation::DecodableType & commandData)
 {
     uint8_t stepMode          = commandData.stepMode;
@@ -1448,7 +1461,7 @@ exit:
     return true;
 }
 
-bool ColorControlServer::colorLoopCommand(const app::ConcreteCommandPath & commandPath,
+bool ColorControlServer::colorLoopCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                           const Commands::ColorLoopSet::DecodableType & commandData)
 {
     uint8_t updateFlags       = commandData.updateFlags.Raw();
@@ -1695,7 +1708,7 @@ EmberEventControl * ColorControlServer::configureXYEventControl(EndpointId endpo
     return controller;
 }
 
-bool ColorControlServer::moveToColorCommand(const app::ConcreteCommandPath & commandPath,
+bool ColorControlServer::moveToColorCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                             const Commands::MoveToColor::DecodableType & commandData)
 {
     uint16_t colorX         = commandData.colorX;
@@ -1758,7 +1771,7 @@ exit:
     return true;
 }
 
-bool ColorControlServer::moveColorCommand(const app::ConcreteCommandPath & commandPath,
+bool ColorControlServer::moveColorCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                           const Commands::MoveColor::DecodableType & commandData)
 {
     int16_t rateX           = commandData.rateX;
@@ -1851,7 +1864,7 @@ exit:
     return true;
 }
 
-bool ColorControlServer::stepColorCommand(const app::ConcreteCommandPath & commandPath,
+bool ColorControlServer::stepColorCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                           const Commands::StepColor::DecodableType & commandData)
 {
     int16_t stepX           = commandData.stepX;
@@ -2169,7 +2182,7 @@ void ColorControlServer::updateTempCommand(EndpointId endpoint)
  * @return true
  * @return false
  */
-bool ColorControlServer::moveColorTempCommand(const app::ConcreteCommandPath & commandPath,
+bool ColorControlServer::moveColorTempCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                               const Commands::MoveColorTemperature::DecodableType & commandData)
 {
     uint8_t moveMode                 = commandData.moveMode;
@@ -2267,7 +2280,7 @@ exit:
     return true;
 }
 
-bool ColorControlServer::moveToColorTempCommand(const app::ConcreteCommandPath & commandPath,
+bool ColorControlServer::moveToColorTempCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                 const Commands::MoveToColorTemperature::DecodableType & commandData)
 {
     uint16_t colorTemperature = commandData.colorTemperatureMireds;
@@ -2288,7 +2301,7 @@ bool ColorControlServer::moveToColorTempCommand(const app::ConcreteCommandPath &
     return true;
 }
 
-bool ColorControlServer::stepColorTempCommand(const app::ConcreteCommandPath & commandPath,
+bool ColorControlServer::stepColorTempCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                               const Commands::StepColorTemperature::DecodableType & commandData)
 {
     uint8_t stepMode                 = commandData.stepMode;
@@ -2477,7 +2490,7 @@ void ColorControlServer::levelControlColorTempChangeCommand(EndpointId endpoint)
 bool emberAfColorControlClusterMoveHueCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                const Commands::MoveHue::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveHueCommand(commandPath.mEndpointId, commandData.moveMode, commandData.rate,
+    return ColorControlServer::Instance().moveHueCommand(commandObj, commandPath, commandData.moveMode, commandData.rate,
                                                          commandData.optionsMask, commandData.optionsOverride, false);
 }
 
@@ -2486,13 +2499,13 @@ bool emberAfColorControlClusterMoveSaturationCallback(app::CommandHandler * comm
                                                       const Commands::MoveSaturation::DecodableType & commandData)
 {
 
-    return ColorControlServer::Instance().moveSaturationCommand(commandPath, commandData);
+    return ColorControlServer::Instance().moveSaturationCommand(commandObj, commandPath, commandData);
 }
 
 bool emberAfColorControlClusterMoveToHueCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                  const Commands::MoveToHue::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveToHueCommand(commandPath.mEndpointId, commandData.hue, commandData.direction,
+    return ColorControlServer::Instance().moveToHueCommand(commandObj, commandPath, commandData.hue, commandData.direction,
                                                            commandData.transitionTime, commandData.optionsMask,
                                                            commandData.optionsOverride, false);
 }
@@ -2501,7 +2514,7 @@ bool emberAfColorControlClusterMoveToSaturationCallback(app::CommandHandler * co
                                                         const app::ConcreteCommandPath & commandPath,
                                                         const Commands::MoveToSaturation::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveToSaturationCommand(commandPath, commandData);
+    return ColorControlServer::Instance().moveToSaturationCommand(commandObj, commandPath, commandData);
 }
 
 bool emberAfColorControlClusterMoveToHueAndSaturationCallback(app::CommandHandler * commandObj,
@@ -2509,14 +2522,14 @@ bool emberAfColorControlClusterMoveToHueAndSaturationCallback(app::CommandHandle
                                                               const Commands::MoveToHueAndSaturation::DecodableType & commandData)
 {
     return ColorControlServer::Instance().moveToHueAndSaturationCommand(
-        commandPath.mEndpointId, commandData.hue, commandData.saturation, commandData.transitionTime, commandData.optionsMask,
+        commandObj, commandPath, commandData.hue, commandData.saturation, commandData.transitionTime, commandData.optionsMask,
         commandData.optionsOverride, false);
 }
 
 bool emberAfColorControlClusterStepHueCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                const Commands::StepHue::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().stepHueCommand(commandPath.mEndpointId, commandData.stepMode, commandData.stepSize,
+    return ColorControlServer::Instance().stepHueCommand(commandObj, commandPath, commandData.stepMode, commandData.stepSize,
                                                          commandData.transitionTime, commandData.optionsMask,
                                                          commandData.optionsOverride, false);
 }
@@ -2525,14 +2538,14 @@ bool emberAfColorControlClusterStepSaturationCallback(app::CommandHandler * comm
                                                       const app::ConcreteCommandPath & commandPath,
                                                       const Commands::StepSaturation::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().stepSaturationCommand(commandPath, commandData);
+    return ColorControlServer::Instance().stepSaturationCommand(commandObj, commandPath, commandData);
 }
 
 bool emberAfColorControlClusterEnhancedMoveHueCallback(app::CommandHandler * commandObj,
                                                        const app::ConcreteCommandPath & commandPath,
                                                        const Commands::EnhancedMoveHue::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveHueCommand(commandPath.mEndpointId, commandData.moveMode, commandData.rate,
+    return ColorControlServer::Instance().moveHueCommand(commandObj, commandPath, commandData.moveMode, commandData.rate,
                                                          commandData.optionsMask, commandData.optionsOverride, true);
 }
 
@@ -2540,7 +2553,7 @@ bool emberAfColorControlClusterEnhancedMoveToHueCallback(app::CommandHandler * c
                                                          const app::ConcreteCommandPath & commandPath,
                                                          const Commands::EnhancedMoveToHue::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveToHueCommand(commandPath.mEndpointId, commandData.enhancedHue, commandData.direction,
+    return ColorControlServer::Instance().moveToHueCommand(commandObj, commandPath, commandData.enhancedHue, commandData.direction,
                                                            commandData.transitionTime, commandData.optionsMask,
                                                            commandData.optionsOverride, true);
 }
@@ -2549,7 +2562,7 @@ bool emberAfColorControlClusterEnhancedMoveToHueAndSaturationCallback(
     app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
     const Commands::EnhancedMoveToHueAndSaturation::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveToHueAndSaturationCommand(commandPath.mEndpointId, commandData.enhancedHue,
+    return ColorControlServer::Instance().moveToHueAndSaturationCommand(commandObj, commandPath, commandData.enhancedHue,
                                                                         commandData.saturation, commandData.transitionTime,
                                                                         commandData.optionsMask, commandData.optionsOverride, true);
 }
@@ -2558,7 +2571,7 @@ bool emberAfColorControlClusterEnhancedStepHueCallback(app::CommandHandler * com
                                                        const app::ConcreteCommandPath & commandPath,
                                                        const Commands::EnhancedStepHue::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().stepHueCommand(commandPath.mEndpointId, commandData.stepMode, commandData.stepSize,
+    return ColorControlServer::Instance().stepHueCommand(commandObj, commandPath, commandData.stepMode, commandData.stepSize,
                                                          commandData.transitionTime, commandData.optionsMask,
                                                          commandData.optionsOverride, true);
 }
@@ -2566,7 +2579,7 @@ bool emberAfColorControlClusterEnhancedStepHueCallback(app::CommandHandler * com
 bool emberAfColorControlClusterColorLoopSetCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                     const Commands::ColorLoopSet::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().colorLoopCommand(commandPath, commandData);
+    return ColorControlServer::Instance().colorLoopCommand(commandObj, commandPath, commandData);
 }
 
 #endif // EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_HSV
@@ -2576,19 +2589,19 @@ bool emberAfColorControlClusterColorLoopSetCallback(app::CommandHandler * comman
 bool emberAfColorControlClusterMoveToColorCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                    const Commands::MoveToColor::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveToColorCommand(commandPath, commandData);
+    return ColorControlServer::Instance().moveToColorCommand(commandObj, commandPath, commandData);
 }
 
 bool emberAfColorControlClusterMoveColorCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                  const Commands::MoveColor::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveColorCommand(commandPath, commandData);
+    return ColorControlServer::Instance().moveColorCommand(commandObj, commandPath, commandData);
 }
 
 bool emberAfColorControlClusterStepColorCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                  const Commands::StepColor::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().stepColorCommand(commandPath, commandData);
+    return ColorControlServer::Instance().stepColorCommand(commandObj, commandPath, commandData);
 }
 
 #endif // EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_XY
@@ -2599,21 +2612,21 @@ bool emberAfColorControlClusterMoveToColorTemperatureCallback(app::CommandHandle
                                                               const app::ConcreteCommandPath & commandPath,
                                                               const Commands::MoveToColorTemperature::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveToColorTempCommand(commandPath, commandData);
+    return ColorControlServer::Instance().moveToColorTempCommand(commandObj, commandPath, commandData);
 }
 
 bool emberAfColorControlClusterMoveColorTemperatureCallback(app::CommandHandler * commandObj,
                                                             const app::ConcreteCommandPath & commandPath,
                                                             const Commands::MoveColorTemperature::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveColorTempCommand(commandPath, commandData);
+    return ColorControlServer::Instance().moveColorTempCommand(commandObj, commandPath, commandData);
 }
 
 bool emberAfColorControlClusterStepColorTemperatureCallback(app::CommandHandler * commandObj,
                                                             const app::ConcreteCommandPath & commandPath,
                                                             const Commands::StepColorTemperature::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().stepColorTempCommand(commandPath, commandData);
+    return ColorControlServer::Instance().stepColorTempCommand(commandObj, commandPath, commandData);
 }
 
 void emberAfPluginLevelControlCoupledColorTempChangeCallback(EndpointId endpoint)

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af-types.h>
 #include <app/util/basic-types.h>
@@ -133,42 +134,45 @@ public:
     bool stopMoveStepCommand(chip::EndpointId, uint8_t optionsMask, uint8_t optionsOverride);
 
 #ifdef EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_HSV
-    bool moveHueCommand(chip::EndpointId endpoint, uint8_t moveMode, uint16_t rate, uint8_t optionsMask, uint8_t optionsOverride,
+    bool moveHueCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                        uint8_t moveMode, uint16_t rate, uint8_t optionsMask, uint8_t optionsOverride, bool isEnhanced);
+    bool moveToHueCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath, uint16_t hue,
+                          uint8_t hueMoveMode, uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride,
+                          bool isEnhanced);
+    bool moveToHueAndSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                                       uint16_t hue, uint8_t saturation, uint16_t transitionTime, uint8_t optionsMask,
+                                       uint8_t optionsOverride, bool isEnhanced);
+    bool stepHueCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                        uint8_t stepMode, uint16_t stepSize, uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride,
                         bool isEnhanced);
-    bool moveToHueCommand(chip::EndpointId endpoint, uint16_t hue, uint8_t hueMoveMode, uint16_t transitionTime,
-                          uint8_t optionsMask, uint8_t optionsOverride, bool isEnhanced);
-    bool moveToHueAndSaturationCommand(chip::EndpointId endpoint, uint16_t hue, uint8_t saturation, uint16_t transitionTime,
-                                       uint8_t optionsMask, uint8_t optionsOverride, bool isEnhanced);
-    bool stepHueCommand(chip::EndpointId endpoint, uint8_t stepMode, uint16_t stepSize, uint16_t transitionTime,
-                        uint8_t optionsMask, uint8_t optionsOverride, bool isEnhanced);
-    bool moveSaturationCommand(const chip::app::ConcreteCommandPath & commandPath,
+    bool moveSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                                const chip::app::Clusters::ColorControl::Commands::MoveSaturation::DecodableType & commandData);
-    bool moveToSaturationCommand(const chip::app::ConcreteCommandPath & commandPath,
+    bool moveToSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                                  const chip::app::Clusters::ColorControl::Commands::MoveToSaturation::DecodableType & commandData);
-    bool stepSaturationCommand(const chip::app::ConcreteCommandPath & commandPath,
+    bool stepSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                                const chip::app::Clusters::ColorControl::Commands::StepSaturation::DecodableType & commandData);
-    bool colorLoopCommand(const chip::app::ConcreteCommandPath & commandPath,
+    bool colorLoopCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                           const chip::app::Clusters::ColorControl::Commands::ColorLoopSet::DecodableType & commandData);
     void updateHueSatCommand(chip::EndpointId endpoint);
 #endif // EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_HSV
 
 #ifdef EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_XY
-    bool moveToColorCommand(const chip::app::ConcreteCommandPath & commandPath,
+    bool moveToColorCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                             const chip::app::Clusters::ColorControl::Commands::MoveToColor::DecodableType & commandData);
-    bool moveColorCommand(const chip::app::ConcreteCommandPath & commandPath,
+    bool moveColorCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                           const chip::app::Clusters::ColorControl::Commands::MoveColor::DecodableType & commandData);
-    bool stepColorCommand(const chip::app::ConcreteCommandPath & commandPath,
+    bool stepColorCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                           const chip::app::Clusters::ColorControl::Commands::StepColor::DecodableType & commandData);
     void updateXYCommand(chip::EndpointId endpoint);
 #endif // EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_XY
 
 #ifdef EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_TEMP
-    bool moveColorTempCommand(const chip::app::ConcreteCommandPath & commandPath,
+    bool moveColorTempCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                               const chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::DecodableType & commandData);
     bool
-    moveToColorTempCommand(const chip::app::ConcreteCommandPath & commandPath,
+    moveToColorTempCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                            const chip::app::Clusters::ColorControl::Commands::MoveToColorTemperature::DecodableType & commandData);
-    bool stepColorTempCommand(const chip::app::ConcreteCommandPath & commandPath,
+    bool stepColorTempCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                               const chip::app::Clusters::ColorControl::Commands::StepColorTemperature::DecodableType & commandData);
     void levelControlColorTempChangeCommand(chip::EndpointId endpoint);
     void startUpColorTempCommand(chip::EndpointId endpoint);

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -22,6 +22,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af-types.h>
 #include <app/util/basic-types.h>
+#include <protocols/interaction_model/StatusCode.h>
 
 /**********************************************************
  * Defines and Macros
@@ -130,8 +131,9 @@ public:
     static ColorControlServer & Instance();
 
     bool HasFeature(chip::EndpointId endpoint, ColorControlFeature feature);
-    EmberAfStatus stopAllColorTransitions(chip::EndpointId endpoint);
-    bool stopMoveStepCommand(chip::EndpointId, uint8_t optionsMask, uint8_t optionsOverride);
+    chip::Protocols::InteractionModel::Status stopAllColorTransitions(chip::EndpointId endpoint);
+    bool stopMoveStepCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                             uint8_t optionsMask, uint8_t optionsOverride);
 
 #ifdef EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_HSV
     bool moveHueCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
@@ -220,7 +222,8 @@ private:
 
 #ifdef EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_TEMP
     Color16uTransitionState * getTempTransitionState(chip::EndpointId endpoint);
-    EmberAfStatus moveToColorTemp(chip::EndpointId aEndpoint, uint16_t colorTemperature, uint16_t transitionTime);
+    chip::Protocols::InteractionModel::Status moveToColorTemp(chip::EndpointId aEndpoint, uint16_t colorTemperature,
+                                                              uint16_t transitionTime);
     uint16_t getTemperatureCoupleToLevelMin(chip::EndpointId endpoint);
     EmberEventControl * configureTempEventControl(chip::EndpointId);
 #endif // EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_TEMP

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -220,7 +220,7 @@ exit:
     // If isDelegateNull, no one will call responder, so HasSentResponse will be false
     if (!responder.HasSentResponse())
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -256,7 +256,7 @@ exit:
     // If isDelegateNull, no one will call responder, so HasSentResponse will be false
     if (!responder.HasSentResponse())
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -39,6 +39,7 @@ using namespace chip::app::Clusters::ContentLauncher;
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 using namespace chip::AppPlatform;
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
+using chip::Protocols::InteractionModel::Status;
 
 static constexpr size_t kContentLaunchDelegateTableSize =
     EMBER_AF_CONTENT_LAUNCHER_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;

--- a/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
+++ b/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
@@ -111,9 +111,7 @@ bool emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::DecodableType & commandData)
 {
-    // TODO: Shouldn't the default "no-op" impl return some sort of error?
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
-    emberAfSendImmediateDefaultResponse(status);
+    commandObj->AddStatus(commandPath, chip::Protocols::InteractionModel::Status::UnsupportedCommand);
     return true;
 }
 

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -422,7 +422,7 @@ void DoorLockServer::getUserCommandHandler(chip::app::CommandHandler * commandOb
     if (!SupportsUSR(commandPath.mEndpointId))
     {
         emberAfDoorLockClusterPrintln("[GetUser] User management is not supported [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND);
+        commandObj->AddStatus(commandPath, Status::UnsupportedCommand);
         return;
     }
 
@@ -431,7 +431,7 @@ void DoorLockServer::getUserCommandHandler(chip::app::CommandHandler * commandOb
     {
         emberAfDoorLockClusterPrintln("[GetUser] User index out of bounds [userIndex=%d,numberOfTotalUsersSupported=%d]", userIndex,
                                       maxNumberOfUsers);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -512,7 +512,7 @@ exit:
     {
         ChipLogError(Zcl, "[GetUser] Command processing failed [endpointId=%d,userIndex=%d,err=\"%s\"]", commandPath.mEndpointId,
                      userIndex, err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 }
 
@@ -524,7 +524,7 @@ void DoorLockServer::clearUserCommandHandler(chip::app::CommandHandler * command
     if (!SupportsUSR(commandPath.mEndpointId))
     {
         emberAfDoorLockClusterPrintln("[ClearUser] User management is not supported [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND);
+        commandObj->AddStatus(commandPath, Status::UnsupportedCommand);
         return;
     }
 
@@ -533,7 +533,7 @@ void DoorLockServer::clearUserCommandHandler(chip::app::CommandHandler * command
     {
         ChipLogError(Zcl, "[ClearUser] Unable to get the fabric IDX [endpointId=%d,userIndex=%d]", commandPath.mEndpointId,
                      userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -542,7 +542,7 @@ void DoorLockServer::clearUserCommandHandler(chip::app::CommandHandler * command
     {
         ChipLogError(Zcl, "[ClearUser] Unable to get the source node index [endpointId=%d,userIndex=%d]", commandPath.mEndpointId,
                      userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -551,7 +551,7 @@ void DoorLockServer::clearUserCommandHandler(chip::app::CommandHandler * command
     {
         emberAfDoorLockClusterPrintln("[ClearUser] User index out of bounds [userIndex=%d,numberOfTotalUsersSupported=%d]",
                                       userIndex, maxNumberOfUsers);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -575,7 +575,7 @@ void DoorLockServer::clearUserCommandHandler(chip::app::CommandHandler * command
         {
             ChipLogError(Zcl, "[ClearUser] App reported failure when resetting the user [userIndex=%d,status=0x%x]", i, status);
 
-            emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+            commandObj->AddStatus(commandPath, Status::Failure);
             return;
         }
     }
@@ -584,7 +584,7 @@ void DoorLockServer::clearUserCommandHandler(chip::app::CommandHandler * command
     sendRemoteLockUserChange(commandPath.mEndpointId, LockDataTypeEnum::kUserIndex, DataOperationTypeEnum::kClear, sourceNodeId,
                              fabricIdx, 0xFFFE, 0xFFFE);
 
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
 }
 
 void DoorLockServer::setCredentialCommandHandler(
@@ -597,7 +597,7 @@ void DoorLockServer::setCredentialCommandHandler(
     if (kUndefinedFabricIndex == fabricIdx)
     {
         ChipLogError(Zcl, "[SetCredential] Unable to get the fabric IDX [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -605,7 +605,7 @@ void DoorLockServer::setCredentialCommandHandler(
     if (chip::kUndefinedNodeId == sourceNodeId)
     {
         ChipLogError(Zcl, "[SetCredential] Unable to get the source node index [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -621,7 +621,7 @@ void DoorLockServer::setCredentialCommandHandler(
     {
         emberAfDoorLockClusterPrintln("[SetCredential] Credential type is not supported [endpointId=%d,credentialType=%u]",
                                       commandPath.mEndpointId, to_underlying(credentialType));
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND);
+        commandObj->AddStatus(commandPath, Status::UnsupportedCommand);
         return;
     }
 
@@ -757,7 +757,7 @@ void DoorLockServer::getCredentialStatusCommandHandler(chip::app::CommandHandler
         emberAfDoorLockClusterPrintln("[GetCredentialStatus] Credential type is not supported [endpointId=%d,credentialType=%u"
                                       "]",
                                       commandPath.mEndpointId, to_underlying(credentialType));
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND);
+        commandObj->AddStatus(commandPath, Status::UnsupportedCommand);
         return;
     }
 
@@ -775,7 +775,7 @@ void DoorLockServer::getCredentialStatusCommandHandler(chip::app::CommandHandler
                                       "[endpointId=%d,credentialIndex=%d,credentialType=%u,creator=%u,modifier=%u]",
                                       commandPath.mEndpointId, credentialIndex, to_underlying(credentialType),
                                       credentialInfo.createdBy, credentialInfo.lastModifiedBy);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -791,7 +791,7 @@ void DoorLockServer::getCredentialStatusCommandHandler(chip::app::CommandHandler
                          "[GetCredentialStatus] Database possibly corrupted - credential exists without user assigned "
                          "[endpointId=%d,credentialType=%u,credentialIndex=%d]",
                          commandPath.mEndpointId, to_underlying(credentialType), credentialIndex);
-            emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+            commandObj->AddStatus(commandPath, Status::Failure);
             return;
         }
     }
@@ -849,14 +849,14 @@ void DoorLockServer::clearCredentialCommandHandler(
     auto modifier = getFabricIndex(commandObj);
     if (kUndefinedFabricIndex == modifier)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
     auto sourceNodeId = getNodeId(commandObj);
     if (chip::kUndefinedNodeId == sourceNodeId)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -890,7 +890,7 @@ void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler 
     if (!SupportsWeekDaySchedules(endpointId))
     {
         emberAfDoorLockClusterPrintln("[SetWeekDaySchedule] Ignore command (not supported) [endpointId=%d]", endpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -900,7 +900,7 @@ void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler 
     if (kUndefinedFabricIndex == fabricIdx)
     {
         ChipLogError(Zcl, "[SetWeekDaySchedule] Unable to get the fabric IDX [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -908,7 +908,7 @@ void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler 
     if (chip::kUndefinedNodeId == sourceNodeId)
     {
         ChipLogError(Zcl, "[SetWeekDaySchedule] Unable to get the source node index [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -917,7 +917,7 @@ void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler 
         emberAfDoorLockClusterPrintln(
             "[SetWeekDaySchedule] Unable to add schedule - index out of range [endpointId=%d,weekDayIndex=%d,userIndex=%d]",
             endpointId, weekDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -926,7 +926,7 @@ void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler 
         emberAfDoorLockClusterPrintln("[SetWeekDaySchedule] Unable to add schedule - user does not exist "
                                       "[endpointId=%d,weekDayIndex=%d,userIndex=%d]",
                                       endpointId, weekDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -945,7 +945,7 @@ void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler 
         emberAfDoorLockClusterPrintln("[SetWeekDaySchedule] Unable to add schedule - daysMask is out of range "
                                       "[endpointId=%d,weekDayIndex=%d,userIndex=%d,daysMask=%x]",
                                       endpointId, weekDayIndex, userIndex, daysMask.Raw());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -955,7 +955,7 @@ void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler 
         emberAfDoorLockClusterPrintln("[SetWeekDaySchedule] Unable to add schedule - start time out of range "
                                       "[endpointId=%d,weekDayIndex=%d,userIndex=%d,startTime=\"%d:%d\",endTime=\"%d:%d\"]",
                                       endpointId, weekDayIndex, userIndex, startHour, startMinute, endHour, endMinute);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -964,7 +964,7 @@ void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler 
         emberAfDoorLockClusterPrintln("[SetWeekDaySchedule] Unable to add schedule - invalid time "
                                       "[endpointId=%d,weekDayIndex=%d,userIndex=%d,startTime=\"%d:%d\",endTime=\"%d:%d\"]",
                                       endpointId, weekDayIndex, userIndex, startHour, startMinute, endHour, endMinute);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -976,7 +976,7 @@ void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler 
                      "[SetWeekDaySchedule] Unable to add schedule - internal error "
                      "[endpointId=%d,weekDayIndex=%d,userIndex=%d,status=%u]",
                      endpointId, weekDayIndex, userIndex, to_underlying(status));
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -987,7 +987,7 @@ void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler 
     sendRemoteLockUserChange(endpointId, LockDataTypeEnum::kWeekDaySchedule, DataOperationTypeEnum::kAdd, sourceNodeId, fabricIdx,
                              userIndex, static_cast<uint16_t>(weekDayIndex));
 
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
 }
 
 void DoorLockServer::getWeekDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
@@ -998,7 +998,7 @@ void DoorLockServer::getWeekDayScheduleCommandHandler(chip::app::CommandHandler 
     if (!SupportsWeekDaySchedules(endpointId))
     {
         emberAfDoorLockClusterPrintln("[GetWeekDaySchedule] Ignore command (not supported) [endpointId=%d]", endpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -1041,7 +1041,7 @@ void DoorLockServer::clearWeekDayScheduleCommandHandler(chip::app::CommandHandle
     if (!SupportsWeekDaySchedules(endpointId))
     {
         emberAfDoorLockClusterPrintln("[ClearWeekDaySchedule] Ignore command (not supported) [endpointId=%d]", endpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -1051,7 +1051,7 @@ void DoorLockServer::clearWeekDayScheduleCommandHandler(chip::app::CommandHandle
     if (kUndefinedFabricIndex == fabricIdx)
     {
         ChipLogError(Zcl, "[ClearWeekDaySchedule] Unable to get the fabric IDX [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -1059,7 +1059,7 @@ void DoorLockServer::clearWeekDayScheduleCommandHandler(chip::app::CommandHandle
     if (chip::kUndefinedNodeId == sourceNodeId)
     {
         ChipLogError(Zcl, "[ClearWeekDaySchedule] Unable to get the source node index [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -1068,7 +1068,7 @@ void DoorLockServer::clearWeekDayScheduleCommandHandler(chip::app::CommandHandle
         emberAfDoorLockClusterPrintln(
             "[ClearWeekDaySchedule] User or WeekDay index is out of range [endpointId=%d,weekDayIndex=%d,userIndex=%d]", endpointId,
             weekDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -1076,7 +1076,7 @@ void DoorLockServer::clearWeekDayScheduleCommandHandler(chip::app::CommandHandle
     {
         emberAfDoorLockClusterPrintln("[ClearWeekDaySchedule] User does not exist [endpointId=%d,weekDayIndex=%d,userIndex=%d]",
                                       endpointId, weekDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -1100,14 +1100,14 @@ void DoorLockServer::clearWeekDayScheduleCommandHandler(chip::app::CommandHandle
         emberAfDoorLockClusterPrintln(
             "[ClearWeekDaySchedule] Unable to clear the user schedules - app error [endpointId=%d,userIndex=%d,status=%u]",
             endpointId, userIndex, to_underlying(clearStatus));
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
     sendRemoteLockUserChange(endpointId, LockDataTypeEnum::kWeekDaySchedule, DataOperationTypeEnum::kClear, sourceNodeId, fabricIdx,
                              userIndex, static_cast<uint16_t>(weekDayIndex));
 
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
 }
 
 void DoorLockServer::setYearDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
@@ -1118,7 +1118,7 @@ void DoorLockServer::setYearDayScheduleCommandHandler(chip::app::CommandHandler 
     if (!SupportsYearDaySchedules(endpointId))
     {
         emberAfDoorLockClusterPrintln("[SetYearDaySchedule] Ignore command (not supported) [endpointId=%d]", endpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -1128,7 +1128,7 @@ void DoorLockServer::setYearDayScheduleCommandHandler(chip::app::CommandHandler 
     if (kUndefinedFabricIndex == fabricIdx)
     {
         ChipLogError(Zcl, "[SetYearDaySchedule] Unable to get the fabric IDX [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -1136,7 +1136,7 @@ void DoorLockServer::setYearDayScheduleCommandHandler(chip::app::CommandHandler 
     if (chip::kUndefinedNodeId == sourceNodeId)
     {
         ChipLogError(Zcl, "[SetYearDaySchedule] Unable to get the source node index [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -1145,7 +1145,7 @@ void DoorLockServer::setYearDayScheduleCommandHandler(chip::app::CommandHandler 
         emberAfDoorLockClusterPrintln(
             "[SetYearDaySchedule] Unable to add schedule - index out of range [endpointId=%d,yearDayIndex=%d,userIndex=%d]",
             endpointId, yearDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -1154,7 +1154,7 @@ void DoorLockServer::setYearDayScheduleCommandHandler(chip::app::CommandHandler 
         emberAfDoorLockClusterPrintln("[SetYearDaySchedule] Unable to add schedule - user does not exist "
                                       "[endpointId=%d,yearDayIndex=%d,userIndex=%d]",
                                       endpointId, yearDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -1164,7 +1164,7 @@ void DoorLockServer::setYearDayScheduleCommandHandler(chip::app::CommandHandler 
                                       "[endpointId=%d,yearDayIndex=%d,userIndex=%d,localStarTime=%" PRIu32 ",localEndTime=%" PRIu32
                                       "]",
                                       endpointId, yearDayIndex, userIndex, localStartTime, localEndTime);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -1176,7 +1176,7 @@ void DoorLockServer::setYearDayScheduleCommandHandler(chip::app::CommandHandler 
                      "[SetYearDaySchedule] Unable to add schedule - internal error "
                      "[endpointId=%d,yearDayIndex=%d,userIndex=%d,status=%u]",
                      endpointId, yearDayIndex, userIndex, to_underlying(status));
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -1187,7 +1187,7 @@ void DoorLockServer::setYearDayScheduleCommandHandler(chip::app::CommandHandler 
     sendRemoteLockUserChange(endpointId, LockDataTypeEnum::kYearDaySchedule, DataOperationTypeEnum::kAdd, sourceNodeId, fabricIdx,
                              userIndex, static_cast<uint16_t>(yearDayIndex));
 
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
 }
 
 void DoorLockServer::getYearDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
@@ -1198,7 +1198,7 @@ void DoorLockServer::getYearDayScheduleCommandHandler(chip::app::CommandHandler 
     if (!SupportsYearDaySchedules(endpointId))
     {
         emberAfDoorLockClusterPrintln("[GetYearDaySchedule] Ignore command (not supported) [endpointId=%d]", endpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
     emberAfDoorLockClusterPrintln("[GetYearDaySchedule] incoming command [endpointId=%d]", endpointId);
@@ -1240,7 +1240,7 @@ void DoorLockServer::clearYearDayScheduleCommandHandler(chip::app::CommandHandle
     if (!SupportsYearDaySchedules(endpointId))
     {
         emberAfDoorLockClusterPrintln("[ClearYearDaySchedule] Ignore command (not supported) [endpointId=%d]", endpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
     emberAfDoorLockClusterPrintln("[ClearYearDaySchedule] incoming command [endpointId=%d]", endpointId);
@@ -1249,7 +1249,7 @@ void DoorLockServer::clearYearDayScheduleCommandHandler(chip::app::CommandHandle
     if (kUndefinedFabricIndex == fabricIdx)
     {
         ChipLogError(Zcl, "[ClearYearDaySchedule] Unable to get the fabric IDX [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -1257,7 +1257,7 @@ void DoorLockServer::clearYearDayScheduleCommandHandler(chip::app::CommandHandle
     if (chip::kUndefinedNodeId == sourceNodeId)
     {
         ChipLogError(Zcl, "[ClearYearDaySchedule] Unable to get the source node index [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -1266,7 +1266,7 @@ void DoorLockServer::clearYearDayScheduleCommandHandler(chip::app::CommandHandle
         emberAfDoorLockClusterPrintln(
             "[ClearYearDaySchedule] User or YearDay index is out of range [endpointId=%d,yearDayIndex=%d,userIndex=%d]", endpointId,
             yearDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -1274,7 +1274,7 @@ void DoorLockServer::clearYearDayScheduleCommandHandler(chip::app::CommandHandle
     {
         emberAfDoorLockClusterPrintln("[ClearYearDaySchedule] User does not exist [endpointId=%d,yearDayIndex=%d,userIndex=%d]",
                                       endpointId, yearDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -1298,14 +1298,14 @@ void DoorLockServer::clearYearDayScheduleCommandHandler(chip::app::CommandHandle
         emberAfDoorLockClusterPrintln(
             "[ClearYearDaySchedule] Unable to clear the user schedules - app error [endpointId=%d,userIndex=%d,status=%u]",
             endpointId, userIndex, to_underlying(clearStatus));
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
     sendRemoteLockUserChange(endpointId, LockDataTypeEnum::kYearDaySchedule, DataOperationTypeEnum::kClear, sourceNodeId, fabricIdx,
                              userIndex, static_cast<uint16_t>(yearDayIndex));
 
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
 }
 
 chip::BitFlags<DoorLockFeature> DoorLockServer::GetFeatures(chip::EndpointId endpointId)
@@ -3098,7 +3098,7 @@ void DoorLockServer::setHolidayScheduleCommandHandler(chip::app::CommandHandler 
     if (!SupportsHolidaySchedules(endpointId))
     {
         emberAfDoorLockClusterPrintln("[SetHolidaySchedule] Ignore command (not supported) [endpointId=%d]", endpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -3109,7 +3109,7 @@ void DoorLockServer::setHolidayScheduleCommandHandler(chip::app::CommandHandler 
         emberAfDoorLockClusterPrintln(
             "[SetHolidaySchedule] Unable to add schedule - index out of range [endpointId=%d,scheduleIndex=%d]", endpointId,
             holidayIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -3118,7 +3118,7 @@ void DoorLockServer::setHolidayScheduleCommandHandler(chip::app::CommandHandler 
         emberAfDoorLockClusterPrintln("[SetHolidaySchedule] Unable to add schedule - schedule ends earlier than starts"
                                       "[endpointId=%d,scheduleIndex=%d,localStarTime=%" PRIu32 ",localEndTime=%" PRIu32 "]",
                                       endpointId, holidayIndex, localStartTime, localEndTime);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -3128,7 +3128,7 @@ void DoorLockServer::setHolidayScheduleCommandHandler(chip::app::CommandHandler 
                                       "[endpointId=%d,scheduleIndex=%d,localStarTime=%" PRIu32 ",localEndTime=%" PRIu32
                                       ", operatingMode=%d]",
                                       endpointId, holidayIndex, localStartTime, localEndTime, to_underlying(operatingMode));
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -3138,7 +3138,7 @@ void DoorLockServer::setHolidayScheduleCommandHandler(chip::app::CommandHandler 
     {
         ChipLogError(Zcl, "[SetHolidaySchedule] Unable to add schedule - internal error [endpointId=%d,scheduleIndex=%d,status=%u]",
                      endpointId, holidayIndex, to_underlying(status));
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
 
@@ -3147,7 +3147,7 @@ void DoorLockServer::setHolidayScheduleCommandHandler(chip::app::CommandHandler 
                                   ",operatingMode=%d]",
                                   endpointId, holidayIndex, localStartTime, localEndTime, to_underlying(operatingMode));
 
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
 }
 
 void DoorLockServer::getHolidayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
@@ -3158,7 +3158,7 @@ void DoorLockServer::getHolidayScheduleCommandHandler(chip::app::CommandHandler 
     {
         emberAfDoorLockClusterPrintln("[GetHolidaySchedule] Ignore command (not supported) [endpointId=%d,scheduleIndex=%d]",
                                       endpointId, holidayIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
     emberAfDoorLockClusterPrintln("[GetHolidaySchedule] incoming command [endpointId=%d,scheduleIndex=%d]", endpointId,
@@ -3191,7 +3191,7 @@ void DoorLockServer::clearHolidayScheduleCommandHandler(chip::app::CommandHandle
     if (!SupportsHolidaySchedules(endpointId))
     {
         emberAfDoorLockClusterPrintln("[ClearHolidaySchedule] Ignore command (not supported) [endpointId=%d]", endpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
     emberAfDoorLockClusterPrintln("[ClearHolidaySchedule] incoming command [endpointId=%d,scheduleIndex=%d]", endpointId,
@@ -3201,7 +3201,7 @@ void DoorLockServer::clearHolidayScheduleCommandHandler(chip::app::CommandHandle
     {
         emberAfDoorLockClusterPrintln("[ClearHolidaySchedule] Holiday index is out of range [endpointId=%d,scheduleIndex=%d]",
                                       endpointId, holidayIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
 
@@ -3225,10 +3225,10 @@ void DoorLockServer::clearHolidayScheduleCommandHandler(chip::app::CommandHandle
         emberAfDoorLockClusterPrintln(
             "[ClearHolidaySchedule] Unable to clear the user schedules - app error [endpointId=%d,scheduleIndex=%d,status=%u]",
             endpointId, holidayIndex, to_underlying(clearStatus));
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return;
     }
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
 }
 
 bool DoorLockServer::RemoteOperationEnabled(chip::EndpointId endpointId) const

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -41,6 +41,7 @@ using namespace chip;
 using namespace chip::app;
 using namespace chip::app::DataModel;
 using namespace chip::app::Clusters::DoorLock;
+using chip::Protocols::InteractionModel::Status;
 
 static constexpr uint8_t DOOR_LOCK_SCHEDULE_MAX_HOUR   = 23;
 static constexpr uint8_t DOOR_LOCK_SCHEDULE_MAX_MINUTE = 59;

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -30,6 +30,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
 #include <app/util/config.h>
+#include <protocols/interaction_model/StatusCode.h>
 
 #ifndef DOOR_LOCK_SERVER_ENDPOINT
 #define DOOR_LOCK_SERVER_ENDPOINT 1
@@ -219,10 +220,11 @@ private:
                              uint16_t userIndex, const Nullable<chip::CharSpan> & userName, const Nullable<uint32_t> & userUniqueId,
                              const Nullable<UserStatusEnum> & userStatus, const Nullable<UserTypeEnum> & userType,
                              const Nullable<CredentialRuleEnum> & credentialRule);
-    EmberAfStatus clearUser(chip::EndpointId endpointId, chip::FabricIndex modifierFabricId, chip::NodeId sourceNodeId,
-                            uint16_t userIndex, bool sendUserChangeEvent);
-    EmberAfStatus clearUser(chip::EndpointId endpointId, chip::FabricIndex modifierFabricId, chip::NodeId sourceNodeId,
-                            uint16_t userIndex, const EmberAfPluginDoorLockUserInfo & user, bool sendUserChangeEvent);
+    chip::Protocols::InteractionModel::Status clearUser(chip::EndpointId endpointId, chip::FabricIndex modifierFabricId,
+                                                        chip::NodeId sourceNodeId, uint16_t userIndex, bool sendUserChangeEvent);
+    chip::Protocols::InteractionModel::Status clearUser(chip::EndpointId endpointId, chip::FabricIndex modifierFabricId,
+                                                        chip::NodeId sourceNodeId, uint16_t userIndex,
+                                                        const EmberAfPluginDoorLockUserInfo & user, bool sendUserChangeEvent);
 
     bool clearFabricFromUsers(chip::EndpointId endpointId, chip::FabricIndex fabricIndex);
 
@@ -252,11 +254,13 @@ private:
                               const EmberAfPluginDoorLockCredentialInfo & existingCredential, const chip::ByteSpan & credentialData,
                               uint16_t userIndex, const Nullable<UserStatusEnum> & userStatus, Nullable<UserTypeEnum> userType);
 
-    EmberAfStatus clearCredential(chip::EndpointId endpointId, chip::FabricIndex modifier, chip::NodeId sourceNodeId,
-                                  CredentialTypeEnum credentialType, uint16_t credentialIndex, bool sendUserChangeEvent);
-    EmberAfStatus clearCredentials(chip::EndpointId endpointId, chip::FabricIndex modifier, chip::NodeId sourceNodeId);
-    EmberAfStatus clearCredentials(chip::EndpointId endpointId, chip::FabricIndex modifier, chip::NodeId sourceNodeId,
-                                   CredentialTypeEnum credentialType);
+    chip::Protocols::InteractionModel::Status clearCredential(chip::EndpointId endpointId, chip::FabricIndex modifier,
+                                                              chip::NodeId sourceNodeId, CredentialTypeEnum credentialType,
+                                                              uint16_t credentialIndex, bool sendUserChangeEvent);
+    chip::Protocols::InteractionModel::Status clearCredentials(chip::EndpointId endpointId, chip::FabricIndex modifier,
+                                                               chip::NodeId sourceNodeId);
+    chip::Protocols::InteractionModel::Status clearCredentials(chip::EndpointId endpointId, chip::FabricIndex modifier,
+                                                               chip::NodeId sourceNodeId, CredentialTypeEnum credentialType);
 
     bool clearFabricFromCredentials(chip::EndpointId endpointId, CredentialTypeEnum credentialType,
                                     chip::FabricIndex fabricToRemove);

--- a/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
+++ b/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
@@ -296,7 +296,7 @@ bool emberAfGroupKeyManagementClusterKeySetWriteCallback(
 
     if (nullptr == provider || nullptr == fabric)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return true;
     }
 
@@ -305,7 +305,7 @@ bool emberAfGroupKeyManagementClusterKeySetWriteCallback(
     CHIP_ERROR err = fabric->GetCompressedFabricIdBytes(compressed_fabric_id);
     if (CHIP_NO_ERROR != err)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return true;
     }
 
@@ -314,7 +314,7 @@ bool emberAfGroupKeyManagementClusterKeySetWriteCallback(
     {
         // If the EpochKey0 field is null or its associated EpochStartTime0 field is null,
         // then this command SHALL fail with an INVALID_COMMAND
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return true;
     }
 
@@ -333,7 +333,7 @@ bool emberAfGroupKeyManagementClusterKeySetWriteCallback(
         {
             // If the EpochKey1 field is not null, its associated EpochStartTime1 field SHALL contain
             // a later epoch start time than the epoch start time found in the EpochStartTime0 field.
-            emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+            commandObj->AddStatus(commandPath, Status::InvalidCommand);
             return true;
         }
         keyset.epoch_keys[1].start_time = commandData.groupKeySet.epochStartTime1.Value();
@@ -352,7 +352,7 @@ bool emberAfGroupKeyManagementClusterKeySetWriteCallback(
             // * The EpochKey1 field SHALL NOT be null
             // * Its associated EpochStartTime1 field SHALL contain a later epoch start time
             //   than the epoch start time found in the EpochStartTime0 field.
-            emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+            commandObj->AddStatus(commandPath, Status::InvalidCommand);
             return true;
         }
         keyset.epoch_keys[2].start_time = commandData.groupKeySet.epochStartTime2.Value();
@@ -391,7 +391,7 @@ bool emberAfGroupKeyManagementClusterKeySetReadCallback(
 
     if (nullptr == provider)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return true;
     }
 
@@ -399,7 +399,7 @@ bool emberAfGroupKeyManagementClusterKeySetReadCallback(
     if (CHIP_NO_ERROR != provider->GetKeySet(fabric, commandData.groupKeySetID, keyset))
     {
         // KeySet ID not found
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_NOT_FOUND);
+        commandObj->AddStatus(commandPath, Status::NotFound);
         return true;
     }
 
@@ -517,14 +517,14 @@ bool emberAfGroupKeyManagementClusterKeySetReadAllIndicesCallback(
 
     if (nullptr == provider)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return true;
     }
 
     auto keysIt = provider->IterateKeySets(fabric);
     if (nullptr == keysIt)
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return true;
     }
 

--- a/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
+++ b/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
@@ -31,6 +31,7 @@ using namespace chip::app;
 using namespace chip::Credentials;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::GroupKeyManagement;
+using chip::Protocols::InteractionModel::Status;
 
 //
 // Attributes

--- a/src/app/clusters/groups-client/groups-client.cpp
+++ b/src/app/clusters/groups-client/groups-client.cpp
@@ -23,7 +23,7 @@ using namespace chip;
 bool emberAfGroupsClusterAddGroupResponseCallback(app::CommandHandler * commandObj, uint8_t status, GroupId groupId)
 {
     emberAfGroupsClusterPrintln("RX: AddGroupResponse 0x%x, 0x%2x", status, groupId);
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
     return true;
 }
 
@@ -33,7 +33,7 @@ bool emberAfGroupsClusterViewGroupResponseCallback(app::CommandHandler * command
     emberAfGroupsClusterPrint("RX: ViewGroupResponse 0x%x, 0x%2x, \"", status, groupId);
     emberAfGroupsClusterPrintString(groupName);
     emberAfGroupsClusterPrintln("\"");
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
     return true;
 }
 
@@ -47,13 +47,13 @@ bool emberAfGroupsClusterGetGroupMembershipResponseCallback(app::CommandHandler 
         emberAfGroupsClusterPrint(" [0x%2x]", emberAfGetInt16u(groupList + (i << 1), 0, 2));
     }
     emberAfGroupsClusterPrintln("%s", "");
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
     return true;
 }
 
 bool emberAfGroupsClusterRemoveGroupResponseCallback(app::CommandHandler * commandObj, uint8_t status, GroupId groupId)
 {
     emberAfGroupsClusterPrintln("RX: RemoveGroupResponse 0x%x, 0x%2x", status, groupId);
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
     return true;
 }

--- a/src/app/clusters/identify-client/identify-client.cpp
+++ b/src/app/clusters/identify-client/identify-client.cpp
@@ -30,6 +30,6 @@ using namespace chip;
 bool emberAfIdentifyClusterIdentifyQueryResponseCallback(app::CommandHandler * commandObj, uint16_t timeout)
 {
     emberAfIdentifyClusterPrintln("RX: IdentifyQueryResponse 0x%4x", timeout);
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
     return true;
 }

--- a/src/app/clusters/identify-server/identify-server.cpp
+++ b/src/app/clusters/identify-server/identify-server.cpp
@@ -28,6 +28,7 @@
 
 #include <app/util/af.h>
 #include <app/util/common.h>
+#include <app/util/error-mapping.h>
 #include <array>
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -204,9 +205,9 @@ bool emberAfIdentifyClusterIdentifyCallback(CommandHandler * commandObj, const a
     auto & identifyTime = commandData.identifyTime;
 
     // cmd Identify
-    return EMBER_SUCCESS ==
-        emberAfSendImmediateDefaultResponse(
-               Clusters::Identify::Attributes::IdentifyTime::Set(commandPath.mEndpointId, identifyTime));
+    commandObj->AddStatus(commandPath,
+                          ToInteractionModelStatus(Attributes::IdentifyTime::Set(commandPath.mEndpointId, identifyTime)));
+    return true;
 }
 
 bool emberAfIdentifyClusterTriggerEffectCallback(CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,

--- a/src/app/clusters/identify-server/identify-server.cpp
+++ b/src/app/clusters/identify-server/identify-server.cpp
@@ -43,6 +43,7 @@
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters::Identify;
+using chip::Protocols::InteractionModel::Status;
 
 static Identify * firstIdentify = nullptr;
 

--- a/src/app/clusters/identify-server/identify-server.cpp
+++ b/src/app/clusters/identify-server/identify-server.cpp
@@ -239,7 +239,7 @@ bool emberAfIdentifyClusterTriggerEffectCallback(CommandHandler * commandObj, co
         identify->mOnEffectIdentifier(identify);
     }
 
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
     return true;
 }
 

--- a/src/app/clusters/keypad-input-server/keypad-input-server.cpp
+++ b/src/app/clusters/keypad-input-server/keypad-input-server.cpp
@@ -183,7 +183,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfKeypadInputClusterSendKeyCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
     return true;
 }

--- a/src/app/clusters/keypad-input-server/keypad-input-server.cpp
+++ b/src/app/clusters/keypad-input-server/keypad-input-server.cpp
@@ -42,6 +42,7 @@ using namespace chip::app::Clusters::KeypadInput;
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 using namespace chip::AppPlatform;
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
+using chip::Protocols::InteractionModel::Status;
 
 static constexpr size_t kKeypadInputDelegateTableSize =
     EMBER_AF_KEYPAD_INPUT_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
@@ -183,7 +184,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfKeypadInputClusterSendKeyCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
     return true;
 }

--- a/src/app/clusters/media-input-server/media-input-server.cpp
+++ b/src/app/clusters/media-input-server/media-input-server.cpp
@@ -35,6 +35,7 @@
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::MediaInput;
+using Protocols::InteractionModel::Status;
 
 static constexpr size_t kMediaInputDelegateTableSize =
     EMBER_AF_MEDIA_INPUT_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
@@ -170,9 +171,9 @@ CHIP_ERROR MediaInputAttrAccess::ReadCurrentInputAttribute(app::AttributeValueEn
 bool emberAfMediaInputClusterSelectInputCallback(app::CommandHandler * command, const app::ConcreteCommandPath & commandPath,
                                                  const Commands::SelectInput::DecodableType & commandData)
 {
-    CHIP_ERROR err       = CHIP_NO_ERROR;
-    EndpointId endpoint  = commandPath.mEndpointId;
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    EndpointId endpoint = commandPath.mEndpointId;
+    Status status       = Status::Success;
 
     auto & input = commandData.index;
 
@@ -181,68 +182,68 @@ bool emberAfMediaInputClusterSelectInputCallback(app::CommandHandler * command, 
 
     if (!delegate->HandleSelectInput(input))
     {
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
 exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaInputClusterSelectInputCallback error: %s", err.AsString());
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
 
-    emberAfSendImmediateDefaultResponse(status);
+    command->AddStatus(commandPath, status);
     return true;
 }
 
 bool emberAfMediaInputClusterShowInputStatusCallback(app::CommandHandler * command, const app::ConcreteCommandPath & commandPath,
                                                      const Commands::ShowInputStatus::DecodableType & commandData)
 {
-    CHIP_ERROR err       = CHIP_NO_ERROR;
-    EndpointId endpoint  = commandPath.mEndpointId;
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    EndpointId endpoint = commandPath.mEndpointId;
+    Status status       = Status::Success;
 
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
 
     if (!delegate->HandleShowInputStatus())
     {
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
 
 exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaInputClusterShowInputStatusCallback error: %s", err.AsString());
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
 
-    emberAfSendImmediateDefaultResponse(status);
+    command->AddStatus(commandPath, status);
     return true;
 }
 
 bool emberAfMediaInputClusterHideInputStatusCallback(app::CommandHandler * command, const app::ConcreteCommandPath & commandPath,
                                                      const Commands::HideInputStatus::DecodableType & commandData)
 {
-    CHIP_ERROR err       = CHIP_NO_ERROR;
-    EndpointId endpoint  = commandPath.mEndpointId;
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    EndpointId endpoint = commandPath.mEndpointId;
+    Status status       = Status::Success;
 
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
 
     if (!delegate->HandleHideInputStatus())
     {
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
 
 exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaInputClusterHideInputStatusCallback error: %s", err.AsString());
-        status = EMBER_ZCL_STATUS_FAILURE;
+        status = Status::Failure;
     }
 
-    emberAfSendImmediateDefaultResponse(status);
+    command->AddStatus(commandPath, status);
     return true;
 }
 

--- a/src/app/clusters/media-playback-server/media-playback-server.cpp
+++ b/src/app/clusters/media-playback-server/media-playback-server.cpp
@@ -245,7 +245,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterPlayCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -269,7 +269,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterPauseCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -293,7 +293,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterStopCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -317,7 +317,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterFastForwardCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -341,7 +341,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterPreviousCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -365,7 +365,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterRewindCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -391,7 +391,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterSkipBackwardCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -416,7 +416,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterSkipForwardCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -441,7 +441,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterSeekCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -465,7 +465,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterNextCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -489,7 +489,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterStartOverCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;

--- a/src/app/clusters/media-playback-server/media-playback-server.cpp
+++ b/src/app/clusters/media-playback-server/media-playback-server.cpp
@@ -42,6 +42,7 @@ using namespace chip::app::Clusters::MediaPlayback;
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 using namespace chip::AppPlatform;
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
+using chip::Protocols::InteractionModel::Status;
 
 static constexpr size_t kMediaPlaybackDelegateTableSize =
     EMBER_AF_MEDIA_PLAYBACK_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
@@ -245,7 +246,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterPlayCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -269,7 +270,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterPauseCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -293,7 +294,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterStopCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -317,7 +318,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterFastForwardCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -341,7 +342,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterPreviousCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -365,7 +366,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterRewindCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -391,7 +392,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterSkipBackwardCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -416,7 +417,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterSkipForwardCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -441,7 +442,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterSeekCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -465,7 +466,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterNextCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;
@@ -489,7 +490,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfMediaPlaybackClusterStartOverCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -100,13 +100,13 @@ bool emberAfModeSelectClusterChangeToModeCallback(CommandHandler * commandHandle
     uint8_t newMode       = commandData.newMode;
     // Check that the newMode matches one of the supported options
     const ModeSelect::Structs::ModeOptionStruct::Type * modeOptionPtr;
-    EmberAfStatus checkSupportedModeStatus =
+    Status checkSupportedModeStatus =
         ModeSelect::getSupportedModesManager()->getModeOptionByMode(endpointId, newMode, &modeOptionPtr);
-    if (EMBER_ZCL_STATUS_SUCCESS != checkSupportedModeStatus)
+    if (Status::Success != checkSupportedModeStatus)
     {
         emberAfPrintln(EMBER_AF_PRINT_DEBUG, "ModeSelect: Failed to find the option with mode %u", newMode);
-        emberAfSendImmediateDefaultResponse(checkSupportedModeStatus);
-        return false;
+        commandHandler->AddStatus(commandPath, checkSupportedModeStatus);
+        return true;
     }
     ModeSelect::Attributes::CurrentMode::Set(endpointId, newMode);
 
@@ -263,12 +263,5 @@ static InteractionModel::Status verifyModeValue(const EndpointId endpointId, con
         return InteractionModel::Status::Success;
     }
     const ModeSelect::Structs::ModeOptionStruct::Type * modeOptionPtr;
-    EmberAfStatus checkSupportedModeStatus =
-        ModeSelect::getSupportedModesManager()->getModeOptionByMode(endpointId, newMode, &modeOptionPtr);
-    if (EMBER_ZCL_STATUS_SUCCESS != checkSupportedModeStatus)
-    {
-        const InteractionModel::Status returnStatus = ToInteractionModelStatus(checkSupportedModeStatus);
-        return returnStatus;
-    }
-    return InteractionModel::Status::Success;
+    return ModeSelect::getSupportedModesManager()->getModeOptionByMode(endpointId, newMode, &modeOptionPtr);
 }

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -40,6 +40,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ModeSelect;
 using namespace chip::Protocols;
+using chip::Protocols::InteractionModel::Status;
 
 using BootReasonType = GeneralDiagnostics::BootReasonEnum;
 
@@ -110,7 +111,7 @@ bool emberAfModeSelectClusterChangeToModeCallback(CommandHandler * commandHandle
     ModeSelect::Attributes::CurrentMode::Set(endpointId, newMode);
 
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "ModeSelect: ChangeToMode successful");
-    commandObj->AddStatus(commandPath, Status::Success);
+    commandHandler->AddStatus(commandPath, Status::Success);
     return true;
 }
 

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -110,7 +110,7 @@ bool emberAfModeSelectClusterChangeToModeCallback(CommandHandler * commandHandle
     ModeSelect::Attributes::CurrentMode::Set(endpointId, newMode);
 
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "ModeSelect: ChangeToMode successful");
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
     return true;
 }
 

--- a/src/app/clusters/mode-select-server/supported-modes-manager.h
+++ b/src/app/clusters/mode-select-server/supported-modes-manager.h
@@ -23,6 +23,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/basic-types.h>
+#include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {
 namespace app {
@@ -73,10 +74,11 @@ public:
      * @param endpointId The endpoint for which to search the ModeOptionStruct.
      * @param mode The mode for which to search the ModeOptionStruct.
      * @param dataPtr The pointer to receive the ModeOptionStruct, if one is found.
-     * @return EMBER_ZCL_STATUS_SUCCESS if successfully found the option. Otherwise, returns appropriate status code (found in
+     * @return Status::Success if successfully found the option. Otherwise, returns appropriate status code (found in
      * <app/util/af-enums.h>)
      */
-    virtual EmberAfStatus getModeOptionByMode(EndpointId endpointId, uint8_t mode, const ModeOptionStructType ** dataPtr) const = 0;
+    virtual Protocols::InteractionModel::Status getModeOptionByMode(EndpointId endpointId, uint8_t mode,
+                                                                    const ModeOptionStructType ** dataPtr) const = 0;
 
     virtual ~SupportedModesManager() {}
 };

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -22,6 +22,7 @@
 #include <app/reporting/reporting.h>
 #include <app/util/af-event.h>
 #include <app/util/af.h>
+#include <app/util/error-mapping.h>
 #include <app/util/util.h>
 
 #ifdef EMBER_AF_PLUGIN_SCENES
@@ -325,27 +326,27 @@ EmberAfStatus OnOffServer::getOnOffValueForStartUp(chip::EndpointId endpoint, bo
     return status;
 }
 
-bool OnOffServer::offCommand(const app::ConcreteCommandPath & commandPath)
+bool OnOffServer::offCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath)
 {
     EmberAfStatus status = setOnOffValue(commandPath.mEndpointId, Commands::Off::Id, false);
 
-    emberAfSendImmediateDefaultResponse(status);
+    commandObj->AddStatus(commandPath, app::ToInteractionModelStatus(status));
     return true;
 }
 
-bool OnOffServer::onCommand(const app::ConcreteCommandPath & commandPath)
+bool OnOffServer::onCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath)
 {
     EmberAfStatus status = setOnOffValue(commandPath.mEndpointId, Commands::On::Id, false);
 
-    emberAfSendImmediateDefaultResponse(status);
+    commandObj->AddStatus(commandPath, app::ToInteractionModelStatus(status));
     return true;
 }
 
-bool OnOffServer::toggleCommand(const app::ConcreteCommandPath & commandPath)
+bool OnOffServer::toggleCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath)
 {
     EmberAfStatus status = setOnOffValue(commandPath.mEndpointId, Commands::Toggle::Id, false);
 
-    emberAfSendImmediateDefaultResponse(status);
+    commandObj->AddStatus(commandPath, app::ToInteractionModelStatus(status));
     return true;
 }
 
@@ -355,7 +356,7 @@ bool OnOffServer::offWithEffectCommand(app::CommandHandler * commandObj, const a
     OnOffEffectIdentifier effectId = commandData.effectIdentifier;
     uint8_t effectVariant          = commandData.effectVariant;
     chip::EndpointId endpoint      = commandPath.mEndpointId;
-    EmberAfStatus status           = EMBER_ZCL_STATUS_SUCCESS;
+    Status status                  = Status::Success;
 
     if (SupportsLightingApplications(endpoint))
     {
@@ -398,21 +399,20 @@ bool OnOffServer::offWithEffectCommand(app::CommandHandler * commandObj, const a
             }
         }
 
-        status = setOnOffValue(endpoint, Commands::Off::Id, false);
+        status = app::ToInteractionModelStatus(setOnOffValue(endpoint, Commands::Off::Id, false));
     }
     else
     {
-        status = EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND;
+        status = Status::UnsupportedCommand;
     }
 
-    emberAfSendImmediateDefaultResponse(status);
+    commandObj->AddStatus(commandPath, status);
     return true;
 }
 
 bool OnOffServer::OnWithRecallGlobalSceneCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath)
 {
     chip::EndpointId endpoint = commandPath.mEndpointId;
-    EmberAfStatus status      = EMBER_ZCL_STATUS_SUCCESS;
 
     if (!SupportsLightingApplications(endpoint))
     {
@@ -429,7 +429,7 @@ bool OnOffServer::OnWithRecallGlobalSceneCommand(app::CommandHandler * commandOb
 
     if (globalSceneControl)
     {
-        emberAfSendImmediateDefaultResponse(status);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -446,7 +446,7 @@ bool OnOffServer::OnWithRecallGlobalSceneCommand(app::CommandHandler * commandOb
     OnOff::Attributes::GlobalSceneControl::Set(endpoint, true);
     setOnOffValue(endpoint, Commands::On::Id, false);
 
-    emberAfSendImmediateDefaultResponse(status);
+    commandObj->AddStatus(commandPath, Status::Success);
     return true;
 }
 
@@ -470,28 +470,28 @@ uint32_t OnOffServer::calculateNextWaitTimeMS()
     return (uint32_t) waitTime.count();
 }
 
-bool OnOffServer::OnWithTimedOffCommand(const app::ConcreteCommandPath & commandPath,
+bool OnOffServer::OnWithTimedOffCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                         const Commands::OnWithTimedOff::DecodableType & commandData)
 {
     BitFlags<OnOffControl> onOffControl = commandData.onOffControl;
     uint16_t onTime                     = commandData.onTime;
     uint16_t offWaitTime                = commandData.offWaitTime;
-    EmberAfStatus status                = EMBER_ZCL_STATUS_SUCCESS;
+    Status status                       = Status::Success;
     chip::EndpointId endpoint           = commandPath.mEndpointId;
     bool isOn                           = false;
     uint16_t currentOffWaitTime         = MAX_TIME_VALUE;
     uint16_t currentOnTime              = 0;
 
     EmberEventControl * event = configureEventControl(endpoint);
-    VerifyOrExit(event != nullptr, status = EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT);
-    VerifyOrExit(SupportsLightingApplications(endpoint), status = EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND);
+    VerifyOrExit(event != nullptr, status = Status::UnsupportedEndpoint);
+    VerifyOrExit(SupportsLightingApplications(endpoint), status = Status::UnsupportedCommand);
 
     OnOff::Attributes::OnOff::Get(endpoint, &isOn);
 
     // OnOff is off and the commands is only accepted if on
     if (onOffControl.Has(OnOffControl::kAcceptOnlyWhenOn) && !isOn)
     {
-        emberAfSendImmediateDefaultResponse(status);
+        commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
 
@@ -526,7 +526,7 @@ bool OnOffServer::OnWithTimedOffCommand(const app::ConcreteCommandPath & command
     }
 
 exit:
-    emberAfSendImmediateDefaultResponse(status);
+    commandObj->AddStatus(commandPath, status);
     return true;
 }
 
@@ -705,19 +705,19 @@ OnOffEffect::~OnOffEffect()
 bool emberAfOnOffClusterOffCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                     const Commands::Off::DecodableType & commandData)
 {
-    return OnOffServer::Instance().offCommand(commandPath);
+    return OnOffServer::Instance().offCommand(commandObj, commandPath);
 }
 
 bool emberAfOnOffClusterOnCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                    const Commands::On::DecodableType & commandData)
 {
-    return OnOffServer::Instance().onCommand(commandPath);
+    return OnOffServer::Instance().onCommand(commandObj, commandPath);
 }
 
 bool emberAfOnOffClusterToggleCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                        const Commands::Toggle::DecodableType & commandData)
 {
-    return OnOffServer::Instance().toggleCommand(commandPath);
+    return OnOffServer::Instance().toggleCommand(commandObj, commandPath);
 }
 
 bool emberAfOnOffClusterOffWithEffectCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
@@ -736,7 +736,7 @@ bool emberAfOnOffClusterOnWithRecallGlobalSceneCallback(app::CommandHandler * co
 bool emberAfOnOffClusterOnWithTimedOffCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                const Commands::OnWithTimedOff::DecodableType & commandData)
 {
-    return OnOffServer::Instance().OnWithTimedOffCommand(commandPath, commandData);
+    return OnOffServer::Instance().OnWithTimedOffCommand(commandObj, commandPath, commandData);
 }
 
 void emberAfOnOffClusterServerInitCallback(chip::EndpointId endpoint)

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -35,6 +35,7 @@
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::OnOff;
+using chip::Protocols::InteractionModel::Status;
 
 /**********************************************************
  * Attributes Definition

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -415,7 +415,7 @@ bool OnOffServer::OnWithRecallGlobalSceneCommand(app::CommandHandler * commandOb
 
     if (!SupportsLightingApplications(endpoint))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND);
+        commandObj->AddStatus(commandPath, Status::UnsupportedCommand);
         return true;
     }
 

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -48,14 +48,14 @@ public:
 
     static OnOffServer & Instance();
 
-    bool offCommand(const chip::app::ConcreteCommandPath & commandPath);
-    bool onCommand(const chip::app::ConcreteCommandPath & commandPath);
-    bool toggleCommand(const chip::app::ConcreteCommandPath & commandPath);
+    bool offCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath);
+    bool onCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath);
+    bool toggleCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath);
     void initOnOffServer(chip::EndpointId endpoint);
     bool offWithEffectCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                               const chip::app::Clusters::OnOff::Commands::OffWithEffect::DecodableType & commandData);
     bool OnWithRecallGlobalSceneCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath);
-    bool OnWithTimedOffCommand(const chip::app::ConcreteCommandPath & commandPath,
+    bool OnWithTimedOffCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                                const chip::app::Clusters::OnOff::Commands::OnWithTimedOff::DecodableType & commandData);
     void updateOnOffTimeCommand(chip::EndpointId endpoint);
     EmberAfStatus getOnOffValue(chip::EndpointId endpoint, bool * currentOnOffValue);

--- a/src/app/clusters/scenes-client/scenes-client.cpp
+++ b/src/app/clusters/scenes-client/scenes-client.cpp
@@ -42,14 +42,14 @@ bool emberAfScenesClusterRemoveSceneResponseCallback(app::CommandHandler * comma
                                                      uint8_t sceneId)
 {
     emberAfScenesClusterPrintln("RX: RemoveSceneResponse 0x%x, 0x%2x, 0x%x", status, groupId, sceneId);
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
     return true;
 }
 
 bool emberAfScenesClusterRemoveAllScenesResponseCallback(app::CommandHandler * commandObj, uint8_t status, GroupId groupId)
 {
     emberAfScenesClusterPrintln("RX: RemoveAllScenesResponse 0x%x, 0x%2x", status, groupId);
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
     return true;
 }
 
@@ -57,7 +57,7 @@ bool emberAfScenesClusterStoreSceneResponseCallback(app::CommandHandler * comman
                                                     uint8_t sceneId)
 {
     emberAfScenesClusterPrintln("RX: StoreSceneResponse 0x%x, 0x%2x, 0x%x", status, groupId, sceneId);
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
     return true;
 }
 
@@ -79,7 +79,7 @@ bool emberAfScenesClusterGetSceneMembershipResponseCallback(app::CommandHandler 
     }
 
     emberAfScenesClusterPrintln("%s", "");
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
     return true;
 }
 

--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -25,6 +25,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage-null-handling.h>
+#include <app/util/error-mapping.h>
 
 #ifdef EMBER_AF_PLUGIN_GROUPS_SERVER
 #include <app/clusters/groups-server/groups-server.h>
@@ -408,7 +409,6 @@ bool emberAfScenesClusterRecallSceneCallback(app::CommandHandler * commandObj, c
     // value of TransitionTime.
 
     EmberAfStatus status;
-    EmberStatus sendStatus = EMBER_SUCCESS;
     emberAfScenesClusterPrintln("RX: RecallScene 0x%2x, 0x%x", groupId, sceneId);
     status = emberAfScenesClusterRecallSavedSceneCallback(fabricIndex, emberAfCurrentEndpoint(), groupId, sceneId);
 #ifdef EMBER_AF_PLUGIN_ZLL_SCENES_SERVER
@@ -417,10 +417,10 @@ bool emberAfScenesClusterRecallSceneCallback(app::CommandHandler * commandObj, c
         emberAfPluginZllScenesServerRecallSceneZllExtensions(emberAfCurrentEndpoint());
     }
 #endif
-    sendStatus = emberAfSendImmediateDefaultResponse(status);
-    if (EMBER_SUCCESS != sendStatus)
+    CHIP_ERROR sendErr = commandObj->AddStatus(commandPath, app::ToInteractionModelStatus(status));
+    if (CHIP_NO_ERROR != sendErr)
     {
-        emberAfScenesClusterPrintln("Scenes: failed to send %s: 0x%x", "default_response", sendStatus);
+        emberAfScenesClusterPrintln("Scenes: failed to send %s: %" CHIP_ERROR_FORMAT, "status_response", sendErr.Format());
     }
     return true;
 }

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -191,7 +191,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfTargetNavigatorClusterNavigateTargetCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
 
     return true;

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -41,6 +41,7 @@ using namespace chip::app::Clusters::TargetNavigator;
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 using namespace chip::AppPlatform;
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
+using chip::Protocols::InteractionModel::Status;
 
 static constexpr size_t kTargetNavigatorDelegateTableSize =
     EMBER_AF_TARGET_NAVIGATOR_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
@@ -191,7 +192,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfTargetNavigatorClusterNavigateTargetCallback error: %s", err.AsString());
-        commandObj->AddStatus(commandPath, Status::Failure);
+        command->AddStatus(commandPath, Status::Failure);
     }
 
     return true;

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -41,6 +41,7 @@ using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::UnitTesting;
 using namespace chip::app::Clusters::UnitTesting::Commands;
 using namespace chip::app::Clusters::UnitTesting::Attributes;
+using chip::Protocols::InteractionModel::Status;
 
 // The number of elements in the test attribute list
 constexpr uint8_t kAttributeListLength = 4;
@@ -674,7 +675,7 @@ CHIP_ERROR TestAttrAccess::WriteListFabricScopedAttribute(const ConcreteDataAttr
 
 } // namespace
 
-bool emberAfUnitTestingClusterTestCallback(app::CommandHandler *, const app::ConcreteCommandPath & commandPath,
+bool emberAfUnitTestingClusterTestCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                            const Clusters::UnitTesting::Commands::Test::DecodableType & commandData)
 {
     // Setup the test variables
@@ -720,7 +721,8 @@ bool emberAfUnitTestingClusterTestAddArgumentsCallback(CommandHandler * apComman
 {
     if (commandData.arg1 > UINT8_MAX - commandData.arg2)
     {
-        return commandObj->AddStatus(commandPath, Status::InvalidCommand);
+        apCommandObj->AddStatus(commandPath, Status::InvalidCommand);
+        return true;
     }
 
     TestAddArgumentsResponse::Type responseData;

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -696,7 +696,7 @@ bool emberAfUnitTestingClusterTestCallback(app::CommandHandler *, const app::Con
 
     gNullablesAndOptionalsStruct = Structs::NullablesAndOptionalsStruct::Type();
 
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
     return true;
 }
 
@@ -720,7 +720,7 @@ bool emberAfUnitTestingClusterTestAddArgumentsCallback(CommandHandler * apComman
 {
     if (commandData.arg1 > UINT8_MAX - commandData.arg2)
     {
-        return emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        return commandObj->AddStatus(commandPath, Status::InvalidCommand);
     }
 
     TestAddArgumentsResponse::Type responseData;
@@ -766,7 +766,7 @@ bool emberAfUnitTestingClusterTestListStructArgumentRequestCallback(
 
     if (CHIP_NO_ERROR != structIterator.GetStatus())
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return true;
     }
 
@@ -787,7 +787,7 @@ bool emberAfUnitTestingClusterTestEmitTestEventRequestCallback(
 
     if (CHIP_NO_ERROR != LogEvent(event, commandPath.mEndpointId, responseData.value))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return true;
     }
     commandObj->AddResponse(commandPath, responseData);
@@ -803,7 +803,7 @@ bool emberAfUnitTestingClusterTestEmitTestFabricScopedEventRequestCallback(
     event.fabricIndex = commandData.arg1;
     if (CHIP_NO_ERROR != LogEvent(event, commandPath.mEndpointId, responseData.value))
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return true;
     }
     commandObj->AddResponse(commandPath, responseData);
@@ -825,7 +825,7 @@ bool emberAfUnitTestingClusterTestListInt8UArgumentRequestCallback(
 
     if (CHIP_NO_ERROR != uint8Iterator.GetStatus())
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return true;
     }
 
@@ -847,7 +847,7 @@ bool emberAfUnitTestingClusterTestNestedStructListArgumentRequestCallback(
 
     if (CHIP_NO_ERROR != structIterator.GetStatus())
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return true;
     }
 
@@ -875,14 +875,14 @@ bool emberAfUnitTestingClusterTestListNestedStructListArgumentRequestCallback(
 
         if (CHIP_NO_ERROR != subStructIterator.GetStatus())
         {
-            emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+            commandObj->AddStatus(commandPath, Status::Failure);
             return true;
         }
     }
 
     if (CHIP_NO_ERROR != structIterator.GetStatus())
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
         return true;
     }
 
@@ -921,7 +921,7 @@ bool emberAfUnitTestingClusterTestListInt8UReverseRequestCallback(
     }
 
 exit:
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+    commandObj->AddStatus(commandPath, Status::Failure);
     return true;
 }
 

--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -751,7 +751,7 @@ bool emberAfThermostatClusterSetpointRaiseLowerCallback(app::CommandHandler * co
         break;
     }
 
-    emberAfSendImmediateDefaultResponse(status);
+    commandObj->AddStatus(commandPath, app::ToInteractionModelStatus(status));
     return true;
 }
 

--- a/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
@@ -139,7 +139,7 @@ bool emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(app::CommandHandl
                                                                const Commands::ResetCounts::DecodableType & commandData)
 {
     ConnectivityMgr().ResetThreadNetworkDiagnosticsCounts();
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
     return true;
 }
 

--- a/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
@@ -37,6 +37,7 @@ using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ThreadNetworkDiagnostics;
 using namespace chip::app::Clusters::ThreadNetworkDiagnostics::Attributes;
 using namespace chip::DeviceLayer;
+using chip::Protocols::InteractionModel::Status;
 
 namespace {
 

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -26,6 +26,7 @@
 #include <app/util/af-types.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/error-mapping.h>
 #include <lib/support/TypeTraits.h>
 #include <string.h>
 
@@ -568,7 +569,7 @@ void PostAttributeChange(chip::EndpointId endpoint, chip::AttributeId attributeI
     }
 }
 
-EmberAfStatus GetMotionLockStatus(chip::EndpointId endpoint)
+Status GetMotionLockStatus(chip::EndpointId endpoint)
 {
     BitMask<Mode> mode                 = ModeGet(endpoint);
     BitMask<ConfigStatus> configStatus = ConfigStatusGet(endpoint);
@@ -579,17 +580,17 @@ EmberAfStatus GetMotionLockStatus(chip::EndpointId endpoint)
         if (mode.Has(Mode::kMaintenanceMode))
         {
             // Mainterance Mode
-            return EMBER_ZCL_STATUS_BUSY;
+            return Status::Busy;
         }
 
         if (mode.Has(Mode::kCalibrationMode))
         {
             // Calibration Mode
-            return EMBER_ZCL_STATUS_FAILURE;
+            return Status::Failure;
         }
     }
 
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Status::Success;
 }
 
 void SetDefaultDelegate(EndpointId endpoint, Delegate * delegate)
@@ -626,11 +627,11 @@ bool emberAfWindowCoveringClusterUpOrOpenCallback(app::CommandHandler * commandO
 
     emberAfWindowCoveringClusterPrint("UpOrOpen command received");
 
-    EmberAfStatus status = GetMotionLockStatus(endpoint);
-    if (EMBER_ZCL_STATUS_SUCCESS != status)
+    Status status = GetMotionLockStatus(endpoint);
+    if (Status::Success != status)
     {
         emberAfWindowCoveringClusterPrint("Err device locked");
-        emberAfSendImmediateDefaultResponse(status);
+        commandObj->AddStatus(commandPath, status);
         return true;
     }
 
@@ -676,11 +677,11 @@ bool emberAfWindowCoveringClusterDownOrCloseCallback(app::CommandHandler * comma
 
     emberAfWindowCoveringClusterPrint("DownOrClose command received");
 
-    EmberAfStatus status = GetMotionLockStatus(endpoint);
-    if (EMBER_ZCL_STATUS_SUCCESS != status)
+    Status status = GetMotionLockStatus(endpoint);
+    if (Status::Success != status)
     {
         emberAfWindowCoveringClusterPrint("Err device locked");
-        emberAfSendImmediateDefaultResponse(status);
+        commandObj->AddStatus(commandPath, status);
         return true;
     }
 
@@ -726,11 +727,11 @@ bool emberAfWindowCoveringClusterStopMotionCallback(app::CommandHandler * comman
 
     emberAfWindowCoveringClusterPrint("StopMotion command received");
 
-    EmberAfStatus status = GetMotionLockStatus(endpoint);
-    if (EMBER_ZCL_STATUS_SUCCESS != status)
+    Status status = GetMotionLockStatus(endpoint);
+    if (Status::Success != status)
     {
         emberAfWindowCoveringClusterPrint("Err device locked");
-        emberAfSendImmediateDefaultResponse(status);
+        commandObj->AddStatus(commandPath, status);
         return true;
     }
 
@@ -772,11 +773,11 @@ bool emberAfWindowCoveringClusterGoToLiftValueCallback(app::CommandHandler * com
 
     emberAfWindowCoveringClusterPrint("GoToLiftValue %u command received", liftValue);
 
-    EmberAfStatus status = GetMotionLockStatus(endpoint);
-    if (EMBER_ZCL_STATUS_SUCCESS != status)
+    Status status = GetMotionLockStatus(endpoint);
+    if (Status::Success != status)
     {
         emberAfWindowCoveringClusterPrint("Err device locked");
-        emberAfSendImmediateDefaultResponse(status);
+        commandObj->AddStatus(commandPath, status);
         return true;
     }
 
@@ -814,11 +815,11 @@ bool emberAfWindowCoveringClusterGoToLiftPercentageCallback(app::CommandHandler 
 
     emberAfWindowCoveringClusterPrint("GoToLiftPercentage %u command received", percent100ths);
 
-    EmberAfStatus status = GetMotionLockStatus(endpoint);
-    if (EMBER_ZCL_STATUS_SUCCESS != status)
+    Status status = GetMotionLockStatus(endpoint);
+    if (Status::Success != status)
     {
         emberAfWindowCoveringClusterPrint("Err device locked");
-        emberAfSendImmediateDefaultResponse(status);
+        commandObj->AddStatus(commandPath, status);
         return true;
     }
 
@@ -864,11 +865,11 @@ bool emberAfWindowCoveringClusterGoToTiltValueCallback(app::CommandHandler * com
 
     emberAfWindowCoveringClusterPrint("GoToTiltValue %u command received", tiltValue);
 
-    EmberAfStatus status = GetMotionLockStatus(endpoint);
-    if (EMBER_ZCL_STATUS_SUCCESS != status)
+    Status status = GetMotionLockStatus(endpoint);
+    if (Status::Success != status)
     {
         emberAfWindowCoveringClusterPrint("Err device locked");
-        emberAfSendImmediateDefaultResponse(status);
+        commandObj->AddStatus(commandPath, status);
         return true;
     }
 
@@ -906,11 +907,11 @@ bool emberAfWindowCoveringClusterGoToTiltPercentageCallback(app::CommandHandler 
 
     emberAfWindowCoveringClusterPrint("GoToTiltPercentage %u command received", percent100ths);
 
-    EmberAfStatus status = GetMotionLockStatus(endpoint);
-    if (EMBER_ZCL_STATUS_SUCCESS != status)
+    Status status = GetMotionLockStatus(endpoint);
+    if (Status::Success != status)
     {
         emberAfWindowCoveringClusterPrint("Err device locked");
-        emberAfSendImmediateDefaultResponse(status);
+        commandObj->AddStatus(commandPath, status);
         return true;
     }
 

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -36,6 +36,7 @@
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::WindowCovering;
+using chip::Protocols::InteractionModel::Status;
 
 #define CHECK_BOUNDS_INVALID(MIN, VAL, MAX) ((VAL < MIN) || (VAL > MAX))
 #define CHECK_BOUNDS_VALID(MIN, VAL, MAX) (!CHECK_BOUNDS_INVALID(MIN, VAL, MAX))
@@ -755,7 +756,7 @@ bool emberAfWindowCoveringClusterStopMotionCallback(app::CommandHandler * comman
         (void) Attributes::TargetPositionTiltPercent100ths::Set(endpoint, current);
     }
 
-    return EMBER_SUCCESS == commandObj->AddStatus(commandPath, Status::Success);
+    return CHIP_NO_ERROR == commandObj->AddStatus(commandPath, Status::Success);
 }
 
 /**

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -660,7 +660,7 @@ bool emberAfWindowCoveringClusterUpOrOpenCallback(app::CommandHandler * commandO
         emberAfWindowCoveringClusterPrint("WindowCovering has no delegate set for endpoint:%u", endpoint);
     }
 
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
 
     return true;
 }
@@ -691,7 +691,7 @@ bool emberAfWindowCoveringClusterDownOrCloseCallback(app::CommandHandler * comma
     {
         Attributes::TargetPositionTiltPercent100ths::Set(endpoint, WC_PERCENT100THS_MAX_CLOSED);
     }
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    commandObj->AddStatus(commandPath, Status::Success);
 
     Delegate * delegate = GetDelegate(endpoint);
     if (delegate)
@@ -755,7 +755,7 @@ bool emberAfWindowCoveringClusterStopMotionCallback(app::CommandHandler * comman
         (void) Attributes::TargetPositionTiltPercent100ths::Set(endpoint, current);
     }
 
-    return EMBER_SUCCESS == emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    return EMBER_SUCCESS == commandObj->AddStatus(commandPath, Status::Success);
 }
 
 /**
@@ -791,12 +791,12 @@ bool emberAfWindowCoveringClusterGoToLiftValueCallback(app::CommandHandler * com
         {
             emberAfWindowCoveringClusterPrint("WindowCovering has no delegate set for endpoint:%u", endpoint);
         }
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
     }
     else
     {
         emberAfWindowCoveringClusterPrint("Err Device is not PA LF");
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
     return true;
 }
@@ -835,17 +835,17 @@ bool emberAfWindowCoveringClusterGoToLiftPercentageCallback(app::CommandHandler 
             {
                 emberAfWindowCoveringClusterPrint("WindowCovering has no delegate set for endpoint:%u", endpoint);
             }
-            emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+            commandObj->AddStatus(commandPath, Status::Success);
         }
         else
         {
-            emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+            commandObj->AddStatus(commandPath, Status::ConstraintError);
         }
     }
     else
     {
         emberAfWindowCoveringClusterPrint("Err Device is not PA LF");
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
     return true;
 }
@@ -883,12 +883,12 @@ bool emberAfWindowCoveringClusterGoToTiltValueCallback(app::CommandHandler * com
         {
             emberAfWindowCoveringClusterPrint("WindowCovering has no delegate set for endpoint:%u", endpoint);
         }
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        commandObj->AddStatus(commandPath, Status::Success);
     }
     else
     {
         emberAfWindowCoveringClusterPrint("Err Device is not PA TL");
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
     return true;
 }
@@ -927,17 +927,17 @@ bool emberAfWindowCoveringClusterGoToTiltPercentageCallback(app::CommandHandler 
             {
                 emberAfWindowCoveringClusterPrint("WindowCovering has no delegate set for endpoint:%u", endpoint);
             }
-            emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+            commandObj->AddStatus(commandPath, Status::Success);
         }
         else
         {
-            emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+            commandObj->AddStatus(commandPath, Status::ConstraintError);
         }
     }
     else
     {
         emberAfWindowCoveringClusterPrint("Err Device is not PA TL");
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        commandObj->AddStatus(commandPath, Status::Failure);
     }
     return true;
 }

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -21,6 +21,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/enums.h>
 #include <app/util/af-types.h>
+#include <protocols/interaction_model/StatusCode.h>
 
 #include <app/data-model/Nullable.h>
 
@@ -115,7 +116,7 @@ uint16_t TiltToPercent100ths(chip::EndpointId endpoint, uint16_t tilt);
 uint16_t Percent100thsToTilt(chip::EndpointId endpoint, uint16_t percent100ths);
 void TiltPositionSet(chip::EndpointId endpoint, NPercent100ths position);
 
-EmberAfStatus GetMotionLockStatus(chip::EndpointId endpoint);
+Protocols::InteractionModel::Status GetMotionLockStatus(chip::EndpointId endpoint);
 
 /**
  * @brief PostAttributeChange is called when an Attribute is modified.

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -521,19 +521,6 @@ EmberStatus emberEventControlSetDelayMS(EmberEventControl * control, uint32_t de
 EmberStatus emberAfSendDefaultResponse(const EmberAfClusterCommand * cmd, EmberAfStatus status);
 
 /**
- * @brief Sends a default response to a cluster command using the
- * current command.
- *
- * This function is used to prepare and send a default response to a cluster
- * command.
- *
- * @param status Status code for the default response command.
- * @return An ::EmberStatus value that indicates the success or failure of
- * sending the response.
- */
-EmberStatus emberAfSendImmediateDefaultResponse(EmberAfStatus status);
-
-/**
  * @brief Access to client API APS frame.
  */
 EmberApsFrame * emberAfGetCommandApsFrame(void);

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -334,11 +334,6 @@ void emAfApplyDisableDefaultResponse(uint8_t * frame_control)
     }
 }
 
-EmberStatus emberAfSendImmediateDefaultResponse(EmberAfStatus status)
-{
-    return emberAfSendDefaultResponse(emberAfCurrentCommand(), status);
-}
-
 EmberStatus emberAfSendDefaultResponse(const EmberAfClusterCommand * cmd, EmberAfStatus status)
 {
     // Default Response commands are only sent in response to unicast commands.


### PR DESCRIPTION
REVIEW NOTE: This PR consists of three commits:

1. A search-and-replace for some common patterns.
2. A manual commit to make things compile after the search-and-replace.
3. A manual commit to remove the other uses of emberAfSendImmediateDefaultResponse