### PR TITLE
Check for github-actions updates every week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -97,7 +97,7 @@ jobs:
                     -- scripts/tests/cirque_tests.sh bootstrap
             - name: Artifact suffix
               id: outsuffix
-              uses: haya14busa/action-cond@v1.0.0
+              uses: haya14busa/action-cond@v1
               if: ${{ !env.ACT }}
               with:
                   cond: ${{ github.event.pull_request.number == '' }}


### PR DESCRIPTION
### Problem

There is no automatic check for used github-actions updates. External actions might contain vulnerabilities, so it's better to keep track of any updates.

### Changes

- added dependabot config for github-actions
- use only major version number for haya14busa/action-cond action constraint