### PR TITLE
Add `libsdl2-dev` to chip-build image

### DIFF
--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -45,6 +45,7 @@ RUN set -x \
     libpixman-1-dev \
     libreadline-dev \
     libsdl-pango-dev \
+    libsdl2-dev \
     libssl-dev \
     libtool \
     libudev-dev \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.39 Version bump reason: [Tizen] Fixup for QEMU docker image
+0.6.40 Version bump reason: [Linux] add libsdl2 to allow ui variants to be built


### PR DESCRIPTION
This would allow validation that the `-with-ui` images work for linux, to allow compilation validation for imgui UI builds.