### PR TITLE
Revert "Enable Test_TC_OO_2_4 to run in CI (#25159)"

### DIFF
--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -85,10 +85,9 @@ def _GetManualTests() -> Set[str]:
 
 def _GetFlakyTests() -> Set[str]:
     """List of flaky tests, ideally this list should become empty."""
-    return_value = set()
-    # We need more data as to why this test flakes sometimes. We have added additional logging.
-    # return_value.add("Test_TC_OO_2_4.yaml")
-    return return_value
+    return {
+        "Test_TC_OO_2_4.yaml"
+    }
 
 
 def _GetSlowTests() -> Set[str]:


### PR DESCRIPTION
This reverts commit e170238ee07cf7dd0e4404c19bf475566cea8d6f. We have a failure in over here to analyize now:
https://github.com/project-chip/connectedhomeip/actions/runs/4243209454/jobs/7375662859
