### PR TITLE
[Ameba] init route hook after getting ipv6

### DIFF
--- a/examples/all-clusters-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/ameba/main/DeviceCallbacks.cpp
@@ -72,6 +72,18 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
         OnInternetConnectivityChange(event);
         break;
 
+    case DeviceEventType::kCHIPoBLEConnectionEstablished:
+        ChipLogProgress(DeviceLayer, "CHIPoBLE Connection Established");
+        break;
+
+    case DeviceEventType::kCHIPoBLEConnectionClosed:
+        ChipLogProgress(DeviceLayer, "CHIPoBLE Connection Closed");
+        break;
+
+    case DeviceEventType::kCHIPoBLEAdvertisingChange:
+        ChipLogProgress(DeviceLayer, "CHIPoBLE advertising has changed");
+        break;
+
     case DeviceEventType::kInterfaceIpAddressChanged:
         if ((event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV4_Assigned) ||
             (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned))
@@ -82,6 +94,15 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
             // newly selected address.
             chip::app::DnssdServer::Instance().StartServer();
         }
+        if (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned)
+        {
+            ChipLogProgress(DeviceLayer, "Initializing route hook...");
+            ameba_route_hook_init();
+        }
+        break;
+
+    case DeviceEventType::kCommissioningComplete:
+        ChipLogProgress(DeviceLayer, "Commissioning Complete");
         break;
     }
 }
@@ -122,9 +143,6 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
     {
         ChipLogProgress(DeviceLayer, "IPv6 Server ready...");
         chip::app::DnssdServer::Instance().StartServer();
-
-        ChipLogProgress(DeviceLayer, "Initializing route hook...");
-        ameba_route_hook_init();
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
         // Init OTA requestor only when we have gotten IPv6 address
         if (!isOTAInitialized)

--- a/examples/light-switch-app/ameba/chip_main.cmake
+++ b/examples/light-switch-app/ameba/chip_main.cmake
@@ -156,6 +156,9 @@ list(
     ${chip_dir}/examples/light-switch-app/ameba/main/Globals.cpp
     ${chip_dir}/examples/light-switch-app/ameba/main/LEDWidget.cpp
 
+    ${chip_dir}/examples/platform/ameba/route_hook/ameba_route_hook.c
+    ${chip_dir}/examples/platform/ameba/route_hook/ameba_route_table.c
+
     ${chip_dir}/examples/providers/DeviceInfoProviderImpl.cpp
 )
 

--- a/examples/light-switch-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/light-switch-app/ameba/main/DeviceCallbacks.cpp
@@ -32,6 +32,7 @@
 #include <app/util/basic-types.h>
 #include <app/util/util.h>
 #include <lib/dnssd/Advertiser.h>
+#include <route_hook/ameba_route_hook.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 #include <support/logging/Constants.h>
@@ -71,6 +72,18 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
         OnInternetConnectivityChange(event);
         break;
 
+    case DeviceEventType::kCHIPoBLEConnectionEstablished:
+        ChipLogProgress(DeviceLayer, "CHIPoBLE Connection Established");
+        break;
+
+    case DeviceEventType::kCHIPoBLEConnectionClosed:
+        ChipLogProgress(DeviceLayer, "CHIPoBLE Connection Closed");
+        break;
+
+    case DeviceEventType::kCHIPoBLEAdvertisingChange:
+        ChipLogProgress(DeviceLayer, "CHIPoBLE advertising has changed");
+        break;
+
     case DeviceEventType::kInterfaceIpAddressChanged:
         if ((event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV4_Assigned) ||
             (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned))
@@ -81,6 +94,15 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
             // newly selected address.
             chip::app::DnssdServer::Instance().StartServer();
         }
+        if (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned)
+        {
+            ChipLogProgress(DeviceLayer, "Initializing route hook...");
+            ameba_route_hook_init();
+        }
+        break;
+
+    case DeviceEventType::kCommissioningComplete:
+        ChipLogProgress(DeviceLayer, "Commissioning Complete");
         break;
     }
 }

--- a/examples/lighting-app/ameba/chip_main.cmake
+++ b/examples/lighting-app/ameba/chip_main.cmake
@@ -149,6 +149,9 @@ list(
     ${chip_dir}/examples/lighting-app/ameba/main/Globals.cpp
     ${chip_dir}/examples/lighting-app/ameba/main/LEDWidget.cpp
 
+    ${chip_dir}/examples/platform/ameba/route_hook/ameba_route_hook.c
+    ${chip_dir}/examples/platform/ameba/route_hook/ameba_route_table.c
+
     ${chip_dir}/examples/providers/DeviceInfoProviderImpl.cpp
 )
 

--- a/examples/lighting-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/lighting-app/ameba/main/DeviceCallbacks.cpp
@@ -33,6 +33,7 @@
 #include <app/util/basic-types.h>
 #include <app/util/util.h>
 #include <lib/dnssd/Advertiser.h>
+#include <route_hook/ameba_route_hook.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 #include <support/logging/Constants.h>
@@ -69,6 +70,18 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
         OnInternetConnectivityChange(event);
         break;
 
+    case DeviceEventType::kCHIPoBLEConnectionEstablished:
+        ChipLogProgress(DeviceLayer, "CHIPoBLE Connection Established");
+        break;
+
+    case DeviceEventType::kCHIPoBLEConnectionClosed:
+        ChipLogProgress(DeviceLayer, "CHIPoBLE Connection Closed");
+        break;
+
+    case DeviceEventType::kCHIPoBLEAdvertisingChange:
+        ChipLogProgress(DeviceLayer, "CHIPoBLE advertising has changed");
+        break;
+
     case DeviceEventType::kInterfaceIpAddressChanged:
         if ((event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV4_Assigned) ||
             (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned))
@@ -79,6 +92,15 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
             // newly selected address.
             chip::app::DnssdServer::Instance().StartServer();
         }
+        if (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned)
+        {
+            ChipLogProgress(DeviceLayer, "Initializing route hook...");
+            ameba_route_hook_init();
+        }
+        break;
+
+    case DeviceEventType::kCommissioningComplete:
+        ChipLogProgress(DeviceLayer, "Commissioning Complete");
         break;
     }
 }

--- a/examples/ota-requestor-app/ameba/chip_main.cmake
+++ b/examples/ota-requestor-app/ameba/chip_main.cmake
@@ -26,6 +26,9 @@ list(
     ${chip_dir}/src/app/clusters/ota-requestor/ota-requestor-server.cpp
     ${chip_dir}/examples/platform/ameba/ota/OTAInitializer.cpp
 
+    ${chip_dir}/examples/platform/ameba/route_hook/ameba_route_hook.c
+    ${chip_dir}/examples/platform/ameba/route_hook/ameba_route_table.c
+
     ${chip_dir}/examples/providers/DeviceInfoProviderImpl.cpp
 )
 

--- a/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
@@ -64,7 +64,6 @@ void InitOTARequestorHandler(System::Layer * systemLayer, void * appState)
 }
 #endif
 
-
 void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_t arg)
 {
     switch (event->Type)

--- a/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
@@ -33,6 +33,7 @@
 #include <app/util/basic-types.h>
 #include <app/util/util.h>
 #include <lib/dnssd/Advertiser.h>
+#include <route_hook/ameba_route_hook.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 #include <support/logging/Constants.h>
@@ -63,12 +64,25 @@ void InitOTARequestorHandler(System::Layer * systemLayer, void * appState)
 }
 #endif
 
+
 void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_t arg)
 {
     switch (event->Type)
     {
     case DeviceEventType::kInternetConnectivityChange:
         OnInternetConnectivityChange(event);
+        break;
+
+    case DeviceEventType::kCHIPoBLEConnectionEstablished:
+        ChipLogProgress(DeviceLayer, "CHIPoBLE Connection Established");
+        break;
+
+    case DeviceEventType::kCHIPoBLEConnectionClosed:
+        ChipLogProgress(DeviceLayer, "CHIPoBLE Connection Closed");
+        break;
+
+    case DeviceEventType::kCHIPoBLEAdvertisingChange:
+        ChipLogProgress(DeviceLayer, "CHIPoBLE advertising has changed");
         break;
 
     case DeviceEventType::kInterfaceIpAddressChanged:
@@ -81,6 +95,15 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
             // newly selected address.
             chip::app::DnssdServer::Instance().StartServer();
         }
+        if (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned)
+        {
+            ChipLogProgress(DeviceLayer, "Initializing route hook...");
+            ameba_route_hook_init();
+        }
+        break;
+
+    case DeviceEventType::kCommissioningComplete:
+        ChipLogProgress(DeviceLayer, "Commissioning Complete");
         break;
     }
 }


### PR DESCRIPTION
- move route hook initialisation code
- init route hook when ipv6 address is acquired
- added route hook to other examples
