### PR TITLE
[Ameba] only trigger ota query when ota is initialized

### DIFF
--- a/examples/all-clusters-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/ameba/main/DeviceCallbacks.cpp
@@ -128,7 +128,7 @@ void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Cluster
 void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
-    static bool isOTAInitialized = false;
+    bool isOTAInitialized = OTAInitializer::Instance().CheckInit();
 #endif
     if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established)
     {
@@ -149,7 +149,6 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
         {
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);
-            isOTAInitialized = true;
         }
 #endif
     }

--- a/examples/all-clusters-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/ameba/main/DeviceCallbacks.cpp
@@ -127,9 +127,6 @@ void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Cluster
 
 void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event)
 {
-#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
-    bool isOTAInitialized = OTAInitializer::Instance().CheckInit();
-#endif
     if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established)
     {
         ChipLogProgress(DeviceLayer, "IPv4 Server ready...");
@@ -145,7 +142,7 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
         chip::app::DnssdServer::Instance().StartServer();
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
         // Init OTA requestor only when we have gotten IPv6 address
-        if (!isOTAInitialized)
+        if (OTAInitializer::Instance().CheckInit())
         {
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);

--- a/examples/chef/ameba/main/DeviceCallbacks.cpp
+++ b/examples/chef/ameba/main/DeviceCallbacks.cpp
@@ -106,7 +106,7 @@ void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Cluster
 void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
-    static bool isOTAInitialized = false;
+    bool isOTAInitialized = OTAInitializer::Instance().CheckInit();
 #endif
     if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established)
     {
@@ -127,7 +127,6 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
         {
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);
-            isOTAInitialized = true;
         }
 #endif
     }

--- a/examples/chef/ameba/main/DeviceCallbacks.cpp
+++ b/examples/chef/ameba/main/DeviceCallbacks.cpp
@@ -105,9 +105,6 @@ void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Cluster
 
 void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event)
 {
-#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
-    bool isOTAInitialized = OTAInitializer::Instance().CheckInit();
-#endif
     if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established)
     {
         ChipLogProgress(DeviceLayer, "IPv4 Server ready...");
@@ -123,7 +120,7 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
         chip::app::DnssdServer::Instance().StartServer();
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
         // Init OTA requestor only when we have gotten IPv6 address
-        if (!isOTAInitialized)
+        if (OTAInitializer::Instance().CheckInit())
         {
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);

--- a/examples/light-switch-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/light-switch-app/ameba/main/DeviceCallbacks.cpp
@@ -128,7 +128,7 @@ void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Cluster
 void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
-    static bool isOTAInitialized = false;
+    bool isOTAInitialized = OTAInitializer::Instance().CheckInit();
 #endif
     if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established)
     {
@@ -149,7 +149,6 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
         {
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);
-            isOTAInitialized = true;
         }
 #endif
     }

--- a/examples/light-switch-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/light-switch-app/ameba/main/DeviceCallbacks.cpp
@@ -127,9 +127,6 @@ void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Cluster
 
 void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event)
 {
-#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
-    bool isOTAInitialized = OTAInitializer::Instance().CheckInit();
-#endif
     if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established)
     {
         ChipLogProgress(DeviceLayer, "IPv4 Server ready...");
@@ -145,7 +142,7 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
         chip::app::DnssdServer::Instance().StartServer();
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
         // Init OTA requestor only when we have gotten IPv6 address
-        if (!isOTAInitialized)
+        if (OTAInitializer::Instance().CheckInit())
         {
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);

--- a/examples/lighting-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/lighting-app/ameba/main/DeviceCallbacks.cpp
@@ -108,7 +108,7 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
 void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
-    static bool isOTAInitialized = false;
+    bool isOTAInitialized = OTAInitializer::Instance().CheckInit();
 #endif
 
     if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established)
@@ -130,7 +130,6 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
         {
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);
-            isOTAInitialized = true;
         }
 #endif
     }

--- a/examples/lighting-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/lighting-app/ameba/main/DeviceCallbacks.cpp
@@ -107,10 +107,6 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
 
 void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event)
 {
-#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
-    bool isOTAInitialized = OTAInitializer::Instance().CheckInit();
-#endif
-
     if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established)
     {
         printf("IPv4 Server ready...");
@@ -126,7 +122,7 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
         chip::app::DnssdServer::Instance().StartServer();
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
         // Init OTA requestor only when we have gotten IPv6 address
-        if (!isOTAInitialized)
+        if (OTAInitializer::Instance().CheckInit())
         {
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);

--- a/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
@@ -128,7 +128,7 @@ void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Cluster
 void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
-    static bool isOTAInitialized = false;
+    bool isOTAInitialized = OTAInitializer::Instance().CheckInit();
 #endif
     if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established)
     {
@@ -149,7 +149,6 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
         {
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);
-            isOTAInitialized = true;
         }
 #endif
     }

--- a/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
@@ -127,9 +127,6 @@ void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Cluster
 
 void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event)
 {
-#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
-    bool isOTAInitialized = OTAInitializer::Instance().CheckInit();
-#endif
     if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established)
     {
         ChipLogProgress(DeviceLayer, "IPv4 Server ready...");
@@ -145,7 +142,7 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
         chip::app::DnssdServer::Instance().StartServer();
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
         // Init OTA requestor only when we have gotten IPv6 address
-        if (!isOTAInitialized)
+        if (OTAInitializer::Instance().CheckInit())
         {
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);

--- a/examples/platform/ameba/ota/OTAInitializer.cpp
+++ b/examples/platform/ameba/ota/OTAInitializer.cpp
@@ -36,16 +36,18 @@ AmebaOTAImageProcessor gImageProcessor;
 extern "C" void amebaQueryImageCmdHandler()
 {
     ChipLogProgress(DeviceLayer, "Calling amebaQueryImageCmdHandler");
-    PlatformMgr().ScheduleWork([](intptr_t) { GetRequestorInstance()->TriggerImmediateQuery(); });
+    if(OTAInitializer::Instance().CheckInit()) 
+        PlatformMgr().ScheduleWork([](intptr_t) { GetRequestorInstance()->TriggerImmediateQuery(); });
 }
 
 extern "C" void amebaApplyUpdateCmdHandler()
 {
     ChipLogProgress(DeviceLayer, "Calling amebaApplyUpdateCmdHandler");
-    PlatformMgr().ScheduleWork([](intptr_t) { GetRequestorInstance()->ApplyUpdate(); });
+    if(OTAInitializer::Instance().CheckInit()) 
+        PlatformMgr().ScheduleWork([](intptr_t) { GetRequestorInstance()->ApplyUpdate(); });
 }
 
-void OTAInitializer::InitOTARequestor(void)
+void OTAInitializer::InitOTARequestor()
 {
     SetRequestorInstance(&gRequestorCore);
     gRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
@@ -55,4 +57,10 @@ void OTAInitializer::InitOTARequestor(void)
     // Connect the Downloader and Image Processor objects
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
+    initialized = true;
+}
+
+bool OTAInitializer::CheckInit()
+{
+    return initialized;
 }

--- a/examples/platform/ameba/ota/OTAInitializer.cpp
+++ b/examples/platform/ameba/ota/OTAInitializer.cpp
@@ -36,14 +36,14 @@ AmebaOTAImageProcessor gImageProcessor;
 extern "C" void amebaQueryImageCmdHandler()
 {
     ChipLogProgress(DeviceLayer, "Calling amebaQueryImageCmdHandler");
-    if(OTAInitializer::Instance().CheckInit()) 
+    if (OTAInitializer::Instance().CheckInit())
         PlatformMgr().ScheduleWork([](intptr_t) { GetRequestorInstance()->TriggerImmediateQuery(); });
 }
 
 extern "C" void amebaApplyUpdateCmdHandler()
 {
     ChipLogProgress(DeviceLayer, "Calling amebaApplyUpdateCmdHandler");
-    if(OTAInitializer::Instance().CheckInit()) 
+    if (OTAInitializer::Instance().CheckInit())
         PlatformMgr().ScheduleWork([](intptr_t) { GetRequestorInstance()->ApplyUpdate(); });
 }
 

--- a/examples/platform/ameba/ota/OTAInitializer.h
+++ b/examples/platform/ameba/ota/OTAInitializer.h
@@ -24,4 +24,8 @@ public:
         return sInitOTA;
     }
     void InitOTARequestor(void);
+    bool CheckInit(void);
+
+private:
+    bool initialized = false;
 };


### PR DESCRIPTION
- `amebaQueryImageCmdHandler` and `amebaApplyUpdateCmdHandler` should only get the requestor instance when requestor is initialized, otherwise, it will hardfault
- added function to check whether OTA is initialized
