### PR TITLE
Add darwin availability annotations for new Occupancy Sensing enums/bitmaps.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -6675,6 +6675,8 @@
               - IntentEnum
               - StatusEnum
               - TransferProtocolEnum
+          OccupancySensing:
+              - OccupancySensorTypeEnum
       enum values:
           DoorLock:
               LockDataTypeEnum:
@@ -6693,6 +6695,24 @@
               TransferProtocolEnum:
                   - ResponsePayload
                   - BDX
+          OccupancySensing:
+              OccupancySensorTypeEnum:
+                  - PIR
+                  - Ultrasonic
+                  - PIRAndUltrasonic
+                  - PhysicalContact
+      bitmaps:
+          OccupancySensing:
+              - OccupancyBitmap
+              - OccupancySensorTypeBitmap
+      bitmap values:
+          OccupancySensing:
+              OccupancyBitmap:
+                  - Occupied
+              OccupancySensorTypeBitmap:
+                  - PIR
+                  - Ultrasonic
+                  - PhysicalContact
   deprecated:
       attributes:
           TimeSynchronization:


### PR DESCRIPTION
These were added in https://github.com/project-chip/connectedhomeip/pull/24363
