### PR TITLE
[chip-trace-decoder] Add back logging

### DIFF
--- a/examples/common/tracing/BUILD.gn
+++ b/examples/common/tracing/BUILD.gn
@@ -67,6 +67,8 @@ executable("chip-trace-decoder") {
 
   output_dir = root_out_dir
 
+  deps = [ "${chip_root}/src/platform/logging:force_stdio" ]
+
   public_deps = [
     "${chip_root}/src/lib",
     "${chip_root}/third_party/jsoncpp",


### PR DESCRIPTION
##### Problem

While trying to read a trace using `chip-trace-decoder --source my-trace-file` I noticed that it does not logs anything anymore.
This PR adds it back.