### PR TITLE
Remove obsolete android_binary build rule

### DIFF
--- a/build/chip/java/rules.gni
+++ b/build/chip/java/rules.gni
@@ -355,24 +355,6 @@ template("android_library") {
   }
 }
 
-template("android_binary") {
-  java_binary(target_name) {
-    forward_variables_from(invoker, "*")
-
-    if (!defined(javac_flags)) {
-      javac_flags = []
-    }
-
-    javac_flags += [
-      "-Xlint:-options",
-      "-source",
-      "8",
-      "-target",
-      "8",
-    ]
-  }
-}
-
 template("java_prebuilt") {
   java_library(target_name) {
     forward_variables_from(invoker, "*")


### PR DESCRIPTION
Android app now use gradle build system to package Android app,  example built from android_binary build rule can not run on Android directly. This build rule is not in use, and obsolete. 
