### PR TITLE
Tizen WiFi and bluetooth fix

### DIFF
--- a/examples/all-clusters-app/tizen/tizen-manifest.xml
+++ b/examples/all-clusters-app/tizen/tizen-manifest.xml
@@ -9,6 +9,7 @@
         <privilege>http://tizen.org/privilege/internet</privilege>
         <privilege>http://tizen.org/privilege/network.get</privilege>
         <privilege>http://tizen.org/privilege/network.set</privilege>
+        <privilege>http://tizen.org/privilege/network.profile</privilege>
     </privileges>
     <feature name="http://tizen.org/feature/network.bluetooth">true</feature>
     <feature name="http://tizen.org/feature/network.bluetooth.le">true</feature>

--- a/examples/all-clusters-minimal-app/tizen/tizen-manifest.xml
+++ b/examples/all-clusters-minimal-app/tizen/tizen-manifest.xml
@@ -9,6 +9,7 @@
         <privilege>http://tizen.org/privilege/internet</privilege>
         <privilege>http://tizen.org/privilege/network.get</privilege>
         <privilege>http://tizen.org/privilege/network.set</privilege>
+        <privilege>http://tizen.org/privilege/network.profile</privilege>
     </privileges>
     <feature name="http://tizen.org/feature/network.bluetooth">true</feature>
     <feature name="http://tizen.org/feature/network.bluetooth.le">true</feature>

--- a/examples/lighting-app/tizen/src/main.cpp
+++ b/examples/lighting-app/tizen/src/main.cpp
@@ -19,6 +19,8 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
+#include <app/clusters/network-commissioning/network-commissioning.h>
+#include <platform/Tizen/NetworkCommissioningDriver.h>
 
 #include <LightingManager.h>
 #include <TizenServiceAppMain.h>
@@ -26,6 +28,13 @@
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+namespace {
+DeviceLayer::NetworkCommissioning::TizenWiFiDriver sTizenWiFiDriver;
+Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(0, &sTizenWiFiDriver);
+} // namespace
+#endif
 
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
@@ -36,7 +45,12 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     }
 }
 
-void ApplicationInit() {}
+void ApplicationInit()
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    sWiFiNetworkCommissioningInstance.Init();
+#endif
+}
 
 int main(int argc, char * argv[])
 {

--- a/examples/lighting-app/tizen/tizen-manifest.xml
+++ b/examples/lighting-app/tizen/tizen-manifest.xml
@@ -9,6 +9,7 @@
         <privilege>http://tizen.org/privilege/internet</privilege>
         <privilege>http://tizen.org/privilege/network.get</privilege>
         <privilege>http://tizen.org/privilege/network.set</privilege>
+        <privilege>http://tizen.org/privilege/network.profile</privilege>
     </privileges>
     <feature name="http://tizen.org/feature/network.bluetooth">true</feature>
     <feature name="http://tizen.org/feature/network.bluetooth.le">true</feature>

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -668,6 +668,10 @@ int BLEManagerImpl::StartBLEAdvertising()
     VerifyOrExit(ret == BT_ERROR_NONE,
                  ChipLogError(DeviceLayer, "bt_adapter_le_add_advertising_service_data() failed. ret: %d", ret));
 
+    ret = bt_adapter_le_set_advertising_device_name(mAdvertiser, BT_ADAPTER_LE_PACKET_ADVERTISING, true);
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "bt_adapter_le_set_advertising_device_name() failed. ret: %d", ret));
+
     BLEManagerImpl::NotifyBLEPeripheralAdvConfiguredComplete(true, nullptr);
 
     ret = bt_adapter_le_start_advertising_new(mAdvertiser, AdvertisingStateChangedCb, nullptr);

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -29,9 +29,9 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/PlatformManager.h>
 
 #include "MainLoop.h"
-#include "platform/PlatformManager.h"
 
 namespace {
 static constexpr const char * __WiFiDeviceStateToStr(wifi_manager_device_state_e state)

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -31,6 +31,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 
 #include "MainLoop.h"
+#include "platform/PlatformManager.h"
 
 namespace {
 static constexpr const char * __WiFiDeviceStateToStr(wifi_manager_device_state_e state)
@@ -277,8 +278,11 @@ void WiFiManager::_ConnectedCb(wifi_manager_error_e wifiErr, void * userData)
         ChipLogProgress(DeviceLayer, "WiFi is connected");
         if (sInstance.mpConnectCallback != nullptr)
         {
+
+            chip::DeviceLayer::PlatformMgr().LockChipStack();
             sInstance.mpConnectCallback->OnResult(NetworkCommissioning::Status::kSuccess, CharSpan(), 0);
             sInstance.mpConnectCallback = nullptr;
+            chip::DeviceLayer::PlatformMgr().UnlockChipStack();
         }
     }
     else
@@ -286,8 +290,10 @@ void WiFiManager::_ConnectedCb(wifi_manager_error_e wifiErr, void * userData)
         ChipLogError(DeviceLayer, "FAIL: connect WiFi [%s]", get_error_message(wifiErr));
         if (sInstance.mpConnectCallback != nullptr)
         {
+            chip::DeviceLayer::PlatformMgr().LockChipStack();
             sInstance.mpConnectCallback->OnResult(NetworkCommissioning::Status::kUnknownError, CharSpan(), 0);
             sInstance.mpConnectCallback = nullptr;
+            chip::DeviceLayer::PlatformMgr().UnlockChipStack();
         }
     }
 

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -273,12 +273,11 @@ void WiFiManager::_ConnectedCb(wifi_manager_error_e wifiErr, void * userData)
 {
     auto loop = reinterpret_cast<GMainLoop *>(userData);
 
-    if (wifiErr == WIFI_MANAGER_ERROR_NONE)
+    if (wifiErr == WIFI_MANAGER_ERROR_NONE || wifiErr == WIFI_MANAGER_ERROR_ALREADY_EXISTS)
     {
         ChipLogProgress(DeviceLayer, "WiFi is connected");
         if (sInstance.mpConnectCallback != nullptr)
         {
-
             chip::DeviceLayer::PlatformMgr().LockChipStack();
             sInstance.mpConnectCallback->OnResult(NetworkCommissioning::Status::kSuccess, CharSpan(), 0);
             sInstance.mpConnectCallback = nullptr;


### PR DESCRIPTION
## Problem

* During pairing ble-wifi, there is a chip stack locking error
* The application does not have the correct privileges to manipulate the wifi adapter. 

## Changes

* Add missing `network.profile` privileges to all tizen apps; this privilege is not documented as required, but the application's log shows that this one is missing. 
* Enable advertising of the Tizen device name. 
* Add locking chip stack in WiFi connected callback. 
* Allow the device to be already connected to WiFi

## Testing
Tested on two Tizen devices. 
chip-tool:
``` sh
./chip-tool pairing ble-wifi 0x01 <wifi> <pass> 20202021 3840
```
lighting-app:
``` sh
app_launcher -s org.tizen.matter.example.lighting wifi true
```

To test these changes with the Linux chip-tool there have to be merged changes in Tizen API. I've tested it locally using the same commands as above. 