### PR TITLE
ESP32 support chip shell for custom UART which can be set in sdkconfig

### DIFF
--- a/examples/platform/esp32/shell_extension/launch.cpp
+++ b/examples/platform/esp32/shell_extension/launch.cpp
@@ -41,7 +41,7 @@ void LaunchShell()
 #if CONFIG_HEAP_TRACING_STANDALONE || CONFIG_HEAP_TASK_TRACKING
     idf::chip::RegisterHeapTraceCommands();
 #endif // CONFIG_HEAP_TRACING_STANDALONE || CONFIG_HEAP_TASK_TRACKING
-#if CONFIG_ESP_CONSOLE_UART_DEFAULT
+#if CONFIG_ESP_CONSOLE_UART_DEFAULT || CONFIG_ESP_CONSOLE_UART_CUSTOM
     xTaskCreate(&MatterShellTask, "chip_cli", 2048, NULL, 5, NULL);
 #elif CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
     // Increase task stack size when using usb serial jtag

--- a/src/lib/shell/streamer_esp32.cpp
+++ b/src/lib/shell/streamer_esp32.cpp
@@ -121,7 +121,7 @@ ssize_t streamer_esp32_read(streamer_t * streamer, char * buf, size_t len)
 
 ssize_t streamer_esp32_write(streamer_t * streamer, const char * buf, size_t len)
 {
-#if CONFIG_ESP_CONSOLE_UART_DEFAULT || defined CONFIG_ESP_CONSOLE_UART_CUSTOM
+#if CONFIG_ESP_CONSOLE_UART_DEFAULT || CONFIG_ESP_CONSOLE_UART_CUSTOM
     return uart_write_bytes(CONFIG_ESP_CONSOLE_UART_NUM, buf, len);
 #endif
 #if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG

--- a/src/lib/shell/streamer_esp32.cpp
+++ b/src/lib/shell/streamer_esp32.cpp
@@ -25,7 +25,7 @@
 #include <lib/core/CHIPError.h>
 #include <stdio.h>
 #include <string.h>
-#if CONFIG_ESP_CONSOLE_UART_DEFAULT
+#if CONFIG_ESP_CONSOLE_UART_DEFAULT || CONFIG_ESP_CONSOLE_UART_CUSTOM
 #include "driver/uart.h"
 #endif
 #if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
@@ -55,7 +55,7 @@ int streamer_esp32_init(streamer_t * streamer)
     fflush(stdout);
     fsync(fileno(stdout));
     setvbuf(stdin, NULL, _IONBF, 0);
-#if CONFIG_ESP_CONSOLE_UART_DEFAULT
+#if CONFIG_ESP_CONSOLE_UART_DEFAULT || CONFIG_ESP_CONSOLE_UART_CUSTOM
     esp_vfs_dev_uart_port_set_rx_line_endings(CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CR);
     esp_vfs_dev_uart_port_set_tx_line_endings(CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CRLF);
     if (!uart_is_driver_installed(CONFIG_ESP_CONSOLE_UART_NUM))
@@ -63,7 +63,7 @@ int streamer_esp32_init(streamer_t * streamer)
         ESP_ERROR_CHECK(uart_driver_install(CONFIG_ESP_CONSOLE_UART_NUM, 256, 0, 0, NULL, 0));
     }
     uart_config_t uart_config = {
-        .baud_rate           = 115200,
+        .baud_rate           = CONFIG_ESP_CONSOLE_UART_BAUDRATE,
         .data_bits           = UART_DATA_8_BITS,
         .parity              = UART_PARITY_DISABLE,
         .stop_bits           = UART_STOP_BITS_1,
@@ -77,7 +77,7 @@ int streamer_esp32_init(streamer_t * streamer)
     };
     ESP_ERROR_CHECK(uart_param_config(CONFIG_ESP_CONSOLE_UART_NUM, &uart_config));
     esp_vfs_dev_uart_use_driver(0);
-#endif // CONFIG_ESP_CONSOLE_UART_DEFAULT
+#endif // CONFIG_ESP_CONSOLE_UART_DEFAULT || CONFIG_ESP_CONSOLE_UART_CUSTOM
 
 #if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
     esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
@@ -121,7 +121,7 @@ ssize_t streamer_esp32_read(streamer_t * streamer, char * buf, size_t len)
 
 ssize_t streamer_esp32_write(streamer_t * streamer, const char * buf, size_t len)
 {
-#if CONFIG_ESP_CONSOLE_UART_DEFAULT
+#if CONFIG_ESP_CONSOLE_UART_DEFAULT || defined CONFIG_ESP_CONSOLE_UART_CUSTOM
     return uart_write_bytes(CONFIG_ESP_CONSOLE_UART_NUM, buf, len);
 #endif
 #if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG


### PR DESCRIPTION
ESP32 chip shell support for custom UART which can be set in sdkconfig file or via `idf.py menuconfig` (CONFIG_ESP_CONSOLE_UART_CUSTOM). 