### PR TITLE
[matter_yamltests] Generate an error if a cluster definition exists b…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -25,6 +25,45 @@ from .pics_checker import PICSChecker
 from .yaml_loader import YamlLoader
 
 
+class UnknownPathQualifierError(TestStepError):
+    """Raise when an attribute/command/event name is not found in the definitions."""
+
+    def __init__(self, content, target_type, target_name, candidate_names=[]):
+        if candidate_names:
+            message = f'Unknown {target_type}: "{target_name}". Candidates are: "{candidate_names}"'
+
+            for candidate_name in candidate_names:
+                if candidate_name.lower() == target_name.lower():
+                    message = f'Unknown {target_type}: "{target_name}". Did you mean "{candidate_name}" ?'
+                    break
+        else:
+            message = f'The cluster does not have any {target_type}s.'
+
+        super().__init__(message)
+        self.tag_key_with_error(content, target_type)
+
+
+class TestStepAttributeKeyError(UnknownPathQualifierError):
+    """Raise when an attribute name is not found in the definitions."""
+
+    def __init__(self, content, target_name, candidate_names=[]):
+        super().__init__(content, 'attribute', target_name, candidate_names)
+
+
+class TestStepCommandKeyError(UnknownPathQualifierError):
+    """Raise when a command name is not found in the definitions."""
+
+    def __init__(self, content, target_name, candidate_names=[]):
+        super().__init__(content, 'command', target_name, candidate_names)
+
+
+class TestStepEventKeyError(UnknownPathQualifierError):
+    """Raise when an event name is not found in the definitions."""
+
+    def __init__(self, content, target_name, candidate_names=[]):
+        super().__init__(content, 'event', target_name, candidate_names)
+
+
 class PostProcessCheckStatus(Enum):
     '''Indicates the post processing check step status.'''
     SUCCESS = 'success',
@@ -175,42 +214,7 @@ class _TestStepWithPlaceholders:
             self._convert_single_value_to_values(response)
         self.responses_with_placeholders = responses
 
-        argument_mapping = None
-        response_mapping = None
-        response_mapping_name = None
-
-        if definitions is not None:
-            if self.is_attribute:
-                attribute = definitions.get_attribute_by_name(
-                    self.cluster, self.attribute)
-                if attribute:
-                    attribute_mapping = self._as_mapping(definitions, self.cluster,
-                                                         attribute.definition.data_type.name)
-                    argument_mapping = attribute_mapping
-                    response_mapping = attribute_mapping
-                    response_mapping_name = attribute.definition.data_type.name
-            elif self.is_event:
-                event = definitions.get_event_by_name(
-                    self.cluster, self.event)
-                if event:
-                    event_mapping = self._as_mapping(definitions, self.cluster,
-                                                     event.name)
-                    argument_mapping = event_mapping
-                    response_mapping = event_mapping
-                    response_mapping_name = event.name
-            else:
-                command = definitions.get_command_by_name(
-                    self.cluster, self.command)
-                if command:
-                    argument_mapping = self._as_mapping(
-                        definitions, self.cluster, command.input_param)
-                    response_mapping = self._as_mapping(
-                        definitions, self.cluster, command.output_param)
-                    response_mapping_name = command.output_param
-
-        self.argument_mapping = argument_mapping
-        self.response_mapping = response_mapping
-        self.response_mapping_name = response_mapping_name
+        self._update_mappings(test, definitions)
         self.update_arguments(self.arguments_with_placeholders)
         self.update_responses(self.responses_with_placeholders)
 
@@ -224,6 +228,89 @@ class _TestStepWithPlaceholders:
                 if 'constraints' not in value:
                     continue
                 get_constraints(value['constraints'])
+
+    def _update_mappings(self, test: dict, definitions: SpecDefinitions):
+        cluster_name = self.cluster
+        if definitions is None or not definitions.has_cluster_by_name(cluster_name):
+            self.argument_mapping = None
+            self.response_mapping = None
+            self.response_mapping_name = None
+            return
+
+        argument_mapping = None
+        response_mapping = None
+        response_mapping_name = None
+
+        if self.is_attribute:
+            attribute_name = self.attribute
+            attribute = definitions.get_attribute_by_name(
+                cluster_name,
+                attribute_name
+            )
+
+            if not attribute:
+                targets = definitions.get_attribute_names(cluster_name)
+                raise TestStepAttributeKeyError(test, attribute_name, targets)
+
+            attribute_mapping = self._as_mapping(
+                definitions,
+                cluster_name,
+                attribute.definition.data_type.name
+            )
+
+            argument_mapping = attribute_mapping
+            response_mapping = attribute_mapping
+            response_mapping_name = attribute.definition.data_type.name
+        elif self.is_event:
+            event_name = self.event
+            event = definitions.get_event_by_name(
+                cluster_name,
+                event_name
+            )
+
+            if not event:
+                targets = definitions.get_event_names(cluster_name)
+                raise TestStepEventKeyError(test, event_name, targets)
+
+            event_mapping = self._as_mapping(
+                definitions,
+                cluster_name,
+                event_name
+            )
+
+            argument_mapping = event_mapping
+            response_mapping = event_mapping
+            response_mapping_name = event.name
+        else:
+            command_name = self.command
+            command = definitions.get_command_by_name(
+                cluster_name,
+                command_name
+            )
+
+            if not command:
+                targets = definitions.get_command_names(cluster_name)
+                raise TestStepCommandKeyError(test, command_name, targets)
+
+            if command.input_param is None:
+                argument_mapping = {}
+            else:
+                argument_mapping = self._as_mapping(
+                    definitions,
+                    cluster_name,
+                    command.input_param
+                )
+
+            response_mapping = self._as_mapping(
+                definitions,
+                cluster_name,
+                command.output_param
+            )
+            response_mapping_name = command.output_param
+
+        self.argument_mapping = argument_mapping
+        self.response_mapping = response_mapping
+        self.response_mapping_name = response_mapping_name
 
     def _convert_single_value_to_values(self, container):
         if container is None or 'values' in container:
@@ -272,7 +359,7 @@ class _TestStepWithPlaceholders:
                 response, self.response_mapping)
 
     def _update_with_definition(self, container: dict, mapping_type):
-        if not container or not mapping_type:
+        if not container or mapping_type is None:
             return
 
         values = container['values']

--- a/scripts/py_matter_yamltests/test_spec_definitions.py
+++ b/scripts/py_matter_yamltests/test_spec_definitions.py
@@ -252,8 +252,8 @@ class TestSpecDefinitions(unittest.TestCase):
             'Test', 'TestCommand'), Command)
         self.assertIsNone(
             definitions.get_command_by_name('test', 'TestCommand'))
-        self.assertRaises(KeyError, definitions.get_command_by_name,
-                          'Test', 'testcommand')
+        self.assertIsNone(
+            definitions.get_command_by_name('Test', 'testcommand'))
 
     def test_get_response_by_name(self):
         definitions = SpecDefinitions(
@@ -268,8 +268,8 @@ class TestSpecDefinitions(unittest.TestCase):
             'Test', 'TestCommandResponse'), Struct)
         self.assertIsNone(definitions.get_response_by_name(
             'test', 'TestCommandResponse'))
-        self.assertRaises(KeyError, definitions.get_response_by_name,
-                          'Test', 'testcommandresponse')
+        self.assertIsNone(definitions.get_response_by_name(
+            'Test', 'testcommandresponse'))
 
     def test_get_attribute_by_name(self):
         definitions = SpecDefinitions(
@@ -288,10 +288,10 @@ class TestSpecDefinitions(unittest.TestCase):
             'test', 'TestAttribute'))
         self.assertIsNone(definitions.get_attribute_by_name(
             'test', 'TestGlobalAttribute'))
-        self.assertRaises(KeyError, definitions.get_attribute_by_name,
-                          'Test', 'testattribute')
-        self.assertRaises(KeyError, definitions.get_attribute_by_name,
-                          'Test', 'testglobalattribute')
+        self.assertIsNone(definitions.get_attribute_by_name(
+            'Test', 'testattribute'))
+        self.assertIsNone(definitions.get_attribute_by_name(
+            'Test', 'testglobalattribute'))
 
     def test_get_event_by_name(self):
         definitions = SpecDefinitions(
@@ -303,8 +303,7 @@ class TestSpecDefinitions(unittest.TestCase):
         self.assertIsInstance(
             definitions.get_event_by_name('Test', 'TestEvent'), Event)
         self.assertIsNone(definitions.get_event_by_name('test', 'TestEvent'))
-        self.assertRaises(
-            KeyError, definitions.get_event_by_name, 'Test', 'testevent')
+        self.assertIsNone(definitions.get_event_by_name('Test', 'testevent'))
 
     def test_get_bitmap_by_name(self):
         definitions = SpecDefinitions(
@@ -316,8 +315,7 @@ class TestSpecDefinitions(unittest.TestCase):
         self.assertIsInstance(definitions.get_bitmap_by_name(
             'Test', 'TestBitmap'), Bitmap)
         self.assertIsNone(definitions.get_bitmap_by_name('test', 'TestBitmap'))
-        self.assertRaises(KeyError, definitions.get_bitmap_by_name,
-                          'Test', 'testbitmap')
+        self.assertIsNone(definitions.get_bitmap_by_name('Test', 'testbitmap'))
 
     def test_get_enum_by_name(self):
         definitions = SpecDefinitions(
@@ -329,8 +327,7 @@ class TestSpecDefinitions(unittest.TestCase):
         self.assertIsInstance(
             definitions.get_enum_by_name('Test', 'TestEnum'), Enum)
         self.assertIsNone(definitions.get_enum_by_name('test', 'TestEnum'))
-        self.assertRaises(
-            KeyError, definitions.get_enum_by_name, 'Test', 'testenum')
+        self.assertIsNone(definitions.get_enum_by_name('Test', 'testenum'))
 
     def test_get_struct_by_name(self):
         definitions = SpecDefinitions(
@@ -342,8 +339,7 @@ class TestSpecDefinitions(unittest.TestCase):
         self.assertIsInstance(definitions.get_struct_by_name(
             'Test', 'TestStruct'), Struct)
         self.assertIsNone(definitions.get_struct_by_name('test', 'TestStruct'))
-        self.assertRaises(
-            KeyError, definitions.get_struct_by_name, 'Test', 'teststruct')
+        self.assertIsNone(definitions.get_struct_by_name('Test', 'teststruct'))
 
     def test_get_type_by_name(self):
         definitions = SpecDefinitions(
@@ -401,6 +397,46 @@ class TestSpecDefinitions(unittest.TestCase):
         event = definitions.get_event_by_name(
             'Test', 'TestEventFabricScoped')
         self.assertTrue(definitions.is_fabric_scoped(event))
+
+    def test_get_cluster_id_by_name(self):
+        definitions = SpecDefinitions(
+            [ParseSource(source=io.StringIO(source_cluster), name='source_cluster')])
+
+        cluster_id = definitions.get_cluster_id_by_name('Test')
+        self.assertEqual(cluster_id, 0x1234)
+
+        cluster_id = definitions.get_cluster_id_by_name('test')
+        self.assertIsNone(cluster_id)
+
+    def test_get_command_names(self):
+        definitions = SpecDefinitions(
+            [ParseSource(source=io.StringIO(source_command), name='source_command')])
+
+        commands = definitions.get_command_names('Test')
+        self.assertEqual(commands, ['TestCommand'])
+
+        commands = definitions.get_command_names('test')
+        self.assertEqual(commands, [])
+
+    def test_get_attribute_names(self):
+        definitions = SpecDefinitions(
+            [ParseSource(source=io.StringIO(source_attribute), name='source_attribute')])
+
+        attributes = definitions.get_attribute_names('Test')
+        self.assertEqual(attributes, ['TestAttribute', 'TestGlobalAttribute'])
+
+        attributes = definitions.get_attribute_names('test')
+        self.assertEqual(attributes, [])
+
+    def test_get_event_names(self):
+        definitions = SpecDefinitions(
+            [ParseSource(source=io.StringIO(source_event), name='source_event')])
+
+        events = definitions.get_event_names('Test')
+        self.assertEqual(events, ['TestEvent', 'TestEventFabricScoped'])
+
+        events = definitions.get_event_names('test')
+        self.assertEqual(events, [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…ut the attribute/event/command can not be found

#### Problem

When a definition for a given cluster exists but the attribute/command/event does not exists it will be caught at runtime by the adapter.
This PR changes that such that it is caught at parsing time.
