### PR TITLE
Do not include endpoint config in types_stub.h

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/static-supported-modes-manager.h
+++ b/examples/all-clusters-app/all-clusters-common/include/static-supported-modes-manager.h
@@ -20,6 +20,7 @@
 
 #include <app/clusters/mode-select-server/supported-modes-manager.h>
 #include <app/util/af.h>
+#include <app/util/config.h>
 #include <cstring>
 
 namespace chip {

--- a/examples/all-clusters-app/all-clusters-common/include/static-supported-modes-manager.h
+++ b/examples/all-clusters-app/all-clusters-common/include/static-supported-modes-manager.h
@@ -22,8 +22,6 @@
 #include <app/util/af.h>
 #include <cstring>
 
-#include <zap-generated/gen_config.h>
-
 namespace chip {
 namespace app {
 namespace Clusters {

--- a/examples/all-clusters-app/all-clusters-common/include/static-supported-modes-manager.h
+++ b/examples/all-clusters-app/all-clusters-common/include/static-supported-modes-manager.h
@@ -22,6 +22,8 @@
 #include <app/util/af.h>
 #include <cstring>
 
+#include <zap-generated/gen_config.h>
+
 namespace chip {
 namespace app {
 namespace Clusters {

--- a/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
@@ -1,3 +1,4 @@
+#include <app/util/config.h>
 #include <static-supported-modes-manager.h>
 
 using namespace std;

--- a/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
@@ -1,7 +1,5 @@
 #include <static-supported-modes-manager.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace std;
 using namespace chip;
 using namespace chip::app::Clusters;

--- a/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
@@ -1,5 +1,7 @@
 #include <static-supported-modes-manager.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace std;
 using namespace chip;
 using namespace chip::app::Clusters;

--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -1,5 +1,6 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/callback.h>
+#include <app/util/config.h>
 
 // Include door lock callbacks only when the server is enabled
 #ifdef EMBER_AF_PLUGIN_DOOR_LOCK_SERVER

--- a/examples/chef/efr32/src/AppTask.cpp
+++ b/examples/chef/efr32/src/AppTask.cpp
@@ -36,6 +36,7 @@
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 
 #ifdef EMBER_AF_PLUGIN_IDENTIFY_SERVER
 #include <app/clusters/identify-server/identify-server.h>

--- a/examples/dynamic-bridge-app/linux/DynamicDevice.cpp
+++ b/examples/dynamic-bridge-app/linux/DynamicDevice.cpp
@@ -19,6 +19,7 @@
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app/util/config.h>
 
 #include "DynamicDevice.h"
 

--- a/examples/dynamic-bridge-app/linux/include/data-model/Attribute.h
+++ b/examples/dynamic-bridge-app/linux/include/data-model/Attribute.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <app/ConcreteAttributePath.h>
+#include <app/util/config.h>
 
 #include "DataModel.h"
 

--- a/examples/placeholder/linux/include/static-supported-modes-manager.h
+++ b/examples/placeholder/linux/include/static-supported-modes-manager.h
@@ -20,6 +20,7 @@
 
 #include <app/clusters/mode-select-server/supported-modes-manager.h>
 #include <app/util/af.h>
+#include <app/util/config.h>
 #include <cstring>
 
 namespace chip {

--- a/examples/placeholder/linux/include/static-supported-modes-manager.h
+++ b/examples/placeholder/linux/include/static-supported-modes-manager.h
@@ -22,8 +22,6 @@
 #include <app/util/af.h>
 #include <cstring>
 
-#include <zap-generated/gen_config.h>
-
 namespace chip {
 namespace app {
 namespace Clusters {

--- a/examples/placeholder/linux/include/static-supported-modes-manager.h
+++ b/examples/placeholder/linux/include/static-supported-modes-manager.h
@@ -22,6 +22,8 @@
 #include <app/util/af.h>
 #include <cstring>
 
+#include <zap-generated/gen_config.h>
+
 namespace chip {
 namespace app {
 namespace Clusters {

--- a/examples/placeholder/linux/static-supported-modes-manager.cpp
+++ b/examples/placeholder/linux/static-supported-modes-manager.cpp
@@ -1,3 +1,4 @@
+#include <app/util/config.h>
 #include <static-supported-modes-manager.h>
 
 using namespace std;

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -18,6 +18,7 @@
 
 #include "AppContentLauncherManager.h"
 #include "../../java/ContentAppAttributeDelegate.h"
+#include <app/util/config.h>
 #include <json/json.h>
 
 using namespace std;

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -20,6 +20,8 @@
 #include "../../java/ContentAppAttributeDelegate.h"
 #include <json/json.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace std;
 using namespace chip::app;
 using namespace chip::app::Clusters;

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -20,8 +20,6 @@
 #include "../../java/ContentAppAttributeDelegate.h"
 #include <json/json.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace std;
 using namespace chip::app;
 using namespace chip::app::Clusters;

--- a/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
+++ b/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
@@ -18,6 +18,7 @@
 #include "AppMediaPlaybackManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app/util/config.h>
 #include <cstdint>
 #include <jni.h>
 #include <json/json.h>

--- a/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
+++ b/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
@@ -25,8 +25,6 @@
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace std;
 using namespace chip;
 using namespace chip::app;

--- a/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
+++ b/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
@@ -25,6 +25,8 @@
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace std;
 using namespace chip;
 using namespace chip::app;

--- a/examples/tv-app/android/java/ChannelManager.cpp
+++ b/examples/tv-app/android/java/ChannelManager.cpp
@@ -19,6 +19,7 @@
 #include "TvApp-JNI.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app/util/config.h>
 #include <cstdlib>
 #include <jni.h>
 #include <lib/core/CHIPSafeCasts.h>

--- a/examples/tv-app/android/java/ChannelManager.cpp
+++ b/examples/tv-app/android/java/ChannelManager.cpp
@@ -26,8 +26,6 @@
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters::Channel;

--- a/examples/tv-app/android/java/ChannelManager.cpp
+++ b/examples/tv-app/android/java/ChannelManager.cpp
@@ -26,6 +26,8 @@
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters::Channel;

--- a/examples/tv-app/android/java/ContentAppAttributeDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppAttributeDelegate.cpp
@@ -23,6 +23,7 @@
 #include "ContentAppAttributeDelegate.h"
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/util/config.h>
 #include <jni.h>
 #include <lib/support/CHIPJNIError.h>
 #include <lib/support/JniReferences.h>

--- a/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
@@ -24,6 +24,7 @@
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/CommandHandlerInterface.h>
+#include <app/util/config.h>
 #include <jni.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/CHIPJNIError.h>

--- a/examples/tv-app/android/java/KeypadInputManager.cpp
+++ b/examples/tv-app/android/java/KeypadInputManager.cpp
@@ -20,6 +20,7 @@
 #include "TvApp-JNI.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app/util/config.h>
 #include <lib/support/CHIPJNIError.h>
 #include <lib/support/JniReferences.h>
 

--- a/examples/tv-app/android/java/KeypadInputManager.cpp
+++ b/examples/tv-app/android/java/KeypadInputManager.cpp
@@ -23,8 +23,6 @@
 #include <lib/support/CHIPJNIError.h>
 #include <lib/support/JniReferences.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 using namespace chip::app::Clusters::KeypadInput;
 

--- a/examples/tv-app/android/java/KeypadInputManager.cpp
+++ b/examples/tv-app/android/java/KeypadInputManager.cpp
@@ -23,6 +23,8 @@
 #include <lib/support/CHIPJNIError.h>
 #include <lib/support/JniReferences.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 using namespace chip::app::Clusters::KeypadInput;
 

--- a/examples/tv-app/android/java/LevelManager.cpp
+++ b/examples/tv-app/android/java/LevelManager.cpp
@@ -19,6 +19,7 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/af.h>
+#include <app/util/config.h>
 #include <jni.h>
 #include <lib/support/CHIPJNIError.h>
 #include <lib/support/JniReferences.h>

--- a/examples/tv-app/android/java/LevelManager.cpp
+++ b/examples/tv-app/android/java/LevelManager.cpp
@@ -24,6 +24,8 @@
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 
 static constexpr size_t kLevelManagerTableSize = EMBER_AF_LEVEL_CONTROL_CLUSTER_SERVER_ENDPOINT_COUNT;

--- a/examples/tv-app/android/java/LevelManager.cpp
+++ b/examples/tv-app/android/java/LevelManager.cpp
@@ -24,8 +24,6 @@
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 
 static constexpr size_t kLevelManagerTableSize = EMBER_AF_LEVEL_CONTROL_CLUSTER_SERVER_ENDPOINT_COUNT;

--- a/examples/tv-app/android/java/MediaPlaybackManager.cpp
+++ b/examples/tv-app/android/java/MediaPlaybackManager.cpp
@@ -19,6 +19,7 @@
 #include "TvApp-JNI.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app/util/config.h>
 #include <cstdint>
 #include <jni.h>
 #include <lib/support/CHIPJNIError.h>

--- a/examples/tv-app/android/java/MediaPlaybackManager.cpp
+++ b/examples/tv-app/android/java/MediaPlaybackManager.cpp
@@ -25,8 +25,6 @@
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
 
-#include <zap-generated/gen_config.h>
-
 #include "MediaPlaybackManager.h"
 
 using namespace chip;

--- a/examples/tv-app/android/java/MediaPlaybackManager.cpp
+++ b/examples/tv-app/android/java/MediaPlaybackManager.cpp
@@ -25,6 +25,8 @@
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
 
+#include <zap-generated/gen_config.h>
+
 #include "MediaPlaybackManager.h"
 
 using namespace chip;

--- a/examples/tv-app/android/java/OnOffManager.cpp
+++ b/examples/tv-app/android/java/OnOffManager.cpp
@@ -19,6 +19,7 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/af.h>
+#include <app/util/config.h>
 #include <jni.h>
 #include <lib/support/CHIPJNIError.h>
 #include <lib/support/JniReferences.h>

--- a/examples/tv-app/android/java/OnOffManager.cpp
+++ b/examples/tv-app/android/java/OnOffManager.cpp
@@ -24,8 +24,6 @@
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 
 static constexpr size_t kOnffManagerTableSize = EMBER_AF_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT;

--- a/examples/tv-app/android/java/OnOffManager.cpp
+++ b/examples/tv-app/android/java/OnOffManager.cpp
@@ -24,6 +24,8 @@
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 
 static constexpr size_t kOnffManagerTableSize = EMBER_AF_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT;

--- a/examples/tv-app/linux/include/channel/ChannelManager.cpp
+++ b/examples/tv-app/linux/include/channel/ChannelManager.cpp
@@ -17,6 +17,8 @@
 
 #include "ChannelManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/util/config.h>
+
 #include <vector>
 
 using namespace chip;

--- a/examples/tv-app/linux/include/channel/ChannelManager.cpp
+++ b/examples/tv-app/linux/include/channel/ChannelManager.cpp
@@ -19,6 +19,8 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <vector>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters::Channel;

--- a/examples/tv-app/linux/include/channel/ChannelManager.cpp
+++ b/examples/tv-app/linux/include/channel/ChannelManager.cpp
@@ -19,8 +19,6 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <vector>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters::Channel;

--- a/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
+++ b/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
@@ -18,6 +18,7 @@
 
 #include "ContentLauncherManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/util/config.h>
 
 using namespace std;
 using namespace chip::app;

--- a/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
+++ b/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
@@ -19,6 +19,8 @@
 #include "ContentLauncherManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace std;
 using namespace chip::app;
 using namespace chip::app::Clusters;

--- a/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
+++ b/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
@@ -19,8 +19,6 @@
 #include "ContentLauncherManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace std;
 using namespace chip::app;
 using namespace chip::app::Clusters;

--- a/examples/tv-app/linux/include/keypad-input/KeypadInputManager.cpp
+++ b/examples/tv-app/linux/include/keypad-input/KeypadInputManager.cpp
@@ -18,6 +18,7 @@
 
 #include "KeypadInputManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/util/config.h>
 
 using namespace chip;
 using namespace chip::app::Clusters::KeypadInput;

--- a/examples/tv-app/linux/include/keypad-input/KeypadInputManager.cpp
+++ b/examples/tv-app/linux/include/keypad-input/KeypadInputManager.cpp
@@ -19,8 +19,6 @@
 #include "KeypadInputManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 using namespace chip::app::Clusters::KeypadInput;
 

--- a/examples/tv-app/linux/include/keypad-input/KeypadInputManager.cpp
+++ b/examples/tv-app/linux/include/keypad-input/KeypadInputManager.cpp
@@ -19,6 +19,8 @@
 #include "KeypadInputManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 using namespace chip::app::Clusters::KeypadInput;
 

--- a/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
+++ b/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
@@ -17,6 +17,7 @@
 
 #include "MediaPlaybackManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/util/config.h>
 
 using namespace std;
 using namespace chip::app::DataModel;

--- a/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
+++ b/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
@@ -18,6 +18,8 @@
 #include "MediaPlaybackManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace std;
 using namespace chip::app::DataModel;
 using namespace chip::app::Clusters::MediaPlayback;

--- a/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
+++ b/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
@@ -18,8 +18,6 @@
 #include "MediaPlaybackManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace std;
 using namespace chip::app::DataModel;
 using namespace chip::app::Clusters::MediaPlayback;

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -23,6 +23,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/app-platform/ContentAppPlatform.h>
 #include <app/server/Server.h>
+#include <app/util/config.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/CHIPArgParser.hpp>

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -35,8 +35,6 @@
 #include <app/app-platform/ContentAppPlatform.h>
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
-#include <app/util/config.h>
-
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::AccountLogin;

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -33,6 +33,8 @@
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 #include <app/app-platform/ContentAppPlatform.h>
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
+       //
+#include <zap-generated/gen_config.h>
 
 using namespace chip;
 using namespace chip::app::Clusters;

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -28,11 +28,14 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
+#include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
 
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 #include <app/app-platform/ContentAppPlatform.h>
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
+
+#include <app/util/config.h>
 
 using namespace chip;
 using namespace chip::app::Clusters;

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -33,8 +33,6 @@
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 #include <app/app-platform/ContentAppPlatform.h>
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
-       //
-#include <zap-generated/gen_config.h>
 
 using namespace chip;
 using namespace chip::app::Clusters;

--- a/src/app/clusters/application-basic-server/application-basic-server.cpp
+++ b/src/app/clusters/application-basic-server/application-basic-server.cpp
@@ -33,6 +33,8 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
+#include <zap-generated/gen_config.h>
+
 #include <list>
 
 using namespace chip;

--- a/src/app/clusters/application-basic-server/application-basic-server.cpp
+++ b/src/app/clusters/application-basic-server/application-basic-server.cpp
@@ -33,8 +33,6 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#include <zap-generated/gen_config.h>
-
 #include <list>
 
 using namespace chip;

--- a/src/app/clusters/application-basic-server/application-basic-server.cpp
+++ b/src/app/clusters/application-basic-server/application-basic-server.cpp
@@ -31,7 +31,10 @@
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 #include <app/data-model/Encode.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
+
+#include <app/util/config.h>
 
 #include <list>
 

--- a/src/app/clusters/application-basic-server/application-basic-server.cpp
+++ b/src/app/clusters/application-basic-server/application-basic-server.cpp
@@ -34,8 +34,6 @@
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#include <app/util/config.h>
-
 #include <list>
 
 using namespace chip;

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -39,8 +39,6 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#include <app/util/config.h>
-
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ApplicationLauncher;

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -38,6 +38,8 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ApplicationLauncher;

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -38,8 +38,6 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ApplicationLauncher;

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -31,12 +31,15 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
+#include <app/util/config.h>
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 #include <app/app-platform/ContentAppPlatform.h>
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 #include <app/data-model/Encode.h>
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
+
+#include <app/util/config.h>
 
 using namespace chip;
 using namespace chip::app::Clusters;

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -33,8 +33,6 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 using namespace chip::app::Clusters::AudioOutput;
 using chip::Protocols::InteractionModel::Status;

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -33,6 +33,8 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 using namespace chip::app::Clusters::AudioOutput;
 using chip::Protocols::InteractionModel::Status;

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -34,8 +34,6 @@
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#include <app/util/config.h>
-
 using namespace chip;
 using namespace chip::app::Clusters::AudioOutput;
 using chip::Protocols::InteractionModel::Status;

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -31,7 +31,10 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
+
+#include <app/util/config.h>
 
 using namespace chip;
 using namespace chip::app::Clusters::AudioOutput;

--- a/src/app/clusters/barrier-control-server/barrier-control-server.cpp
+++ b/src/app/clusters/barrier-control-server/barrier-control-server.cpp
@@ -22,6 +22,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
+#include <app/util/config.h>
 
 #include <assert.h>
 

--- a/src/app/clusters/bindings/PendingNotificationMap.cpp
+++ b/src/app/clusters/bindings/PendingNotificationMap.cpp
@@ -19,6 +19,7 @@
 
 #include <app/clusters/bindings/PendingNotificationMap.h>
 #include <app/util/binding-table.h>
+#include <app/util/config.h>
 
 namespace chip {
 

--- a/src/app/clusters/bindings/PendingNotificationMap.h
+++ b/src/app/clusters/bindings/PendingNotificationMap.h
@@ -16,6 +16,7 @@
  */
 
 #include <app/util/binding-table.h>
+#include <app/util/config.h>
 #include <credentials/FabricTable.h>
 #include <lib/core/DataModelTypes.h>
 

--- a/src/app/clusters/bindings/bindings.cpp
+++ b/src/app/clusters/bindings/bindings.cpp
@@ -28,6 +28,7 @@
 #include <app/clusters/bindings/bindings.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 #include <lib/support/logging/CHIPLogging.h>
 using namespace chip;
 using namespace chip::app;

--- a/src/app/clusters/channel-server/channel-server.cpp
+++ b/src/app/clusters/channel-server/channel-server.cpp
@@ -26,6 +26,7 @@
 #include <app/clusters/channel-server/channel-server.h>
 #include <app/data-model/Encode.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
 
 using namespace chip;

--- a/src/app/clusters/channel-server/channel-server.cpp
+++ b/src/app/clusters/channel-server/channel-server.cpp
@@ -28,6 +28,8 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::Channel;

--- a/src/app/clusters/channel-server/channel-server.cpp
+++ b/src/app/clusters/channel-server/channel-server.cpp
@@ -28,8 +28,6 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::Channel;

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -22,6 +22,7 @@
 #include <app/util/af-event.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 
 using namespace chip;
 using namespace chip::app::Clusters;

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -22,6 +22,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af-types.h>
 #include <app/util/basic-types.h>
+#include <app/util/config.h>
 #include <protocols/interaction_model/StatusCode.h>
 
 /**********************************************************

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -24,6 +24,8 @@
 #include <app/util/basic-types.h>
 #include <protocols/interaction_model/StatusCode.h>
 
+#include <zap-generated/gen_config.h>
+
 /**********************************************************
  * Defines and Macros
  *********************************************************/

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -24,8 +24,6 @@
 #include <app/util/basic-types.h>
 #include <protocols/interaction_model/StatusCode.h>
 
-#include <zap-generated/gen_config.h>
-
 /**********************************************************
  * Defines and Macros
  *********************************************************/

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -28,6 +28,7 @@
 #include <app/data-model/Encode.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
 
 #include <list>

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -30,8 +30,6 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#include <zap-generated/gen_config.h>
-
 #include <list>
 
 using namespace chip;

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -30,6 +30,8 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
+#include <zap-generated/gen_config.h>
+
 #include <list>
 
 using namespace chip;

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -31,8 +31,6 @@
 #include <app/util/config.h>
 #include <protocols/interaction_model/StatusCode.h>
 
-#include <zap-generated/gen_config.h>
-
 #ifndef DOOR_LOCK_SERVER_ENDPOINT
 #define DOOR_LOCK_SERVER_ENDPOINT 1
 #endif

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -31,6 +31,8 @@
 #include <app/util/config.h>
 #include <protocols/interaction_model/StatusCode.h>
 
+#include <zap-generated/gen_config.h>
+
 #ifndef DOOR_LOCK_SERVER_ENDPOINT
 #define DOOR_LOCK_SERVER_ENDPOINT 1
 #endif

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -23,6 +23,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/CommandHandler.h>
 #include <app/util/af.h>
+#include <app/util/config.h>
 #include <credentials/GroupDataProvider.h>
 #include <inttypes.h>
 #include <lib/support/CodeUtils.h>

--- a/src/app/clusters/keypad-input-server/keypad-input-server.cpp
+++ b/src/app/clusters/keypad-input-server/keypad-input-server.cpp
@@ -34,6 +34,7 @@
 #include <app/data-model/Encode.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
 
 using namespace chip;

--- a/src/app/clusters/keypad-input-server/keypad-input-server.cpp
+++ b/src/app/clusters/keypad-input-server/keypad-input-server.cpp
@@ -36,8 +36,6 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::KeypadInput;

--- a/src/app/clusters/keypad-input-server/keypad-input-server.cpp
+++ b/src/app/clusters/keypad-input-server/keypad-input-server.cpp
@@ -36,6 +36,8 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::KeypadInput;

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -24,6 +24,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
+#include <app/util/config.h>
 #include <app/util/error-mapping.h>
 #include <app/util/util.h>
 

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -33,6 +33,8 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>
 
+#include <zap-generated/gen_config.h>
+
 #ifdef EMBER_AF_PLUGIN_SCENES
 #include <app/clusters/scenes/scenes.h>
 #endif // EMBER_AF_PLUGIN_SCENES

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -33,8 +33,6 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>
 
-#include <zap-generated/gen_config.h>
-
 #ifdef EMBER_AF_PLUGIN_SCENES
 #include <app/clusters/scenes/scenes.h>
 #endif // EMBER_AF_PLUGIN_SCENES

--- a/src/app/clusters/level-control/level-control.h
+++ b/src/app/clusters/level-control/level-control.h
@@ -28,6 +28,7 @@
 
 #include <app-common/zap-generated/cluster-enums.h>
 #include <app/util/basic-types.h>
+#include <app/util/config.h>
 
 /** @brief Level Control Cluster Server Post Init
  *

--- a/src/app/clusters/low-power-server/low-power-server.cpp
+++ b/src/app/clusters/low-power-server/low-power-server.cpp
@@ -28,6 +28,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
+#include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <protocols/interaction_model/StatusCode.h>
 

--- a/src/app/clusters/low-power-server/low-power-server.cpp
+++ b/src/app/clusters/low-power-server/low-power-server.cpp
@@ -31,6 +31,8 @@
 #include <platform/CHIPDeviceConfig.h>
 #include <protocols/interaction_model/StatusCode.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 using namespace chip::app::Clusters::LowPower;
 

--- a/src/app/clusters/low-power-server/low-power-server.cpp
+++ b/src/app/clusters/low-power-server/low-power-server.cpp
@@ -31,8 +31,6 @@
 #include <platform/CHIPDeviceConfig.h>
 #include <protocols/interaction_model/StatusCode.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 using namespace chip::app::Clusters::LowPower;
 

--- a/src/app/clusters/media-input-server/media-input-server.cpp
+++ b/src/app/clusters/media-input-server/media-input-server.cpp
@@ -30,6 +30,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
 
 using namespace chip;

--- a/src/app/clusters/media-input-server/media-input-server.cpp
+++ b/src/app/clusters/media-input-server/media-input-server.cpp
@@ -32,8 +32,6 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::MediaInput;

--- a/src/app/clusters/media-input-server/media-input-server.cpp
+++ b/src/app/clusters/media-input-server/media-input-server.cpp
@@ -32,6 +32,8 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::MediaInput;

--- a/src/app/clusters/media-playback-server/media-playback-server.cpp
+++ b/src/app/clusters/media-playback-server/media-playback-server.cpp
@@ -34,6 +34,7 @@
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 #include <app/data-model/Encode.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
 
 using namespace chip;

--- a/src/app/clusters/media-playback-server/media-playback-server.cpp
+++ b/src/app/clusters/media-playback-server/media-playback-server.cpp
@@ -36,6 +36,8 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::MediaPlayback;

--- a/src/app/clusters/media-playback-server/media-playback-server.cpp
+++ b/src/app/clusters/media-playback-server/media-playback-server.cpp
@@ -36,8 +36,6 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::MediaPlayback;

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -27,6 +27,7 @@
 #include <app/clusters/on-off-server/on-off-server.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 #include <app/util/error-mapping.h>
 #include <app/util/odd-sized-integers.h>
 #include <app/util/util.h>

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -22,6 +22,7 @@
 #include <app/reporting/reporting.h>
 #include <app/util/af-event.h>
 #include <app/util/af.h>
+#include <app/util/config.h>
 #include <app/util/error-mapping.h>
 #include <app/util/util.h>
 

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -22,6 +22,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af-types.h>
 #include <app/util/basic-types.h>
+#include <app/util/config.h>
 
 using chip::app::Clusters::OnOff::OnOffFeature;
 

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -23,6 +23,8 @@
 #include <app/util/af-types.h>
 #include <app/util/basic-types.h>
 
+#include <zap-generated/gen_config.h>
+
 using chip::app::Clusters::OnOff::OnOffFeature;
 
 /**********************************************************

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -23,8 +23,6 @@
 #include <app/util/af-types.h>
 #include <app/util/basic-types.h>
 
-#include <zap-generated/gen_config.h>
-
 using chip::app::Clusters::OnOff::OnOffFeature;
 
 /**********************************************************

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -21,6 +21,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
+#include <app/util/config.h>
 #include <app/util/error-mapping.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <protocols/interaction_model/Constants.h>

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -25,6 +25,8 @@
 #include <platform/CHIPDeviceConfig.h>
 #include <protocols/interaction_model/Constants.h>
 
+#include <zap-generated/gen_config.h>
+
 #include <lib/support/Span.h>
 
 #include "ota-provider-delegate.h"

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -25,8 +25,6 @@
 #include <platform/CHIPDeviceConfig.h>
 #include <protocols/interaction_model/Constants.h>
 
-#include <zap-generated/gen_config.h>
-
 #include <lib/support/Span.h>
 
 #include "ota-provider-delegate.h"

--- a/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
+++ b/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
@@ -26,6 +26,7 @@
 #include <app/InteractionModelEngine.h>
 #include <app/util/af-event.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 
 using namespace chip;
 using namespace chip::app;

--- a/src/app/clusters/scenes/scenes-tokens.h
+++ b/src/app/clusters/scenes/scenes-tokens.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <app/util/config.h>
+
 #ifdef EMBER_AF_PLUGIN_SCENES_USE_TOKENS
 
 #define CREATOR_SCENES_NUM_ENTRIES (0x8723)

--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -25,6 +25,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage-null-handling.h>
+#include <app/util/config.h>
 #include <app/util/error-mapping.h>
 
 #ifdef EMBER_AF_PLUGIN_GROUPS_SERVER

--- a/src/app/clusters/scenes/scenes.h
+++ b/src/app/clusters/scenes/scenes.h
@@ -21,8 +21,74 @@
 #include <app/CommandHandler.h>
 #include <app/data-model/DecodableList.h>
 #include <app/util/af-types.h>
+#include <app/util/config.h>
 #include <lib/support/Span.h>
 #include <stdint.h>
+
+/**
+ * @brief A structure used to store scene table entries in RAM or in storage,
+ * depending on a plugin setting.  If endpoint field is
+ * ::EMBER_AF_SCENE_TABLE_UNUSED_ENDPOINT_ID, the entry is unused.
+ */
+typedef struct
+{
+    chip::EndpointId endpoint; // 0x00 when this record is not in use
+    chip::GroupId groupId;     // 0x0000 if not associated with a group
+    uint8_t sceneId;
+#if defined(MATTER_CLUSTER_SCENE_NAME_SUPPORT) && MATTER_CLUSTER_SCENE_NAME_SUPPORT
+    uint8_t name[ZCL_SCENES_CLUSTER_MAXIMUM_NAME_LENGTH + 1];
+#endif
+    uint16_t transitionTime;     // in seconds
+    uint8_t transitionTime100ms; // in tenths of a seconds
+#ifdef ZCL_USING_ON_OFF_CLUSTER_SERVER
+    bool hasOnOffValue;
+    bool onOffValue;
+#endif
+#ifdef ZCL_USING_LEVEL_CONTROL_CLUSTER_SERVER
+    bool hasCurrentLevelValue;
+    chip::app::DataModel::Nullable<uint8_t> currentLevelValue;
+#endif
+#ifdef ZCL_USING_THERMOSTAT_CLUSTER_SERVER
+    bool hasOccupiedCoolingSetpointValue;
+    int16_t occupiedCoolingSetpointValue;
+    bool hasOccupiedHeatingSetpointValue;
+    int16_t occupiedHeatingSetpointValue;
+    bool hasSystemModeValue;
+    uint8_t systemModeValue;
+#endif
+#ifdef ZCL_USING_COLOR_CONTROL_CLUSTER_SERVER
+    bool hasCurrentXValue;
+    uint16_t currentXValue;
+    bool hasCurrentYValue;
+    uint16_t currentYValue;
+    bool hasEnhancedCurrentHueValue;
+    uint16_t enhancedCurrentHueValue;
+    bool hasCurrentSaturationValue;
+    uint8_t currentSaturationValue;
+    bool hasColorLoopActiveValue;
+    uint8_t colorLoopActiveValue;
+    bool hasColorLoopDirectionValue;
+    uint8_t colorLoopDirectionValue;
+    bool hasColorLoopTimeValue;
+    uint16_t colorLoopTimeValue;
+    bool hasColorTemperatureMiredsValue;
+    uint16_t colorTemperatureMiredsValue;
+#endif // ZCL_USING_COLOR_CONTROL_CLUSTER_SERVER
+#ifdef ZCL_USING_DOOR_LOCK_CLUSTER_SERVER
+    bool hasLockStateValue;
+    chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlLockState> lockStateValue;
+#endif
+#ifdef ZCL_USING_WINDOW_COVERING_CLUSTER_SERVER
+    bool hasCurrentPositionLiftPercentageValue;
+    chip::app::DataModel::Nullable<chip::Percent> currentPositionLiftPercentageValue;
+    bool hasCurrentPositionTiltPercentageValue;
+    chip::app::DataModel::Nullable<chip::Percent> currentPositionTiltPercentageValue;
+    bool hasTargetPositionLiftPercent100thsValue;
+    chip::app::DataModel::Nullable<chip::Percent100ths> targetPositionLiftPercent100thsValue;
+    bool hasTargetPositionTiltPercent100thsValue;
+    chip::app::DataModel::Nullable<chip::Percent100ths> targetPositionTiltPercent100thsValue;
+#endif
+} EmberAfSceneTableEntry;
 
 EmberAfStatus emberAfScenesSetSceneCountAttribute(chip::EndpointId endpoint, uint8_t newCount);
 EmberAfStatus emberAfScenesMakeValid(chip::EndpointId endpoint, uint8_t sceneId, chip::GroupId groupId);

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -33,6 +33,7 @@
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 #include <app/data-model/Encode.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
 
 using namespace chip;

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -35,8 +35,6 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::TargetNavigator;

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -35,6 +35,8 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::TargetNavigator;

--- a/src/app/clusters/wake-on-lan-server/wake-on-lan-server.cpp
+++ b/src/app/clusters/wake-on-lan-server/wake-on-lan-server.cpp
@@ -30,6 +30,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
 
 using namespace chip;

--- a/src/app/clusters/wake-on-lan-server/wake-on-lan-server.cpp
+++ b/src/app/clusters/wake-on-lan-server/wake-on-lan-server.cpp
@@ -32,8 +32,6 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
-#include <zap-generated/gen_config.h>
-
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::WakeOnLan;

--- a/src/app/clusters/wake-on-lan-server/wake-on-lan-server.cpp
+++ b/src/app/clusters/wake-on-lan-server/wake-on-lan-server.cpp
@@ -32,6 +32,8 @@
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceConfig.h>
 
+#include <zap-generated/gen_config.h>
+
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::WakeOnLan;

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -26,6 +26,7 @@
 #include <app/util/af-types.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 #include <app/util/error-mapping.h>
 #include <lib/support/TypeTraits.h>
 #include <string.h>

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -30,6 +30,8 @@
 #include <lib/support/TypeTraits.h>
 #include <string.h>
 
+#include <zap-generated/gen_config.h>
+
 #ifdef EMBER_AF_PLUGIN_SCENES
 #include <app/clusters/scenes/scenes.h>
 #endif // EMBER_AF_PLUGIN_SCENES

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -30,8 +30,6 @@
 #include <lib/support/TypeTraits.h>
 #include <string.h>
 
-#include <zap-generated/gen_config.h>
-
 #ifdef EMBER_AF_PLUGIN_SCENES
 #include <app/clusters/scenes/scenes.h>
 #endif // EMBER_AF_PLUGIN_SCENES

--- a/src/app/tests/TestBindingTable.cpp
+++ b/src/app/tests/TestBindingTable.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <app/util/binding-table.h>
+#include <app/util/config.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <lib/support/UnitTestRegistration.h>

--- a/src/app/tests/TestPendingNotificationMap.cpp
+++ b/src/app/tests/TestPendingNotificationMap.cpp
@@ -17,6 +17,7 @@
 
 #include <app/clusters/bindings/PendingNotificationMap.h>
 #include <app/util/binding-table.h>
+#include <app/util/config.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <nlunit-test.h>

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -19,6 +19,7 @@
 
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 
 #include <platform/CHIPDeviceLayer.h>
 

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -408,62 +408,6 @@ struct EmberAfDefinedEndpoint
 // Cluster specific types
 
 /**
- * @brief Bitmask data type for storing one bit of information for each ESI in
- * the ESI table.
- */
-#if (EMBER_AF_PLUGIN_ESI_MANAGEMENT_ESI_TABLE_SIZE <= 8)
-typedef uint8_t EmberAfPluginEsiManagementBitmask;
-#elif (EMBER_AF_PLUGIN_ESI_MANAGEMENT_ESI_TABLE_SIZE <= 16)
-typedef uint16_t EmberAfPluginEsiManagementBitmask;
-#elif (EMBER_AF_PLUGIN_ESI_MANAGEMENT_ESI_TABLE_SIZE <= 32)
-typedef uint32_t EmberAfPluginEsiManagementBitmask;
-#else
-#error "EMBER_AF_PLUGIN_ESI_MANAGEMENT_ESI_TABLE_SIZE cannot exceed 32"
-#endif
-
-/**
- * @brief Struct that describes a load control event.
- *
- * This is used in the load control event callback and
- * within the demand response load control cluster code.
- */
-typedef struct
-{
-    uint32_t eventId;
-#ifdef EMBER_AF_PLUGIN_DRLC_SERVER
-    EmberEUI64 source;
-    chip::EndpointId sourceEndpoint;
-#endif // EMBER_AF_PLUGIN_DRLC_SERVER
-
-#ifdef EMBER_AF_PLUGIN_DRLC
-    EmberAfPluginEsiManagementBitmask esiBitmask;
-#endif // EMBER_AF_PLUGIN_DRLC
-
-    chip::EndpointId destinationEndpoint;
-    uint16_t deviceClass;
-    uint8_t utilityEnrollmentGroup;
-    /**
-     * Start time in seconds
-     */
-    uint32_t startTime;
-    /**
-     * Duration in minutes
-     */
-    uint16_t duration;
-    uint8_t criticalityLevel;
-    uint8_t coolingTempOffset;
-    uint8_t heatingTempOffset;
-    int16_t coolingTempSetPoint;
-    int16_t heatingTempSetPoint;
-    int8_t avgLoadPercentage;
-    uint8_t dutyCycle;
-    uint8_t eventControl;
-    uint32_t startRand;
-    uint32_t durationRand;
-    uint8_t optionControl;
-} EmberAfLoadControlEvent;
-
-/**
  * @brief This is an enum used to indicate the result of the
  *   service discovery.  Unicast discoveries are completed
  *   as soon as a response is received.  Broadcast discoveries
@@ -727,119 +671,6 @@ typedef void (*EmberAfEndpointEventHandler)(chip::EndpointId endpoint);
  * @brief The scene identifier for the global scene.
  */
 #define ZCL_SCENES_GLOBAL_SCENE_SCENE_ID 0x00
-/**
- * @brief A structure used to store scene table entries in RAM or in storage,
- * depending on a plugin setting.  If endpoint field is
- * ::EMBER_AF_SCENE_TABLE_UNUSED_ENDPOINT_ID, the entry is unused.
- */
-typedef struct
-{
-    chip::EndpointId endpoint; // 0x00 when this record is not in use
-    chip::GroupId groupId;     // 0x0000 if not associated with a group
-    uint8_t sceneId;
-#if defined(MATTER_CLUSTER_SCENE_NAME_SUPPORT) && MATTER_CLUSTER_SCENE_NAME_SUPPORT
-    uint8_t name[ZCL_SCENES_CLUSTER_MAXIMUM_NAME_LENGTH + 1];
-#endif
-    uint16_t transitionTime;     // in seconds
-    uint8_t transitionTime100ms; // in tenths of a seconds
-#ifdef ZCL_USING_ON_OFF_CLUSTER_SERVER
-    bool hasOnOffValue;
-    bool onOffValue;
-#endif
-#ifdef ZCL_USING_LEVEL_CONTROL_CLUSTER_SERVER
-    bool hasCurrentLevelValue;
-    chip::app::DataModel::Nullable<uint8_t> currentLevelValue;
-#endif
-#ifdef ZCL_USING_THERMOSTAT_CLUSTER_SERVER
-    bool hasOccupiedCoolingSetpointValue;
-    int16_t occupiedCoolingSetpointValue;
-    bool hasOccupiedHeatingSetpointValue;
-    int16_t occupiedHeatingSetpointValue;
-    bool hasSystemModeValue;
-    uint8_t systemModeValue;
-#endif
-#ifdef ZCL_USING_COLOR_CONTROL_CLUSTER_SERVER
-    bool hasCurrentXValue;
-    uint16_t currentXValue;
-    bool hasCurrentYValue;
-    uint16_t currentYValue;
-    bool hasEnhancedCurrentHueValue;
-    uint16_t enhancedCurrentHueValue;
-    bool hasCurrentSaturationValue;
-    uint8_t currentSaturationValue;
-    bool hasColorLoopActiveValue;
-    uint8_t colorLoopActiveValue;
-    bool hasColorLoopDirectionValue;
-    uint8_t colorLoopDirectionValue;
-    bool hasColorLoopTimeValue;
-    uint16_t colorLoopTimeValue;
-    bool hasColorTemperatureMiredsValue;
-    uint16_t colorTemperatureMiredsValue;
-#endif // ZCL_USING_COLOR_CONTROL_CLUSTER_SERVER
-#ifdef ZCL_USING_DOOR_LOCK_CLUSTER_SERVER
-    bool hasLockStateValue;
-    chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlLockState> lockStateValue;
-#endif
-#ifdef ZCL_USING_WINDOW_COVERING_CLUSTER_SERVER
-    bool hasCurrentPositionLiftPercentageValue;
-    chip::app::DataModel::Nullable<chip::Percent> currentPositionLiftPercentageValue;
-    bool hasCurrentPositionTiltPercentageValue;
-    chip::app::DataModel::Nullable<chip::Percent> currentPositionTiltPercentageValue;
-    bool hasTargetPositionLiftPercent100thsValue;
-    chip::app::DataModel::Nullable<chip::Percent100ths> targetPositionLiftPercent100thsValue;
-    bool hasTargetPositionTiltPercent100thsValue;
-    chip::app::DataModel::Nullable<chip::Percent100ths> targetPositionTiltPercent100thsValue;
-#endif
-} EmberAfSceneTableEntry;
-
-#if !defined(EMBER_AF_PLUGIN_MESSAGING_CLIENT)
-// In order to be able to forward declare callbacks regardless of whether the plugin
-// is enabled, we need to define all data structures.  In order to be able to define
-// the messaging client data struct, we need to declare this variable.
-#define EMBER_AF_PLUGIN_MESSAGING_CLIENT_MESSAGE_SIZE 0
-#endif
-
-typedef struct
-{
-    bool valid;
-    bool active;
-    EmberAfPluginEsiManagementBitmask esiBitmask;
-    chip::EndpointId clientEndpoint;
-    uint32_t messageId;
-    uint8_t messageControl;
-    uint32_t startTime;
-    uint32_t endTime;
-    uint16_t durationInMinutes;
-    uint8_t message[EMBER_AF_PLUGIN_MESSAGING_CLIENT_MESSAGE_SIZE + 1];
-} EmberAfPluginMessagingClientMessage;
-
-#define ZCL_PRICE_CLUSTER_MAXIMUM_RATE_LABEL_LENGTH 11
-typedef struct
-{
-    bool valid;
-    bool active;
-    chip::EndpointId clientEndpoint;
-    uint32_t providerId;
-    uint8_t rateLabel[ZCL_PRICE_CLUSTER_MAXIMUM_RATE_LABEL_LENGTH + 1];
-    uint32_t issuerEventId;
-    uint32_t currentTime;
-    uint8_t unitOfMeasure;
-    uint16_t currency;
-    uint8_t priceTrailingDigitAndPriceTier;
-    uint8_t numberOfPriceTiersAndRegisterTier;
-    uint32_t startTime;
-    uint32_t endTime;
-    uint16_t durationInMinutes;
-    uint32_t price;
-    uint8_t priceRatio;
-    uint32_t generationPrice;
-    uint8_t generationPriceRatio;
-    uint32_t alternateCostDelivered;
-    uint8_t alternateCostUnit;
-    uint8_t alternateCostTrailingDigit;
-    uint8_t numberOfBlockThresholds;
-    uint8_t priceControl;
-} EmberAfPluginPriceClientPrice;
 
 /**
  * @brief Specifies CPP Authorization values
@@ -1578,7 +1409,7 @@ typedef struct
  * @brief Returns the elapsed time between two 32 bit values.
  *   Result may not be valid if the time samples differ by more than 2147483647
  */
-#define elapsedTimeInt32u(oldTime, newTime) ((uint32_t)((uint32_t)(newTime) - (uint32_t)(oldTime)))
+#define elapsedTimeInt32u(oldTime, newTime) ((uint32_t) ((uint32_t) (newTime) - (uint32_t) (oldTime)))
 
 /**
  * @brief The overhead of the ZDO response.

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -1409,7 +1409,7 @@ typedef struct
  * @brief Returns the elapsed time between two 32 bit values.
  *   Result may not be valid if the time samples differ by more than 2147483647
  */
-#define elapsedTimeInt32u(oldTime, newTime) ((uint32_t) ((uint32_t) (newTime) - (uint32_t) (oldTime)))
+#define elapsedTimeInt32u(oldTime, newTime) ((uint32_t)((uint32_t)(newTime) - (uint32_t)(oldTime)))
 
 /**
  * @brief The overhead of the ZDO response.

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -21,6 +21,7 @@
 #include <app/reporting/reporting.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/config.h>
 #include <app/util/generic-callbacks.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -21,6 +21,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/util/af.h>
+#include <app/util/config.h>
 #include <platform/CHIPDeviceLayer.h>
 
 #if !defined(EMBER_SCRIPTED_TEST)

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -21,6 +21,7 @@
 
 // for pulling in defines dealing with EITHER server or client
 #include "app/util/common.h"
+#include <app/util/config.h>
 #include <app/util/error-mapping.h>
 #include <app/util/generic-callbacks.h>
 #include <app/util/odd-sized-integers.h>

--- a/src/app/util/binding-table.cpp
+++ b/src/app/util/binding-table.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <app/util/binding-table.h>
+#include <app/util/config.h>
 
 namespace chip {
 

--- a/src/app/util/binding-table.h
+++ b/src/app/util/binding-table.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <app/util/af-types.h>
+#include <app/util/config.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/core/TLV.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>

--- a/src/app/util/binding-table.h
+++ b/src/app/util/binding-table.h
@@ -26,6 +26,9 @@
 #include <lib/core/TLV.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 
+#include <zap-generated/endpoint_config.h>
+#include <zap-generated/gen_config.h>
+
 namespace chip {
 
 class BindingTable

--- a/src/app/util/binding-table.h
+++ b/src/app/util/binding-table.h
@@ -26,9 +26,6 @@
 #include <lib/core/TLV.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 
-#include <zap-generated/endpoint_config.h>
-#include <zap-generated/gen_config.h>
-
 namespace chip {
 
 class BindingTable

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -33,6 +33,7 @@
 #include <app/util/attribute-storage-null-handling.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/attribute-table.h>
+#include <app/util/config.h>
 #include <app/util/ember-compatibility-functions.h>
 #include <app/util/error-mapping.h>
 #include <app/util/odd-sized-integers.h>

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -27,9 +27,6 @@
 #include <transport/raw/MessageHeader.h>
 static_assert(sizeof(chip::NodeId) == sizeof(uint64_t), "Unexpected node if size");
 
-#include <zap-generated/endpoint_config.h>
-#include <zap-generated/gen_config.h>
-
 /**
  * @brief Defines binding types.
  */

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -22,6 +22,7 @@
 #include <app-common/zap-generated/print-cluster.h>
 #include <app/util/af-event.h>
 #include <app/util/af.h>
+#include <app/util/config.h>
 #include <app/util/ember-compatibility-functions.h>
 #include <app/util/generic-callbacks.h>
 


### PR DESCRIPTION
Including data types should not have a sideffect of including / depending on app-specific endpoint configuration.

This removes endpoint_config/gen_config from types_stub and starded adding direct includes where these seem needed (probably not exhausinve, relying on CI to test compilation for now).

Without this change, Accessors.h is not directly usable without depending on a codegen bit because of a dependency of `Accessors.h -> af-types.h -> types_stub.h -> endpoint_config.h`

`af-types.h` seemed to want some of gen/endpoint config flags (specifically to define structures depending on what clusters are selected), changed this like:
    - removed some unused clusters
    - moved scenese table entry to scenes.h
