### PR TITLE
[CI] Add test to check establish PASE connection only Java API

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -570,6 +570,18 @@ jobs:
                      --tool-args "already-discovered --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 1000" \
                      --factoryreset \
                   '
+            - name: Run Pairing Address-PaseOnly Test
+              timeout-minutes: 10
+              run: |
+                  scripts/run_in_build_env.sh \
+                  './scripts/tests/run_java_test.py \
+                     --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
+                     --app-args "--discriminator 3840 --interface-id -1" \
+                     --tool-path out/linux-x64-java-matter-controller \
+                     --tool-cluster "pairing" \
+                     --tool-args "address-paseonly --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 1000" \
+                     --factoryreset \
+                  '                  
             - name: Uploading core files
               uses: actions/upload-artifact@v3
               if: ${{ failure() && !env.ACT }}

--- a/examples/java-matter-controller/BUILD.gn
+++ b/examples/java-matter-controller/BUILD.gn
@@ -42,6 +42,7 @@ java_binary("java-matter-controller") {
     "java/src/com/matter/controller/commands/discover/DiscoverCommissionersCommand.java",
     "java/src/com/matter/controller/commands/pairing/CloseSessionCommand.java",
     "java/src/com/matter/controller/commands/pairing/DiscoveryFilterType.java",
+    "java/src/com/matter/controller/commands/pairing/PairAddressPaseCommand.java",
     "java/src/com/matter/controller/commands/pairing/PairAlreadyDiscoveredCommand.java",
     "java/src/com/matter/controller/commands/pairing/PairCodeCommand.java",
     "java/src/com/matter/controller/commands/pairing/PairCodePaseCommand.java",

--- a/examples/java-matter-controller/java/src/com/matter/controller/Main.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/Main.java
@@ -60,6 +60,8 @@ public class Main {
         new PairCodeWifiCommand(controller, credentialsIssuer);
     PairCodeThreadCommand pairCodeThreadCommand =
         new PairCodeThreadCommand(controller, credentialsIssuer);
+    PairAddressPaseCommand pairAddressPaseCommand =
+        new PairAddressPaseCommand(controller, credentialsIssuer);
     PairAlreadyDiscoveredCommand pairAlreadyDiscoveredCommand =
         new PairAlreadyDiscoveredCommand(controller, credentialsIssuer);
     PairOnNetworkCommand pairOnNetworkCommand =
@@ -83,6 +85,7 @@ public class Main {
     clusterCommands.add(pairCodePaseCommand);
     clusterCommands.add(pairCodeWifiCommand);
     clusterCommands.add(pairCodeThreadCommand);
+    clusterCommands.add(pairAddressPaseCommand);
     clusterCommands.add(pairAlreadyDiscoveredCommand);
     clusterCommands.add(pairOnNetworkCommand);
     clusterCommands.add(pairOnNetworkShortCommand);

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairAddressPaseCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairAddressPaseCommand.java
@@ -1,0 +1,39 @@
+package com.matter.controller.commands.pairing;
+
+import chip.devicecontroller.ChipDeviceController;
+import com.matter.controller.commands.common.CredentialsIssuer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class PairAddressPaseCommand extends PairingCommand {
+  private static Logger logger = Logger.getLogger(PairAddressPaseCommand.class.getName());
+
+  public PairAddressPaseCommand(ChipDeviceController controller, CredentialsIssuer credsIssue) {
+    super(
+        controller,
+        "address-paseonly",
+        PairingModeType.ADDRESS_PASE_ONLY,
+        PairingNetworkType.NONE,
+        credsIssue);
+  }
+
+  @Override
+  public void onPairingComplete(int errorCode) {
+    logger.log(Level.INFO, "onPairingComplete with error code: " + errorCode);
+    if (errorCode == 0) {
+      setSuccess();
+    } else {
+      setFailure("onPairingComplete failure");
+    }
+  }
+
+  @Override
+  protected void runCommand() {
+    currentCommissioner()
+        .establishPaseConnection(
+            getNodeId(), getRemoteAddr().getHostAddress(), getRemotePort(), getSetupPINCode());
+
+    currentCommissioner().setCompletionListener(this);
+    waitCompleteMs(getTimeoutMillis());
+  }
+}

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.java
@@ -189,10 +189,14 @@ public abstract class PairingCommand extends MatterCommand
         break;
       case CODE:
       case CODE_PASE_ONLY:
-        Only:
         addArgument("payload", mOnboardingPayload, null, false);
         addArgument("discover-once", mDiscoverOnce, null, false);
         addArgument("use-only-onnetwork-discovery", mUseOnlyOnNetworkDiscovery, null, false);
+        break;
+      case ADDRESS_PASE_ONLY:
+        addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null, false);
+        addArgument("device-remote-ip", mRemoteAddr, false);
+        addArgument("device-remote-port", (short) 0, Short.MAX_VALUE, mRemotePort, null, false);
         break;
       case BLE:
         addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null, false);
@@ -202,7 +206,6 @@ public abstract class PairingCommand extends MatterCommand
         addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null, false);
         break;
       case SOFT_AP:
-        AP:
         addArgument("setup-pin-code", 0, 134217727, mSetupPINCode, null, false);
         addArgument("discriminator", (short) 0, (short) 4096, mDiscriminator, null, false);
         addArgument("device-remote-ip", mRemoteAddr, false);

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingModeType.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingModeType.java
@@ -22,6 +22,7 @@ public enum PairingModeType {
   NONE,
   CODE,
   CODE_PASE_ONLY,
+  ADDRESS_PASE_ONLY,
   BLE,
   SOFT_AP,
   ALREADY_DISCOVERED,

--- a/scripts/tests/java/commissioning_test.py
+++ b/scripts/tests/java/commissioning_test.py
@@ -81,6 +81,14 @@ class CommissioningTest:
         DumpProgramOutputToQueue(self.thread_list, Fore.GREEN + "JAVA " + Style.RESET_ALL, java_process, self.queue)
         return java_process.wait()
 
+    def TestCmdAddressPaseOnly(self, nodeid, setuppin, address, port, timeout):
+        java_command = self.command + ['pairing', 'address-paseonly', nodeid, setuppin, address, port, timeout]
+        logging.info(f"Execute: {java_command}")
+        java_process = subprocess.Popen(
+            java_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        DumpProgramOutputToQueue(self.thread_list, Fore.GREEN + "JAVA " + Style.RESET_ALL, java_process, self.queue)
+        return java_process.wait()
+
     def RunTest(self):
         if self.command_name == 'onnetwork-long':
             logging.info("Testing pairing onnetwork-long")
@@ -92,5 +100,10 @@ class CommissioningTest:
             code = self.TestCmdAlreadyDiscovered(self.nodeid, self.setup_pin_code, self.address, self.port, self.timeout)
             if code != 0:
                 raise Exception(f"Testing pairing already-discovered failed with error {code}")
+        elif self.command_name == 'address-paseonly':
+            logging.info("Testing pairing address-paseonly")
+            code = self.TestCmdAddressPaseOnly(self.nodeid, self.setup_pin_code, self.address, self.port, self.timeout)
+            if code != 0:
+                raise Exception(f"Testing pairing address-paseonly failed with error {code}")
         else:
             raise Exception(f"Unsupported command {self.command_name}")


### PR DESCRIPTION
It turns out some of our products do not use the auto-commissioning API since it lacks flexibility, instead, those products establish the PASE connection directly with the product and use a serial of  cluster commands to conduct the pairing process.

Add the CI check to first check Establishing a secure PASE connection to a given device via IP address, will figure out how to validate Establishing  PASE connection via BLE in CI later

