### PR TITLE
Fix event buffer size boundary check

### DIFF
--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -858,6 +858,17 @@ bool CircularEventBuffer::IsFinalDestinationForPriority(PriorityLevel aPriority)
     return !((mpNext != nullptr) && (mpNext->mPriority <= aPriority));
 }
 
+/**
+ * @brief
+ * TLVCircularBuffer::OnInit can modify the state of the buffer, but we don't want that behavior here.
+ * We want to make sure we don't change our state, and just report the currently-available space.
+ */
+CHIP_ERROR CircularEventBuffer::OnInit(TLV::TLVWriter & writer, uint8_t *& bufStart, uint32_t & bufLen)
+{
+    GetCurrentWritableBuffer(bufStart, bufLen);
+    return CHIP_NO_ERROR;
+}
+
 void CircularEventReader::Init(CircularEventBufferWrapper * apBufWrapper)
 {
     CircularEventBuffer * prev;

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -109,6 +109,8 @@ private:
                                                       ///< lesser priority are dropped when they get bumped out of this buffer
 
     size_t mRequiredSpaceForEvicted = 0; ///< Required space for previous buffer to evict event to new buffer
+
+    CHIP_ERROR OnInit(TLV::TLVWriter & writer, uint8_t *& bufStart, uint32_t & bufLen) override;
 };
 
 class CircularEventReader;

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -115,12 +115,8 @@ void ENFORCE_FORMAT(1, 2) SimpleDumpWriter(const char * aFormat, ...)
 void PrintEventLog()
 {
     chip::TLV::TLVReader reader;
-    size_t elementCount;
     chip::app::CircularEventBufferWrapper bufWrapper;
-    chip::app::EventManagement::GetInstance().GetEventReader(reader, chip::app::PriorityLevel::Debug, &bufWrapper);
-
-    chip::TLV::Utilities::Count(reader, elementCount, false);
-    printf("Found %u elements\n", static_cast<unsigned int>(elementCount));
+    chip::app::EventManagement::GetInstance().GetEventReader(reader, chip::app::PriorityLevel::Critical, &bufWrapper);
     chip::TLV::Debug::Dump(reader, SimpleDumpWriter);
 }
 

--- a/src/lib/core/TLVCircularBuffer.cpp
+++ b/src/lib/core/TLVCircularBuffer.cpp
@@ -194,13 +194,19 @@ CHIP_ERROR TLVCircularBuffer::OnInit(TLVWriter & writer, uint8_t *& bufStart, ui
 
 CHIP_ERROR TLVCircularBuffer::GetNewBuffer(TLVWriter & ioWriter, uint8_t *& outBufStart, uint32_t & outBufLen)
 {
-    uint8_t * tail = QueueTail();
-
     if (mQueueLength >= mQueueSize)
     {
         // Queue is out of space, need to evict an element
         ReturnErrorOnFailure(EvictHead());
     }
+
+    GetCurrentWritableBuffer(outBufStart, outBufLen);
+    return CHIP_NO_ERROR;
+}
+
+void TLVCircularBuffer::GetCurrentWritableBuffer(uint8_t *& outBufStart, uint32_t & outBufLen) const
+{
+    uint8_t * tail = QueueTail();
 
     // set the output values, returned buffer must be contiguous
     outBufStart = tail;
@@ -213,8 +219,6 @@ CHIP_ERROR TLVCircularBuffer::GetNewBuffer(TLVWriter & ioWriter, uint8_t *& outB
     {
         outBufLen = static_cast<uint32_t>(mQueueHead - tail);
     }
-
-    return CHIP_NO_ERROR;
 }
 
 /**

--- a/src/lib/core/TLVCircularBuffer.h
+++ b/src/lib/core/TLVCircularBuffer.h
@@ -128,6 +128,17 @@ public:
                                    circular buffer.  See the ProcessEvictedElementFunct type definition on additional information on
                                    implementing the mProcessEvictedElement function. */
 
+protected:
+    /**
+     * @brief
+     *   returns the actual state of what our current available buffer space is
+     *
+     * @param[out] outBufStart The pointer to the current buffer
+     *
+     * @param[out] outBufLen   The available length for writing
+     */
+    void GetCurrentWritableBuffer(uint8_t *& outBufStart, uint32_t & outBufLen) const;
+
 private:
     uint8_t * mQueue;
     uint32_t mQueueSize;


### PR DESCRIPTION
In  TLVCircularBuffer::GetNewBuffer, it would evict head when mQueueLength == mQueueSize, EventManagement would use this TLVCircularBuffer to store events, once our written data size is equal to this queue size, it would evict head in TLVCircularBuffer, in order to resolve this issue, we need override OnInit on CircularEventBuffer and not evict head in TLVCircularBuffer. We do the below things
1. Implement an OnInit override on CircularEventBuffer.
2. Implement a  protected function on TLVCircularBuffer that non-destructively returns the actual state of what our current available buffer space is. That is, basically everything from TLVCircularBuffer::GetNewBuffer after the block where we evict the head.
3. Call that function from both TLVCircularBuffer::GetNewBuffer and our OnInit override.
