### PR TITLE
Make ServiceEvents in tests work better on darwin.

### DIFF
--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -452,6 +452,20 @@ void ServiceEvents(uint32_t aSleepTimeMilliseconds)
     gSystemLayer.HandleEvents();
 #endif
 
+    // Process whatever has been queued via the platform manager so far, if it
+    // accepts events.
+    {
+        auto stopEventLoop = [](intptr_t) -> void { chip::DeviceLayer::PlatformMgr().StopEventLoopTask(); };
+        CHIP_ERROR err     = chip::DeviceLayer::PlatformMgr().ScheduleWork(stopEventLoop, 0);
+        // If ScheduleWork fails, the platform manager is not accepting events
+        // and there is no work to be done, plus doing RunEventLoop would simply
+        // block forever, since we did not schedule our stopWork lambda.
+        if (err == CHIP_NO_ERROR)
+        {
+            chip::DeviceLayer::PlatformMgr().RunEventLoop();
+        }
+    }
+
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     if (gSystemLayer.IsInitialized())
     {

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -57,20 +57,6 @@ using TestContext = Test::LoopbackMessagingContext;
 namespace chip {
 namespace {
 
-void ServiceEvents(TestContext & ctx)
-{
-    // Service any messages
-    ctx.DrainAndServiceIO();
-
-    // Messages may have scheduled work, so service them
-    chip::DeviceLayer::PlatformMgr().ScheduleWork([](intptr_t) -> void { chip::DeviceLayer::PlatformMgr().StopEventLoopTask(); },
-                                                  (intptr_t) nullptr);
-    chip::DeviceLayer::PlatformMgr().RunEventLoop();
-
-    // Work may have sent messages, so service them
-    ctx.DrainAndServiceIO();
-}
-
 class TemporarySessionManager
 {
 public:
@@ -365,19 +351,19 @@ void TestCASESession::SecurePairingStartTest(nlTestSuite * inSuite, void * inCon
                    pairing.EstablishSession(sessionManager, nullptr, ScopedNodeId{ Node01_01, gCommissionerFabricIndex }, nullptr,
                                             nullptr, nullptr, nullptr,
                                             Optional<ReliableMessageProtocolConfig>::Missing()) != CHIP_NO_ERROR);
-    ServiceEvents(ctx);
+    ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite,
                    pairing.EstablishSession(sessionManager, &gCommissionerFabrics,
                                             ScopedNodeId{ Node01_01, gCommissionerFabricIndex }, nullptr, nullptr, nullptr, nullptr,
                                             Optional<ReliableMessageProtocolConfig>::Missing()) != CHIP_NO_ERROR);
-    ServiceEvents(ctx);
+    ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite,
                    pairing.EstablishSession(sessionManager, &gCommissionerFabrics,
                                             ScopedNodeId{ Node01_01, gCommissionerFabricIndex }, context, nullptr, nullptr,
                                             &delegate, Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_NO_ERROR);
-    ServiceEvents(ctx);
+    ctx.DrainAndServiceIO();
 
     auto & loopback = ctx.GetLoopback();
     // There should have been two message sent: Sigma1 and an ack.
@@ -399,7 +385,7 @@ void TestCASESession::SecurePairingStartTest(nlTestSuite * inSuite, void * inCon
                    pairing1.EstablishSession(
                        sessionManager, &gCommissionerFabrics, ScopedNodeId{ Node01_01, gCommissionerFabricIndex }, context1,
                        nullptr, nullptr, &delegate, Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_ERROR_BAD_REQUEST);
-    ServiceEvents(ctx);
+    ctx.DrainAndServiceIO();
 
     loopback.mMessageSendError = CHIP_NO_ERROR;
 }
@@ -436,7 +422,7 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, S
                                                         ScopedNodeId{ Node01_01, gCommissionerFabricIndex }, contextCommissioner,
                                                         nullptr, nullptr, &delegateCommissioner,
                                                         MakeOptional(nonSleepyCommissionerRmpConfig)) == CHIP_NO_ERROR);
-    ServiceEvents(ctx);
+    ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == sTestCaseMessageCount);
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
@@ -504,7 +490,7 @@ void TestCASESession::SecurePairingHandshakeServerTest(nlTestSuite * inSuite, vo
                                                          ScopedNodeId{ Node01_01, gCommissionerFabricIndex }, contextCommissioner,
                                                          nullptr, nullptr, &delegateCommissioner,
                                                          Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_NO_ERROR);
-    ServiceEvents(ctx);
+    ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == sTestCaseMessageCount);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
@@ -525,7 +511,7 @@ void TestCASESession::SecurePairingHandshakeServerTest(nlTestSuite * inSuite, vo
                                                           nullptr, nullptr, &delegateCommissioner,
                                                           Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_NO_ERROR);
 
-    ServiceEvents(ctx);
+    ctx.DrainAndServiceIO();
 
     chip::Platform::Delete(pairingCommissioner);
     chip::Platform::Delete(pairingCommissioner1);
@@ -931,7 +917,7 @@ void TestCASESession::SessionResumptionStorage(nlTestSuite * inSuite, void * inC
             ctx.GetSecureSessionManager(), &gCommissionerFabrics, ScopedNodeId{ Node01_01, gCommissionerFabricIndex },
             contextCommissioner, &testVectors[i].initiatorStorage, nullptr, &delegateCommissioner,
             Optional<ReliableMessageProtocolConfig>::Missing());
-        ServiceEvents(ctx);
+        ctx.DrainAndServiceIO();
         NL_TEST_ASSERT(inSuite, establishmentReturnVal == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == testVectors[i].expectedSentMessageCount);
         NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == i + 1);
@@ -975,7 +961,7 @@ void TestCASESession::SimulateUpdateNOCInvalidatePendingEstablishment(nlTestSuit
                        Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_NO_ERROR);
 
     gDeviceFabrics.SendUpdateFabricNotificationForTest(gDeviceFabricIndex);
-    ServiceEvents(ctx);
+    ctx.DrainAndServiceIO();
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingErrors == 0);
 
     NL_TEST_ASSERT(inSuite,
@@ -983,7 +969,7 @@ void TestCASESession::SimulateUpdateNOCInvalidatePendingEstablishment(nlTestSuit
                                                         ScopedNodeId{ Node01_01, gCommissionerFabricIndex }, contextCommissioner,
                                                         nullptr, nullptr, &delegateCommissioner,
                                                         Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_NO_ERROR);
-    ServiceEvents(ctx);
+    ctx.DrainAndServiceIO();
 
     // At this point the CASESession is in the process of establishing. Confirm that there are no errors and there are session
     // has not been established.
@@ -995,14 +981,14 @@ void TestCASESession::SimulateUpdateNOCInvalidatePendingEstablishment(nlTestSuit
     // Simulating an update to the Fabric NOC for gCommissionerFabrics fabric table.
     // Confirm that CASESession on commisioner side has reported an error.
     gCommissionerFabrics.SendUpdateFabricNotificationForTest(gCommissionerFabricIndex);
-    ServiceEvents(ctx);
+    ctx.DrainAndServiceIO();
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingErrors == 0);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingErrors == 1);
 
     // Simulating an update to the Fabric NOC for gDeviceFabrics fabric table.
     // Confirm that CASESession on accessory side has reported an error.
     gDeviceFabrics.SendUpdateFabricNotificationForTest(gDeviceFabricIndex);
-    ServiceEvents(ctx);
+    ctx.DrainAndServiceIO();
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingErrors == 1);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingErrors == 1);
 
@@ -1085,7 +1071,7 @@ void TestCASESession::Sigma1BadDestinationIdTest(nlTestSuite * inSuite, void * i
     err = exchange->SendMessage(MsgType::CASE_Sigma1, std::move(data), SendMessageFlags::kExpectResponse);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    ServiceEvents(ctx);
+    ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite, caseDelegate.mNumPairingErrors == 1);
     NL_TEST_ASSERT(inSuite, caseDelegate.mNumPairingComplete == 0);


### PR DESCRIPTION
On Linux, because the platform manager just uses the system layer event processing for its events, we are driving platform manager events via ServiceEvents.  Do the same thing on darwin, so we have fewer platform divergences in our unit tests.
