### PR TITLE
[Matter_yamltests] Add to flake8 in workflow and fix python files (part #25193) 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -36,19 +36,7 @@ exclude = third_party
           scripts/helpers/bloat_check.py
           scripts/pregenerate/using_codegen.py
           scripts/pregenerate/using_zap.py
-          scripts/py_matter_yamltests/matter_yamltests/constraints.py
-          scripts/py_matter_yamltests/matter_yamltests/definitions.py
-          scripts/py_matter_yamltests/matter_yamltests/fixes.py
-          scripts/py_matter_yamltests/matter_yamltests/parser.py
-          scripts/py_matter_yamltests/matter_yamltests/pics_checker.py
-          scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_clusters.py
-          scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
-          scripts/py_matter_yamltests/test_pics_checker.py
-          scripts/py_matter_yamltests/test_spec_definitions.py
-          scripts/py_matter_yamltests/test_yaml_loader.py
-          scripts/py_matter_yamltests/test_yaml_parser.py
           scripts/run-clang-tidy-on-compile-commands.py
-          scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
           scripts/tools/check_zcl_file_sync.py
           scripts/tools/convert_ini.py
           scripts/tools/memory/memdf/__init__.py

--- a/scripts/py_matter_yamltests/matter_yamltests/constraints.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/constraints.py
@@ -195,7 +195,7 @@ class BaseConstraint(ABC):
             raise ConstraintAnyOfError(self._context, reason)
         else:
             # This should not happens.
-            raise ConstraintParseError(f'Unknown constraint instance.')
+            raise ConstraintParseError('Unknown constraint instance.')
 
 
 class _ConstraintHasValue(BaseConstraint):
@@ -219,7 +219,7 @@ class _ConstraintHasValue(BaseConstraint):
 
     def get_reason(self, value, value_type_name) -> str:
         if self._has_value:
-            return f"The constraint expects a value but there isn't one."
+            return "The constraint expects a value but there isn't one."
         return f"The response contains the value ({value}), but wasn't expecting any value."
 
 
@@ -572,7 +572,7 @@ class _ConstraintIsHexString(BaseConstraint):
             chars = []
 
             for char in value:
-                if not char in string.hexdigits:
+                if char not in string.hexdigits:
                     chars.append(char)
 
             if len(chars) == 1:

--- a/scripts/py_matter_yamltests/matter_yamltests/constraints.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/constraints.py
@@ -15,6 +15,7 @@
 #    limitations under the License.
 #
 
+import math
 import re
 import string
 from abc import ABC, abstractmethod

--- a/scripts/py_matter_yamltests/matter_yamltests/definitions.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/definitions.py
@@ -18,7 +18,8 @@ import glob
 import io
 from typing import List, Optional
 
-from matter_idl.matter_idl_types import *
+from matter_idl.matter_idl_types import (
+    Attribute, Bitmap, Cluster, Command, Enum, Event, FieldQuality, Struct, StructQuality, StructTag)
 from matter_idl.zapxml import ParseSource, ParseXmls
 
 from .pseudo_clusters.pseudo_clusters import PseudoClusters

--- a/scripts/py_matter_yamltests/matter_yamltests/definitions.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/definitions.py
@@ -18,8 +18,8 @@ import glob
 import io
 from typing import List, Optional
 
-from matter_idl.matter_idl_types import (
-    Attribute, Bitmap, Cluster, Command, Enum, Event, FieldQuality, Struct, StructQuality, StructTag)
+from matter_idl.matter_idl_types import (Attribute, Bitmap, Cluster, Command, Enum, Event, FieldQuality, Struct, StructQuality,
+                                         StructTag)
 from matter_idl.zapxml import ParseSource, ParseXmls
 
 from .pseudo_clusters.pseudo_clusters import PseudoClusters

--- a/scripts/py_matter_yamltests/matter_yamltests/fixes.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/fixes.py
@@ -60,7 +60,7 @@ def try_apply_yaml_unrepresentable_integer_for_javascript_fixes(value):
     if type(value) is str:
         try:
             value = int(value)
-        except:
+        except ValueError:
             pass
     return value
 

--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -1110,7 +1110,7 @@ class TestParser:
 
     def __apply_config_override(self, config, config_override):
         for key, value in config_override.items():
-            if value is None or not key in config:
+            if value is None or key not in config:
                 continue
 
             is_node_id = key == 'nodeId' or (isinstance(

--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -695,7 +695,8 @@ class TestStep:
             return result
 
         check_type = PostProcessCheckType.RESPONSE_VALIDATION
-        error_failure_wrong_response_number = f'The test expects {len(self.responses)} responses but got {len(received_responses)} responses.'
+        error_failure_wrong_response_number = (f'The test expects {len(self.responses)} responses '
+                                               f'but got {len(received_responses)} responses.')
 
         received_responses_copy = copy.deepcopy(received_responses)
         for expected_response in self.responses:
@@ -743,7 +744,6 @@ class TestStep:
         check_type = PostProcessCheckType.WAIT_VALIDATION
         error_success = 'The test expectation "{wait_for}" for "{cluster}.{wait_type}" on endpoint {endpoint} is true'
         error_failure = 'The test expectation "{expected} == {received}" is false'
-        error_failure_multiple_responses = 'The test expects a single response but got {len(received_responses)} responses.'
 
         if len(received_responses) > 1:
             result.error(check_type, error_failure.multiple_responses)
@@ -758,7 +758,7 @@ class TestStep:
             received_wait_type = received_response.get('event')
         else:
             expected_wait_type = self.command
-            received_wait_type = receive_response.get('command')
+            received_wait_type = received_response.get('command')
 
         expected_values = [
             self.wait_for,

--- a/scripts/py_matter_yamltests/matter_yamltests/pics_checker.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pics_checker.py
@@ -122,7 +122,7 @@ class PICSChecker():
         token = self.__normalize(token)
         self.__expression_index += 1
 
-        if pics.get(token) == None:
+        if pics.get(token) is None:
             # By default, let's consider that if a PICS item is not defined, it is |false|.
             # It allows to create a file that only contains enabled features.
             return False

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_clusters.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_clusters.py
@@ -40,7 +40,7 @@ class PseudoClusters:
         if command:
             status = await command(request)
             # If the command does not returns an error, it is considered a success.
-            if status == None:
+            if status is None:
                 status = {}
 
         return status, []

--- a/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
@@ -22,7 +22,7 @@ from .fixes import add_yaml_support_for_scientific_notation_without_dot
 
 try:
     from yaml import CSafeLoader as SafeLoader
-except:
+except ImportError:
     from yaml import SafeLoader
 
 import os
@@ -240,7 +240,7 @@ class YamlLoader:
         if 'verification' in content:
             disabled = content.get('disabled')
             command = content.get('command')
-            if disabled != True and command != 'UserPrompt':
+            if disabled is not True and command != 'UserPrompt':
                 raise TestStepVerificationStandaloneError(content)
 
     def __rule_response_value_and_values_are_mutually_exclusive(self, content):

--- a/scripts/py_matter_yamltests/test_pics_checker.py
+++ b/scripts/py_matter_yamltests/test_pics_checker.py
@@ -14,7 +14,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import io
 import unittest
 from unittest.mock import mock_open, patch
 

--- a/scripts/py_matter_yamltests/test_spec_definitions.py
+++ b/scripts/py_matter_yamltests/test_spec_definitions.py
@@ -17,7 +17,7 @@
 import io
 import unittest
 
-from matter_yamltests.definitions import *
+from matter_yamltests.definitions import Attribute, Bitmap, Command, Enum, Event, ParseSource, SpecDefinitions, Struct
 
 source_cluster = '''<?xml version="1.0"?>
   <configurator>

--- a/scripts/py_matter_yamltests/test_yaml_loader.py
+++ b/scripts/py_matter_yamltests/test_yaml_loader.py
@@ -15,7 +15,6 @@
 #    limitations under the License.
 #
 
-import io
 import unittest
 from unittest.mock import mock_open, patch
 

--- a/scripts/py_matter_yamltests/test_yaml_parser.py
+++ b/scripts/py_matter_yamltests/test_yaml_parser.py
@@ -23,7 +23,7 @@ import io
 import tempfile
 import unittest
 
-from matter_yamltests.definitions import *
+from matter_yamltests.definitions import ParseSource, SpecDefinitions
 from matter_yamltests.parser import TestParser, TestParserConfig
 
 simple_test_description = '''<?xml version="1.0"?>

--- a/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
+++ b/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
@@ -16,6 +16,7 @@
 
 import asyncio
 import atexit
+import builtins
 import logging
 import os
 import tempfile
@@ -23,7 +24,7 @@ import traceback
 
 # isort: off
 
-from chip import ChipDeviceCtrl  # Needed before chip.FabricAdmin
+from chip import ChipDeviceCtrl  # noqa: F401 # Needed before chip.FabricAdmin
 import chip.FabricAdmin  # Needed before chip.CertificateAuthority
 
 # isort: on
@@ -31,7 +32,7 @@ import chip.FabricAdmin  # Needed before chip.CertificateAuthority
 # ensure matter IDL is availale for import, otherwise set relative paths
 try:
     from matter_idl import matter_idl_types
-except:
+except ImportError:
     SCRIPT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
     import sys
 
@@ -40,11 +41,13 @@ except:
 
     from matter_idl import matter_idl_types
 
+    __ALL__ = (matter_idl_types)
+
 
 import chip.CertificateAuthority
 import chip.native
 import click
-from chip.ChipStack import *
+from chip.ChipStack import ChipStack
 from chip.yaml.runner import ReplTestRunner
 from matter_yamltests.definitions import SpecDefinitionsFromPaths
 from matter_yamltests.parser import PostProcessCheckStatus, TestParser, TestParserConfig
@@ -53,6 +56,8 @@ _DEFAULT_CHIP_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 _CLUSTER_XML_DIRECTORY_PATH = os.path.abspath(
     os.path.join(_DEFAULT_CHIP_ROOT, "src/app/zap-templates/zcl/data-model/"))
+
+certificateAuthorityManager = None
 
 
 async def execute_test(yaml, runner):

--- a/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
+++ b/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
@@ -16,7 +16,6 @@
 
 import asyncio
 import atexit
-import builtins
 import logging
 import os
 import tempfile
@@ -77,7 +76,7 @@ async def execute_test(yaml, runner):
         post_processing_result = test_step.post_process_response(
             decoded_response)
         if not post_processing_result.is_success():
-            logging.warning(f"Test step failure in 'test_step.label'")
+            logging.warning(f"Test step failure in {test_step.label}")
             for entry in post_processing_result.entries:
                 if entry.state == PostProcessCheckStatus.SUCCESS:
                     continue

--- a/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
+++ b/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
@@ -24,6 +24,8 @@ import traceback
 
 # isort: off
 
+# F401 is "Module imported but unused" line will be ignored by linter
+# ChipDeviceCtrl is not used directly in this file but it is needed
 from chip import ChipDeviceCtrl  # noqa: F401 # Needed before chip.FabricAdmin
 import chip.FabricAdmin  # Needed before chip.CertificateAuthority
 


### PR DESCRIPTION
This pull request is a part of #25193 ( part fix python files in Matter_yamltests )

### Problem

Python files need prevent things like syntax errors, typos, bad style, etc... it saves time for reviewing your code. Many python files needed bug fixes.

### Changes

Fix all python files in Matter_yamltests where linter find problem. Adding Matter_yamltests to check with flake8.

### Testing

CI will test and maybe some another manual testing

