### PR TITLE
[matter_yamltests] Add CommissionerCommands::PairWithCode discoverOnc…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/commissioner_commands.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/commissioner_commands.py
@@ -24,6 +24,7 @@ _DEFINITION = '''<?xml version="1.0"?>
     <command source="client" code="0" name="PairWithCode">
         <arg name="nodeId" type="node_id"/>
         <arg name="payload" type="char_string"/>
+        <arg name="discoverOnce" type="boolean" optional="true"/>
     </command>
 
     <command source="client" code="1" name="Unpair">


### PR DESCRIPTION
…e argument to the cluster definition

#### Problem

This PR adds `discoverOnce` argument definition to `scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/commissioner_commands.py`