### PR TITLE
[Android] Add Read basicInformation Cluster Unique ID attribute

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/BasicClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/BasicClientFragment.kt
@@ -124,6 +124,7 @@ class BasicClientFragment : Fragment() {
       getString(R.string.basic_cluster_serial_number_text) -> sendReadSerialNumberAttribute()
       getString(R.string.basic_cluster_local_config_disabled_text) -> sendReadLocalConfigDisabledAttribute()
       getString(R.string.basic_cluster_reachable_text) -> sendReadReachableAttribute()
+      getString(R.string.basic_cluster_unique_id_text) -> sendReadUniqueIDAttribute()
       getString(R.string.basic_cluster_cluster_revision_text) -> sendReadClusterRevisionAttribute()
     }
   }
@@ -147,6 +148,7 @@ class BasicClientFragment : Fragment() {
     ATTRIBUTES.add(getString(R.string.basic_cluster_serial_number_text))
     ATTRIBUTES.add(getString(R.string.basic_cluster_local_config_disabled_text))
     ATTRIBUTES.add(getString(R.string.basic_cluster_reachable_text))
+    ATTRIBUTES.add(getString(R.string.basic_cluster_unique_id_text))
     ATTRIBUTES.add(getString(R.string.basic_cluster_cluster_revision_text))
   }
 
@@ -437,6 +439,20 @@ class BasicClientFragment : Fragment() {
       override fun onError(ex: Exception) {
         showMessage("Read Reachable failure $ex")
         Log.e(TAG, "Read Reachable failure", ex)
+      }
+    })
+  }
+
+  private suspend fun sendReadUniqueIDAttribute() {
+    getBasicClusterForDevice().readUniqueIDAttribute(object : ChipClusters.CharStringAttributeCallback {
+      override fun onSuccess(value: String) {
+        Log.i(TAG,"[Read Success] UniqueID $value")
+        showMessage("[Read Success] UniqueID: $value")
+      }
+
+      override fun onError(ex: Exception) {
+        showMessage("Read UniqueID failure $ex")
+        Log.e(TAG, "Read UniqueID failure", ex)
       }
     })
   }

--- a/examples/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/examples/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -131,6 +131,7 @@
     <string name="basic_cluster_serial_number_text">SerialNumber</string>
     <string name="basic_cluster_local_config_disabled_text">LocalConfigDisabled</string>
     <string name="basic_cluster_reachable_text">Reachable</string>
+    <string name="basic_cluster_unique_id_text">UniqueID</string>
     <string name="basic_cluster_cluster_revision_text">ClusterRevision</string>
 
     <string name="read_dialog_title_text">Read</string>


### PR DESCRIPTION
Added uniqueID attribute reading UI of Basic Information Cluster in Android ChipTool App.

Refer : https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/service_device_management/BasicInformationCluster.adoc#719-uniqueid-attribute

