### PR TITLE
Remove the legacy CredentialStruct definition.

### DIFF
--- a/examples/lock-app/genio/src/LockManager.cpp
+++ b/examples/lock-app/genio/src/LockManager.cpp
@@ -678,13 +678,13 @@ bool LockManager::setLockState(chip::EndpointId endpointId, DlLockState lockStat
     {
         for (uint8_t j = 0; j < kMaxCredentialsPerUser; j++)
         {
-            if (mLockCredentials[mCredentials[i][j].CredentialIndex - 1].credentialType != CredentialTypeEnum::kPin ||
-                mLockCredentials[mCredentials[i][j].CredentialIndex - 1].status == DlCredentialStatus::kAvailable)
+            if (mLockCredentials[mCredentials[i][j].credentialIndex - 1].credentialType != CredentialTypeEnum::kPin ||
+                mLockCredentials[mCredentials[i][j].credentialIndex - 1].status == DlCredentialStatus::kAvailable)
             {
                 continue;
             }
 
-            if (mLockCredentials[mCredentials[i][j].CredentialIndex - 1].credentialData.data_equal(pin.Value()) &&
+            if (mLockCredentials[mCredentials[i][j].credentialIndex - 1].credentialData.data_equal(pin.Value()) &&
                 mLockUsers[i].userStatus != UserStatusEnum::kOccupiedDisabled)
             {
                 ChipLogDetail(

--- a/examples/lock-app/infineon/cyw30739/src/LockManager.cpp
+++ b/examples/lock-app/infineon/cyw30739/src/LockManager.cpp
@@ -383,9 +383,12 @@ bool LockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip:
 
     for (size_t i = 0; i < totalCredentials; ++i)
     {
-        mCredentials[userIndex][i]                 = credentials[i];
-        mCredentials[userIndex][i].CredentialType  = 1;
-        mCredentials[userIndex][i].CredentialIndex = i + 1;
+        mCredentials[userIndex][i] = credentials[i];
+        // TODO: Why are we modifying the passed-in credentials?
+        // https://github.com/project-chip/connectedhomeip/issues/25081
+        // For now, preserve pre-existing behavior, which set credentialType to 1.
+        mCredentials[userIndex][i].credentialType  = CredentialTypeEnum::kPin;
+        mCredentials[userIndex][i].credentialIndex = i + 1;
     }
 
     userInStorage.credentials = chip::Span<const CredentialStruct>(mCredentials[userIndex], totalCredentials);

--- a/examples/lock-app/infineon/psoc6/src/LockManager.cpp
+++ b/examples/lock-app/infineon/psoc6/src/LockManager.cpp
@@ -383,9 +383,12 @@ bool LockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip:
 
     for (size_t i = 0; i < totalCredentials; ++i)
     {
-        mCredentials[userIndex][i]                 = credentials[i];
-        mCredentials[userIndex][i].CredentialType  = 1;
-        mCredentials[userIndex][i].CredentialIndex = i + 1;
+        mCredentials[userIndex][i] = credentials[i];
+        // TODO: Why are we modifying the passed-in credentials?
+        // https://github.com/project-chip/connectedhomeip/issues/25081
+        // For now, preserve pre-existing behavior, which set credentialType to 1.
+        mCredentials[userIndex][i].credentialType  = CredentialTypeEnum::kPin;
+        mCredentials[userIndex][i].credentialIndex = i + 1;
     }
 
     userInStorage.credentials = chip::Span<const CredentialStruct>(mCredentials[userIndex], totalCredentials);

--- a/examples/lock-app/linux/src/LockEndpoint.cpp
+++ b/examples/lock-app/linux/src/LockEndpoint.cpp
@@ -424,7 +424,7 @@ bool LockEndpoint::setLockState(DlLockState lockState, const Optional<chip::Byte
     auto credentialIndex = static_cast<unsigned>(credential - pinCredentials.begin());
     auto user = std::find_if(mLockUsers.begin(), mLockUsers.end(), [credential, credentialIndex](const LockUserInfo & u) {
         return std::any_of(u.credentials.begin(), u.credentials.end(), [&credential, credentialIndex](const CredentialStruct & c) {
-            return c.CredentialIndex == credentialIndex && c.CredentialType == to_underlying(credential->credentialType);
+            return c.credentialIndex == credentialIndex && c.credentialType == credential->credentialType;
         });
     });
     if (user == mLockUsers.end())

--- a/examples/lock-app/silabs/SiWx917/src/LockManager.cpp
+++ b/examples/lock-app/silabs/SiWx917/src/LockManager.cpp
@@ -378,9 +378,12 @@ bool LockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip:
 
     for (size_t i = 0; i < totalCredentials; ++i)
     {
-        mCredentials[userIndex][i]                 = credentials[i];
-        mCredentials[userIndex][i].CredentialType  = 1;
-        mCredentials[userIndex][i].CredentialIndex = i + 1;
+        mCredentials[userIndex][i] = credentials[i];
+        // TODO: Why are we modifying the passed-in credentials?
+        // https://github.com/project-chip/connectedhomeip/issues/25082
+        // For now, preserve pre-existing behavior, which set credentialType to 1.
+        mCredentials[userIndex][i].credentialType  = CredentialTypeEnum::kPin;
+        mCredentials[userIndex][i].credentialIndex = i + 1;
     }
 
     userInStorage.credentials = chip::Span<const CredentialStruct>(mCredentials[userIndex], totalCredentials);

--- a/examples/lock-app/silabs/efr32/src/LockManager.cpp
+++ b/examples/lock-app/silabs/efr32/src/LockManager.cpp
@@ -378,9 +378,12 @@ bool LockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip:
 
     for (size_t i = 0; i < totalCredentials; ++i)
     {
-        mCredentials[userIndex][i]                 = credentials[i];
-        mCredentials[userIndex][i].CredentialType  = 1;
-        mCredentials[userIndex][i].CredentialIndex = i + 1;
+        mCredentials[userIndex][i] = credentials[i];
+        // TODO: Why are we modifying the passed-in credentials?
+        // https://github.com/project-chip/connectedhomeip/issues/25082
+        // For now, preserve pre-existing behavior, which set credentialType to 1.
+        mCredentials[userIndex][i].credentialType  = CredentialTypeEnum::kPin;
+        mCredentials[userIndex][i].credentialIndex = i + 1;
     }
 
     userInStorage.credentials = chip::Span<const CredentialStruct>(mCredentials[userIndex], totalCredentials);

--- a/examples/platform/esp32/lock/BoltLockManager.cpp
+++ b/examples/platform/esp32/lock/BoltLockManager.cpp
@@ -430,9 +430,12 @@ bool BoltLockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, c
 
     for (size_t i = 0; i < totalCredentials; ++i)
     {
-        mCredentials[userIndex][i]                 = credentials[i];
-        mCredentials[userIndex][i].CredentialType  = 1;
-        mCredentials[userIndex][i].CredentialIndex = i + 1;
+        mCredentials[userIndex][i] = credentials[i];
+        // TODO: Why are we modifying the passed-in credentials?
+        // https://github.com/project-chip/connectedhomeip/issues/25083
+        // For now, preserve pre-existing behavior, which set credentialType to 1.
+        mCredentials[userIndex][i].credentialType  = CredentialTypeEnum::kPin;
+        mCredentials[userIndex][i].credentialIndex = i + 1;
     }
 
     userInStorage.credentials = chip::Span<const CredentialStruct>(mCredentials[userIndex], totalCredentials);

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include <app-common/zap-generated/af-structs.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
@@ -56,7 +55,8 @@ using chip::app::Clusters::DoorLock::UserTypeEnum;
 using chip::app::DataModel::List;
 using chip::app::DataModel::Nullable;
 
-using LockOpCredentials = chip::app::Clusters::DoorLock::Structs::CredentialStruct::Type;
+using CredentialStruct  = chip::app::Clusters::DoorLock::Structs::CredentialStruct::Type;
+using LockOpCredentials = CredentialStruct;
 
 typedef bool (*RemoteLockOpHandler)(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pinCode,
                                     OperationErrorEnum & err);

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -1,7 +1,4 @@
-LegacyStructs:
-    # List of structs for which we output a legacy definition in af-structs.h
-    # Ideally this list should become empty.
-    - CredentialStruct
+LegacyStructs: [] # Will be removed together with af-structs.h
 
 WeakEnums:
     # Allow-list of enums that we generate as enums, not enum classes.

--- a/zzz_generated/app-common/app-common/zap-generated/af-structs.h
+++ b/zzz_generated/app-common/app-common/zap-generated/af-structs.h
@@ -29,10 +29,3 @@
 #include <protocols/interaction_model/Constants.h>
 
 #include "enums.h"
-
-// Struct for CredentialStruct
-typedef struct _CredentialStruct
-{
-    uint8_t CredentialType;
-    uint16_t CredentialIndex;
-} CredentialStruct;


### PR DESCRIPTION
Switches consumers to Clusters::DoorLock::Structs::CredentialStruct::Type.

af-structs.h is now empty, but will be removed in a separate PR to make things a bit easier to review.


