### PR TITLE
Bump build timeout on k32w.

### DIFF
--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -79,7 +79,7 @@ jobs:
                       .environment/pigweed-venv/*.log
 
             - name: Build examples
-              timeout-minutes: 50
+              timeout-minutes: 70
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \


### PR DESCRIPTION
We keep hitting the timeout, even at 50 minutes.

