### PR TITLE
[OnOff] Fix OffWaitTime delayed state off

### DIFF
--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -109,8 +109,6 @@ EmberAfStatus OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::Comman
     EmberAfStatus status;
     bool currentValue, newValue;
 
-    emberAfOnOffClusterPrintln("On/Off set value: %x %x", endpoint, static_cast<uint8_t>(command));
-
     // read current on/off value
     status = Attributes::OnOff::Get(endpoint, &currentValue);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
@@ -122,14 +120,14 @@ EmberAfStatus OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::Comman
     // if the value is already what we want to set it to then do nothing
     if ((!currentValue && command == Commands::Off::Id) || (currentValue && command == Commands::On::Id))
     {
-        emberAfOnOffClusterPrintln("On/off already set to new value");
+        emberAfOnOffClusterPrintln("Endpoint %x On/off already set to new value", endpoint);
         return EMBER_ZCL_STATUS_SUCCESS;
     }
 
     // we either got a toggle, or an on when off, or an off when on,
     // so we need to swap the value
     newValue = !currentValue;
-    emberAfOnOffClusterPrintln("Toggle on/off from %x to %x", currentValue, newValue);
+    emberAfOnOffClusterPrintln("Toggle ep%x on/off from state %x to %x", endpoint, currentValue, newValue);
 
     // the sequence of updating on/off attribute and kick off level change effect should
     // be depend on whether we are turning on or off. If we are turning on the light, we
@@ -192,12 +190,6 @@ EmberAfStatus OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::Comman
     }
     else // Set Off
     {
-        if (SupportsLightingApplications(endpoint))
-        {
-            emberAfOnOffClusterPrintln("Off Command - OnTime :  0");
-            Attributes::OnTime::Set(endpoint, 0); // Reset onTime
-        }
-
 #ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
         // If initiatedByLevelChange is false, then we assume that the level change
         // ZCL stuff has not happened and we do it here
@@ -206,8 +198,8 @@ EmberAfStatus OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::Comman
             emberAfOnOffClusterLevelControlEffectCallback(endpoint, newValue);
         }
         else
-        {
 #endif
+        {
             // write the new on/off value
             status = Attributes::OnOff::Set(endpoint, newValue);
             if (status != EMBER_ZCL_STATUS_SUCCESS)
@@ -215,9 +207,13 @@ EmberAfStatus OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::Comman
                 emberAfOnOffClusterPrintln("ERR: writing on/off %x", status);
                 return status;
             }
-#ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
+
+            if (SupportsLightingApplications(endpoint))
+            {
+                emberAfOnOffClusterPrintln("Off completed. reset OnTime to  0");
+                Attributes::OnTime::Set(endpoint, 0); // Reset onTime
+            }
         }
-#endif
     }
 
 #ifdef EMBER_AF_PLUGIN_SCENES
@@ -382,7 +378,6 @@ bool OnOffServer::offWithEffectCommand(app::CommandHandler * commandObj, const a
 #endif // EMBER_AF_PLUGIN_SCENES
 
             OnOff::Attributes::GlobalSceneControl::Set(endpoint, false);
-            Attributes::OnTime::Set(endpoint, 0);
         }
 
         // Only apply effect if OnOff is on

--- a/src/test_driver/linux-cirque/MobileDeviceTest.py
+++ b/src/test_driver/linux-cirque/MobileDeviceTest.py
@@ -121,9 +121,9 @@ class TestPythonController(CHIPVirtualHome):
                 self.get_device_pretty_id(device_id)))
             self.assertTrue(self.sequenceMatch(self.get_device_log(device_id).decode('utf-8'), [
                 "Received command for Endpoint=1 Cluster=0x0000_0006 Command=0x0000_0001",
-                "Toggle on/off from 0 to 1",
+                "Toggle ep1 on/off from state 0 to 1",
                 "Received command for Endpoint=1 Cluster=0x0000_0006 Command=0x0000_0000",
-                "Toggle on/off from 1 to 0",
+                "Toggle ep1 on/off from state 1 to 0",
                 "No command 0x0000_0001 in Cluster 0x0000_0006 on Endpoint 0xe9"]),
                 "Datamodel test failed: cannot find matching string from device {}".format(device_id))
 


### PR DESCRIPTION
Fix #24920

There is a timing window where `OnOff::Attributes::OnTime:` is set to `0` in `offWithEffectCommand` or in `setOnOffValue`  and the cluster timer call back -> `onOffWaitTimeOffEventHandler` -> `updateOnOffTimeCommand` is run before the `Attributes::OnOff::Set` off is done in `setOnOffValue`. This problematic timing window is exacerbated by `emberAfOnOffClusterLevelControlEffectCallback` delaying the Off state.

Fix entails reseting OnOff::Attributes::OnTime only in `setOnOffValue` and only after the OnOff state is finally set to off

Tested and validate on EFR32 lighting-app by repeating the sequence
```
./chip-tool onoff on 1 1
./chip-tool onoff on-with-timed-off 1 300 300 1 1
./chip-tool onoff off-with-effect 0 0 1 1
./chip-tool onoff read off-wait-time 1 1
```
And confirmed that off-wait-time is never directly set to 0
