### PR TITLE
Fix app crash when show History in ClusterInteractionFragment

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/clusterinteraction/ClusterInteractionFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/clusterinteraction/ClusterInteractionFragment.kt
@@ -81,7 +81,7 @@ class ClusterInteractionFragment : Fragment() {
   private fun showFragment(fragment: Fragment) {
     val fragmentTransaction = requireActivity().supportFragmentManager
       .beginTransaction()
-      .replace(R.id.fragment_container, fragment, fragment.javaClass.simpleName)
+      .replace(R.id.nav_host_fragment, fragment, fragment.javaClass.simpleName)
     fragmentTransaction.addToBackStack(null)
     fragmentTransaction.commit()
   }


### PR DESCRIPTION
1. Go to 'CLUSTER INTERACTION TOOL' from main menu
2. Click 'History' in the bottom of the navigation bar

**Expected**: Show History command list
**Actual**: The App crashed 

```
    --------- beginning of crash
2023-02-14 13:08:55.169 29257-29257/com.google.chip.chiptool E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.google.chip.chiptool, PID: 29257
    java.lang.IllegalArgumentException: No view found for id 0x7f0900da (com.google.chip.chiptool:id/fragment_container) for fragment ClusterInteractionHistoryFragment{be0e8ae} (3791c3d7-2add-4a02-ada2-053fd1df294c) id=0x7f0900da ClusterInteractionHistoryFragment}
        at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:513)
        at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:277)
        at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2177)
        at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:2088)
        at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1990)
        at androidx.fragment.app.FragmentManager$5.run(FragmentManager.java:524)
        at android.os.Handler.handleCallback(Handler.java:942)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7898)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```
