### PR TITLE
Adding methods related to CASE and PASE sessions in AppDelegate and implementing them.

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -41,7 +41,8 @@
 #include <common/Esp32AppServer.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
-
+#include <lib/core/ScopedNodeId.h>
+#include <lib/support/logging/CHIPLogging.h>
 #if CONFIG_HAVE_DISPLAY
 #include "DeviceWithDisplay.h"
 #endif
@@ -81,7 +82,11 @@ namespace {
 class AppCallbacks : public AppDelegate
 {
 public:
-    void OnCommissioningSessionStarted() override { bluetoothLED.Set(true); }
+    void OnCommissioningSessionStarted() override
+    {
+        ESP_LOGI(TAG, "PASE established successfully");
+        bluetoothLED.Set(true);
+    }
     void OnCommissioningSessionStopped() override
     {
         bluetoothLED.Set(false);
@@ -89,10 +94,16 @@ public:
     }
     void OnCommissioningWindowOpened() override { pairingWindowLED.Set(true); }
     void OnCommissioningWindowClosed() override { pairingWindowLED.Set(false); }
-    void OnPASEStarted() override { ESP_LOGI(TAG, "PASE started"); }
-    void OnPASEComplete() override { ESP_LOGI(TAG, "PASE established successfully"); }
-    void OnPASEFailed(CHIP_ERROR err) override { ESP_LOGE(TAG, "PASE failed err= %" CHIP_ERROR_FORMAT, err.Format()); }
-    void OnCASEComplete() override { ESP_LOGI(TAG, "CASE established successfully"); }
+    void OnCommissioningSessionEstablishmentStarted() override { ESP_LOGI(TAG, "PASE started"); }
+    void OnCommissioningSessionEstablishmentFailed(CHIP_ERROR err) override
+    {
+        ESP_LOGE(TAG, "PASE failed err= %" CHIP_ERROR_FORMAT, err.Format());
+    }
+    void OnCASEStarted() override { ESP_LOGI(TAG, "CASE started"); }
+    void OnCASEComplete(ScopedNodeId id) override
+    {
+        ESP_LOGI(TAG, "CASE established successfully to peer:" ChipLogFormatScopedNodeId, ChipLogValueScopedNodeId(id));
+    }
     void OnCASEFailed(CHIP_ERROR err) override { ESP_LOGE(TAG, "CASE failed err= %" CHIP_ERROR_FORMAT, err.Format()); }
 };
 

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -89,6 +89,11 @@ public:
     }
     void OnCommissioningWindowOpened() override { pairingWindowLED.Set(true); }
     void OnCommissioningWindowClosed() override { pairingWindowLED.Set(false); }
+    void OnPASEStarted() override { ESP_LOGI(TAG, "PASE started"); }
+    void OnPASEComplete() override { ESP_LOGI(TAG, "PASE established successfully"); }
+    void OnPASEFailed(CHIP_ERROR err) override { ESP_LOGE(TAG, "PASE failed err= %" CHIP_ERROR_FORMAT, err.Format()); }
+    void OnCASEComplete() override { ESP_LOGI(TAG, "CASE established successfully"); }
+    void OnCASEFailed(CHIP_ERROR err) override { ESP_LOGE(TAG, "CASE failed err= %" CHIP_ERROR_FORMAT, err.Format()); }
 };
 
 AppCallbacks sCallbacks;

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -22,11 +22,16 @@
 
 #pragma once
 #include <lib/core/CHIPError.h>
+#include <lib/core/ScopedNodeId.h>
 
 class AppDelegate
 {
 public:
     virtual ~AppDelegate() {}
+
+    /* OnCommissioningSessionStarted indicates that PASE Session establishment has
+     * completed and a PASE session now exists.
+     */
     virtual void OnCommissioningSessionStarted() {}
     virtual void OnCommissioningSessionStopped() {}
 
@@ -40,9 +45,13 @@ public:
      */
     virtual void OnCommissioningWindowOpened() {}
     virtual void OnCommissioningWindowClosed() {}
-    virtual void OnPASEStarted() {}
-    virtual void OnPASEFailed(CHIP_ERROR err) {}
-    virtual void OnPASEComplete() {}
+    /*
+     * The below methods related to CASE and PASE are for the responder side of relevant communications.
+     * The methods expose the notifications related to CASE and PASE sessions on the application side.
+     */
+    virtual void OnCommissioningSessionEstablishmentStarted() {}
+    virtual void OnCommissioningSessionEstablishmentFailed(CHIP_ERROR err) {}
+    virtual void OnCASEStarted() {}
     virtual void OnCASEFailed(CHIP_ERROR err) {}
-    virtual void OnCASEComplete() {}
+    virtual void OnCASEComplete(chip::ScopedNodeId id) {}
 };

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -21,6 +21,7 @@
  */
 
 #pragma once
+#include <lib/core/CHIPError.h>
 
 class AppDelegate
 {
@@ -39,4 +40,9 @@ public:
      */
     virtual void OnCommissioningWindowOpened() {}
     virtual void OnCommissioningWindowClosed() {}
+    virtual void OnPASEStarted() {}
+    virtual void OnPASEFailed(CHIP_ERROR err) {}
+    virtual void OnPASEComplete() {}
+    virtual void OnCASEFailed(CHIP_ERROR err) {}
+    virtual void OnCASEComplete() {}
 };

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -127,6 +127,10 @@ void CommissioningWindowManager::Cleanup()
 void CommissioningWindowManager::OnSessionEstablishmentError(CHIP_ERROR err)
 {
     DeviceLayer::SystemLayer().CancelTimer(HandleSessionEstablishmentTimeout, this);
+    if (mAppDelegate != nullptr)
+    {
+        mAppDelegate->OnPASEFailed(err);
+    }
     HandleFailedAttempt(err);
 }
 
@@ -162,6 +166,10 @@ void CommissioningWindowManager::OnSessionEstablishmentStarted()
     // As per specifications, section 5.5: Commissioning Flows
     constexpr System::Clock::Timeout kPASESessionEstablishmentTimeout = System::Clock::Seconds16(60);
     DeviceLayer::SystemLayer().StartTimer(kPASESessionEstablishmentTimeout, HandleSessionEstablishmentTimeout, this);
+    if (mAppDelegate != nullptr)
+    {
+        mAppDelegate->OnPASEStarted();
+    }
 }
 
 void CommissioningWindowManager::OnSessionEstablished(const SessionHandle & session)
@@ -172,6 +180,7 @@ void CommissioningWindowManager::OnSessionEstablished(const SessionHandle & sess
     if (mAppDelegate != nullptr)
     {
         mAppDelegate->OnCommissioningSessionStarted();
+        mAppDelegate->OnPASEComplete();
     }
 
     DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -129,7 +129,7 @@ void CommissioningWindowManager::OnSessionEstablishmentError(CHIP_ERROR err)
     DeviceLayer::SystemLayer().CancelTimer(HandleSessionEstablishmentTimeout, this);
     if (mAppDelegate != nullptr)
     {
-        mAppDelegate->OnPASEFailed(err);
+        mAppDelegate->OnCommissioningSessionEstablishmentFailed(err);
     }
     HandleFailedAttempt(err);
 }
@@ -168,7 +168,7 @@ void CommissioningWindowManager::OnSessionEstablishmentStarted()
     DeviceLayer::SystemLayer().StartTimer(kPASESessionEstablishmentTimeout, HandleSessionEstablishmentTimeout, this);
     if (mAppDelegate != nullptr)
     {
-        mAppDelegate->OnPASEStarted();
+        mAppDelegate->OnCommissioningSessionEstablishmentStarted();
     }
 }
 
@@ -180,7 +180,6 @@ void CommissioningWindowManager::OnSessionEstablished(const SessionHandle & sess
     if (mAppDelegate != nullptr)
     {
         mAppDelegate->OnCommissioningSessionStarted();
-        mAppDelegate->OnPASEComplete();
     }
 
     DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -298,6 +298,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     err = mCASESessionManager.Init(&DeviceLayer::SystemLayer(), caseSessionManagerConfig);
     SuccessOrExit(err);
 
+    mCASEServer.SetAppDelegate(initParams.appDelegate);
     err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr, &mSessions, &mFabrics, mSessionResumptionStorage,
                                                     mCertificateValidityPolicy, mGroupsProvider);
     SuccessOrExit(err);

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -150,6 +150,14 @@ void CASEServer::PrepareForSessionEstablishment(const ScopedNodeId & previouslyE
     VerifyOrDie(mPinnedSecureSession.HasValue());
 }
 
+void CASEServer::OnSessionEstablishmentStarted()
+{
+    if (mAppDelegate != nullptr)
+    {
+        mAppDelegate->OnCASEStarted();
+    }
+}
+
 void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)
 {
     ChipLogError(Inet, "CASE Session establishment failed: %" CHIP_ERROR_FORMAT, err.Format());
@@ -167,7 +175,7 @@ void CASEServer::OnSessionEstablished(const SessionHandle & session)
                     ChipLogValueScopedNodeId(session->GetPeer()));
     if (mAppDelegate != nullptr)
     {
-        mAppDelegate->OnCASEComplete();
+        mAppDelegate->OnCASEComplete(session->GetPeer());
     }
     PrepareForSessionEstablishment(session->GetPeer());
 }

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -154,6 +154,10 @@ void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)
 {
     ChipLogError(Inet, "CASE Session establishment failed: %" CHIP_ERROR_FORMAT, err.Format());
 
+    if (mAppDelegate != nullptr)
+    {
+        mAppDelegate->OnCASEFailed(err);
+    }
     PrepareForSessionEstablishment();
 }
 
@@ -161,6 +165,10 @@ void CASEServer::OnSessionEstablished(const SessionHandle & session)
 {
     ChipLogProgress(Inet, "CASE Session established to peer: " ChipLogFormatScopedNodeId,
                     ChipLogValueScopedNodeId(session->GetPeer()));
+    if (mAppDelegate != nullptr)
+    {
+        mAppDelegate->OnCASEComplete();
+    }
     PrepareForSessionEstablishment(session->GetPeer());
 }
 } // namespace chip

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -62,6 +62,7 @@ public:
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
     void OnSessionEstablished(const SessionHandle & session) override;
+    void OnSessionEstablishmentStarted() override;
 
     //// UnsolicitedMessageHandler Implementation ////
     CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override;

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <app/server/AppDelegate.h>
 #include <credentials/CertificateValidityPolicy.h>
 #include <credentials/GroupDataProvider.h>
 #include <messaging/ExchangeDelegate.h>
@@ -56,6 +57,8 @@ public:
                                              Credentials::CertificateValidityPolicy * policy,
                                              Credentials::GroupDataProvider * responderGroupDataProvider);
 
+    void SetAppDelegate(AppDelegate * delegate) { mAppDelegate = delegate; }
+
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
     void OnSessionEstablished(const SessionHandle & session) override;
@@ -92,6 +95,7 @@ private:
     CASESession mPairingSession;
     SessionManager * mSessionManager = nullptr;
 
+    AppDelegate * mAppDelegate                          = nullptr;
     FabricTable * mFabrics                              = nullptr;
     Credentials::GroupDataProvider * mGroupDataProvider = nullptr;
 


### PR DESCRIPTION

**Problem:**
#22165

**Change Overview:**

- Added the methods related to CASE and PASE sessions to the AppDelegate.
- The following events related to CASE and PASE sessions have been exposed on the application side through 
   all-clusters-app.
      OnCASEEstabilished()
      OnCASEFailed()
      OnPASEStarted()
      OnPASEEstabilished()
      OnPASEFailed()

**Testing**
Successfully build the all-clusters-app example and flashed it.Successfully commissioned the device and received appropriate logs related to the CASE and PASE sessions on the application side.

