### PR TITLE
[Silabs][EFR32] Fix lock-app with matter shell build failure

### DIFF
--- a/examples/lock-app/silabs/efr32/BUILD.gn
+++ b/examples/lock-app/silabs/efr32/BUILD.gn
@@ -82,6 +82,10 @@ efr32_executable("lock_app") {
     "src/main.cpp",
   ]
 
+  if (chip_build_libshell) {
+    sources += [ "src/EventHandlerLibShell.cpp" ]
+  }
+
   deps = [
     ":sdk",
     "${examples_plat_dir}:efr32-common",


### PR DESCRIPTION
Add the missing source file to the lock-app build.gn when shell is enabled

Tested the lock-app build and shell locally
