### PR TITLE
Add WriteGroupAttributes to chip-repl

### DIFF
--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -128,13 +128,10 @@ def _GetSlowTests() -> Set[str]:
 def _GetInDevelopmentTests() -> Set[str]:
     """Tests that fail in YAML for some reason.
 
-       Goal is for this set to become empty.
+       Currently this is empty and returns an empty set, but this is kept around in case
+       there are tests that are a work in progress.
     """
-    return {
-        # Needs group support in repl / The test is incorrect - see https://github.com/CHIP-Specifications/chip-test-plans/issues/2431 for details.
-        "Test_TC_SC_5_2.yaml",
-        "TestGroupMessaging.yaml",     # Needs group support in repl
-    }
+    return set()
 
 
 def _AllYamlTests():

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -939,6 +939,34 @@ class ChipDeviceController():
             future, eventLoop, device.deviceProxy, attrs, timedRequestTimeoutMs=timedRequestTimeoutMs, interactionTimeoutMs=interactionTimeoutMs, busyWaitMs=busyWaitMs).raise_on_error()
         return await future
 
+    def WriteGroupAttribute(self, groupid: int, attributes: typing.List[typing.Tuple[ClusterObjects.ClusterAttributeDescriptor, int]], busyWaitMs: typing.Union[None, int] = None):
+        '''
+        Write a list of attributes on a target group.
+
+        groupid: Group ID to send write attribute to.
+        attributes: A list of tuples of type (cluster-object, data-version):
+
+        E.g
+            (Clusters.UnitTesting.Attributes.XYZAttribute('hello'), 1) -- Group Write 'hello' with data version 1
+        '''
+        self.CheckIsActive()
+
+        attrs = []
+        invalid_endpoint = 0xFFFF
+        for v in attributes:
+            if len(v) == 2:
+                attrs.append(ClusterAttribute.AttributeWriteRequest(
+                    invalid_endpoint, v[0], v[1], 1, v[0].value))
+            else:
+                attrs.append(ClusterAttribute.AttributeWriteRequest(
+                    invalid_endpoint, v[0], 0, 0, v[0].value))
+
+        ClusterAttribute.WriteGroupAttributes(
+            groupid, self.devCtrl, attrs, busyWaitMs=busyWaitMs).raise_on_error()
+
+        # An empty list is the expected return for sending group write attribute.
+        return []
+
     def _parseAttributePathTuple(self, pathTuple: typing.Union[
         None,  # Empty tuple, all wildcard
         typing.Tuple[int],  # Endpoint

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -944,7 +944,7 @@ class ChipDeviceController():
         Write a list of attributes on a target group.
 
         groupid: Group ID to send write attribute to.
-        attributes: A list of tuples of type (cluster-object, data-version):
+        attributes: A list of tuples of type (cluster-object, data-version). The data-version can be omitted.
 
         E.g
             (Clusters.UnitTesting.Attributes.XYZAttribute('hello'), 1) -- Group Write 'hello' with data version 1


### PR DESCRIPTION
Updated the yamltests runner that uses chip-repl to send write group attributes

Test:
* Confirmed that attribute group write messages are sent when running TestGroupMessaging.yaml with chip-repl based yamltest runner.
* CI now runs test that rely on sending write group attributes