### PR TITLE
Allow chip-repl to send group commands

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -78,8 +78,8 @@ shared_library("ChipDeviceCtrl") {
       "chip/native/PyChipError.cpp",
       "chip/utils/DeviceProxyUtils.cpp",
     ]
-    defines += ["CHIP_CONFIG_MAX_GROUPS_PER_FABRIC=50"]
-    defines += ["CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC=50"]
+    defines += [ "CHIP_CONFIG_MAX_GROUPS_PER_FABRIC=50" ]
+    defines += [ "CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC=50" ]
   } else {
     sources += [
       "chip/server/Options.cpp",

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -51,6 +51,8 @@ shared_library("ChipDeviceCtrl") {
 
   sources += [ "chip/native/CommonStackInit.cpp" ]
 
+  defines = []
+
   if (chip_controller) {
     sources += [
       "ChipCommissionableNodeController-ScriptBinding.cpp",
@@ -76,6 +78,8 @@ shared_library("ChipDeviceCtrl") {
       "chip/native/PyChipError.cpp",
       "chip/utils/DeviceProxyUtils.cpp",
     ]
+    defines += ["CHIP_CONFIG_MAX_GROUPS_PER_FABRIC=50"]
+    defines += ["CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC=50"]
   } else {
     sources += [
       "chip/server/Options.cpp",

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -100,7 +100,7 @@ chip::Controller::CommissioningParameters sCommissioningParameters;
 
 chip::Controller::ScriptDevicePairingDelegate sPairingDelegate;
 chip::Controller::ScriptPairingDeviceDiscoveryDelegate sPairingDeviceDiscoveryDelegate;
-chip::Credentials::GroupDataProviderImpl sGroupDataProvider{ 5, 8 };
+chip::Credentials::GroupDataProviderImpl sGroupDataProvider;
 chip::Credentials::PersistentStorageOpCertStore sPersistentStorageOpCertStore;
 
 // NOTE: Remote device ID is in sync with the echo server device id

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -100,7 +100,7 @@ chip::Controller::CommissioningParameters sCommissioningParameters;
 
 chip::Controller::ScriptDevicePairingDelegate sPairingDelegate;
 chip::Controller::ScriptPairingDeviceDiscoveryDelegate sPairingDeviceDiscoveryDelegate;
-chip::Credentials::GroupDataProviderImpl sGroupDataProvider;
+chip::Credentials::GroupDataProviderImpl sGroupDataProvider{ 5, 8 };
 chip::Credentials::PersistentStorageOpCertStore sPersistentStorageOpCertStore;
 
 // NOTE: Remote device ID is in sync with the echo server device id
@@ -234,6 +234,7 @@ PyChipError pychip_DeviceController_StackInit(Controller::Python::StorageAdapter
 
     sGroupDataProvider.SetStorageDelegate(storageAdapter);
     PyReturnErrorOnFailure(ToPyChipError(sGroupDataProvider.Init()));
+    Credentials::SetGroupDataProvider(&sGroupDataProvider);
     factoryParams.groupDataProvider = &sGroupDataProvider;
 
     PyReturnErrorOnFailure(ToPyChipError(sPersistentStorageOpCertStore.Init(storageAdapter)));

--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -465,6 +465,21 @@ PyChipError pychip_OpCreds_AllocateController(OpCredsContext * context, chip::Co
     return ToPyChipError(CHIP_NO_ERROR);
 }
 
+PyChipError pychip_OpCreds_InitGroupTestingData(chip::Controller::DeviceCommissioner * devCtrl)
+{
+    VerifyOrReturnError(devCtrl != nullptr, ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
+
+    uint8_t compressedFabricId[sizeof(uint64_t)] = { 0 };
+    chip::MutableByteSpan compressedFabricIdSpan(compressedFabricId);
+
+    CHIP_ERROR err = devCtrl->GetCompressedFabricIdBytes(compressedFabricIdSpan);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
+
+    err = chip::GroupTesting::InitData(&sGroupDataProvider, devCtrl->GetFabricIndex(), compressedFabricIdSpan);
+
+    return ToPyChipError(err);
+}
+
 PyChipError pychip_OpCreds_SetMaximallyLargeCertsUsed(OpCredsContext * context, bool enabled)
 {
     VerifyOrReturnError(context != nullptr && context->mAdapter != nullptr, ToPyChipError(CHIP_ERROR_INCORRECT_STATE));

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -894,23 +894,17 @@ class ChipDeviceController():
             ), payload, timedRequestTimeoutMs=timedRequestTimeoutMs, interactionTimeoutMs=interactionTimeoutMs, busyWaitMs=busyWaitMs).raise_on_error()
         return await future
 
-    async def SendGroupCommand(self, groupid: int, payload: ClusterObjects.ClusterCommand, timedRequestTimeoutMs: typing.Union[None, int] = None, interactionTimeoutMs: typing.Union[None, int] = None, busyWaitMs: typing.Union[None, int] = None):
+    def SendGroupCommand(self, groupid: int, payload: ClusterObjects.ClusterCommand, busyWaitMs: typing.Union[None, int] = None):
         '''
         Send a group cluster-object encapsulated command to a group_id and get returned a future that can be awaited upon to get confirmation command was sent.
-
-        timedWriteTimeoutMs: Timeout for a timed invoke request. Omit or set to 'None' to indicate a non-timed request.
-        interactionTimeoutMs: Overall timeout for the interaction. Omit or set to 'None' to have the SDK automatically compute the right
-                              timeout value based on transport characteristics as well as the responsiveness of the target.
         '''
         self.CheckIsActive()
 
-        eventLoop = asyncio.get_running_loop()
-        future = eventLoop.create_future()
-
         ClusterCommand.SendGroupCommand(
-            future, eventLoop, groupid, self.devCtrl, payload, timedRequestTimeoutMs=timedRequestTimeoutMs,
-            interactionTimeoutMs=interactionTimeoutMs, busyWaitMs=busyWaitMs).raise_on_error()
-        return await future
+            groupid, self.devCtrl, payload, busyWaitMs=busyWaitMs).raise_on_error()
+
+        # None is the expected return for sending group commands.
+        return None
 
     async def WriteAttribute(self, nodeid: int, attributes: typing.List[typing.Tuple[int, ClusterObjects.ClusterAttributeDescriptor, int]], timedRequestTimeoutMs: typing.Union[None, int] = None, interactionTimeoutMs: typing.Union[None, int] = None, busyWaitMs: typing.Union[None, int] = None):
         '''

--- a/src/controller/python/chip/clusters/Command.py
+++ b/src/controller/python/chip/clusters/Command.py
@@ -116,21 +116,12 @@ class AsyncCommandTransaction:
             self._handleError, status, chipError, None
         )
 
-    def _handleGroupCommandDone(self):
-        self._future.set_result(None)
-
-    def handleGroupCommandDone(self):
-        self._event_loop.call_soon_threadsafe(
-            self._handleGroupCommandDone)
-
 
 _OnCommandSenderResponseCallbackFunct = CFUNCTYPE(
     None, py_object, c_uint16, c_uint32, c_uint32, c_uint16, c_uint8, c_void_p, c_uint32)
 _OnCommandSenderErrorCallbackFunct = CFUNCTYPE(
     None, py_object, c_uint16, c_uint8, PyChipError)
 _OnCommandSenderDoneCallbackFunct = CFUNCTYPE(
-    None, py_object)
-_OnGroupCommandSenderDoneCallbackFunct = CFUNCTYPE(
     None, py_object)
 
 
@@ -148,13 +139,6 @@ def _OnCommandSenderErrorCallback(closure, imStatus: int, clusterStatus: int, ch
 
 @_OnCommandSenderDoneCallbackFunct
 def _OnCommandSenderDoneCallback(closure):
-    ctypes.pythonapi.Py_DecRef(ctypes.py_object(closure))
-
-
-@_OnGroupCommandSenderDoneCallbackFunct
-def _OnGroupCommandSenderDoneCallback(closure):
-    # Group commands have no response so we leverage the group command done callback
-    closure.handleGroupCommandDone()
     ctypes.pythonapi.Py_DecRef(ctypes.py_object(closure))
 
 
@@ -191,30 +175,18 @@ def SendCommand(future: Future, eventLoop, responseType: Type, device, commandPa
         ))
 
 
-def SendGroupCommand(future: Future, eventLoop, groupId: int, devCtrl: c_void_p, payload: ClusterCommand, timedRequestTimeoutMs: Union[None, int] = None, interactionTimeoutMs: Union[None, int] = None, busyWaitMs: Union[None, int] = None) -> PyChipError:
+def SendGroupCommand(groupId: int, devCtrl: c_void_p, payload: ClusterCommand, busyWaitMs: Union[None, int] = None) -> PyChipError:
     ''' Send a cluster-object encapsulated group command to a device and does the following:
             - None (on a successful response containing no data)
             - Raises an exception if any errors are encountered.
-
-        If a valid timedRequestTimeoutMs is provided, a timed interaction will be initiated instead.
-        If a valid interactionTimeoutMs is provided, the interaction will terminate with a CHIP_ERROR_TIMEOUT if a response
-        has not been received within that timeout. If it isn't provided, a sensible value will be automatically computed that
-        accounts for the underlying characteristics of both the transport and the responsiveness of the receiver.
     '''
-    if payload.must_use_timed_invoke and timedRequestTimeoutMs is None or timedRequestTimeoutMs == 0:
-        raise chip.interaction_model.InteractionModelError(chip.interaction_model.Status.NeedsTimedInteraction)
-
     handle = chip.native.GetLibraryHandle()
-    transaction = AsyncCommandTransaction(future, eventLoop, None)
 
     payloadTLV = payload.ToTLV()
-    ctypes.pythonapi.Py_IncRef(ctypes.py_object(transaction))
     return builtins.chipStack.Call(
         lambda: handle.pychip_CommandSender_SendGroupCommand(
-            ctypes.py_object(transaction), c_uint16(groupId), devCtrl,
-            c_uint16(0 if timedRequestTimeoutMs is None else timedRequestTimeoutMs),
+            c_uint16(groupId), devCtrl,
             payload.cluster_id, payload.command_id, payloadTLV, len(payloadTLV),
-            ctypes.c_uint16(0 if interactionTimeoutMs is None else interactionTimeoutMs),
             ctypes.c_uint16(0 if busyWaitMs is None else busyWaitMs),
         ))
 
@@ -230,9 +202,9 @@ def Init():
         setter.Set('pychip_CommandSender_SendCommand',
                    PyChipError, [py_object, c_void_p, c_uint16, c_uint32, c_uint32, c_char_p, c_size_t, c_uint16])
         setter.Set('pychip_CommandSender_SendGroupCommand',
-                   PyChipError, [py_object, c_uint16, c_void_p, c_uint16, c_uint32, c_uint32, c_char_p, c_size_t, c_uint16, c_uint16])
+                   PyChipError, [c_uint16, c_void_p, c_uint32, c_uint32, c_char_p, c_size_t, c_uint16])
         setter.Set('pychip_CommandSender_InitCallbacks', None, [
-                   _OnCommandSenderResponseCallbackFunct, _OnCommandSenderErrorCallbackFunct, _OnCommandSenderDoneCallbackFunct, _OnGroupCommandSenderDoneCallbackFunct])
+                   _OnCommandSenderResponseCallbackFunct, _OnCommandSenderErrorCallbackFunct, _OnCommandSenderDoneCallbackFunct])
 
     handle.pychip_CommandSender_InitCallbacks(
-        _OnCommandSenderResponseCallback, _OnCommandSenderErrorCallback, _OnCommandSenderDoneCallback, _OnGroupCommandSenderDoneCallback)
+        _OnCommandSenderResponseCallback, _OnCommandSenderErrorCallback, _OnCommandSenderDoneCallback)

--- a/src/controller/python/chip/clusters/command.cpp
+++ b/src/controller/python/chip/clusters/command.cpp
@@ -38,8 +38,7 @@ PyChipError pychip_CommandSender_SendCommand(void * appContext, DeviceProxy * de
                                              const uint8_t * payload, size_t length, uint16_t interactionTimeoutMs,
                                              uint16_t busyWaitMs);
 
-PyChipError pychip_CommandSender_SendGroupCommand(chip::GroupId groupId,
-                                                  chip::Controller::DeviceCommissioner * devCtrl,
+PyChipError pychip_CommandSender_SendGroupCommand(chip::GroupId groupId, chip::Controller::DeviceCommissioner * devCtrl,
                                                   chip::ClusterId clusterId, chip::CommandId commandId, const uint8_t * payload,
                                                   size_t length, uint16_t busyWaitMs);
 }
@@ -177,8 +176,7 @@ exit:
     return ToPyChipError(err);
 }
 
-PyChipError pychip_CommandSender_SendGroupCommand(chip::GroupId groupId,
-                                                  chip::Controller::DeviceCommissioner * devCtrl,
+PyChipError pychip_CommandSender_SendGroupCommand(chip::GroupId groupId, chip::Controller::DeviceCommissioner * devCtrl,
                                                   chip::ClusterId clusterId, chip::CommandId commandId, const uint8_t * payload,
                                                   size_t length, uint16_t busyWaitMs)
 {
@@ -187,7 +185,7 @@ PyChipError pychip_CommandSender_SendGroupCommand(chip::GroupId groupId,
     chip::Messaging::ExchangeManager * exchangeManager = chip::app::InteractionModelEngine::GetInstance()->GetExchangeManager();
     VerifyOrReturnError(exchangeManager != nullptr, ToPyChipError(CHIP_ERROR_INCORRECT_STATE));
 
-    std::unique_ptr<CommandSender> sender                = std::make_unique<CommandSender>(nullptr /* callback */, exchangeManager);
+    std::unique_ptr<CommandSender> sender = std::make_unique<CommandSender>(nullptr /* callback */, exchangeManager);
 
     app::CommandPathParams cmdParams = { groupId, clusterId, commandId, (app::CommandPathFlags::kGroupIdValid) };
 

--- a/src/controller/python/chip/yaml/runner.py
+++ b/src/controller/python/chip/yaml/runner.py
@@ -188,10 +188,9 @@ class InvokeAction(BaseAction):
     def run_action(self, dev_ctrl: ChipDeviceController) -> _ActionResult:
         try:
             if self._group_id:
-                resp = asyncio.run(dev_ctrl.SendGroupCommand(
+                resp = dev_ctrl.SendGroupCommand(
                     self._group_id, self._request_object,
-                    timedRequestTimeoutMs=self._interation_timeout_ms,
-                    busyWaitMs=self._busy_wait_ms))
+                    busyWaitMs=self._busy_wait_ms)
             else:
                 resp = asyncio.run(dev_ctrl.SendCommand(
                     self._node_id, self._endpoint, self._request_object,

--- a/src/controller/python/chip/yaml/runner.py
+++ b/src/controller/python/chip/yaml/runner.py
@@ -156,6 +156,11 @@ class InvokeAction(BaseAction):
         self._expected_response_object = None
         self._endpoint = test_step.endpoint
         self._node_id = test_step.node_id
+        self._group_id = test_step.group_id
+
+        if self._node_id is None and self._group_id is None:
+            raise UnexpectedParsingError(
+                'Both node_id and group_id are None, at least one needs to be provided')
 
         command = context.data_model_lookup.get_command(self._cluster, self._command_name)
 
@@ -182,10 +187,16 @@ class InvokeAction(BaseAction):
 
     def run_action(self, dev_ctrl: ChipDeviceController) -> _ActionResult:
         try:
-            resp = asyncio.run(dev_ctrl.SendCommand(
-                self._node_id, self._endpoint, self._request_object,
-                timedRequestTimeoutMs=self._interation_timeout_ms,
-                busyWaitMs=self._busy_wait_ms))
+            if self._group_id:
+                resp = asyncio.run(dev_ctrl.SendGroupCommand(
+                    self._group_id, self._request_object,
+                    timedRequestTimeoutMs=self._interation_timeout_ms,
+                    busyWaitMs=self._busy_wait_ms))
+            else:
+                resp = asyncio.run(dev_ctrl.SendCommand(
+                    self._node_id, self._endpoint, self._request_object,
+                    timedRequestTimeoutMs=self._interation_timeout_ms,
+                    busyWaitMs=self._busy_wait_ms))
         except chip.interaction_model.InteractionModelError as error:
             return _ActionResult(status=_ActionStatus.ERROR, response=error)
 
@@ -736,6 +747,7 @@ class ReplTestRunner:
         self._certificate_authority_manager = certificate_authority_manager
         self._dev_ctrls = {}
 
+        alpha_dev_ctrl.InitGroupTestingData()
         self._dev_ctrls['alpha'] = alpha_dev_ctrl
 
     def _invoke_action_factory(self, test_step, cluster: str):
@@ -1014,6 +1026,7 @@ class ReplTestRunner:
                     fabric = certificate_authority.NewFabricAdmin(vendorId=0xFFF1,
                                                                   fabricId=fabric_id)
                 dev_ctrl = fabric.NewController()
+                dev_ctrl.InitGroupTestingData()
                 self._dev_ctrls[action.identity] = dev_ctrl
         else:
             dev_ctrl = self._dev_ctrls['alpha']


### PR DESCRIPTION
With chip-repl now able to send we have updated the yamltests runner that uses chip-repl to send group commands

Test: Confirmed that group messages are sent when running TestGroupMessaging.yaml with chip-repl based yamltest runner.