### PR TITLE
Variable "_custom_impl_clusters" unused before it went out of scope

### DIFF
--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -193,6 +193,12 @@ template("chip_data_model") {
       _custom_impl_clusters = invoker.zap_clusters_with_custom_implementation
     }
 
+    if (_cluster_sources == []) {
+      # The variable is only used within the nested foreach-loop and will be
+      # unused before it goes out of scope when the outter-loop is not entered.
+      not_needed([ "_custom_impl_clusters" ])
+    }
+
     foreach(cluster, _cluster_sources) {
       _custom_impl = false
       foreach(ci, _custom_impl_clusters) {


### PR DESCRIPTION
When generating data model with no clusters then a build error is generated due to the "_custom_impl_clusters" variable being unused before it went out of scope.

```
ERROR at //src/app/chip_data_model.gni:192:29: Assignment had no effect.
    _custom_impl_clusters = []
                            ^
You set the variable "_custom_impl_clusters" here and it was unused
before it went out of scope.
```

To prevent the issue, "_custom_impl_clusters" can be marked as not needed.
