### PR TITLE
[TC-WNCV-2.2] Fix WindowCover ConfigStatus initialization

### DIFF
--- a/examples/window-app/common/src/WindowApp.cpp
+++ b/examples/window-app/common/src/WindowApp.cpp
@@ -427,8 +427,9 @@ void WindowApp::Cover::Init(chip::EndpointId endpoint)
     chip::BitMask<ConfigStatus> configStatus = ConfigStatusGet(endpoint);
     configStatus.Set(ConfigStatus::kLiftEncoderControlled);
     configStatus.Set(ConfigStatus::kTiltEncoderControlled);
-    configStatus.Set(ConfigStatus::kOnlineReserved);
     ConfigStatusSet(endpoint, configStatus);
+
+    chip::app::Clusters::WindowCovering::ConfigStatusUpdateFeatures(endpoint);
 
     // Attribute: Id 13 EndProductType
     EndProductTypeSet(endpoint, EndProductType::kInteriorBlind);


### PR DESCRIPTION
#### Description
ConfigStatus was not being correctly based on the feature map.

#### Test
Manual test to make sure ConfigStatus matches the FeatureMap

