### PR TITLE
Don't claim minimal mdns is initialized until it's advertising on some IPv6 interface.

### DIFF
--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -279,8 +279,8 @@ CHIP_ERROR ServerBase::Listen(chip::Inet::EndPointManager<chip::Inet::UDPEndPoin
         }
 #endif
 
-        // If at least one interface is used by the mDNS server, notify the application that DNS-SD is ready.
-        if (!mIsInitialized)
+        // If at least one IPv6 interface is used by the mDNS server, notify the application that DNS-SD is ready.
+        if (!mIsInitialized && addressType == chip::Inet::IPAddressType::kIPv6)
         {
 #if !CHIP_DEVICE_LAYER_NONE
             chip::DeviceLayer::ChipDeviceEvent event{};


### PR DESCRIPTION
This fixes two things:

1. We now don't consider advertising properly initialized until we are advertising on at least one ipv6 interface.

2. Actually check which sorts of addresses interfaces have, instead of just assuming that all interfaces have both IPv4 and IPv6 addresses.

Fixes https://github.com/project-chip/connectedhomeip/issues/25013
