### PR TITLE
[nrfconnect] Fixed setting tilt/lift for window covering

### DIFF
--- a/examples/window-app/nrfconnect/main/WindowCovering.cpp
+++ b/examples/window-app/nrfconnect/main/WindowCovering.cpp
@@ -62,9 +62,20 @@ void WindowCovering::DriveCurrentLiftPosition(intptr_t)
     VerifyOrReturn(Attributes::CurrentPositionLiftPercent100ths::Get(Endpoint(), current) == EMBER_ZCL_STATUS_SUCCESS);
     VerifyOrReturn(Attributes::TargetPositionLiftPercent100ths::Get(Endpoint(), target) == EMBER_ZCL_STATUS_SUCCESS);
 
-    UpdateOperationalStatus(MoveType::LIFT, ComputeOperationalState(target, current));
+    OperationalState state = ComputeOperationalState(target, current);
+    UpdateOperationalStatus(MoveType::LIFT, state);
 
-    positionToSet.SetNonNull(CalculateSingleStep(MoveType::LIFT));
+    chip::Percent100ths step = CalculateSingleStep(MoveType::LIFT);
+
+    if (state == OperationalState::MovingUpOrOpen)
+    {
+        positionToSet.SetNonNull(step > target.Value() ? step : target.Value());
+    }
+    else if (state == OperationalState::MovingDownOrClose)
+    {
+        positionToSet.SetNonNull(step < target.Value() ? step : target.Value());
+    }
+
     LiftPositionSet(Endpoint(), positionToSet);
 
     // assume single move completed
@@ -156,9 +167,20 @@ void WindowCovering::DriveCurrentTiltPosition(intptr_t)
     VerifyOrReturn(Attributes::CurrentPositionTiltPercent100ths::Get(Endpoint(), current) == EMBER_ZCL_STATUS_SUCCESS);
     VerifyOrReturn(Attributes::TargetPositionTiltPercent100ths::Get(Endpoint(), target) == EMBER_ZCL_STATUS_SUCCESS);
 
-    UpdateOperationalStatus(MoveType::TILT, ComputeOperationalState(target, current));
+    OperationalState state = ComputeOperationalState(target, current);
+    UpdateOperationalStatus(MoveType::TILT, state);
 
-    positionToSet.SetNonNull(CalculateSingleStep(MoveType::TILT));
+    chip::Percent100ths step = CalculateSingleStep(MoveType::TILT);
+
+    if (state == OperationalState::MovingUpOrOpen)
+    {
+        positionToSet.SetNonNull(step > target.Value() ? step : target.Value());
+    }
+    else if (state == OperationalState::MovingDownOrClose)
+    {
+        positionToSet.SetNonNull(step < target.Value() ? step : target.Value());
+    }
+
     TiltPositionSet(Endpoint(), positionToSet);
 
     // assume single move completed


### PR DESCRIPTION
Window covering sample has a bug that allows to set only lift/tilt positions that are multiple of 5% (step value).

It was fixed by adding a logic that compares the next step value with the target value.


