### PR TITLE
Process SelectActionFragment Button handling within SelectActionFragment class

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -123,42 +123,6 @@ class CHIPToolActivity :
     showFragment(DeviceProvisioningFragment.newInstance(deviceInfo!!, networkCredentials))
   }
 
-  override fun handleScanQrCodeClicked() {
-    showFragment(BarcodeFragment.newInstance(), false)
-  }
-
-  override fun handleClusterInteractionClicked() {
-    showFragment(ClusterInteractionFragment.newInstance())
-  }
-
-  override fun handleWildcardClicked() {
-    showFragment(WildcardFragment.newInstance())
-  }
-
-  override fun handleOnOffClicked() {
-    showFragment(OnOffClientFragment.newInstance())
-  }
-
-  override fun handleSensorClicked() {
-    showFragment(SensorClientFragment.newInstance())
-  }
-
-  override fun handleMultiAdminClicked() {
-    showFragment(MultiAdminClientFragment.newInstance())
-  }
-
-  override fun handleOpCredClicked() {
-    showFragment(OpCredClientFragment.newInstance())
-  }
-
-  override fun handleBasicClicked() {
-    showFragment(BasicClientFragment.newInstance())
-  }
-
-  override fun handleAttestationTestClicked() {
-    showFragment(AttestationTestFragment.newInstance())
-  }
-
   override fun handleReadFromLedgerClicked(deviceInfo: CHIPDeviceInfo) {
     showFragment(CHIPLedgerDetailsFragment.newInstance(deviceInfo))
   }
@@ -168,22 +132,8 @@ class CHIPToolActivity :
     startActivity(redirectIntent)
   }
 
-  override fun handleProvisionWiFiCredentialsClicked() {
-    networkType = ProvisionNetworkType.WIFI
-    showFragment(BarcodeFragment.newInstance(), false)
-  }
-
-  override fun handleProvisionThreadCredentialsClicked() {
-    networkType = ProvisionNetworkType.THREAD
-    showFragment(BarcodeFragment.newInstance(), false)
-  }
-
-  override fun handleProvisionCustomFlowClicked() {
-    showFragment(BarcodeFragment.newInstance(), false)
-  }
-
-  override fun handleUnpairDeviceClicked() {
-    showFragment(UnpairDeviceFragment.newInstance())
+  override fun SetNetworkType(type: ProvisionNetworkType) {
+    networkType = type
   }
 
   private fun showFragment(fragment: Fragment, showOnBack: Boolean = true) {


### PR DESCRIPTION
Currently, all handling of Buttons in SelectActionFragment are done in CHIPToolActivity via callback.

A fragment defines and manages its own layout, has its own lifecycle, and handle its own input events. Instead of processing everything in CHIPToolActivity.kt, we should move the Fragment input event handling into its corresponding Fragment class.    

