### PR TITLE
Stop assuming a particular threading model when generating shutdown events.

### DIFF
--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
@@ -162,7 +162,8 @@ void AllClustersAppCommandHandler::OnRebootSignalHandler(BootReasonType bootReas
 {
     if (ConfigurationMgr().StoreBootReason(static_cast<uint32_t>(bootReason)) != CHIP_NO_ERROR)
     {
-        Server::GetInstance().DispatchShutDownAndStopEventLoop();
+        Server::GetInstance().GenerateShutDownEvent();
+        PlatformMgr().ScheduleWork([](intptr_t) { PlatformMgr().StopEventLoopTask(); });
     }
     else
     {

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -23,6 +23,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
+#include <app/server/Server.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/Linux/NetworkCommissioningDriver.h>
 
@@ -107,6 +108,7 @@ void UiAppMainLoopImplementation::RunMainLoop()
 
 void UiAppMainLoopImplementation::SignalSafeStopMainLoop()
 {
+    Server::GetInstance().GenerateShutDownEvent();
     example::Ui::StopEventLoop();
 }
 

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -141,7 +141,8 @@ void StopSignalHandler(int signal)
     }
     else
     {
-        Server::GetInstance().DispatchShutDownAndStopEventLoop();
+        Server::GetInstance().GenerateShutDownEvent();
+        PlatformMgr().ScheduleWork([](intptr_t) { PlatformMgr().StopEventLoopTask(); });
     }
 }
 #endif // !defined(ENABLE_CHIP_SHELL)

--- a/examples/platform/linux/AppMain.h
+++ b/examples/platform/linux/AppMain.h
@@ -55,7 +55,11 @@ public:
      * Stop the above `RunMainLoop` function.
      *
      * Generally should contain at least a
-     *    Server::GetInstance().DispatchShutDownAndStopEventLoop()
+     *
+     *    Server::GetInstance().GenerateShutDownEvent()
+     *
+     * and then call StopEventLoopTask() in whatever way is appropriate for the
+     * way the event loop was started.
      */
     virtual void SignalSafeStopMainLoop() = 0;
 };
@@ -64,7 +68,11 @@ class DefaultAppMainLoopImplementation : public AppMainLoopImplementation
 {
 public:
     void RunMainLoop() override { chip::DeviceLayer::PlatformMgr().RunEventLoop(); }
-    void SignalSafeStopMainLoop() override { chip::Server::GetInstance().DispatchShutDownAndStopEventLoop(); }
+    void SignalSafeStopMainLoop() override
+    {
+        chip::Server::GetInstance().GenerateShutDownEvent();
+        chip::DeviceLayer::PlatformMgr().ScheduleWork([](intptr_t) { chip::DeviceLayer::PlatformMgr().StopEventLoopTask(); });
+    }
 };
 
 /**

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -70,15 +70,6 @@ using chip::Transport::UdpListenParameters;
 
 namespace {
 
-void StopEventLoop(intptr_t arg)
-{
-    CHIP_ERROR err = chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(AppServer, "Stopping event loop: %" CHIP_ERROR_FORMAT, err.Format());
-    }
-}
-
 class DeviceTypeResolver : public chip::Access::AccessControl::DeviceTypeResolver
 {
 public:
@@ -449,10 +440,9 @@ void Server::RejoinExistingMulticastGroups()
     }
 }
 
-void Server::DispatchShutDownAndStopEventLoop()
+void Server::GenerateShutDownEvent()
 {
     PlatformMgr().ScheduleWork([](intptr_t) { PlatformMgr().HandleServerShuttingDown(); });
-    PlatformMgr().ScheduleWork(StopEventLoop);
 }
 
 void Server::ScheduleFactoryReset()

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -305,7 +305,7 @@ struct CommonCaseDeviceServerInitParams : public ServerInitParams
  * after `Server::Shutdown()` is called.
  *
  * TODO: Separate lifecycle ownership for some more capabilities that should not belong to
- *       common logic, such as `DispatchShutDownAndStopEventLoop`.
+ *       common logic, such as `GenerateShutDownEvent`.
  *
  * TODO: Replace all uses of GetInstance() to "reach in" to this state from all cluster
  *       server common logic that deal with global node state with either a common NodeState
@@ -361,10 +361,10 @@ public:
     app::DefaultAttributePersistenceProvider & GetDefaultAttributePersister() { return mAttributePersister; }
 
     /**
-     * This function send the ShutDown event before stopping
-     * the event loop.
+     * This function causes the ShutDown event to be generated async on the
+     * Matter event loop.  Should be called before stopping the event loop.
      */
-    void DispatchShutDownAndStopEventLoop();
+    void GenerateShutDownEvent();
 
     void Shutdown();
 

--- a/src/lib/shell/MainLoopMW320.cpp
+++ b/src/lib/shell/MainLoopMW320.cpp
@@ -161,7 +161,11 @@ static void AtExitShell(void);
 static CHIP_ERROR ShutdownHandler(int argc, char ** argv)
 {
     streamer_printf(streamer_get(), "Shutdown and Goodbye\r\n");
-    chip::Server::GetInstance().DispatchShutDownAndStopEventLoop();
+    Server::GetInstance().GenerateShutDownEvent();
+    // TODO: This is assuming that we did (on a different thread from this one)
+    // RunEventLoop(), not StartEventLoopTask().  It will not work correctly
+    // with StartEventLoopTask().
+    DeviceLayer::PlatformMgr().ScheduleWork([](intptr_t) { DeviceLayer::PlatformMgr().StopEventLoopTask(); });
     AtExitShell();
     exit(0);
     return CHIP_NO_ERROR;


### PR DESCRIPTION
We should be able to generate a shutdown event regardless of whether we're doing RunEventLoop or StartEventLoopTask.  That means leaving the shutdown of the event loop to the API consumer, since those cases need to be handled somewhat differently.
