### PR TITLE
Handle an (invalid) empty InvokeResponses list.

### DIFF
--- a/src/controller/InvokeInteraction.h
+++ b/src/controller/InvokeInteraction.h
@@ -51,6 +51,9 @@ InvokeCommandRequest(Messaging::ExchangeManager * aExchangeMgr, const SessionHan
                      const Optional<uint16_t> & timedInvokeTimeoutMs,
                      const Optional<System::Clock::Timeout> & responseTimeout = NullOptional)
 {
+    // InvokeCommandRequest expects responses, so cannot happen over a group session.
+    VerifyOrReturnError(!sessionHandle->IsGroupSession(), CHIP_ERROR_INVALID_ARGUMENT);
+
     app::CommandPathParams commandPath = { endpointId, 0, RequestObjectT::GetClusterId(), RequestObjectT::GetCommandId(),
                                            (app::CommandPathFlags::kEndpointIdValid) };
 
@@ -91,14 +94,13 @@ InvokeCommandRequest(Messaging::ExchangeManager * aExchangeMgr, const SessionHan
 }
 
 /*
- * A typed group command invocation function that takes as input a cluster-object representation of a command request and
- * callbacks when completed trought the done callback
+ * A typed group command invocation function that takes as input a cluster-object representation of a command request.
  *
  * The RequestObjectT is generally expected to be a ClusterName::Commands::CommandName::Type struct, but any object
  * that can be encoded using the DataModel::Encode machinery and exposes the GetClusterId() and GetCommandId() functions
  * and a ResponseType type is expected to work.
  *
- * Since this sends a group command, no response will be received and all allocated rescources will be cleared before exing this
+ * Since this sends a group command, no response will be received and all allocated resources will be cleared before exiting this
  * function
  */
 template <typename RequestObjectT>

--- a/src/controller/TypedCommandCallback.h
+++ b/src/controller/TypedCommandCallback.h
@@ -72,7 +72,20 @@ private:
         mOnError(aError);
     }
 
-    void OnDone(app::CommandSender * apCommandSender) override { mOnDone(apCommandSender); }
+    void OnDone(app::CommandSender * apCommandSender) override
+    {
+        if (!mCalledCallback)
+        {
+            // This can happen if the server sends a response with an empty
+            // InvokeResponses list.  Since we are not sending wildcard command
+            // paths, that's not a valid response and we should treat it as an
+            // error.  Use the error we would have gotten if we in fact expected
+            // a nonempty list.
+            OnError(apCommandSender, CHIP_END_OF_TLV);
+        }
+
+        mOnDone(apCommandSender);
+    }
 
     OnSuccessCallbackType mOnSuccess;
     OnErrorCallbackType mOnError;


### PR DESCRIPTION
Without this change, InvokeInteraction could end up not calling either of its callbacks if the server responded with an empty InvokeResponses list.

