### PR TITLE
[nrfconnect] Fixed window app setting value issue.

### DIFF
--- a/examples/window-app/nrfconnect/main/WindowCovering.cpp
+++ b/examples/window-app/nrfconnect/main/WindowCovering.cpp
@@ -65,15 +65,19 @@ void WindowCovering::DriveCurrentLiftPosition(intptr_t)
     OperationalState state = ComputeOperationalState(target, current);
     UpdateOperationalStatus(MoveType::LIFT, state);
 
-    chip::Percent100ths step = CalculateSingleStep(MoveType::LIFT);
+    chip::Percent100ths position = CalculateNextPosition(MoveType::LIFT);
 
     if (state == OperationalState::MovingUpOrOpen)
     {
-        positionToSet.SetNonNull(step > target.Value() ? step : target.Value());
+        positionToSet.SetNonNull(position > target.Value() ? position : target.Value());
     }
     else if (state == OperationalState::MovingDownOrClose)
     {
-        positionToSet.SetNonNull(step < target.Value() ? step : target.Value());
+        positionToSet.SetNonNull(position < target.Value() ? position : target.Value());
+    }
+    else
+    {
+        positionToSet.SetNonNull(current.Value());
     }
 
     LiftPositionSet(Endpoint(), positionToSet);
@@ -95,7 +99,7 @@ void WindowCovering::DriveCurrentLiftPosition(intptr_t)
     }
 }
 
-chip::Percent100ths WindowCovering::CalculateSingleStep(MoveType aMoveType)
+chip::Percent100ths WindowCovering::CalculateNextPosition(MoveType aMoveType)
 {
     EmberAfStatus status{};
     chip::Percent100ths percent100ths{};
@@ -170,15 +174,19 @@ void WindowCovering::DriveCurrentTiltPosition(intptr_t)
     OperationalState state = ComputeOperationalState(target, current);
     UpdateOperationalStatus(MoveType::TILT, state);
 
-    chip::Percent100ths step = CalculateSingleStep(MoveType::TILT);
+    chip::Percent100ths position = CalculateNextPosition(MoveType::TILT);
 
     if (state == OperationalState::MovingUpOrOpen)
     {
-        positionToSet.SetNonNull(step > target.Value() ? step : target.Value());
+        positionToSet.SetNonNull(position > target.Value() ? position : target.Value());
     }
     else if (state == OperationalState::MovingDownOrClose)
     {
-        positionToSet.SetNonNull(step < target.Value() ? step : target.Value());
+        positionToSet.SetNonNull(position < target.Value() ? position : target.Value());
+    }
+    else
+    {
+        positionToSet.SetNonNull(current.Value());
     }
 
     TiltPositionSet(Endpoint(), positionToSet);
@@ -226,7 +234,7 @@ void WindowCovering::StartMove(MoveType aMoveType)
 void WindowCovering::SetSingleStepTarget(OperationalState aDirection)
 {
     UpdateOperationalStatus(mCurrentUIMoveType, aDirection);
-    SetTargetPosition(aDirection, CalculateSingleStep(mCurrentUIMoveType));
+    SetTargetPosition(aDirection, CalculateNextPosition(mCurrentUIMoveType));
 }
 
 void WindowCovering::UpdateOperationalStatus(MoveType aMoveType, OperationalState aDirection)

--- a/examples/window-app/nrfconnect/main/include/WindowCovering.h
+++ b/examples/window-app/nrfconnect/main/include/WindowCovering.h
@@ -69,7 +69,7 @@ private:
     static void UpdateOperationalStatus(MoveType aMoveType, OperationalState aDirection);
     static bool TargetCompleted(MoveType aMoveType, NPercent100ths aCurrent, NPercent100ths aTarget);
     static void StartTimer(MoveType aMoveType, uint32_t aTimeoutMs);
-    static chip::Percent100ths CalculateSingleStep(MoveType aMoveType);
+    static chip::Percent100ths CalculateNextPosition(MoveType aMoveType);
     static void DriveCurrentLiftPosition(intptr_t);
     static void DriveCurrentTiltPosition(intptr_t);
     static void MoveTimerTimeoutCallback(chip::System::Layer * systemLayer, void * appState);


### PR DESCRIPTION
Setting the position in other states than moving or open/close is not correctly handled, what leads to setting null position and bricking the algorithm, so changing the position is not possible anymore

Added properly handling the case that position doesn't change.

