### PR TITLE
Fix runtime crash caused by java.lang.ClassNotFoundException

### DIFF
--- a/examples/java-matter-controller/Manifest.txt
+++ b/examples/java-matter-controller/Manifest.txt
@@ -1,3 +1,3 @@
 Main-Class: com.matter.controller.Main
-Class-Path: ../lib/third_party/connectedhomeip/src/controller/java/CHIPController.jar ../lib/third_party/connectedhomeip/src/setup_payload/java/SetupPayloadParser.jar
+Class-Path: ../lib/third_party/connectedhomeip/src/controller/java/CHIPController.jar ../lib/third_party/connectedhomeip/src/setup_payload/java/SetupPayloadParser.jar ../lib/third_party/connectedhomeip/third_party/java_deps/stub_src/Android.jar ../lib/third_party/connectedhomeip/third_party/java_deps/json-20220924.jar ../lib/third_party/connectedhomeip/third_party/java_deps/jsr305-3.0.2.jar
 

--- a/third_party/java_deps/stub_src/android/util/Log.java
+++ b/third_party/java_deps/stub_src/android/util/Log.java
@@ -21,19 +21,88 @@
 package android.util;
 
 public final class Log {
-  public static int d(String tag, String message) {
-    return 0;
+
+  public static final int VERBOSE = 2;
+
+  public static final int DEBUG = 3;
+
+  public static final int INFO = 4;
+
+  public static final int WARN = 5;
+
+  public static final int ERROR = 6;
+
+  public static final int ASSERT = 7;
+
+  public static final int NONE = Integer.MAX_VALUE;
+
+  /**
+   * Send a DEBUG log message.
+   *
+   * @param tag Used to identify the source of a log message. It usually identifies the class or
+   *     activity where the log call occurs.
+   * @param msg The message you would like logged.
+   * @return A positive value if the message was loggable.
+   */
+  public static int d(String tag, String msg) {
+    return log(DEBUG, tag, msg);
   }
 
+  /**
+   * Send a ERROR log message.
+   *
+   * @param tag Used to identify the source of a log message. It usually identifies the class or
+   *     activity where the log call occurs.
+   * @param msg The message you would like logged.
+   * @return A positive value if the message was loggable.
+   */
   public static int e(String tag, String msg) {
-    return 0;
+    return log(ERROR, tag, msg);
   }
 
+  /**
+   * Send a ERROR log message and log the exception.
+   *
+   * @param tag Used to identify the source of a log message. It usually identifies the class or
+   *     activity where the log call occurs.
+   * @param msg The message you would like logged.
+   * @param tr An exception to log.
+   * @return A positive value if the message was loggable.
+   */
   public static int e(String tag, String msg, Throwable tr) {
-    return 0;
+    return log(ERROR, tag, msg, tr);
   }
 
-  public static int w(String tag, String message) {
-    return 0;
+  /**
+   * Send a WARN log message.
+   *
+   * @param tag Used to identify the source of a log message. It usually identifies the class or
+   *     activity where the log call occurs.
+   * @param msg The message you would like logged.
+   * @return A positive value if the message was loggable.
+   */
+  public static int w(String tag, String msg) {
+    return log(WARN, tag, msg);
+  }
+
+  private static int log(int level, String tag, String msg) {
+    if (level > ASSERT) {
+      return -1;
+    }
+
+    System.out.println(tag + ':' + msg);
+
+    return 1;
+  }
+
+  private static int log(int level, String tag, String msg, Throwable tr) {
+    if (level > ASSERT) {
+      return -1;
+    }
+
+    System.out.println(tag + ':' + msg);
+    System.out.println(tr.toString());
+
+    return 1;
   }
 }


### PR DESCRIPTION
Currently, package android.util is implemented as stub functions on x86, the java-matter-controller crashes when run into any of stub functions during run-time

```
[Dynamic-linking native method java.lang.Throwable.fillInStackTrace ... JNI]
Exception in thread "main" java.lang.NoClassDefFoundError: android/util/Log
[Dynamic-linking native method java.lang.StackTraceElement.initStackTraceElements ... JNI]
	at chip.devicecontroller.ChipDeviceController.<init>(ChipDeviceController.java:58)
	at com.matter.controller.Main.main(Main.java:105)
Caused by: java.lang.ClassNotFoundException: android.util.Log
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)

```
Implement the missing part of Log functions to just print the log message to console, we could latter improve these functions with java.util.logging.Logger
