### PR TITLE
New "prefix_mappings" build argument to set "-fdebug-prefix-map=" cflag

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -537,6 +537,13 @@ config("stack_protector_default") {
   cflags = [ "-fno-stack-protector" ]
 }
 
+config("prefix_mappings_default") {
+  cflags = []
+  foreach(prefix_mapping, prefix_mappings) {
+    cflags += [ "-fdebug-prefix-map=${prefix_mapping}" ]
+  }
+}
+
 config("pic_default") {
   if (enable_pic) {
     cflags = [ "-fPIC" ]

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -53,4 +53,7 @@ declare_args() {
 
   # Enable address sanitizer
   is_asan = false
+
+  # Debug prefix mapping (values for -fdebug-prefix-map=).
+  prefix_mappings = []
 }

--- a/build/config/defaults.gni
+++ b/build/config/defaults.gni
@@ -90,6 +90,10 @@ declare_args() {
   default_configs_dead_code =
       [ "${build_root}/config/compiler:dead_code_elimination_default" ]
 
+  # Default configs for prefix mappings.
+  default_configs_prefix_mappings =
+      [ "${build_root}/config/compiler:prefix_mappings_default" ]
+
   # Extra default configs.
   default_configs_extra = []
 }
@@ -115,6 +119,7 @@ default_configs += default_configs_fuzzing
 default_configs += default_configs_coverage
 default_configs += default_configs_target
 default_configs += default_configs_dead_code
+default_configs += default_configs_prefix_mappings
 default_configs += default_configs_extra
 
 executable_default_configs = []


### PR DESCRIPTION
To improve build reproducibility a build argument was added to set the "-fdebug-prefix-map=" cflag, which allows replacing build-time paths which may differ between builds.

https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html#index-fdebug-prefix-map

> When compiling files residing in directory old, record debugging
information describing them as if the files resided in directory new instead. This can be used to replace a build-time path with an install-time path in the debug info. It can also be used to change an absolute path to a relative path by using . for new. This can give more reproducible builds, which are location independent, but may require an extra command to tell GDB where to find the source files.

When using GDB, the `set substitute-path from to` command can be used to substitute placeholder values.

https://sourceware.org/gdb/onlinedocs/gdb/Source-Path.html#set-substitute_002dpath

Example 1: Replace absolute path to current dir with relative path

```
--args="prefix_mappings=[\"${PWD}/=.\"]"
```

Example 2: Replace multiple paths with substitution placeholders

```
--args="prefix_mappings=[\"${PWD}/=PWD\",\"${ANDROID_HOME}=ANDROID_HOME\",\"${ANDROID_NDK_HOME}=ANDROID_NDK_HOME\"]"
```
