### PR TITLE
[Android] Fix CHipTool crash after QRCode scan

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/BarcodeFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/BarcodeFragment.kt
@@ -187,7 +187,7 @@ class BarcodeFragment : Fragment() {
             Log.e(TAG, "Unrecognized QR Code", ex)
             Toast.makeText(requireContext(), "Unrecognized QR Code", Toast.LENGTH_SHORT).show()
         }
-        FragmentUtil.getHost(this, Callback::class.java)
+        FragmentUtil.getHost(this@BarcodeFragment, Callback::class.java)
             ?.onCHIPDeviceInfoReceived(CHIPDeviceInfo.fromSetupPayload(payload))
     }
 
@@ -201,7 +201,7 @@ class BarcodeFragment : Fragment() {
                 Toast.makeText(requireContext(), "Unrecognized QR Code", Toast.LENGTH_SHORT).show()
                 return@post
             }
-            FragmentUtil.getHost(this, Callback::class.java)
+            FragmentUtil.getHost(this@BarcodeFragment, Callback::class.java)
                 ?.onCHIPDeviceInfoReceived(CHIPDeviceInfo.fromSetupPayload(payload))
         }
     }


### PR DESCRIPTION
Fixes #25140

Attempted to call a Callback other than the calling BarcodeFragmentCallback. To clarify this, the BarcodeFragment object return was made clear when calling getHost.