### PR TITLE
[matter_yamltests] Add CommissionerCommands and DiscoveryCommands method definitions

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/constraints.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/constraints.py
@@ -87,7 +87,7 @@ class _ConstraintType(BaseConstraint):
             success = True
         elif self._type == 'vendor_id' and type(value) is int:
             success = value >= 0 and value <= 0xFFFF
-        elif self._type == 'device_type_id' and type(value) is int:
+        elif self._type == 'devtype_id' and type(value) is int:
             success = value >= 0 and value <= 0xFFFFFFFF
         elif self._type == 'cluster_id' and type(value) is int:
             success = value >= 0 and value <= 0xFFFFFFFF

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/commissioner_commands.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/commissioner_commands.py
@@ -1,0 +1,46 @@
+#
+#    Copyright (c) 2023 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the 'License');
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an 'AS IS' BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from ..pseudo_cluster import PseudoCluster
+
+_DEFINITION = '''<?xml version="1.0"?>
+<configurator>
+<cluster>
+    <name>CommissionerCommands</name>
+    <code>0xFFF1FD04</code>
+
+    <command source="client" code="0" name="PairWithCode">
+        <arg name="nodeId" type="node_id"/>
+        <arg name="payload" type="char_string"/>
+    </command>
+
+    <command source="client" code="1" name="Unpair">
+      <arg name="nodeId" type="node_id"/>
+    </command>
+
+    <command source="client" code="2" name="GetCommissionerNodeId" response="GetCommissionerNodeIdResponse">
+    </command>
+
+    <command source="server" code="0" name="GetCommissionerNodeIdResponse">
+      <arg name="nodeId" type="node_id"/>
+    </command>
+</cluster>
+</configurator>
+'''
+
+
+class CommissionerCommands(PseudoCluster):
+    name = 'CommissionerCommands'
+    definition = _DEFINITION

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/discovery_commands.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/discovery_commands.py
@@ -1,0 +1,84 @@
+#
+#    Copyright (c) 2023 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the 'License');
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an 'AS IS' BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from ..pseudo_cluster import PseudoCluster
+
+_DEFINITION = '''<?xml version="1.0"?>
+<configurator>
+<cluster>
+    <name>DiscoveryCommands</name>
+    <code>0xFFF1FD05</code>
+
+    <command source="client" code="0" name="FindCommissionable" response="FindResponse">
+    </command>
+
+    <command source="client" code="1" name="FindCommissionableByShortDiscriminator" response="FindResponse">
+        <arg name="value" type="int16u"/>
+    </command>
+
+    <command source="client" code="2" name="FindCommissionableByLongDiscriminator" response="FindResponse">
+        <arg name="value" type="int16u"/>
+    </command>
+
+    <command source="client" code="3" name="FindCommissionableByCommissioningMode" response="FindResponse">
+    </command>
+
+    <command source="client" code="4" name="FindCommissionableByVendorId" response="FindResponse">
+        <arg name="value" type="vendor_id"/>
+    </command>
+
+    <command source="client" code="5" name="FindCommissionableByDeviceType" response="FindResponse">
+        <arg name="value" type="devtype_id"/>
+    </command>
+
+    <command source="client" code="6" name="FindCommissioner" response="FindCommissionerResponse">
+    </command>
+
+    <command source="client" code="7" name="FindCommissionerByVendorId" response="FindCommissionerResponse">
+        <arg name="value" type="vendor_id"/>
+    </command>
+
+    <command source="client" code="8" name="FindCommissionerByDeviceType" response="FindCommissionerResponse">
+        <arg name="value" type="devtype_id"/>
+    </command>
+
+    <command source="server" code="9" name="FindResponse">
+        <arg name="hostName" type="char_string"/>
+        <arg name="instanceName" type="char_string"/>
+        <arg name="longDiscriminator" type="int16u"/>
+        <arg name="shortDiscriminator" type="int16u"/>
+        <arg name="vendorId" type="vendor_id"/>
+        <arg name="productId" type="int16u"/>
+        <arg name="commissioningMode" type="int8u"/>
+        <arg name="deviceType" type="devtype_id"/>
+        <arg name="deviceName" type="char_string"/>
+        <arg name="rotatingId" type="octet_string"/>
+        <arg name="rotatingIdLen" type="int64u"/>
+        <arg name="pairingHint" type="int16u"/>
+        <arg name="pairingInstruction" type="char_string"/>
+        <arg name="supportsTcp" type="boolean"/>
+        <arg name="numIPs" type="int8u"/>
+        <arg name="port" type="int16u"/>
+        <arg name="mrpRetryIntervalIdle" type="int32u" optional="true"/>
+        <arg name="mrpRetryIntervalActive" type="int32u" optional="true"/>
+    </command>
+</cluster>
+</configurator>
+'''
+
+
+class DiscoveryCommands(PseudoCluster):
+    name = 'DiscoveryCommands'
+    definition = _DEFINITION

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_clusters.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_clusters.py
@@ -12,6 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from .clusters.commissioner_commands import CommissionerCommands
 from .clusters.delay_commands import DelayCommands
 from .clusters.log_commands import LogCommands
 from .clusters.system_commands import SystemCommands
@@ -46,6 +47,7 @@ class PseudoClusters:
 
 def get_default_pseudo_clusters() -> PseudoClusters:
     clusters = [
+        CommissionerCommands(),
         DelayCommands(),
         LogCommands(),
         SystemCommands()

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_clusters.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_clusters.py
@@ -14,6 +14,7 @@
 
 from .clusters.commissioner_commands import CommissionerCommands
 from .clusters.delay_commands import DelayCommands
+from .clusters.discovery_commands import DiscoveryCommands
 from .clusters.log_commands import LogCommands
 from .clusters.system_commands import SystemCommands
 from .pseudo_cluster import PseudoCluster
@@ -49,6 +50,7 @@ def get_default_pseudo_clusters() -> PseudoClusters:
     clusters = [
         CommissionerCommands(),
         DelayCommands(),
+        DiscoveryCommands(),
         LogCommands(),
         SystemCommands()
     ]


### PR DESCRIPTION
#### Problem

`CommissionerCommands` and `DiscoveryCommands` does not have a definition. It makes errors happening at runtime instead of parsing time.
