### PR TITLE
[chip-tool] Add discover-once parameter to DiscoverCommissionablesCom…

### DIFF
--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
@@ -26,7 +26,12 @@ void DiscoverCommissionablesCommandBase::OnDiscoveredDevice(const chip::Dnssd::D
 {
     nodeData.LogDetail();
     LogErrorOnFailure(RemoteDataModelLogger::LogDiscoveredNodeData(nodeData));
-    SetCommandExitStatus(CHIP_NO_ERROR);
+
+    if (mDiscoverOnce.ValueOr(true))
+    {
+        CurrentCommissioner().StopCommissionableDiscovery();
+        SetCommandExitStatus(CHIP_NO_ERROR);
+    }
 }
 
 CHIP_ERROR DiscoverCommissionablesCommand::RunCommand()

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
@@ -25,13 +25,19 @@ class DiscoverCommissionablesCommandBase : public CHIPCommand, public chip::Cont
 public:
     DiscoverCommissionablesCommandBase(const char * name, CredentialIssuerCommands * credsIssuerConfig) :
         CHIPCommand(name, credsIssuerConfig)
-    {}
+    {
+        AddArgument("discover-once", 0, 1, &mDiscoverOnce,
+                    "Boolean indicating whether to stop discovery after the first result. Defaults to true.");
+    }
 
     /////////// DeviceDiscoveryDelegate Interface /////////
     void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
 
     /////////// CHIPCommand Interface /////////
     chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(30); }
+
+private:
+    chip::Optional<bool> mDiscoverOnce;
 };
 
 class DiscoverCommissionablesCommand : public DiscoverCommissionablesCommandBase


### PR DESCRIPTION
…mand such that it only returns a single result by default to mimick what the test harness is doing

#### Problem

The discover commands are now used also for testing using `matter_yamltests`. One difference with what the test harness used to do for `TestDiscovery` is that it does not ignore all results after the first one. This PR adds an option (that defaults to true to mimick the test harness) to the discover commissionable set of commands.

An example of the kind of  failures is may generates if it does not exists is: https://github.com/project-chip/connectedhomeip/actions/runs/4234128470/jobs/7356009195
