### PR TITLE
Remove KeypadLockout, TemperatureDisplayMode weak enums

### DIFF
--- a/src/app/clusters/thermostat-user-interface-configuration-server/thermostat-user-interface-configuration-server.cpp
+++ b/src/app/clusters/thermostat-user-interface-configuration-server/thermostat-user-interface-configuration-server.cpp
@@ -1,56 +1,85 @@
+/**
+ *
+ *    Copyright (c) 2021-2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #include <app/util/af.h>
 
-#include <app/util/af-event.h>
-#include <app/util/attribute-storage.h>
-
-#include <app-common/zap-generated/attributes/Accessors.h>
-#include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/enums.h>
-#include <app-common/zap-generated/ids/Attributes.h>
-#include <app/CommandHandler.h>
 #include <app/ConcreteAttributePath.h>
-#include <app/ConcreteCommandPath.h>
-#include <app/util/error-mapping.h>
 #include <lib/core/CHIPEncoding.h>
 
-using namespace chip;
 using namespace chip::app;
-using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::ThermostatUserInterfaceConfiguration;
+using chip::Protocols::InteractionModel::Status;
 
-Protocols::InteractionModel::Status MatterThermostatUserInterfaceConfigurationClusterServerPreAttributeChangedCallback(
-    const app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value)
+namespace {
+//
+// Those types are defined as drafts in
+// src/app/zap-templates/zcl/data-model/draft/types/thermostat-user-interface-configuration.xml
+//
+enum class TemperatureDisplayMode : uint8_t
+{
+    kCelsius    = 0x0,
+    kFahrenheit = 0x1,
+};
+
+enum class KeypadLockout : uint8_t
+{
+    kNoLockout         = 0x0,
+    kLevelOneLockout   = 0x1,
+    kLevelTwoLockout   = 0x2,
+    kLevelThreeLockout = 0x3,
+    kLevelFourLockout  = 0x4,
+    kLevelFiveLockout  = 0x5,
+};
+
+} // namespace
+
+Status MatterThermostatUserInterfaceConfigurationClusterServerPreAttributeChangedCallback(
+    const ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value)
 {
     if (size != 0)
     {
-        if (ThermostatUserInterfaceConfiguration::Attributes::TemperatureDisplayMode::Id == attributePath.mAttributeId)
+        if (Attributes::TemperatureDisplayMode::Id == attributePath.mAttributeId)
         {
-            EmberAfTemperatureDisplayMode mode = static_cast<EmberAfTemperatureDisplayMode>(chip::Encoding::Get8(value));
-            if ((EMBER_ZCL_TEMPERATURE_DISPLAY_MODE_CELSIUS != mode) && (EMBER_ZCL_TEMPERATURE_DISPLAY_MODE_FAHRENHEIT != mode))
+            auto mode = static_cast<TemperatureDisplayMode>(chip::Encoding::Get8(value));
+            if ((TemperatureDisplayMode::kCelsius != mode) && (TemperatureDisplayMode::kFahrenheit != mode))
             {
-                return Protocols::InteractionModel::Status::Failure;
+                return Status::Failure;
             }
         }
-        else if (ThermostatUserInterfaceConfiguration::Attributes::KeypadLockout::Id == attributePath.mAttributeId)
+        else if (Attributes::KeypadLockout::Id == attributePath.mAttributeId)
         {
-            EmberAfKeypadLockout lockout = static_cast<EmberAfKeypadLockout>(chip::Encoding::Get8(value));
-            if ((EMBER_ZCL_KEYPAD_LOCKOUT_NO_LOCKOUT != lockout) && (EMBER_ZCL_KEYPAD_LOCKOUT_LEVEL_ONE_LOCKOUT != lockout) &&
-                (EMBER_ZCL_KEYPAD_LOCKOUT_LEVEL_TWO_LOCKOUT != lockout) &&
-                (EMBER_ZCL_KEYPAD_LOCKOUT_LEVEL_THREE_LOCKOUT != lockout) &&
-                (EMBER_ZCL_KEYPAD_LOCKOUT_LEVEL_FOUR_LOCKOUT != lockout) && (EMBER_ZCL_KEYPAD_LOCKOUT_LEVELFIVE_LOCKOUT != lockout))
+            auto lockout = static_cast<KeypadLockout>(chip::Encoding::Get8(value));
+            if ((KeypadLockout::kNoLockout != lockout) && (KeypadLockout::kLevelOneLockout != lockout) &&
+                (KeypadLockout::kLevelTwoLockout != lockout) && (KeypadLockout::kLevelThreeLockout != lockout) &&
+                (KeypadLockout::kLevelFourLockout != lockout) && (KeypadLockout::kLevelFiveLockout != lockout))
             {
-                return Protocols::InteractionModel::Status::Failure;
+                return Status::Failure;
             }
         }
-        else if (ThermostatUserInterfaceConfiguration::Attributes::ScheduleProgrammingVisibility::Id == attributePath.mAttributeId)
+        else if (Attributes::ScheduleProgrammingVisibility::Id == attributePath.mAttributeId)
         {
-            uint8_t prog = chip::Encoding::Get8(value);
+            auto prog = chip::Encoding::Get8(value);
             if (prog > 1)
             {
-                return Protocols::InteractionModel::Status::Failure;
+                return Status::Failure;
             }
         }
     }
 
-    return Protocols::InteractionModel::Status::Success;
+    return Status::Success;
 }

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -18,7 +18,6 @@ WeakEnums:
     - IdentifyEffectVariant
     - IdentifyIdentifyType
     - InterfaceTypeEnum
-    - KeypadLockout
     - LevelControlOptions
     - MoveMode
     - NetworkFaultEnum
@@ -28,7 +27,6 @@ WeakEnums:
     - SaturationMoveMode
     - SaturationStepMode
     - StepMode
-    - TemperatureDisplayMode
 
 DefineBitmaps:
     # Allow-list of bitmaps that we generates as #define as well as enum classes.

--- a/zzz_generated/app-common/app-common/zap-generated/enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/enums.h
@@ -156,17 +156,6 @@ enum EmberAfInterfaceTypeEnum : uint8_t
     EMBER_ZCL_INTERFACE_TYPE_ENUM_THREAD      = 4,
 };
 
-// Enum for KeypadLockout
-enum EmberAfKeypadLockout : uint8_t
-{
-    EMBER_ZCL_KEYPAD_LOCKOUT_NO_LOCKOUT          = 0,
-    EMBER_ZCL_KEYPAD_LOCKOUT_LEVEL_ONE_LOCKOUT   = 1,
-    EMBER_ZCL_KEYPAD_LOCKOUT_LEVEL_TWO_LOCKOUT   = 2,
-    EMBER_ZCL_KEYPAD_LOCKOUT_LEVEL_THREE_LOCKOUT = 3,
-    EMBER_ZCL_KEYPAD_LOCKOUT_LEVEL_FOUR_LOCKOUT  = 4,
-    EMBER_ZCL_KEYPAD_LOCKOUT_LEVELFIVE_LOCKOUT   = 5,
-};
-
 // Enum for MoveMode
 enum EmberAfMoveMode : uint8_t
 {
@@ -242,13 +231,6 @@ enum EmberAfStepMode : uint8_t
 {
     EMBER_ZCL_STEP_MODE_UP   = 0,
     EMBER_ZCL_STEP_MODE_DOWN = 1,
-};
-
-// Enum for TemperatureDisplayMode
-enum EmberAfTemperatureDisplayMode : uint8_t
-{
-    EMBER_ZCL_TEMPERATURE_DISPLAY_MODE_CELSIUS    = 0,
-    EMBER_ZCL_TEMPERATURE_DISPLAY_MODE_FAHRENHEIT = 1,
 };
 
 #define EMBER_AF_BARRIER_CONTROL_CAPABILITIES_PARTIAL_BARRIER (1)


### PR DESCRIPTION
####

This PR removes `KeypadLockout` and `TemperatureDisplayMode` from the weak enums list.

What is interesting about those is that they are "draft" types, i.e they do not carry a cluster code. As such removing them from the allowed list of weak enums makes them unavailable. 

I have redefined them as `enum class` directly in `thermostat-user-interface-configuration-server.cpp` since everything is self-contained there.
