### PR TITLE
[Bouffalolab] Enable USB CDC for BL706 debug print output

### DIFF
--- a/examples/lighting-app/bouffalolab/bl602/CHIPProjectConfig.h
+++ b/examples/lighting-app/bouffalolab/bl602/CHIPProjectConfig.h
@@ -89,6 +89,7 @@
  */
 #ifndef CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING
 #define CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING "0.1ALPHA"
+#endif
 
 /**
  * CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION
@@ -98,7 +99,6 @@
 /* The SoftwareVersion attribute of the Basic cluster. */
 #ifndef CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION
 #define CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION 0x0001
-#endif
 #endif
 
 /**
@@ -111,16 +111,6 @@
  */
 #define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_REVISION 1
 
-/**
- * CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING
- *
- * A string identifying the firmware revision running on the device.
- * CHIP service currently expects the firmware version to be in the format
- * {MAJOR_VERSION}.0d{MINOR_VERSION}
- */
-#ifndef CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING
-#define CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING "0.1ALPHA"
-#endif
 /**
  * CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
  *

--- a/examples/lighting-app/bouffalolab/bl602/board.h
+++ b/examples/lighting-app/bouffalolab/bl602/board.h
@@ -43,10 +43,14 @@
 #define LED_B_PIN 17
 
 #define LED_R_PIN_PORT 0
-#define LED_R_PIN 20
+#define LED_R_PIN 14
 
 #define LED_G_PIN_PORT 1
-#define LED_G_PIN 21
+#define LED_G_PIN 11
+
+// comment out for last hardware
+//#define LED_R_PIN 20
+//#define LED_G_PIN 21
 
 #define MAX_PWM_CHANNEL 3
 

--- a/examples/lighting-app/bouffalolab/bl602/board.h
+++ b/examples/lighting-app/bouffalolab/bl602/board.h
@@ -42,13 +42,14 @@
 #define LED_B_PIN_PORT 2
 #define LED_B_PIN 17
 
-#define LED_R_PIN_PORT 0
+#define LED_R_PIN_PORT 4
 #define LED_R_PIN 14
 
 #define LED_G_PIN_PORT 1
 #define LED_G_PIN 11
 
 // comment out for last hardware
+//#define LED_R_PIN_PORT 0
 //#define LED_R_PIN 20
 //#define LED_G_PIN 21
 

--- a/examples/lighting-app/bouffalolab/bl702/BUILD.gn
+++ b/examples/lighting-app/bouffalolab/bl702/BUILD.gn
@@ -83,7 +83,7 @@ bl_iot_sdk("sdk") {
   if (defined(enable_cdc_module) && enable_cdc_module) {
     defines += [ "CFG_USB_CDC_ENABLE" ]
   }
-  
+
   if (chip_enable_pw_rpc) {
     include_dirs += [ "${examples_plat_common_dir}/rpc" ]
     defines += [ "PW_RPC_ENABLED=1" ]

--- a/examples/lighting-app/bouffalolab/bl702/BUILD.gn
+++ b/examples/lighting-app/bouffalolab/bl702/BUILD.gn
@@ -80,6 +80,10 @@ bl_iot_sdk("sdk") {
     defines += [ "CFG_USE_PSRAM=1" ]
   }
 
+  if (defined(enable_cdc_module) && enable_cdc_module) {
+    defines += [ "CFG_USB_CDC_ENABLE" ]
+  }
+  
   if (chip_enable_pw_rpc) {
     include_dirs += [ "${examples_plat_common_dir}/rpc" ]
     defines += [ "PW_RPC_ENABLED=1" ]
@@ -114,6 +118,10 @@ bouffalolab_executable("lighting_app") {
     defines += [ "BL706_NIGHT_LIGHT" ]
   } else if ("BL702-IoT-DVK" == board || "BL706-IoT-DVK" == board) {
     defines += [ "BL706_IOT_DVK" ]
+  }
+
+  if (defined(enable_cdc_module) && enable_cdc_module) {
+    defines += [ "CFG_USB_CDC_ENABLE" ]
   }
 
   sources = [

--- a/examples/lighting-app/bouffalolab/bl702/CHIPProjectConfig.h
+++ b/examples/lighting-app/bouffalolab/bl702/CHIPProjectConfig.h
@@ -81,14 +81,14 @@
 #define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_REVISION 1
 
 /**
- * CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING
+ * CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING
  *
- * A string identifying the firmware revision running on the device.
- * CHIP service currently expects the firmware version to be in the format
+ * A string identifying the software version running on the device.
+ * CHIP service currently expects the software version to be in the format
  * {MAJOR_VERSION}.0d{MINOR_VERSION}
  */
-#ifndef CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING
-#define CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING "0.1ALPHA"
+#ifndef CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING
+#define CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING "0.1ALPHA"
 #endif
 
 /**

--- a/examples/lighting-app/bouffalolab/common/AppTask.cpp
+++ b/examples/lighting-app/bouffalolab/common/AppTask.cpp
@@ -531,7 +531,7 @@ void AppTask::TimerEventHandler(app_event_t event)
             else
             {
 
-#if defined (BL706_NIGHT_LIGHT) && ! defined (LED_BTN_RESET)
+#if defined(BL706_NIGHT_LIGHT) && !defined(LED_BTN_RESET)
 
                 if (GetAppTask().mButtonPressedTime)
                 {

--- a/examples/lighting-app/bouffalolab/common/AppTask.cpp
+++ b/examples/lighting-app/bouffalolab/common/AppTask.cpp
@@ -531,7 +531,7 @@ void AppTask::TimerEventHandler(app_event_t event)
             else
             {
 
-#ifdef BL706_NIGHT_LIGHT
+#if defined (BL706_NIGHT_LIGHT) && ! defined (LED_BTN_RESET)
 
                 if (GetAppTask().mButtonPressedTime)
                 {
@@ -560,7 +560,6 @@ void AppTask::TimerEventHandler(app_event_t event)
                     }
                 }
 #else
-#ifdef LED_BTN_RESET
                 if (ButtonPressed())
                 {
                     if (!GetAppTask().mIsFactoryResetIndicat &&
@@ -574,7 +573,6 @@ void AppTask::TimerEventHandler(app_event_t event)
                 {
                     GetAppTask().PostEvent(APP_EVENT_BTN_FACTORY_RESET_CANCEL);
                 }
-#endif
 #endif
             }
         }

--- a/examples/platform/bouffalolab/common/plat/MemMonitoring.cpp
+++ b/examples/platform/bouffalolab/common/plat/MemMonitoring.cpp
@@ -20,6 +20,7 @@
 #include <MemMonitoring.h>
 #include <plat.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <MemMonitoring.h>
 
 static StackType_t monitoringStack[MONITORING_STACK_SIZE_byte / sizeof(StackType_t)];
 static StaticTask_t monitoringTaskStruct;

--- a/examples/platform/bouffalolab/common/plat/MemMonitoring.cpp
+++ b/examples/platform/bouffalolab/common/plat/MemMonitoring.cpp
@@ -17,9 +17,10 @@
  */
 
 #include <FreeRTOS.h>
-#include <MemMonitoring.h>
 #include <plat.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/ErrorStr.h>
 #include <MemMonitoring.h>
 
 static StackType_t monitoringStack[MONITORING_STACK_SIZE_byte / sizeof(StackType_t)];
@@ -58,8 +59,10 @@ void MemMonitoring::HeapMonitoring(void * pvParameter)
         ChipLogProgress(NotSpecified, "\r\n");
         ChipLogProgress(NotSpecified, "SRAM Heap, min left: %d, current left %d", xPortGetMinimumEverFreeHeapSize(),
                         xPortGetFreeHeapSize());
+#ifdef CFG_USE_PSRAM
         ChipLogProgress(NotSpecified, "PSRAM Heap, min left: %d, current left %d", xPortGetMinimumEverFreeHeapSizePsram(),
                         xPortGetFreeHeapSizePsram());
+#endif
         ChipLogProgress(NotSpecified, "============================= / total run time %ld", pulTotalRunTime);
 
         vTaskDelay(pdMS_TO_TICKS(10000));

--- a/examples/platform/bouffalolab/common/plat/MemMonitoring.cpp
+++ b/examples/platform/bouffalolab/common/plat/MemMonitoring.cpp
@@ -17,11 +17,11 @@
  */
 
 #include <FreeRTOS.h>
-#include <plat.h>
-#include <platform/CHIPDeviceLayer.h>
+#include <MemMonitoring.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ErrorStr.h>
-#include <MemMonitoring.h>
+#include <plat.h>
+#include <platform/CHIPDeviceLayer.h>
 
 static StackType_t monitoringStack[MONITORING_STACK_SIZE_byte / sizeof(StackType_t)];
 static StaticTask_t monitoringTaskStruct;

--- a/examples/platform/bouffalolab/common/plat/main.cpp
+++ b/examples/platform/bouffalolab/common/plat/main.cpp
@@ -170,7 +170,13 @@ extern "C" void vApplicationGetTimerTaskMemory(StaticTask_t ** ppxTimerTaskTCBBu
 }
 
 #if (configUSE_TICK_HOOK != 0)
-extern "C" void vApplicationTickHook(void) {}
+extern "C" void vApplicationTickHook(void) 
+{
+#if defined(CFG_USB_CDC_ENABLE)
+    extern void usb_cdc_monitor(void);
+    usb_cdc_monitor();
+#endif
+}
 #endif
 
 void vApplicationSleep(TickType_t xExpectedIdleTime) {}
@@ -337,6 +343,11 @@ extern "C" void START_ENTRY(void)
 #ifdef SYS_AOS_LOOP_ENABLE
     ChipLogProgress(NotSpecified, "Starting AOS loop Task");
     aos_loop_start();
+#else
+#if defined(CFG_USB_CDC_ENABLE)
+    extern void usb_cdc_start(int fd_console);
+    usb_cdc_start(-1);
+#endif
 #endif
 
     ChipLogProgress(NotSpecified, "Starting App Task");

--- a/examples/platform/bouffalolab/common/plat/main.cpp
+++ b/examples/platform/bouffalolab/common/plat/main.cpp
@@ -170,7 +170,7 @@ extern "C" void vApplicationGetTimerTaskMemory(StaticTask_t ** ppxTimerTaskTCBBu
 }
 
 #if (configUSE_TICK_HOOK != 0)
-extern "C" void vApplicationTickHook(void) 
+extern "C" void vApplicationTickHook(void)
 {
 #if defined(CFG_USB_CDC_ENABLE)
     extern void usb_cdc_monitor(void);

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -497,7 +497,7 @@ def BuildBouffalolabTarget():
         TargetPart('BL602-NIGHT-LIGHT', board=BouffalolabBoard.BL602_NIGHT_LIGHT, module_type="BL602"),
         TargetPart('XT-ZB6-DevKit', board=BouffalolabBoard.XT_ZB6_DevKit, module_type="BL706C-22"),
         TargetPart('BL706-IoT-DVK', board=BouffalolabBoard.BL706_IoT_DVK, module_type="BL706C-22"),
-        TargetPart('BL706-NIGHT-LIGHT', board=BouffalolabBoard.BL706_NIGHT_LIGHT, module_type="BL702"),
+        TargetPart('BL706-NIGHT-LIGHT', board=BouffalolabBoard.BL706_NIGHT_LIGHT, module_type="BL706C-22"),
     ])
 
     # Apps
@@ -508,6 +508,7 @@ def BuildBouffalolabTarget():
     target.AppendModifier('shell', enable_shell=True)
     target.AppendModifier('115200', baudrate=115200)
     target.AppendModifier('rpc', enable_rpcs=True)
+    target.AppendModifier('cdc', enable_cdc=True)
 
     return target
 

--- a/scripts/build/builders/bouffalolab.py
+++ b/scripts/build/builders/bouffalolab.py
@@ -77,7 +77,8 @@ class BouffalolabBuilder(GnBuilder):
                  enable_rpcs: bool = False,
                  module_type: str = "BL706C-22",
                  baudrate=2000000,
-                 enable_shell: bool = False
+                 enable_shell: bool = False,
+                 enable_cdc: bool = False
                  ):
 
         bouffalo_chip = "bl702" if "BL70" in module_type else "bl602"
@@ -103,6 +104,8 @@ class BouffalolabBuilder(GnBuilder):
 
         if bouffalo_chip == "bl702":
             self.argsOpt.append('module_type=\"{}\"'.format(module_type))
+            if enable_cdc:
+                self.argsOpt.append('enable_cdc_module=true')
 
         if enable_rpcs:
             self.argsOpt.append('import("//with_pw_rpc.gni")')

--- a/scripts/build/builders/bouffalolab.py
+++ b/scripts/build/builders/bouffalolab.py
@@ -104,8 +104,11 @@ class BouffalolabBuilder(GnBuilder):
 
         if bouffalo_chip == "bl702":
             self.argsOpt.append('module_type=\"{}\"'.format(module_type))
-            if enable_cdc:
-                self.argsOpt.append('enable_cdc_module=true')
+
+        if enable_cdc:
+            if bouffalo_chip != "bl702":
+                raise Exception('Chip %s does NOT support USB CDC' % bouffalo_chip)
+            self.argsOpt.append('enable_cdc_module=true')
 
         if enable_rpcs:
             self.argsOpt.append('import("//with_pw_rpc.gni")')

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -1,6 +1,6 @@
 ameba-amebad-{all-clusters,all-clusters-minimal,light,light-switch,pigweed}
 android-{arm,arm64,x86,x64,androidstudio-arm,androidstudio-arm64,androidstudio-x86,androidstudio-x64}-{chip-tool,chip-test,tv-server,tv-casting-app,java-matter-controller}[-no-debug]
-bouffalolab-{bl602-iot-matter-v1,bl602-iot-dvk-3s,bl602-night-light,xt-zb6-devkit,bl706-iot-dvk,bl706-night-light}-light[-shell][-115200][-rpc]
+bouffalolab-{bl602-iot-matter-v1,bl602-iot-dvk-3s,bl602-night-light,xt-zb6-devkit,bl706-iot-dvk,bl706-night-light}-light[-shell][-115200][-rpc][-cdc]
 cc13x2x7_26x2x7-{all-clusters,all-clusters-minimal,lock,pump,pump-controller,shell}[-ftd][-mtd]
 cc32xx-lock
 cyw30739-cyw930739m2evb_01-{light,lock,ota-requestor}[-no-progress-logging]

--- a/third_party/bouffalolab/bl702/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl702/bl_iot_sdk.gni
@@ -90,7 +90,7 @@ template("bl_iot_sdk") {
     cflags_c = [ "-Wno-format-truncation" ]
 
     configs += [
-      ":${sdk_target_name}_config", 
+      ":${sdk_target_name}_config",
       ":${sdk_target_name}_config_freertos",
     ]
   }
@@ -220,7 +220,7 @@ template("bl_iot_sdk") {
     ]
 
     cflags_c = [ "-Wno-sign-compare" ]
-    configs += [ 
+    configs += [
       ":${sdk_target_name}_config_hosal",
       ":${sdk_target_name}_config_BSP_Driver",
       ":${sdk_target_name}_config_freertos",

--- a/third_party/bouffalolab/bl702/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl702/bl_iot_sdk.gni
@@ -220,7 +220,12 @@ template("bl_iot_sdk") {
     ]
 
     cflags_c = [ "-Wno-sign-compare" ]
-
+    configs += [ 
+      ":${sdk_target_name}_config_hosal",
+      ":${sdk_target_name}_config_BSP_Driver",
+      ":${sdk_target_name}_config_freertos",
+      ":${sdk_target_name}_config_stage",
+    ]
     public_configs = [ ":${sdk_target_name}_config" ]
   }
 

--- a/third_party/bouffalolab/bl702/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl702/bl_iot_sdk.gni
@@ -88,6 +88,11 @@ template("bl_iot_sdk") {
     libs = [ "${bl_iot_sdk_root}/components/platform/soc/bl702/bl702_rf/lib/libbl702_rf.a" ]
 
     cflags_c = [ "-Wno-format-truncation" ]
+
+    configs += [
+      ":${sdk_target_name}_config", 
+      ":${sdk_target_name}_config_freertos",
+    ]
   }
 
   config("${sdk_target_name}_config_BSP_Driver") {


### PR DESCRIPTION
Enable USB CDC for Bouffalolab BL706 debug print output.
