### PR TITLE
[TC-SC-5.2] Add a UserPrompt with to manually '!PICS_SDK_CI_ONLY' validates that the DUT has not sent a response

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_SC_5_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_5_2.yaml
@@ -135,6 +135,17 @@ tests:
               - name: "ms"
                 value: 1000
 
+    - label: "Verify there is no response from DUT"
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      PICS: "!PICS_SDK_CI_ONLY"
+      arguments:
+          values:
+              - name: "message"
+                value: "Verify that there is no response from DUT"
+              - name: "expectedValue"
+                value: "y"
+
     - label: "TH sends ViewGroup command"
       PICS: G.S.F00
       command: "ViewGroup"


### PR DESCRIPTION
#### Problem

This PR just adds an additional step to `Test_TC_SC_5_2.yaml` to manually validate that a there is no response from the DUT.