### PR TITLE
Rewrite discover-once to really stop right after the first PASE sessi…

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -158,7 +158,6 @@ public:
 
     /////////// DeviceDiscoveryDelegate Interface /////////
     void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
-    bool IsDiscoverOnce() { return mDiscoverOnce.ValueOr(false); }
 
     /////////// DeviceAttestationDelegate /////////
     chip::Optional<uint16_t> FailSafeExpiryTimeoutSecs() const override;

--- a/examples/darwin-framework-tool/commands/pairing/DeviceControllerDelegateBridge.mm
+++ b/examples/darwin-framework-tool/commands/pairing/DeviceControllerDelegateBridge.mm
@@ -36,7 +36,7 @@
         _commandBridge->SetCommandExitStatus(CHIP_ERROR_INCORRECT_STATE);
         break;
     case MTRCommissioningStatusDiscoveringMoreDevices:
-        ChipLogProgress(chipTool, "Secure Pairing Discovering More Devices");
+        ChipLogError(chipTool, "MTRCommissioningStatusDiscoveringMoreDevices: This should not happen.");
         break;
     case MTRCommissioningStatusUnknown:
         ChipLogError(chipTool, "Uknown Pairing Status");

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -277,9 +277,6 @@ void PairingCommand::OnStatusUpdate(DevicePairingDelegate::Status status)
     case DevicePairingDelegate::Status::SecurePairingFailed:
         ChipLogError(AppServer, "Secure Pairing Failed");
         break;
-    case DevicePairingDelegate::Status::SecurePairingDiscoveringMoreDevices:
-        ChipLogProgress(AppServer, "Secure Pairing Discovering More Device");
-        break;
     }
 }
 

--- a/src/app/tests/suites/commands/commissioner/CommissionerCommands.h
+++ b/src/app/tests/suites/commands/commissioner/CommissionerCommands.h
@@ -45,7 +45,4 @@ public:
     void OnPairingComplete(CHIP_ERROR error) override;
     void OnPairingDeleted(CHIP_ERROR error) override;
     void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR error) override;
-
-private:
-    chip::Optional<bool> mDiscoverOnce;
 };

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -40,7 +40,6 @@ public:
     {
         SecurePairingSuccess = 0,
         SecurePairingFailed,
-        SecurePairingDiscoveringMoreDevices,
     };
 
     /**

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -68,6 +68,7 @@ enum class SetupCodePairerBehaviour : uint8_t
 enum class DiscoveryType : uint8_t
 {
     kDiscoveryNetworkOnly,
+    kDiscoveryNetworkOnlyWithoutPASEAutoRetry,
     kAll,
 };
 

--- a/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.cpp
@@ -84,8 +84,6 @@ void ScriptDevicePairingDelegate::OnStatusUpdate(DevicePairingDelegate::Status s
             mOnPairingCompleteCallback(ToPyChipError(CHIP_ERROR_INCORRECT_STATE));
         }
         break;
-    case DevicePairingDelegate::Status::SecurePairingDiscoveringMoreDevices:
-        break;
     }
 }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegate.h
@@ -23,7 +23,8 @@ typedef NS_ENUM(NSInteger, MTRCommissioningStatus) {
     MTRCommissioningStatusUnknown = 0,
     MTRCommissioningStatusSuccess = 1,
     MTRCommissioningStatusFailed = 2,
-    MTRCommissioningStatusDiscoveringMoreDevices = 3
+    MTRCommissioningStatusDiscoveringMoreDevices MTR_NEWLY_DEPRECATED("MTRCommissioningStatusDiscoveringMoreDevices is not used.")
+    = 3,
 } API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
 
 @class MTRDeviceController;
@@ -64,8 +65,8 @@ typedef NS_ENUM(NSUInteger, MTRPairingStatus) {
     MTRPairingStatusFailed API_DEPRECATED(
         "Please use MTRCommissioningStatusFailed", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
     = 2,
-    MTRPairingStatusDiscoveringMoreDevices API_DEPRECATED("Please use MTRCommissioningStatusDiscoveringMoreDevices",
-        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
+    MTRPairingStatusDiscoveringMoreDevices API_DEPRECATED("MTRPairingStatusDiscoveringMoreDevices is not used.", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
     = 3
 } API_DEPRECATED("Please use MTRCommissioningStatus", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -51,9 +51,6 @@ MTRCommissioningStatus MTRDeviceControllerDelegateBridge::MapStatus(chip::Contro
     case chip::Controller::DevicePairingDelegate::Status::SecurePairingFailed:
         rv = MTRCommissioningStatusFailed;
         break;
-    case chip::Controller::DevicePairingDelegate::Status::SecurePairingDiscoveringMoreDevices:
-        rv = MTRCommissioningStatusDiscoveringMoreDevices;
-        break;
     }
     return rv;
 }


### PR DESCRIPTION
…on failure

#### Problem

The `discover-once` argument for `chip-tool` is not really stopping the PASE establishment. This PR update the code such that it really only tries a single ip .

I suspect that is should fix the issues related to `discover-once`, notably:
#fix #24971
#fix #22547
#fix #22407

