### PR TITLE
[chip-tool] remove extra blank line in cert print

### DIFF
--- a/examples/common/tracing/decoder/logging/ToCertificateString.cpp
+++ b/examples/common/tracing/decoder/logging/ToCertificateString.cpp
@@ -40,15 +40,16 @@ const char * ToCertificate(const chip::ByteSpan & source, chip::MutableCharSpan 
         return destination.data();
     }
 
-    size_t base64DataLen = BASE64_ENCODED_LEN(source.size()) + 1;
-    if (base64DataLen + strlen(header) + strlen(footer) > destination.size())
+    size_t base64DataLen = BASE64_ENCODED_LEN(source.size());
+    size_t bufferLen = base64DataLen + 1; // add one character for null-terminator
+    if (bufferLen + strlen(header) + strlen(footer) > destination.size())
     {
         ChipLogError(DataManagement, "The certificate buffer is too small to hold the base64 encoded certificate");
         return destination.data();
     }
 
     chip::Platform::ScopedMemoryBuffer<char> str;
-    str.Alloc(base64DataLen);
+    str.Alloc(bufferLen);
 
     auto encodedLen       = chip::Base64Encode(source.data(), source.size(), str.Get());
     str.Get()[encodedLen] = '\0';

--- a/examples/common/tracing/decoder/logging/ToCertificateString.cpp
+++ b/examples/common/tracing/decoder/logging/ToCertificateString.cpp
@@ -41,7 +41,7 @@ const char * ToCertificate(const chip::ByteSpan & source, chip::MutableCharSpan 
     }
 
     size_t base64DataLen = BASE64_ENCODED_LEN(source.size());
-    size_t bufferLen = base64DataLen + 1; // add one character for null-terminator
+    size_t bufferLen     = base64DataLen + 1; // add one character for null-terminator
     if (bufferLen + strlen(header) + strlen(footer) > destination.size())
     {
         ChipLogError(DataManagement, "The certificate buffer is too small to hold the base64 encoded certificate");


### PR DESCRIPTION
Fixes https://github.com/CHIP-Specifications/chip-test-plans/issues/2434

It's a corner case when the cert length is a particular value, which ends at a complete line. **chip-tool** prints an extra blank line:
![image](https://user-images.githubusercontent.com/20312411/220098037-77bc7323-2a8d-4fa9-aff5-c085d151dbaf.png)

After the fix, the output looks good:
![image](https://user-images.githubusercontent.com/20312411/220099270-b4a91528-65d1-49ff-b7cb-0c97a51da142.png)


