### PR TITLE
Enable Test_TC_OO_2_4 to run in CI

### DIFF
--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -85,9 +85,10 @@ def _GetManualTests() -> Set[str]:
 
 def _GetFlakyTests() -> Set[str]:
     """List of flaky tests, ideally this list should become empty."""
-    return {
-        "Test_TC_OO_2_4.yaml"
-    }
+    return_value = set()
+    # We need more data as to why this test flakes sometimes. We have added additional logging.
+    # return_value.add("Test_TC_OO_2_4.yaml")
+    return return_value
 
 
 def _GetSlowTests() -> Set[str]:


### PR DESCRIPTION
We have additional logging in yamltest_with_chip_repl_tester.py that will help us better understand the flake. Unfortunately we are not able to reproduce the flake locally and need flake to happen in CI.

Additionally in the previous flake logs we do have the debug line was not help as it was printing the address of the onOff argument and not the value. That has been address in another PR that has since been merged.