### PR TITLE
[ESP32] Set credential type and index to passed-in credentials

### DIFF
--- a/examples/platform/esp32/lock/BoltLockManager.cpp
+++ b/examples/platform/esp32/lock/BoltLockManager.cpp
@@ -428,15 +428,7 @@ bool BoltLockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, c
     userInStorage.lastModifiedBy = modifier;
     userInStorage.createdBy      = creator;
 
-    for (size_t i = 0; i < totalCredentials; ++i)
-    {
-        mCredentials[userIndex][i] = credentials[i];
-        // TODO: Why are we modifying the passed-in credentials?
-        // https://github.com/project-chip/connectedhomeip/issues/25083
-        // For now, preserve pre-existing behavior, which set credentialType to 1.
-        mCredentials[userIndex][i].credentialType  = CredentialTypeEnum::kPin;
-        mCredentials[userIndex][i].credentialIndex = i + 1;
-    }
+    memcpy(mCredentials, credentials, totalCredentials * sizeof(CredentialStruct));
 
     userInStorage.credentials = chip::Span<const CredentialStruct>(mCredentials[userIndex], totalCredentials);
 

--- a/examples/platform/esp32/lock/BoltLockManager.cpp
+++ b/examples/platform/esp32/lock/BoltLockManager.cpp
@@ -428,8 +428,10 @@ bool BoltLockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, c
     userInStorage.lastModifiedBy = modifier;
     userInStorage.createdBy      = creator;
 
-    memcpy(mCredentials, credentials, totalCredentials * sizeof(CredentialStruct));
-
+    for (size_t i = 0; i < totalCredentials; ++i)
+    {
+        mCredentials[userIndex][i] = credentials[i];
+    }
     userInStorage.credentials = chip::Span<const CredentialStruct>(mCredentials[userIndex], totalCredentials);
 
     // Save user information in NVM flash


### PR DESCRIPTION
Problem:

Fixes #25083.

Changes:

Set credential type and index to passed-in credentials.

Testing:

Tested by setting user credentials.