### PR TITLE
[Silabs] Rename silabs config to be inline with coding standards

### DIFF
--- a/examples/lock-app/silabs/SiWx917/src/LockManager.cpp
+++ b/examples/lock-app/silabs/SiWx917/src/LockManager.cpp
@@ -131,33 +131,33 @@ bool LockManager::IsValidHolidayScheduleIndex(uint8_t scheduleIndex)
 bool LockManager::ReadConfigValues()
 {
     size_t outLen;
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_LockUser, reinterpret_cast<uint8_t *>(&mLockUsers),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_LockUser, reinterpret_cast<uint8_t *>(&mLockUsers),
                                      sizeof(EmberAfPluginDoorLockUserInfo) * ArraySize(mLockUsers), outLen);
 
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_Credential, reinterpret_cast<uint8_t *>(&mLockCredentials),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_Credential, reinterpret_cast<uint8_t *>(&mLockCredentials),
                                      sizeof(EmberAfPluginDoorLockCredentialInfo) * ArraySize(mLockCredentials), outLen);
 
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_LockUserName, reinterpret_cast<uint8_t *>(mUserNames),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_LockUserName, reinterpret_cast<uint8_t *>(mUserNames),
                                      sizeof(mUserNames), outLen);
 
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_CredentialData, reinterpret_cast<uint8_t *>(mCredentialData),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_CredentialData, reinterpret_cast<uint8_t *>(mCredentialData),
                                      sizeof(mCredentialData), outLen);
 
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_UserCredentials, reinterpret_cast<uint8_t *>(mCredentials),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_UserCredentials, reinterpret_cast<uint8_t *>(mCredentials),
                                      sizeof(CredentialStruct) * LockParams.numberOfUsers * LockParams.numberOfCredentialsPerUser,
                                      outLen);
 
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_WeekDaySchedules, reinterpret_cast<uint8_t *>(mWeekdaySchedule),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_WeekDaySchedules, reinterpret_cast<uint8_t *>(mWeekdaySchedule),
                                      sizeof(EmberAfPluginDoorLockWeekDaySchedule) * LockParams.numberOfWeekdaySchedulesPerUser *
                                          LockParams.numberOfUsers,
                                      outLen);
 
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_YearDaySchedules, reinterpret_cast<uint8_t *>(mYeardaySchedule),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_YearDaySchedules, reinterpret_cast<uint8_t *>(mYeardaySchedule),
                                      sizeof(EmberAfPluginDoorLockYearDaySchedule) * LockParams.numberOfYeardaySchedulesPerUser *
                                          LockParams.numberOfUsers,
                                      outLen);
 
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_HolidaySchedules, reinterpret_cast<uint8_t *>(&(mHolidaySchedule)),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_HolidaySchedules, reinterpret_cast<uint8_t *>(&(mHolidaySchedule)),
                                      sizeof(EmberAfPluginDoorLockHolidaySchedule) * LockParams.numberOfHolidaySchedules, outLen);
 
     return true;
@@ -389,13 +389,13 @@ bool LockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip:
     userInStorage.credentials = chip::Span<const CredentialStruct>(mCredentials[userIndex], totalCredentials);
 
     // Save user information in NVM flash
-    SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_LockUser, reinterpret_cast<const uint8_t *>(&mLockUsers),
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_LockUser, reinterpret_cast<const uint8_t *>(&mLockUsers),
                                       sizeof(EmberAfPluginDoorLockUserInfo) * LockParams.numberOfUsers);
 
-    SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_UserCredentials, reinterpret_cast<const uint8_t *>(mCredentials),
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_UserCredentials, reinterpret_cast<const uint8_t *>(mCredentials),
                                       sizeof(CredentialStruct) * LockParams.numberOfUsers * LockParams.numberOfCredentialsPerUser);
 
-    SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_LockUserName, reinterpret_cast<const uint8_t *>(mUserNames),
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_LockUserName, reinterpret_cast<const uint8_t *>(mUserNames),
                                       sizeof(mUserNames));
 
     ChipLogProgress(Zcl, "Successfully set the user [mEndpointId=%d,index=%d]", endpointId, userIndex);
@@ -476,10 +476,10 @@ bool LockManager::SetCredential(chip::EndpointId endpointId, uint16_t credential
     credentialInStorage.credentialData = chip::ByteSpan{ mCredentialData[credentialIndex], credentialData.size() };
 
     // Save credential information in NVM flash
-    SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_Credential, reinterpret_cast<const uint8_t *>(&mLockCredentials),
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_Credential, reinterpret_cast<const uint8_t *>(&mLockCredentials),
                                       sizeof(EmberAfPluginDoorLockCredentialInfo) * LockParams.numberOfCredentialsPerUser);
 
-    SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_CredentialData, reinterpret_cast<const uint8_t *>(&mCredentialData),
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_CredentialData, reinterpret_cast<const uint8_t *>(&mCredentialData),
                                       sizeof(mCredentialData));
 
     ChipLogProgress(Zcl, "Successfully set the credential [credentialType=%u]", to_underlying(credentialType));
@@ -535,8 +535,8 @@ DlStatus LockManager::SetWeekdaySchedule(chip::EndpointId endpointId, uint8_t we
     scheduleInStorage.status               = status;
 
     // Save schedule information in NVM flash
-    SILABSConfig::WriteConfigValueBin(
-        SILABSConfig::kConfigKey_WeekDaySchedules, reinterpret_cast<const uint8_t *>(mWeekdaySchedule),
+    SilabsConfig::WriteConfigValueBin(
+        SilabsConfig::kConfigKey_WeekDaySchedules, reinterpret_cast<const uint8_t *>(mWeekdaySchedule),
         sizeof(EmberAfPluginDoorLockWeekDaySchedule) * LockParams.numberOfWeekdaySchedulesPerUser * LockParams.numberOfUsers);
 
     return DlStatus::kSuccess;
@@ -584,8 +584,8 @@ DlStatus LockManager::SetYeardaySchedule(chip::EndpointId endpointId, uint8_t ye
     scheduleInStorage.status                  = status;
 
     // Save schedule information in NVM flash
-    SILABSConfig::WriteConfigValueBin(
-        SILABSConfig::kConfigKey_YearDaySchedules, reinterpret_cast<const uint8_t *>(mYeardaySchedule),
+    SilabsConfig::WriteConfigValueBin(
+        SilabsConfig::kConfigKey_YearDaySchedules, reinterpret_cast<const uint8_t *>(mYeardaySchedule),
         sizeof(EmberAfPluginDoorLockYearDaySchedule) * LockParams.numberOfYeardaySchedulesPerUser * LockParams.numberOfUsers);
 
     return DlStatus::kSuccess;
@@ -628,7 +628,7 @@ DlStatus LockManager::SetHolidaySchedule(chip::EndpointId endpointId, uint8_t ho
     scheduleInStorage.status                  = status;
 
     // Save schedule information in NVM flash
-    SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_HolidaySchedules,
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_HolidaySchedules,
                                       reinterpret_cast<const uint8_t *>(&(mHolidaySchedule)),
                                       sizeof(EmberAfPluginDoorLockHolidaySchedule) * LockParams.numberOfHolidaySchedules);
 

--- a/examples/lock-app/silabs/efr32/src/LockManager.cpp
+++ b/examples/lock-app/silabs/efr32/src/LockManager.cpp
@@ -131,33 +131,33 @@ bool LockManager::IsValidHolidayScheduleIndex(uint8_t scheduleIndex)
 bool LockManager::ReadConfigValues()
 {
     size_t outLen;
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_LockUser, reinterpret_cast<uint8_t *>(&mLockUsers),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_LockUser, reinterpret_cast<uint8_t *>(&mLockUsers),
                                      sizeof(EmberAfPluginDoorLockUserInfo) * ArraySize(mLockUsers), outLen);
 
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_Credential, reinterpret_cast<uint8_t *>(&mLockCredentials),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_Credential, reinterpret_cast<uint8_t *>(&mLockCredentials),
                                      sizeof(EmberAfPluginDoorLockCredentialInfo) * ArraySize(mLockCredentials), outLen);
 
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_LockUserName, reinterpret_cast<uint8_t *>(mUserNames),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_LockUserName, reinterpret_cast<uint8_t *>(mUserNames),
                                      sizeof(mUserNames), outLen);
 
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_CredentialData, reinterpret_cast<uint8_t *>(mCredentialData),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_CredentialData, reinterpret_cast<uint8_t *>(mCredentialData),
                                      sizeof(mCredentialData), outLen);
 
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_UserCredentials, reinterpret_cast<uint8_t *>(mCredentials),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_UserCredentials, reinterpret_cast<uint8_t *>(mCredentials),
                                      sizeof(CredentialStruct) * LockParams.numberOfUsers * LockParams.numberOfCredentialsPerUser,
                                      outLen);
 
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_WeekDaySchedules, reinterpret_cast<uint8_t *>(mWeekdaySchedule),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_WeekDaySchedules, reinterpret_cast<uint8_t *>(mWeekdaySchedule),
                                      sizeof(EmberAfPluginDoorLockWeekDaySchedule) * LockParams.numberOfWeekdaySchedulesPerUser *
                                          LockParams.numberOfUsers,
                                      outLen);
 
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_YearDaySchedules, reinterpret_cast<uint8_t *>(mYeardaySchedule),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_YearDaySchedules, reinterpret_cast<uint8_t *>(mYeardaySchedule),
                                      sizeof(EmberAfPluginDoorLockYearDaySchedule) * LockParams.numberOfYeardaySchedulesPerUser *
                                          LockParams.numberOfUsers,
                                      outLen);
 
-    SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_HolidaySchedules, reinterpret_cast<uint8_t *>(&(mHolidaySchedule)),
+    SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_HolidaySchedules, reinterpret_cast<uint8_t *>(&(mHolidaySchedule)),
                                      sizeof(EmberAfPluginDoorLockHolidaySchedule) * LockParams.numberOfHolidaySchedules, outLen);
 
     return true;
@@ -389,13 +389,13 @@ bool LockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip:
     userInStorage.credentials = chip::Span<const CredentialStruct>(mCredentials[userIndex], totalCredentials);
 
     // Save user information in NVM flash
-    SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_LockUser, reinterpret_cast<const uint8_t *>(&mLockUsers),
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_LockUser, reinterpret_cast<const uint8_t *>(&mLockUsers),
                                       sizeof(EmberAfPluginDoorLockUserInfo) * LockParams.numberOfUsers);
 
-    SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_UserCredentials, reinterpret_cast<const uint8_t *>(mCredentials),
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_UserCredentials, reinterpret_cast<const uint8_t *>(mCredentials),
                                       sizeof(CredentialStruct) * LockParams.numberOfUsers * LockParams.numberOfCredentialsPerUser);
 
-    SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_LockUserName, reinterpret_cast<const uint8_t *>(mUserNames),
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_LockUserName, reinterpret_cast<const uint8_t *>(mUserNames),
                                       sizeof(mUserNames));
 
     ChipLogProgress(Zcl, "Successfully set the user [mEndpointId=%d,index=%d]", endpointId, userIndex);
@@ -476,10 +476,10 @@ bool LockManager::SetCredential(chip::EndpointId endpointId, uint16_t credential
     credentialInStorage.credentialData = chip::ByteSpan{ mCredentialData[credentialIndex], credentialData.size() };
 
     // Save credential information in NVM flash
-    SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_Credential, reinterpret_cast<const uint8_t *>(&mLockCredentials),
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_Credential, reinterpret_cast<const uint8_t *>(&mLockCredentials),
                                       sizeof(EmberAfPluginDoorLockCredentialInfo) * LockParams.numberOfCredentialsPerUser);
 
-    SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_CredentialData, reinterpret_cast<const uint8_t *>(&mCredentialData),
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_CredentialData, reinterpret_cast<const uint8_t *>(&mCredentialData),
                                       sizeof(mCredentialData));
 
     ChipLogProgress(Zcl, "Successfully set the credential [credentialType=%u]", to_underlying(credentialType));
@@ -535,8 +535,8 @@ DlStatus LockManager::SetWeekdaySchedule(chip::EndpointId endpointId, uint8_t we
     scheduleInStorage.status               = status;
 
     // Save schedule information in NVM flash
-    SILABSConfig::WriteConfigValueBin(
-        SILABSConfig::kConfigKey_WeekDaySchedules, reinterpret_cast<const uint8_t *>(mWeekdaySchedule),
+    SilabsConfig::WriteConfigValueBin(
+        SilabsConfig::kConfigKey_WeekDaySchedules, reinterpret_cast<const uint8_t *>(mWeekdaySchedule),
         sizeof(EmberAfPluginDoorLockWeekDaySchedule) * LockParams.numberOfWeekdaySchedulesPerUser * LockParams.numberOfUsers);
 
     return DlStatus::kSuccess;
@@ -584,8 +584,8 @@ DlStatus LockManager::SetYeardaySchedule(chip::EndpointId endpointId, uint8_t ye
     scheduleInStorage.status                  = status;
 
     // Save schedule information in NVM flash
-    SILABSConfig::WriteConfigValueBin(
-        SILABSConfig::kConfigKey_YearDaySchedules, reinterpret_cast<const uint8_t *>(mYeardaySchedule),
+    SilabsConfig::WriteConfigValueBin(
+        SilabsConfig::kConfigKey_YearDaySchedules, reinterpret_cast<const uint8_t *>(mYeardaySchedule),
         sizeof(EmberAfPluginDoorLockYearDaySchedule) * LockParams.numberOfYeardaySchedulesPerUser * LockParams.numberOfUsers);
 
     return DlStatus::kSuccess;
@@ -628,7 +628,7 @@ DlStatus LockManager::SetHolidaySchedule(chip::EndpointId endpointId, uint8_t ho
     scheduleInStorage.status                  = status;
 
     // Save schedule information in NVM flash
-    SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_HolidaySchedules,
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_HolidaySchedules,
                                       reinterpret_cast<const uint8_t *>(&(mHolidaySchedule)),
                                       sizeof(EmberAfPluginDoorLockHolidaySchedule) * LockParams.numberOfHolidaySchedules);
 

--- a/examples/platform/silabs/SiWx917/SiWx917DeviceDataProvider.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917DeviceDataProvider.cpp
@@ -34,7 +34,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetSetupDiscriminator(uint16_t & setupDiscri
     CHIP_ERROR err;
     uint32_t setupDiscriminator32;
 
-    err = SILABSConfig::ReadConfigValue(SILABSConfig::kConfigKey_SetupDiscriminator, setupDiscriminator32);
+    err = SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_SetupDiscriminator, setupDiscriminator32);
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR) && CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
@@ -50,7 +50,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetSetupDiscriminator(uint16_t & setupDiscri
 
 CHIP_ERROR EFR32DeviceDataProvider::GetSpake2pIterationCount(uint32_t & iterationCount)
 {
-    CHIP_ERROR err = SILABSConfig::ReadConfigValue(SILABSConfig::kConfigKey_Spake2pIterationCount, iterationCount);
+    CHIP_ERROR err = SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_Spake2pIterationCount, iterationCount);
 
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_ITERATION_COUNT) && CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_ITERATION_COUNT
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -70,7 +70,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetSpake2pSalt(MutableByteSpan & saltBuf)
     char saltB64[kSpake2pSalt_MaxBase64Len] = { 0 };
     size_t saltB64Len                       = 0;
 
-    err = SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_Spake2pSalt, saltB64, sizeof(saltB64), saltB64Len);
+    err = SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_Spake2pSalt, saltB64, sizeof(saltB64), saltB64Len);
 
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_SALT)
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -103,7 +103,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetSpake2pVerifier(MutableByteSpan & verifie
     char verifierB64[kSpake2pSerializedVerifier_MaxBase64Len] = { 0 };
     size_t verifierB64Len                                     = 0;
 
-    err = SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_Spake2pVerifier, verifierB64, sizeof(verifierB64),
+    err = SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_Spake2pVerifier, verifierB64, sizeof(verifierB64),
                                            verifierB64Len);
 
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_VERIFIER)
@@ -133,7 +133,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetSetupPayload(MutableCharSpan & payloadBuf
     uint8_t payloadBitSet[kTotalPayloadDataSizeInBytes] = { 0 };
     size_t bitSetLen                                    = 0;
 
-    err = SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_SetupPayloadBitSet, payloadBitSet, kTotalPayloadDataSizeInBytes,
+    err = SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_SetupPayloadBitSet, payloadBitSet, kTotalPayloadDataSizeInBytes,
                                            bitSetLen);
 
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE) && CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
@@ -170,7 +170,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetSetupPayload(MutableCharSpan & payloadBuf
 CHIP_ERROR EFR32DeviceDataProvider::GetVendorName(char * buf, size_t bufSize)
 {
     size_t vendorNameLen = 0; // without counting null-terminator
-    return SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_VendorName, buf, bufSize, vendorNameLen);
+    return SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_VendorName, buf, bufSize, vendorNameLen);
 }
 
 CHIP_ERROR EFR32DeviceDataProvider::GetVendorId(uint16_t & vendorId)
@@ -178,7 +178,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetVendorId(uint16_t & vendorId)
     ChipError err       = CHIP_NO_ERROR;
     uint32_t vendorId32 = 0;
 
-    err = SILABSConfig::ReadConfigValue(SILABSConfig::kConfigKey_VendorId, vendorId32);
+    err = SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_VendorId, vendorId32);
 
 #if defined(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID) && CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -196,7 +196,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetVendorId(uint16_t & vendorId)
 CHIP_ERROR EFR32DeviceDataProvider::GetProductName(char * buf, size_t bufSize)
 {
     size_t productNameLen = 0; // without counting null-terminator
-    return SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_ProductName, buf, bufSize, productNameLen);
+    return SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_ProductName, buf, bufSize, productNameLen);
 }
 
 CHIP_ERROR EFR32DeviceDataProvider::GetProductId(uint16_t & productId)
@@ -204,7 +204,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetProductId(uint16_t & productId)
     ChipError err        = CHIP_NO_ERROR;
     uint32_t productId32 = 0;
 
-    err = SILABSConfig::ReadConfigValue(SILABSConfig::kConfigKey_ProductId, productId32);
+    err = SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_ProductId, productId32);
 
 #if defined(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID) && CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -223,7 +223,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetHardwareVersionString(char * buf, size_t 
 {
     size_t hardwareVersionStringLen = 0; // without counting null-terminator
     CHIP_ERROR err =
-        SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_HardwareVersionString, buf, bufSize, hardwareVersionStringLen);
+        SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_HardwareVersionString, buf, bufSize, hardwareVersionStringLen);
 #if defined(CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING)
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
@@ -239,7 +239,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetHardwareVersion(uint16_t & hardwareVersio
     CHIP_ERROR err;
     uint32_t hardwareVersion32;
 
-    err = SILABSConfig::ReadConfigValue(SILABSConfig::kConfigKey_HardwareVersion, hardwareVersion32);
+    err = SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_HardwareVersion, hardwareVersion32);
 #if defined(CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION)
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
@@ -261,7 +261,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetRotatingDeviceIdUniqueId(MutableByteSpan 
 
     size_t uniqueIdLen = 0;
     err =
-        SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_UniqueId, uniqueIdSpan.data(), uniqueIdSpan.size(), uniqueIdLen);
+        SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_UniqueId, uniqueIdSpan.data(), uniqueIdSpan.size(), uniqueIdLen);
 #ifdef CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
@@ -283,7 +283,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetRotatingDeviceIdUniqueId(MutableByteSpan 
 CHIP_ERROR EFR32DeviceDataProvider::GetSerialNumber(char * buf, size_t bufSize)
 {
     size_t serialNumberLen = 0; // without counting null-terminator
-    return SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_SerialNum, buf, bufSize, serialNumberLen);
+    return SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_SerialNum, buf, bufSize, serialNumberLen);
 }
 
 CHIP_ERROR EFR32DeviceDataProvider::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day)
@@ -294,7 +294,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetManufacturingDate(uint16_t & year, uint8_
     size_t dateLen;
     char * parseEnd;
 
-    err = SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_ManufacturingDate, reinterpret_cast<uint8_t *>(dateStr),
+    err = SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_ManufacturingDate, reinterpret_cast<uint8_t *>(dateStr),
                                            sizeof(dateStr), dateLen);
     SuccessOrExit(err);
 

--- a/examples/platform/silabs/SiWx917/SiWx917DeviceDataProvider.h
+++ b/examples/platform/silabs/SiWx917/SiWx917DeviceDataProvider.h
@@ -29,11 +29,11 @@ namespace EFR32 {
  */
 
 class EFR32DeviceDataProvider : public CommissionableDataProvider,
-                                public Internal::GenericDeviceInstanceInfoProvider<Internal::SILABSConfig>
+                                public Internal::GenericDeviceInstanceInfoProvider<Internal::SilabsConfig>
 {
 public:
     EFR32DeviceDataProvider() :
-        CommissionableDataProvider(), Internal::GenericDeviceInstanceInfoProvider<Internal::SILABSConfig>(
+        CommissionableDataProvider(), Internal::GenericDeviceInstanceInfoProvider<Internal::SilabsConfig>(
                                           ConfigurationManagerImpl::GetDefaultInstance())
     {}
 

--- a/examples/platform/silabs/SiWx917/matter_config.cpp
+++ b/examples/platform/silabs/SiWx917/matter_config.cpp
@@ -171,5 +171,5 @@ extern "C" void vApplicationIdleHook(void)
     // FreeRTOS Idle callback
 
     // Check CHIP Config nvm3 and repack flash if necessary.
-    Internal::SILABSConfig::RepackNvm3Flash();
+    Internal::SilabsConfig::RepackNvm3Flash();
 }

--- a/examples/platform/silabs/efr32/EFR32DeviceDataProvider.cpp
+++ b/examples/platform/silabs/efr32/EFR32DeviceDataProvider.cpp
@@ -34,7 +34,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetSetupDiscriminator(uint16_t & setupDiscri
     CHIP_ERROR err;
     uint32_t setupDiscriminator32;
 
-    err = SILABSConfig::ReadConfigValue(SILABSConfig::kConfigKey_SetupDiscriminator, setupDiscriminator32);
+    err = SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_SetupDiscriminator, setupDiscriminator32);
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR) && CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
@@ -50,7 +50,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetSetupDiscriminator(uint16_t & setupDiscri
 
 CHIP_ERROR EFR32DeviceDataProvider::GetSpake2pIterationCount(uint32_t & iterationCount)
 {
-    CHIP_ERROR err = SILABSConfig::ReadConfigValue(SILABSConfig::kConfigKey_Spake2pIterationCount, iterationCount);
+    CHIP_ERROR err = SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_Spake2pIterationCount, iterationCount);
 
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_ITERATION_COUNT) && CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_ITERATION_COUNT
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -70,7 +70,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetSpake2pSalt(MutableByteSpan & saltBuf)
     char saltB64[kSpake2pSalt_MaxBase64Len] = { 0 };
     size_t saltB64Len                       = 0;
 
-    err = SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_Spake2pSalt, saltB64, sizeof(saltB64), saltB64Len);
+    err = SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_Spake2pSalt, saltB64, sizeof(saltB64), saltB64Len);
 
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_SALT)
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -103,7 +103,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetSpake2pVerifier(MutableByteSpan & verifie
     char verifierB64[kSpake2pSerializedVerifier_MaxBase64Len] = { 0 };
     size_t verifierB64Len                                     = 0;
 
-    err = SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_Spake2pVerifier, verifierB64, sizeof(verifierB64),
+    err = SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_Spake2pVerifier, verifierB64, sizeof(verifierB64),
                                            verifierB64Len);
 
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_VERIFIER)
@@ -133,7 +133,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetSetupPayload(MutableCharSpan & payloadBuf
     uint8_t payloadBitSet[kTotalPayloadDataSizeInBytes] = { 0 };
     size_t bitSetLen                                    = 0;
 
-    err = SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_SetupPayloadBitSet, payloadBitSet, kTotalPayloadDataSizeInBytes,
+    err = SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_SetupPayloadBitSet, payloadBitSet, kTotalPayloadDataSizeInBytes,
                                            bitSetLen);
 
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE) && CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
@@ -170,7 +170,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetSetupPayload(MutableCharSpan & payloadBuf
 CHIP_ERROR EFR32DeviceDataProvider::GetVendorName(char * buf, size_t bufSize)
 {
     size_t vendorNameLen = 0; // without counting null-terminator
-    return SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_VendorName, buf, bufSize, vendorNameLen);
+    return SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_VendorName, buf, bufSize, vendorNameLen);
 }
 
 CHIP_ERROR EFR32DeviceDataProvider::GetVendorId(uint16_t & vendorId)
@@ -178,7 +178,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetVendorId(uint16_t & vendorId)
     ChipError err       = CHIP_NO_ERROR;
     uint32_t vendorId32 = 0;
 
-    err = SILABSConfig::ReadConfigValue(SILABSConfig::kConfigKey_VendorId, vendorId32);
+    err = SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_VendorId, vendorId32);
 
 #if defined(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID) && CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -196,7 +196,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetVendorId(uint16_t & vendorId)
 CHIP_ERROR EFR32DeviceDataProvider::GetProductName(char * buf, size_t bufSize)
 {
     size_t productNameLen = 0; // without counting null-terminator
-    return SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_ProductName, buf, bufSize, productNameLen);
+    return SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_ProductName, buf, bufSize, productNameLen);
 }
 
 CHIP_ERROR EFR32DeviceDataProvider::GetProductId(uint16_t & productId)
@@ -204,7 +204,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetProductId(uint16_t & productId)
     ChipError err        = CHIP_NO_ERROR;
     uint32_t productId32 = 0;
 
-    err = SILABSConfig::ReadConfigValue(SILABSConfig::kConfigKey_ProductId, productId32);
+    err = SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_ProductId, productId32);
 
 #if defined(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID) && CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -223,7 +223,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetHardwareVersionString(char * buf, size_t 
 {
     size_t hardwareVersionStringLen = 0; // without counting null-terminator
     CHIP_ERROR err =
-        SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_HardwareVersionString, buf, bufSize, hardwareVersionStringLen);
+        SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_HardwareVersionString, buf, bufSize, hardwareVersionStringLen);
 #if defined(CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING)
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
@@ -239,7 +239,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetHardwareVersion(uint16_t & hardwareVersio
     CHIP_ERROR err;
     uint32_t hardwareVersion32;
 
-    err = SILABSConfig::ReadConfigValue(SILABSConfig::kConfigKey_HardwareVersion, hardwareVersion32);
+    err = SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_HardwareVersion, hardwareVersion32);
 #if defined(CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION)
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
@@ -261,7 +261,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetRotatingDeviceIdUniqueId(MutableByteSpan 
 
     size_t uniqueIdLen = 0;
     err =
-        SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_UniqueId, uniqueIdSpan.data(), uniqueIdSpan.size(), uniqueIdLen);
+        SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_UniqueId, uniqueIdSpan.data(), uniqueIdSpan.size(), uniqueIdLen);
 #ifdef CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
@@ -283,7 +283,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetRotatingDeviceIdUniqueId(MutableByteSpan 
 CHIP_ERROR EFR32DeviceDataProvider::GetSerialNumber(char * buf, size_t bufSize)
 {
     size_t serialNumberLen = 0; // without counting null-terminator
-    return SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_SerialNum, buf, bufSize, serialNumberLen);
+    return SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_SerialNum, buf, bufSize, serialNumberLen);
 }
 
 CHIP_ERROR EFR32DeviceDataProvider::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day)
@@ -294,7 +294,7 @@ CHIP_ERROR EFR32DeviceDataProvider::GetManufacturingDate(uint16_t & year, uint8_
     size_t dateLen;
     char * parseEnd;
 
-    err = SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_ManufacturingDate, reinterpret_cast<uint8_t *>(dateStr),
+    err = SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_ManufacturingDate, reinterpret_cast<uint8_t *>(dateStr),
                                            sizeof(dateStr), dateLen);
     SuccessOrExit(err);
 
@@ -326,19 +326,19 @@ exit:
 CHIP_ERROR EFR32DeviceDataProvider::GetPartNumber(char * buf, size_t bufSize)
 {
     size_t partNumberLen = 0; // without counting null-terminator
-    return SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_PartNumber, buf, bufSize, partNumberLen);
+    return SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_PartNumber, buf, bufSize, partNumberLen);
 }
 
 CHIP_ERROR EFR32DeviceDataProvider::GetProductURL(char * buf, size_t bufSize)
 {
     size_t productUrlLen = 0; // without counting null-terminator
-    return SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_ProductURL, buf, bufSize, productUrlLen);
+    return SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_ProductURL, buf, bufSize, productUrlLen);
 }
 
 CHIP_ERROR EFR32DeviceDataProvider::GetProductLabel(char * buf, size_t bufSize)
 {
     size_t productLabelLen = 0; // without counting null-terminator
-    return SILABSConfig::ReadConfigValueStr(SILABSConfig::KConfigKey_ProductLabel, buf, bufSize, productLabelLen);
+    return SilabsConfig::ReadConfigValueStr(SilabsConfig::KConfigKey_ProductLabel, buf, bufSize, productLabelLen);
 }
 
 EFR32DeviceDataProvider & EFR32DeviceDataProvider::GetDeviceDataProvider()

--- a/examples/platform/silabs/efr32/EFR32DeviceDataProvider.h
+++ b/examples/platform/silabs/efr32/EFR32DeviceDataProvider.h
@@ -29,11 +29,11 @@ namespace EFR32 {
  */
 
 class EFR32DeviceDataProvider : public CommissionableDataProvider,
-                                public Internal::GenericDeviceInstanceInfoProvider<Internal::SILABSConfig>
+                                public Internal::GenericDeviceInstanceInfoProvider<Internal::SilabsConfig>
 {
 public:
     EFR32DeviceDataProvider() :
-        CommissionableDataProvider(), Internal::GenericDeviceInstanceInfoProvider<Internal::SILABSConfig>(
+        CommissionableDataProvider(), Internal::GenericDeviceInstanceInfoProvider<Internal::SilabsConfig>(
                                           ConfigurationManagerImpl::GetDefaultInstance())
     {}
 

--- a/examples/platform/silabs/efr32/matter_config.cpp
+++ b/examples/platform/silabs/efr32/matter_config.cpp
@@ -150,8 +150,6 @@ CHIP_ERROR EFR32MatterConfig::InitMatter(const char * appName)
 #ifdef HEAP_MONITORING
     MemMonitoring::startHeapMonitoring();
 #endif
-    SetDeviceInstanceInfoProvider(&EFR32::EFR32DeviceDataProvider::GetDeviceDataProvider());
-    SetCommissionableDataProvider(&EFR32::EFR32DeviceDataProvider::GetDeviceDataProvider());
 
     //==============================================
     // Init Matter Stack
@@ -160,6 +158,9 @@ CHIP_ERROR EFR32MatterConfig::InitMatter(const char * appName)
     // Init Chip memory management before the stack
     ReturnErrorOnFailure(chip::Platform::MemoryInit());
     ReturnErrorOnFailure(PlatformMgr().InitChipStack());
+
+    SetDeviceInstanceInfoProvider(&EFR32::EFR32DeviceDataProvider::GetDeviceDataProvider());
+    SetCommissionableDataProvider(&EFR32::EFR32DeviceDataProvider::GetDeviceDataProvider());
 
     chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(appName);
 

--- a/examples/platform/silabs/efr32/matter_config.cpp
+++ b/examples/platform/silabs/efr32/matter_config.cpp
@@ -251,5 +251,5 @@ extern "C" void vApplicationIdleHook(void)
     // FreeRTOS Idle callback
 
     // Check CHIP Config nvm3 and repack flash if necessary.
-    Internal::SILABSConfig::RepackNvm3Flash();
+    Internal::SilabsConfig::RepackNvm3Flash();
 }

--- a/src/platform/silabs/ConfigurationManagerImpl.h
+++ b/src/platform/silabs/ConfigurationManagerImpl.h
@@ -34,7 +34,7 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the EFR32 platform.
  */
-class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::SILABSConfig>
+class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::SilabsConfig>
 {
 public:
     // This returns an instance of this class.

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -54,11 +54,11 @@ CHIP_ERROR SlWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChangeC
     err                          = CHIP_NO_ERROR;
 #else
     // If reading fails, wifi is not provisioned, no need to go further.
-    err = SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_WiFiSSID, mSavedNetwork.ssid, sizeof(mSavedNetwork.ssid),
+    err = SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_WiFiSSID, mSavedNetwork.ssid, sizeof(mSavedNetwork.ssid),
                                            ssidLen);
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_NO_ERROR);
 
-    err = SILABSConfig::ReadConfigValueStr(SILABSConfig::kConfigKey_WiFiPSK, mSavedNetwork.credentials,
+    err = SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_WiFiPSK, mSavedNetwork.credentials,
                                            sizeof(mSavedNetwork.credentials), credentialsLen);
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_NO_ERROR);
 
@@ -74,9 +74,9 @@ CHIP_ERROR SlWiFiDriver::CommitConfiguration()
 {
     uint8_t securityType = WFX_SEC_WPA2;
 
-    ReturnErrorOnFailure(SILABSConfig::WriteConfigValueStr(SILABSConfig::kConfigKey_WiFiSSID, mStagingNetwork.ssid));
-    ReturnErrorOnFailure(SILABSConfig::WriteConfigValueStr(SILABSConfig::kConfigKey_WiFiPSK, mStagingNetwork.credentials));
-    ReturnErrorOnFailure(SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_WiFiSEC, &securityType, sizeof(securityType)));
+    ReturnErrorOnFailure(SilabsConfig::WriteConfigValueStr(SilabsConfig::kConfigKey_WiFiSSID, mStagingNetwork.ssid));
+    ReturnErrorOnFailure(SilabsConfig::WriteConfigValueStr(SilabsConfig::kConfigKey_WiFiPSK, mStagingNetwork.credentials));
+    ReturnErrorOnFailure(SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_WiFiSEC, &securityType, sizeof(securityType)));
 
     mSavedNetwork = mStagingNetwork;
     return CHIP_NO_ERROR;

--- a/src/platform/silabs/SiWx917/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/SiWx917/ConfigurationManagerImpl.cpp
@@ -52,7 +52,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     CHIP_ERROR err;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<SILABSConfig>::Init();
+    err = Internal::GenericConfigurationManagerImpl<SilabsConfig>::Init();
     SuccessOrExit(err);
 
     // TODO: Initialize the global GroupKeyStore object here (#1626)
@@ -80,19 +80,19 @@ void ConfigurationManagerImpl::InitiateFactoryReset()
 
 CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
 {
-    return SILABSConfig::ReadConfigValue(SILABSConfig::kConfigKey_BootCount, rebootCount);
+    return SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_BootCount, rebootCount);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::IncreaseBootCount(void)
 {
     uint32_t bootCount = 0;
 
-    if (SILABSConfig::ConfigValueExists(SILABSConfig::kConfigKey_BootCount))
+    if (SilabsConfig::ConfigValueExists(SilabsConfig::kConfigKey_BootCount))
     {
         GetRebootCount(bootCount);
     }
 
-    return SILABSConfig::WriteConfigValue(SILABSConfig::kConfigKey_BootCount, bootCount + 1);
+    return SilabsConfig::WriteConfigValue(SilabsConfig::kConfigKey_BootCount, bootCount + 1);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetBootReason(uint32_t & bootReason)
@@ -154,18 +154,18 @@ CHIP_ERROR ConfigurationManagerImpl::GetBootReason(uint32_t & bootReason)
 
 CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
 {
-    if (!SILABSConfig::ConfigValueExists(SILABSConfig::kConfigKey_TotalOperationalHours))
+    if (!SilabsConfig::ConfigValueExists(SilabsConfig::kConfigKey_TotalOperationalHours))
     {
         totalOperationalHours = 0;
         return CHIP_NO_ERROR;
     }
 
-    return SILABSConfig::ReadConfigValue(SILABSConfig::kConfigKey_TotalOperationalHours, totalOperationalHours);
+    return SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_TotalOperationalHours, totalOperationalHours);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOperationalHours)
 {
-    return SILABSConfig::WriteConfigValue(SILABSConfig::kConfigKey_TotalOperationalHours, totalOperationalHours);
+    return SilabsConfig::WriteConfigValue(SilabsConfig::kConfigKey_TotalOperationalHours, totalOperationalHours);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,
@@ -175,7 +175,7 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
     // (where persistedStorageKey represents an index to the counter).
     CHIP_ERROR err;
 
-    err = SILABSConfig::ReadConfigValueCounter(persistedStorageKey, value);
+    err = SilabsConfig::ReadConfigValueCounter(persistedStorageKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
@@ -193,7 +193,7 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform
     // (where persistedStorageKey represents an index to the counter).
     CHIP_ERROR err;
 
-    err = SILABSConfig::WriteConfigValueCounter(persistedStorageKey, value);
+    err = SilabsConfig::WriteConfigValueCounter(persistedStorageKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
@@ -206,62 +206,62 @@ exit:
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
-    return SILABSConfig::ReadConfigValue(key, val);
+    return SilabsConfig::ReadConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
-    return SILABSConfig::ReadConfigValue(key, val);
+    return SilabsConfig::ReadConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
-    return SILABSConfig::ReadConfigValue(key, val);
+    return SilabsConfig::ReadConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
-    return SILABSConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
+    return SilabsConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
-    return SILABSConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
+    return SilabsConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
-    return SILABSConfig::WriteConfigValue(key, val);
+    return SilabsConfig::WriteConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
-    return SILABSConfig::WriteConfigValue(key, val);
+    return SilabsConfig::WriteConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
-    return SILABSConfig::WriteConfigValue(key, val);
+    return SilabsConfig::WriteConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
-    return SILABSConfig::WriteConfigValueStr(key, str);
+    return SilabsConfig::WriteConfigValueStr(key, str);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
-    return SILABSConfig::WriteConfigValueStr(key, str, strLen);
+    return SilabsConfig::WriteConfigValueStr(key, str, strLen);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
-    return SILABSConfig::WriteConfigValueBin(key, data, dataLen);
+    return SilabsConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
 void ConfigurationManagerImpl::RunConfigUnitTest(void)
 {
-    SILABSConfig::RunConfigUnitTest();
+    SilabsConfig::RunConfigUnitTest();
 }
 
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
@@ -270,7 +270,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
-    err = SILABSConfig::FactoryResetConfig();
+    err = SilabsConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", chip::ErrorStr(err));

--- a/src/platform/silabs/SiWx917/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/silabs/SiWx917/KeyValueStoreManagerImpl.cpp
@@ -32,8 +32,8 @@
 using namespace ::chip;
 using namespace ::chip::DeviceLayer::Internal;
 
-#define CONVERT_KEYMAP_INDEX_TO_NVM3KEY(index) (SILABSConfig::kConfigKey_KvsFirstKeySlot + index)
-#define CONVERT_NVM3KEY_TO_KEYMAP_INDEX(nvm3Key) (nvm3Key - SILABSConfig::kConfigKey_KvsFirstKeySlot)
+#define CONVERT_KEYMAP_INDEX_TO_NVM3KEY(index) (SilabsConfig::kConfigKey_KvsFirstKeySlot + index)
+#define CONVERT_NVM3KEY_TO_KEYMAP_INDEX(nvm3Key) (nvm3Key - SilabsConfig::kConfigKey_KvsFirstKeySlot)
 
 namespace chip {
 namespace DeviceLayer {
@@ -45,12 +45,12 @@ char mKvsStoredKeyString[KeyValueStoreManagerImpl::kMaxEntries][PersistentStorag
 CHIP_ERROR KeyValueStoreManagerImpl::Init(void)
 {
     CHIP_ERROR err;
-    err = SILABSConfig::Init();
+    err = SilabsConfig::Init();
     SuccessOrExit(err);
 
     memset(mKvsStoredKeyString, 0, sizeof(mKvsStoredKeyString));
     size_t outLen;
-    err = SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_KvsStringKeyMap,
+    err = SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_KvsStringKeyMap,
                                            reinterpret_cast<uint8_t *>(mKvsStoredKeyString), sizeof(mKvsStoredKeyString), outLen);
 
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND) // Initial boot
@@ -64,7 +64,7 @@ exit:
 
 bool KeyValueStoreManagerImpl::IsValidKvsNvm3Key(uint32_t nvm3Key) const
 {
-    return ((SILABSConfig::kConfigKey_KvsFirstKeySlot <= nvm3Key) && (nvm3Key <= SILABSConfig::kConfigKey_KvsLastKeySlot));
+    return ((SilabsConfig::kConfigKey_KvsFirstKeySlot <= nvm3Key) && (nvm3Key <= SilabsConfig::kConfigKey_KvsLastKeySlot));
 }
 
 CHIP_ERROR KeyValueStoreManagerImpl::MapKvsKeyToNvm3(const char * key, uint32_t & nvm3Key, bool isSlotNeeded) const
@@ -113,7 +113,7 @@ void KeyValueStoreManagerImpl::ForceKeyMapSave()
 
 void KeyValueStoreManagerImpl::OnScheduledKeyMapSave(System::Layer * systemLayer, void * appState)
 {
-    SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_KvsStringKeyMap,
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_KvsStringKeyMap,
                                       reinterpret_cast<const uint8_t *>(mKvsStoredKeyString), sizeof(mKvsStoredKeyString));
 }
 
@@ -138,7 +138,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     VerifyOrReturnError(err == CHIP_NO_ERROR, err);
 
     size_t outLen;
-    err = SILABSConfig::ReadConfigValueBin(nvm3Key, reinterpret_cast<uint8_t *>(value), value_size, outLen, offset_bytes);
+    err = SilabsConfig::ReadConfigValueBin(nvm3Key, reinterpret_cast<uint8_t *>(value), value_size, outLen, offset_bytes);
     if (read_bytes_size)
     {
         *read_bytes_size = outLen;
@@ -160,10 +160,10 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, 
     CHIP_ERROR err = MapKvsKeyToNvm3(key, nvm3Key, /* isSlotNeeded */ true);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err);
 
-    err = SILABSConfig::WriteConfigValueBin(nvm3Key, reinterpret_cast<const uint8_t *>(value), value_size);
+    err = SilabsConfig::WriteConfigValueBin(nvm3Key, reinterpret_cast<const uint8_t *>(value), value_size);
     if (err == CHIP_NO_ERROR)
     {
-        uint32_t keyIndex = nvm3Key - SILABSConfig::kConfigKey_KvsFirstKeySlot;
+        uint32_t keyIndex = nvm3Key - SilabsConfig::kConfigKey_KvsFirstKeySlot;
         Platform::CopyString(mKvsStoredKeyString[keyIndex], key);
         ScheduleKeyMapSave();
     }
@@ -179,7 +179,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)
     CHIP_ERROR err = MapKvsKeyToNvm3(key, nvm3Key);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err);
 
-    err = SILABSConfig::ClearConfigValue(nvm3Key);
+    err = SilabsConfig::ClearConfigValue(nvm3Key);
     if (err == CHIP_NO_ERROR)
     {
         uint32_t keyIndex = CONVERT_NVM3KEY_TO_KEYMAP_INDEX(nvm3Key);
@@ -194,9 +194,9 @@ CHIP_ERROR KeyValueStoreManagerImpl::ErasePartition(void)
 {
     // Iterate over all the Matter Kvs nvm3 records and delete each one...
     CHIP_ERROR err = CHIP_NO_ERROR;
-    for (uint32_t nvm3Key = SILABSConfig::kMinConfigKey_MatterKvs; nvm3Key < SILABSConfig::kMaxConfigKey_MatterKvs; nvm3Key++)
+    for (uint32_t nvm3Key = SilabsConfig::kMinConfigKey_MatterKvs; nvm3Key < SilabsConfig::kMaxConfigKey_MatterKvs; nvm3Key++)
     {
-        err = SILABSConfig::ClearConfigValue(nvm3Key);
+        err = SilabsConfig::ClearConfigValue(nvm3Key);
 
         if (err != CHIP_NO_ERROR)
         {

--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -61,7 +61,7 @@ namespace Internal {
 // The NVM3 default section is placed at end of Flash minus 1 page byt the linker file
 // See examples/platform/efr32/ldscripts/efr32mgXX.ld
 
-CHIP_ERROR SILABSConfig::Init()
+CHIP_ERROR SilabsConfig::Init()
 {
     nvm3_Sem = xSemaphoreCreateBinaryStatic(&nvm3_SemStruct);
 
@@ -73,13 +73,13 @@ CHIP_ERROR SILABSConfig::Init()
     return MapNvm3Error(nvm3_open(nvm3_defaultHandle, nvm3_defaultInit));
 }
 
-void SILABSConfig::DeInit()
+void SilabsConfig::DeInit()
 {
     vSemaphoreDelete(nvm3_Sem);
     nvm3_close(nvm3_defaultHandle);
 }
 
-CHIP_ERROR SILABSConfig::ReadConfigValue(Key key, bool & val)
+CHIP_ERROR SilabsConfig::ReadConfigValue(Key key, bool & val)
 {
     CHIP_ERROR err;
     uint32_t objectType;
@@ -101,7 +101,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SILABSConfig::ReadConfigValue(Key key, uint32_t & val)
+CHIP_ERROR SilabsConfig::ReadConfigValue(Key key, uint32_t & val)
 {
     CHIP_ERROR err;
     uint32_t objectType;
@@ -123,7 +123,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SILABSConfig::ReadConfigValue(Key key, uint64_t & val)
+CHIP_ERROR SilabsConfig::ReadConfigValue(Key key, uint64_t & val)
 {
     CHIP_ERROR err;
     uint32_t objectType;
@@ -145,7 +145,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SILABSConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR SilabsConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     CHIP_ERROR err;
     uint32_t objectType;
@@ -194,7 +194,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SILABSConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR SilabsConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     CHIP_ERROR err;
     uint32_t objectType;
@@ -224,7 +224,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SILABSConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen, size_t offset)
+CHIP_ERROR SilabsConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen, size_t offset)
 {
     CHIP_ERROR err;
     uint32_t objectType;
@@ -261,7 +261,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SILABSConfig::ReadConfigValueCounter(uint8_t counterIdx, uint32_t & val)
+CHIP_ERROR SilabsConfig::ReadConfigValueCounter(uint8_t counterIdx, uint32_t & val)
 {
     CHIP_ERROR err;
     uint32_t tmpVal = 0;
@@ -278,7 +278,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SILABSConfig::WriteConfigValue(Key key, bool val)
+CHIP_ERROR SilabsConfig::WriteConfigValue(Key key, bool val)
 {
     CHIP_ERROR err;
 
@@ -291,7 +291,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SILABSConfig::WriteConfigValue(Key key, uint32_t val)
+CHIP_ERROR SilabsConfig::WriteConfigValue(Key key, uint32_t val)
 {
     CHIP_ERROR err;
 
@@ -304,7 +304,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SILABSConfig::WriteConfigValue(Key key, uint64_t val)
+CHIP_ERROR SilabsConfig::WriteConfigValue(Key key, uint64_t val)
 {
     CHIP_ERROR err;
 
@@ -317,12 +317,12 @@ exit:
     return err;
 }
 
-CHIP_ERROR SILABSConfig::WriteConfigValueStr(Key key, const char * str)
+CHIP_ERROR SilabsConfig::WriteConfigValueStr(Key key, const char * str)
 {
     return WriteConfigValueStr(key, str, (str != NULL) ? strlen(str) : 0);
 }
 
-CHIP_ERROR SILABSConfig::WriteConfigValueStr(Key key, const char * str, size_t strLen)
+CHIP_ERROR SilabsConfig::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
 
@@ -340,7 +340,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SILABSConfig::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR SilabsConfig::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
     CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
 
@@ -358,7 +358,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SILABSConfig::WriteConfigValueCounter(uint8_t counterIdx, uint32_t val)
+CHIP_ERROR SilabsConfig::WriteConfigValueCounter(uint8_t counterIdx, uint32_t val)
 {
     CHIP_ERROR err;
     Key key = kMinConfigKey_MatterCounter + counterIdx;
@@ -372,7 +372,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SILABSConfig::ClearConfigValue(Key key)
+CHIP_ERROR SilabsConfig::ClearConfigValue(Key key)
 {
     CHIP_ERROR err;
 
@@ -384,7 +384,7 @@ exit:
     return err;
 }
 
-bool SILABSConfig::ConfigValueExists(Key key)
+bool SilabsConfig::ConfigValueExists(Key key)
 {
     uint32_t objectType;
     size_t dataLen;
@@ -394,7 +394,7 @@ bool SILABSConfig::ConfigValueExists(Key key)
     return (err == CHIP_NO_ERROR);
 }
 
-bool SILABSConfig::ConfigValueExists(Key key, size_t & dataLen)
+bool SilabsConfig::ConfigValueExists(Key key, size_t & dataLen)
 {
     uint32_t objectType;
     size_t dLen;
@@ -410,7 +410,7 @@ bool SILABSConfig::ConfigValueExists(Key key, size_t & dataLen)
     return (err == CHIP_NO_ERROR);
 }
 
-CHIP_ERROR SILABSConfig::FactoryResetConfig(void)
+CHIP_ERROR SilabsConfig::FactoryResetConfig(void)
 {
     // Deletes all nvm3 'Config' type objects.
     // Note- 'Factory' and 'Counter' type nvm3 objects are NOT deleted.
@@ -438,7 +438,7 @@ CHIP_ERROR SILABSConfig::FactoryResetConfig(void)
     return err;
 }
 
-CHIP_ERROR SILABSConfig::MapNvm3Error(Ecode_t nvm3Res)
+CHIP_ERROR SilabsConfig::MapNvm3Error(Ecode_t nvm3Res)
 {
     CHIP_ERROR err;
 
@@ -458,7 +458,7 @@ CHIP_ERROR SILABSConfig::MapNvm3Error(Ecode_t nvm3Res)
     return err;
 }
 
-CHIP_ERROR SILABSConfig::ForEachRecord(Key firstNvm3Key, Key lastNvm3Key, bool addNewRecord, ForEachRecordFunct funct)
+CHIP_ERROR SilabsConfig::ForEachRecord(Key firstNvm3Key, Key lastNvm3Key, bool addNewRecord, ForEachRecordFunct funct)
 {
     // Iterates through the specified range of nvm3 object key ids.
     // Invokes the callers CB function when appropriate.
@@ -503,7 +503,7 @@ exit:;
     return err;
 }
 
-bool SILABSConfig::ValidConfigKey(Key key)
+bool SilabsConfig::ValidConfigKey(Key key)
 {
     // Returns true if the key is in the Matter nvm3 reserved key range.
     // or if the key is in the User Domain key range
@@ -518,13 +518,13 @@ bool SILABSConfig::ValidConfigKey(Key key)
     return false;
 }
 
-void SILABSConfig::RunConfigUnitTest()
+void SilabsConfig::RunConfigUnitTest()
 {
     // Run common unit test.
-    ::chip::DeviceLayer::Internal::RunConfigUnitTest<SILABSConfig>();
+    ::chip::DeviceLayer::Internal::RunConfigUnitTest<SilabsConfig>();
 }
 
-void SILABSConfig::RepackNvm3Flash(void)
+void SilabsConfig::RepackNvm3Flash(void)
 {
     // Repack nvm3 flash if nvm3 space < headroom threshold.
     // Note- checking periodically during idle periods should prevent

--- a/src/platform/silabs/SilabsConfig.h
+++ b/src/platform/silabs/SilabsConfig.h
@@ -47,7 +47,7 @@ namespace Internal {
 
 /**
  *
- * This implementation uses the Silicon Labs SILABS NVM3 flash data storage library
+ * This implementation uses the Silicon Labs Silabs NVM3 flash data storage library
  * as the underlying storage layer.
  *
  * NOTE: This class is designed to be mixed-in to the concrete subclass of the
@@ -69,12 +69,12 @@ constexpr uint32_t kUserNvm3KeyDomainHiLimit = 0x00FFFFU; // User Domain NVM3 Ke
 constexpr uint32_t kMatterNvm3KeyDomain      = 0x080000U;
 constexpr uint32_t kMatterNvm3KeyLoLimit     = 0x087200U; // Do not modify without Silabs GSDK team approval
 constexpr uint32_t kMatterNvm3KeyHiLimit     = 0x087FFFU; // Do not modify without Silabs GSDK team approval
-constexpr inline uint32_t SILABSConfigKey(uint8_t keyBaseOffset, uint8_t id)
+constexpr inline uint32_t SilabsConfigKey(uint8_t keyBaseOffset, uint8_t id)
 {
     return kMatterNvm3KeyDomain | static_cast<uint32_t>(keyBaseOffset) << 8 | id;
 }
 
-class SILABSConfig
+class SilabsConfig
 {
 public:
     // Definitions for Silicon Labs EFR32 NVM3 driver:-
@@ -94,75 +94,75 @@ public:
 
     // Key definitions for well-known configuration values.
     // Factory config keys
-    static constexpr Key kConfigKey_SerialNum             = SILABSConfigKey(kMatterFactory_KeyBase, 0x00);
-    static constexpr Key kConfigKey_MfrDeviceId           = SILABSConfigKey(kMatterFactory_KeyBase, 0x01);
-    static constexpr Key kConfigKey_MfrDeviceCert         = SILABSConfigKey(kMatterFactory_KeyBase, 0x02);
-    static constexpr Key kConfigKey_MfrDevicePrivateKey   = SILABSConfigKey(kMatterFactory_KeyBase, 0x03);
-    static constexpr Key kConfigKey_ManufacturingDate     = SILABSConfigKey(kMatterFactory_KeyBase, 0x04);
-    static constexpr Key kConfigKey_SetupPayloadBitSet    = SILABSConfigKey(kMatterFactory_KeyBase, 0x05);
-    static constexpr Key kConfigKey_MfrDeviceICACerts     = SILABSConfigKey(kMatterFactory_KeyBase, 0x06);
-    static constexpr Key kConfigKey_SetupDiscriminator    = SILABSConfigKey(kMatterFactory_KeyBase, 0x07);
-    static constexpr Key kConfigKey_Spake2pIterationCount = SILABSConfigKey(kMatterFactory_KeyBase, 0x08);
-    static constexpr Key kConfigKey_Spake2pSalt           = SILABSConfigKey(kMatterFactory_KeyBase, 0x09);
-    static constexpr Key kConfigKey_Spake2pVerifier       = SILABSConfigKey(kMatterFactory_KeyBase, 0x0A);
-    static constexpr Key kConfigKey_ProductId             = SILABSConfigKey(kMatterFactory_KeyBase, 0x0B);
-    static constexpr Key kConfigKey_VendorId              = SILABSConfigKey(kMatterFactory_KeyBase, 0x0C);
-    static constexpr Key kConfigKey_VendorName            = SILABSConfigKey(kMatterFactory_KeyBase, 0x0D);
-    static constexpr Key kConfigKey_ProductName           = SILABSConfigKey(kMatterFactory_KeyBase, 0x0E);
-    static constexpr Key kConfigKey_HardwareVersionString = SILABSConfigKey(kMatterFactory_KeyBase, 0x0F);
-    static constexpr Key KConfigKey_ProductLabel          = SILABSConfigKey(kMatterFactory_KeyBase, 0x10);
-    static constexpr Key kConfigKey_ProductURL            = SILABSConfigKey(kMatterFactory_KeyBase, 0x11);
-    static constexpr Key kConfigKey_PartNumber            = SILABSConfigKey(kMatterFactory_KeyBase, 0x12);
-    static constexpr Key kConfigKey_UniqueId              = SILABSConfigKey(kMatterFactory_KeyBase, 0x1F);
+    static constexpr Key kConfigKey_SerialNum             = SilabsConfigKey(kMatterFactory_KeyBase, 0x00);
+    static constexpr Key kConfigKey_MfrDeviceId           = SilabsConfigKey(kMatterFactory_KeyBase, 0x01);
+    static constexpr Key kConfigKey_MfrDeviceCert         = SilabsConfigKey(kMatterFactory_KeyBase, 0x02);
+    static constexpr Key kConfigKey_MfrDevicePrivateKey   = SilabsConfigKey(kMatterFactory_KeyBase, 0x03);
+    static constexpr Key kConfigKey_ManufacturingDate     = SilabsConfigKey(kMatterFactory_KeyBase, 0x04);
+    static constexpr Key kConfigKey_SetupPayloadBitSet    = SilabsConfigKey(kMatterFactory_KeyBase, 0x05);
+    static constexpr Key kConfigKey_MfrDeviceICACerts     = SilabsConfigKey(kMatterFactory_KeyBase, 0x06);
+    static constexpr Key kConfigKey_SetupDiscriminator    = SilabsConfigKey(kMatterFactory_KeyBase, 0x07);
+    static constexpr Key kConfigKey_Spake2pIterationCount = SilabsConfigKey(kMatterFactory_KeyBase, 0x08);
+    static constexpr Key kConfigKey_Spake2pSalt           = SilabsConfigKey(kMatterFactory_KeyBase, 0x09);
+    static constexpr Key kConfigKey_Spake2pVerifier       = SilabsConfigKey(kMatterFactory_KeyBase, 0x0A);
+    static constexpr Key kConfigKey_ProductId             = SilabsConfigKey(kMatterFactory_KeyBase, 0x0B);
+    static constexpr Key kConfigKey_VendorId              = SilabsConfigKey(kMatterFactory_KeyBase, 0x0C);
+    static constexpr Key kConfigKey_VendorName            = SilabsConfigKey(kMatterFactory_KeyBase, 0x0D);
+    static constexpr Key kConfigKey_ProductName           = SilabsConfigKey(kMatterFactory_KeyBase, 0x0E);
+    static constexpr Key kConfigKey_HardwareVersionString = SilabsConfigKey(kMatterFactory_KeyBase, 0x0F);
+    static constexpr Key KConfigKey_ProductLabel          = SilabsConfigKey(kMatterFactory_KeyBase, 0x10);
+    static constexpr Key kConfigKey_ProductURL            = SilabsConfigKey(kMatterFactory_KeyBase, 0x11);
+    static constexpr Key kConfigKey_PartNumber            = SilabsConfigKey(kMatterFactory_KeyBase, 0x12);
+    static constexpr Key kConfigKey_UniqueId              = SilabsConfigKey(kMatterFactory_KeyBase, 0x1F);
     // Matter Config Keys
-    static constexpr Key kConfigKey_ServiceConfig      = SILABSConfigKey(kMatterConfig_KeyBase, 0x01);
-    static constexpr Key kConfigKey_PairedAccountId    = SILABSConfigKey(kMatterConfig_KeyBase, 0x02);
-    static constexpr Key kConfigKey_ServiceId          = SILABSConfigKey(kMatterConfig_KeyBase, 0x03);
-    static constexpr Key kConfigKey_LastUsedEpochKeyId = SILABSConfigKey(kMatterConfig_KeyBase, 0x05);
-    static constexpr Key kConfigKey_FailSafeArmed      = SILABSConfigKey(kMatterConfig_KeyBase, 0x06);
-    static constexpr Key kConfigKey_GroupKey           = SILABSConfigKey(kMatterConfig_KeyBase, 0x07);
-    static constexpr Key kConfigKey_HardwareVersion    = SILABSConfigKey(kMatterConfig_KeyBase, 0x08);
-    static constexpr Key kConfigKey_RegulatoryLocation = SILABSConfigKey(kMatterConfig_KeyBase, 0x09);
-    static constexpr Key kConfigKey_CountryCode        = SILABSConfigKey(kMatterConfig_KeyBase, 0x0A);
-    static constexpr Key kConfigKey_WiFiSSID           = SILABSConfigKey(kMatterConfig_KeyBase, 0x0C);
-    static constexpr Key kConfigKey_WiFiPSK            = SILABSConfigKey(kMatterConfig_KeyBase, 0x0D);
-    static constexpr Key kConfigKey_WiFiSEC            = SILABSConfigKey(kMatterConfig_KeyBase, 0x0E);
-    static constexpr Key kConfigKey_GroupKeyBase       = SILABSConfigKey(kMatterConfig_KeyBase, 0x0F);
-    static constexpr Key kConfigKey_LockUser           = SILABSConfigKey(kMatterConfig_KeyBase, 0x10);
-    static constexpr Key kConfigKey_Credential         = SILABSConfigKey(kMatterConfig_KeyBase, 0x11);
-    static constexpr Key kConfigKey_LockUserName       = SILABSConfigKey(kMatterConfig_KeyBase, 0x12);
-    static constexpr Key kConfigKey_CredentialData     = SILABSConfigKey(kMatterConfig_KeyBase, 0x13);
-    static constexpr Key kConfigKey_UserCredentials    = SILABSConfigKey(kMatterConfig_KeyBase, 0x14);
-    static constexpr Key kConfigKey_WeekDaySchedules   = SILABSConfigKey(kMatterConfig_KeyBase, 0x15);
-    static constexpr Key kConfigKey_YearDaySchedules   = SILABSConfigKey(kMatterConfig_KeyBase, 0x16);
-    static constexpr Key kConfigKey_HolidaySchedules   = SILABSConfigKey(kMatterConfig_KeyBase, 0x17);
-    static constexpr Key kConfigKey_OpKeyMap           = SILABSConfigKey(kMatterConfig_KeyBase, 0x20);
+    static constexpr Key kConfigKey_ServiceConfig      = SilabsConfigKey(kMatterConfig_KeyBase, 0x01);
+    static constexpr Key kConfigKey_PairedAccountId    = SilabsConfigKey(kMatterConfig_KeyBase, 0x02);
+    static constexpr Key kConfigKey_ServiceId          = SilabsConfigKey(kMatterConfig_KeyBase, 0x03);
+    static constexpr Key kConfigKey_LastUsedEpochKeyId = SilabsConfigKey(kMatterConfig_KeyBase, 0x05);
+    static constexpr Key kConfigKey_FailSafeArmed      = SilabsConfigKey(kMatterConfig_KeyBase, 0x06);
+    static constexpr Key kConfigKey_GroupKey           = SilabsConfigKey(kMatterConfig_KeyBase, 0x07);
+    static constexpr Key kConfigKey_HardwareVersion    = SilabsConfigKey(kMatterConfig_KeyBase, 0x08);
+    static constexpr Key kConfigKey_RegulatoryLocation = SilabsConfigKey(kMatterConfig_KeyBase, 0x09);
+    static constexpr Key kConfigKey_CountryCode        = SilabsConfigKey(kMatterConfig_KeyBase, 0x0A);
+    static constexpr Key kConfigKey_WiFiSSID           = SilabsConfigKey(kMatterConfig_KeyBase, 0x0C);
+    static constexpr Key kConfigKey_WiFiPSK            = SilabsConfigKey(kMatterConfig_KeyBase, 0x0D);
+    static constexpr Key kConfigKey_WiFiSEC            = SilabsConfigKey(kMatterConfig_KeyBase, 0x0E);
+    static constexpr Key kConfigKey_GroupKeyBase       = SilabsConfigKey(kMatterConfig_KeyBase, 0x0F);
+    static constexpr Key kConfigKey_LockUser           = SilabsConfigKey(kMatterConfig_KeyBase, 0x10);
+    static constexpr Key kConfigKey_Credential         = SilabsConfigKey(kMatterConfig_KeyBase, 0x11);
+    static constexpr Key kConfigKey_LockUserName       = SilabsConfigKey(kMatterConfig_KeyBase, 0x12);
+    static constexpr Key kConfigKey_CredentialData     = SilabsConfigKey(kMatterConfig_KeyBase, 0x13);
+    static constexpr Key kConfigKey_UserCredentials    = SilabsConfigKey(kMatterConfig_KeyBase, 0x14);
+    static constexpr Key kConfigKey_WeekDaySchedules   = SilabsConfigKey(kMatterConfig_KeyBase, 0x15);
+    static constexpr Key kConfigKey_YearDaySchedules   = SilabsConfigKey(kMatterConfig_KeyBase, 0x16);
+    static constexpr Key kConfigKey_HolidaySchedules   = SilabsConfigKey(kMatterConfig_KeyBase, 0x17);
+    static constexpr Key kConfigKey_OpKeyMap           = SilabsConfigKey(kMatterConfig_KeyBase, 0x20);
 
     static constexpr Key kConfigKey_GroupKeyMax =
-        SILABSConfigKey(kMatterConfig_KeyBase, 0x1E); // Allows 16 Group Keys to be created.
+        SilabsConfigKey(kMatterConfig_KeyBase, 0x1E); // Allows 16 Group Keys to be created.
 
     // Matter Counter Keys
-    static constexpr Key kConfigKey_BootCount             = SILABSConfigKey(kMatterCounter_KeyBase, 0x00);
-    static constexpr Key kConfigKey_TotalOperationalHours = SILABSConfigKey(kMatterCounter_KeyBase, 0x01);
-    static constexpr Key kConfigKey_LifeTimeCounter       = SILABSConfigKey(kMatterCounter_KeyBase, 0x02);
+    static constexpr Key kConfigKey_BootCount             = SilabsConfigKey(kMatterCounter_KeyBase, 0x00);
+    static constexpr Key kConfigKey_TotalOperationalHours = SilabsConfigKey(kMatterCounter_KeyBase, 0x01);
+    static constexpr Key kConfigKey_LifeTimeCounter       = SilabsConfigKey(kMatterCounter_KeyBase, 0x02);
 
     // Matter KVS storage Keys
-    static constexpr Key kConfigKey_KvsStringKeyMap = SILABSConfigKey(kMatterKvs_KeyBase, 0x00);
-    static constexpr Key kConfigKey_KvsFirstKeySlot = SILABSConfigKey(kMatterKvs_KeyBase, 0x01);
-    static constexpr Key kConfigKey_KvsLastKeySlot  = SILABSConfigKey(kMatterKvs_KeyBase, KVS_MAX_ENTRIES);
+    static constexpr Key kConfigKey_KvsStringKeyMap = SilabsConfigKey(kMatterKvs_KeyBase, 0x00);
+    static constexpr Key kConfigKey_KvsFirstKeySlot = SilabsConfigKey(kMatterKvs_KeyBase, 0x01);
+    static constexpr Key kConfigKey_KvsLastKeySlot  = SilabsConfigKey(kMatterKvs_KeyBase, KVS_MAX_ENTRIES);
 
     // Set key id limits for each group.
-    static constexpr Key kMinConfigKey_MatterFactory = SILABSConfigKey(kMatterFactory_KeyBase, 0x00);
-    static constexpr Key kMaxConfigKey_MatterFactory = SILABSConfigKey(kMatterFactory_KeyBase, 0x1F);
-    static constexpr Key kMinConfigKey_MatterConfig  = SILABSConfigKey(kMatterConfig_KeyBase, 0x00);
-    static constexpr Key kMaxConfigKey_MatterConfig  = SILABSConfigKey(kMatterConfig_KeyBase, 0x20);
+    static constexpr Key kMinConfigKey_MatterFactory = SilabsConfigKey(kMatterFactory_KeyBase, 0x00);
+    static constexpr Key kMaxConfigKey_MatterFactory = SilabsConfigKey(kMatterFactory_KeyBase, 0x1F);
+    static constexpr Key kMinConfigKey_MatterConfig  = SilabsConfigKey(kMatterConfig_KeyBase, 0x00);
+    static constexpr Key kMaxConfigKey_MatterConfig  = SilabsConfigKey(kMatterConfig_KeyBase, 0x20);
 
     // Allows 32 Counters to be created.
-    static constexpr Key kMinConfigKey_MatterCounter = SILABSConfigKey(kMatterCounter_KeyBase, 0x00);
-    static constexpr Key kMaxConfigKey_MatterCounter = SILABSConfigKey(kMatterCounter_KeyBase, 0x1F);
+    static constexpr Key kMinConfigKey_MatterCounter = SilabsConfigKey(kMatterCounter_KeyBase, 0x00);
+    static constexpr Key kMaxConfigKey_MatterCounter = SilabsConfigKey(kMatterCounter_KeyBase, 0x1F);
 
-    static constexpr Key kMinConfigKey_MatterKvs = SILABSConfigKey(kMatterKvs_KeyBase, 0x00);
-    static constexpr Key kMaxConfigKey_MatterKvs = SILABSConfigKey(kMatterKvs_KeyBase, 0xFF);
+    static constexpr Key kMinConfigKey_MatterKvs = SilabsConfigKey(kMatterKvs_KeyBase, 0x00);
+    static constexpr Key kMaxConfigKey_MatterKvs = SilabsConfigKey(kMatterKvs_KeyBase, 0xFF);
 
     static CHIP_ERROR Init(void);
     static void DeInit(void);

--- a/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
@@ -52,7 +52,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     CHIP_ERROR err;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<SILABSConfig>::Init();
+    err = Internal::GenericConfigurationManagerImpl<SilabsConfig>::Init();
     SuccessOrExit(err);
 
     // TODO: Initialize the global GroupKeyStore object here (#1626)
@@ -80,19 +80,19 @@ void ConfigurationManagerImpl::InitiateFactoryReset()
 
 CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
 {
-    return SILABSConfig::ReadConfigValue(SILABSConfig::kConfigKey_BootCount, rebootCount);
+    return SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_BootCount, rebootCount);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::IncreaseBootCount(void)
 {
     uint32_t bootCount = 0;
 
-    if (SILABSConfig::ConfigValueExists(SILABSConfig::kConfigKey_BootCount))
+    if (SilabsConfig::ConfigValueExists(SilabsConfig::kConfigKey_BootCount))
     {
         GetRebootCount(bootCount);
     }
 
-    return SILABSConfig::WriteConfigValue(SILABSConfig::kConfigKey_BootCount, bootCount + 1);
+    return SilabsConfig::WriteConfigValue(SilabsConfig::kConfigKey_BootCount, bootCount + 1);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetBootReason(uint32_t & bootReason)
@@ -154,18 +154,18 @@ CHIP_ERROR ConfigurationManagerImpl::GetBootReason(uint32_t & bootReason)
 
 CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
 {
-    if (!SILABSConfig::ConfigValueExists(SILABSConfig::kConfigKey_TotalOperationalHours))
+    if (!SilabsConfig::ConfigValueExists(SilabsConfig::kConfigKey_TotalOperationalHours))
     {
         totalOperationalHours = 0;
         return CHIP_NO_ERROR;
     }
 
-    return SILABSConfig::ReadConfigValue(SILABSConfig::kConfigKey_TotalOperationalHours, totalOperationalHours);
+    return SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_TotalOperationalHours, totalOperationalHours);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOperationalHours)
 {
-    return SILABSConfig::WriteConfigValue(SILABSConfig::kConfigKey_TotalOperationalHours, totalOperationalHours);
+    return SilabsConfig::WriteConfigValue(SilabsConfig::kConfigKey_TotalOperationalHours, totalOperationalHours);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,
@@ -175,7 +175,7 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
     // (where persistedStorageKey represents an index to the counter).
     CHIP_ERROR err;
 
-    err = SILABSConfig::ReadConfigValueCounter(persistedStorageKey, value);
+    err = SilabsConfig::ReadConfigValueCounter(persistedStorageKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
@@ -193,7 +193,7 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform
     // (where persistedStorageKey represents an index to the counter).
     CHIP_ERROR err;
 
-    err = SILABSConfig::WriteConfigValueCounter(persistedStorageKey, value);
+    err = SilabsConfig::WriteConfigValueCounter(persistedStorageKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
@@ -206,62 +206,62 @@ exit:
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
-    return SILABSConfig::ReadConfigValue(key, val);
+    return SilabsConfig::ReadConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
-    return SILABSConfig::ReadConfigValue(key, val);
+    return SilabsConfig::ReadConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
-    return SILABSConfig::ReadConfigValue(key, val);
+    return SilabsConfig::ReadConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
-    return SILABSConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
+    return SilabsConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
-    return SILABSConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
+    return SilabsConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
-    return SILABSConfig::WriteConfigValue(key, val);
+    return SilabsConfig::WriteConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
-    return SILABSConfig::WriteConfigValue(key, val);
+    return SilabsConfig::WriteConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
-    return SILABSConfig::WriteConfigValue(key, val);
+    return SilabsConfig::WriteConfigValue(key, val);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
-    return SILABSConfig::WriteConfigValueStr(key, str);
+    return SilabsConfig::WriteConfigValueStr(key, str);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
-    return SILABSConfig::WriteConfigValueStr(key, str, strLen);
+    return SilabsConfig::WriteConfigValueStr(key, str, strLen);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
-    return SILABSConfig::WriteConfigValueBin(key, data, dataLen);
+    return SilabsConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
 void ConfigurationManagerImpl::RunConfigUnitTest(void)
 {
-    SILABSConfig::RunConfigUnitTest();
+    SilabsConfig::RunConfigUnitTest();
 }
 
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
@@ -270,7 +270,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
-    err = SILABSConfig::FactoryResetConfig();
+    err = SilabsConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", chip::ErrorStr(err));

--- a/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
@@ -49,15 +49,22 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 
 CHIP_ERROR ConfigurationManagerImpl::Init()
 {
+    CHIP_ERROR err;
+
+    // Initialize the generic implementation base class.
+    err = Internal::GenericConfigurationManagerImpl<SILABSConfig>::Init();
+    SuccessOrExit(err);
+
     // TODO: Initialize the global GroupKeyStore object here (#1626)
 
     IncreaseBootCount();
-    // It is possible to configure the possible reset sources with RMU_ResetControl
-    // In this case, we keep Reset control at default setting
     rebootCause = RMU_ResetCauseGet();
     RMU_ResetCauseClear();
 
-    return CHIP_NO_ERROR;
+    err = CHIP_NO_ERROR;
+
+exit:
+    return err;
 }
 
 bool ConfigurationManagerImpl::CanFactoryReset()

--- a/src/platform/silabs/efr32/Efr32PsaOperationalKeystore.cpp
+++ b/src/platform/silabs/efr32/Efr32PsaOperationalKeystore.cpp
@@ -56,7 +56,7 @@ CHIP_ERROR Efr32PsaOperationalKeystore::Init()
     size_t existingLen = 0;
     bool update_cache  = false;
 
-    if (SILABSConfig::ConfigValueExists(SILABSConfig::kConfigKey_OpKeyMap, existingLen))
+    if (SilabsConfig::ConfigValueExists(SilabsConfig::kConfigKey_OpKeyMap, existingLen))
     {
         // There's a pre-existing key map on disk. Size the map to read it fully.
         size_t outLen = 0;
@@ -76,7 +76,7 @@ CHIP_ERROR Efr32PsaOperationalKeystore::Init()
         VerifyOrExit(mKeyMap, error = CHIP_ERROR_NO_MEMORY);
 
         // Read the existing key map
-        error = SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_OpKeyMap, (uint8_t *) mKeyMap, existingLen, outLen);
+        error = SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_OpKeyMap, (uint8_t *) mKeyMap, existingLen, outLen);
         SuccessOrExit(error);
 
         // If upsizing, extend the map with undefined indices
@@ -127,7 +127,7 @@ CHIP_ERROR Efr32PsaOperationalKeystore::Init()
     // Write-out keymap if needed
     if (update_cache)
     {
-        error = SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_OpKeyMap, mKeyMap, mKeyMapSize);
+        error = SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_OpKeyMap, mKeyMap, mKeyMapSize);
         SuccessOrExit(error);
     }
 
@@ -304,7 +304,7 @@ CHIP_ERROR Efr32PsaOperationalKeystore::CommitOpKeypairForFabric(FabricIndex fab
     mKeyMap[keymap_index] = fabricIndex;
 
     // Persist key map
-    CHIP_ERROR error = SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_OpKeyMap, mKeyMap, mKeyMapSize);
+    CHIP_ERROR error = SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_OpKeyMap, mKeyMap, mKeyMapSize);
     if (error != CHIP_NO_ERROR)
     {
         return error;
@@ -349,7 +349,7 @@ CHIP_ERROR Efr32PsaOperationalKeystore::RemoveOpKeypairForFabric(FabricIndex fab
     mKeyMap[keymap_index] = kUndefinedFabricIndex;
 
     // Persist key map
-    CHIP_ERROR error = SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_OpKeyMap, mKeyMap, mKeyMapSize);
+    CHIP_ERROR error = SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_OpKeyMap, mKeyMap, mKeyMapSize);
     if (error != CHIP_NO_ERROR)
     {
         return error;

--- a/src/platform/silabs/efr32/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/silabs/efr32/KeyValueStoreManagerImpl.cpp
@@ -32,8 +32,8 @@
 using namespace ::chip;
 using namespace ::chip::DeviceLayer::Internal;
 
-#define CONVERT_KEYMAP_INDEX_TO_NVM3KEY(index) (SILABSConfig::kConfigKey_KvsFirstKeySlot + index)
-#define CONVERT_NVM3KEY_TO_KEYMAP_INDEX(nvm3Key) (nvm3Key - SILABSConfig::kConfigKey_KvsFirstKeySlot)
+#define CONVERT_KEYMAP_INDEX_TO_NVM3KEY(index) (SilabsConfig::kConfigKey_KvsFirstKeySlot + index)
+#define CONVERT_NVM3KEY_TO_KEYMAP_INDEX(nvm3Key) (nvm3Key - SilabsConfig::kConfigKey_KvsFirstKeySlot)
 
 namespace chip {
 namespace DeviceLayer {
@@ -45,12 +45,12 @@ char mKvsStoredKeyString[KeyValueStoreManagerImpl::kMaxEntries][PersistentStorag
 CHIP_ERROR KeyValueStoreManagerImpl::Init(void)
 {
     CHIP_ERROR err;
-    err = SILABSConfig::Init();
+    err = SilabsConfig::Init();
     SuccessOrExit(err);
 
     memset(mKvsStoredKeyString, 0, sizeof(mKvsStoredKeyString));
     size_t outLen;
-    err = SILABSConfig::ReadConfigValueBin(SILABSConfig::kConfigKey_KvsStringKeyMap,
+    err = SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_KvsStringKeyMap,
                                            reinterpret_cast<uint8_t *>(mKvsStoredKeyString), sizeof(mKvsStoredKeyString), outLen);
 
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND) // Initial boot
@@ -64,7 +64,7 @@ exit:
 
 bool KeyValueStoreManagerImpl::IsValidKvsNvm3Key(uint32_t nvm3Key) const
 {
-    return ((SILABSConfig::kConfigKey_KvsFirstKeySlot <= nvm3Key) && (nvm3Key <= SILABSConfig::kConfigKey_KvsLastKeySlot));
+    return ((SilabsConfig::kConfigKey_KvsFirstKeySlot <= nvm3Key) && (nvm3Key <= SilabsConfig::kConfigKey_KvsLastKeySlot));
 }
 
 CHIP_ERROR KeyValueStoreManagerImpl::MapKvsKeyToNvm3(const char * key, uint32_t & nvm3Key, bool isSlotNeeded) const
@@ -113,7 +113,7 @@ void KeyValueStoreManagerImpl::ForceKeyMapSave()
 
 void KeyValueStoreManagerImpl::OnScheduledKeyMapSave(System::Layer * systemLayer, void * appState)
 {
-    SILABSConfig::WriteConfigValueBin(SILABSConfig::kConfigKey_KvsStringKeyMap,
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_KvsStringKeyMap,
                                       reinterpret_cast<const uint8_t *>(mKvsStoredKeyString), sizeof(mKvsStoredKeyString));
 }
 
@@ -138,7 +138,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     VerifyOrReturnError(err == CHIP_NO_ERROR, err);
 
     size_t outLen;
-    err = SILABSConfig::ReadConfigValueBin(nvm3Key, reinterpret_cast<uint8_t *>(value), value_size, outLen, offset_bytes);
+    err = SilabsConfig::ReadConfigValueBin(nvm3Key, reinterpret_cast<uint8_t *>(value), value_size, outLen, offset_bytes);
     if (read_bytes_size)
     {
         *read_bytes_size = outLen;
@@ -160,10 +160,10 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, 
     CHIP_ERROR err = MapKvsKeyToNvm3(key, nvm3Key, /* isSlotNeeded */ true);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err);
 
-    err = SILABSConfig::WriteConfigValueBin(nvm3Key, reinterpret_cast<const uint8_t *>(value), value_size);
+    err = SilabsConfig::WriteConfigValueBin(nvm3Key, reinterpret_cast<const uint8_t *>(value), value_size);
     if (err == CHIP_NO_ERROR)
     {
-        uint32_t keyIndex = nvm3Key - SILABSConfig::kConfigKey_KvsFirstKeySlot;
+        uint32_t keyIndex = nvm3Key - SilabsConfig::kConfigKey_KvsFirstKeySlot;
         Platform::CopyString(mKvsStoredKeyString[keyIndex], key);
         ScheduleKeyMapSave();
     }
@@ -179,7 +179,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)
     CHIP_ERROR err = MapKvsKeyToNvm3(key, nvm3Key);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err);
 
-    err = SILABSConfig::ClearConfigValue(nvm3Key);
+    err = SilabsConfig::ClearConfigValue(nvm3Key);
     if (err == CHIP_NO_ERROR)
     {
         uint32_t keyIndex = CONVERT_NVM3KEY_TO_KEYMAP_INDEX(nvm3Key);
@@ -194,9 +194,9 @@ CHIP_ERROR KeyValueStoreManagerImpl::ErasePartition(void)
 {
     // Iterate over all the Matter Kvs nvm3 records and delete each one...
     CHIP_ERROR err = CHIP_NO_ERROR;
-    for (uint32_t nvm3Key = SILABSConfig::kMinConfigKey_MatterKvs; nvm3Key < SILABSConfig::kMaxConfigKey_MatterKvs; nvm3Key++)
+    for (uint32_t nvm3Key = SilabsConfig::kMinConfigKey_MatterKvs; nvm3Key < SilabsConfig::kMaxConfigKey_MatterKvs; nvm3Key++)
     {
-        err = SILABSConfig::ClearConfigValue(nvm3Key);
+        err = SilabsConfig::ClearConfigValue(nvm3Key);
 
         if (err != CHIP_NO_ERROR)
         {

--- a/third_party/silabs/BUILD.gn
+++ b/third_party/silabs/BUILD.gn
@@ -86,6 +86,7 @@ if (use_silabs_thread_lib) {
 
     include_dirs = [
       "${chip_root}/examples/platform/silabs/efr32",
+      "${chip_root}/examples/platform/silabs",
       "${sdk_support_root}/matter/efr32/${silabs_family}/${silabs_board}",
       "${sl_ot_efr32_root}/platform-abstraction/efr32",
       "${sl_openthread_root}/src/",


### PR DESCRIPTION
#### Description 
* Rename silabs config form `SILABSConfig` to `SilabsConfig`
* Fix configuration manager init

#### Tests
* Built application manually to make sure it works
