### PR TITLE
[nrfconnect] Changed log levels for two modules

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -33,8 +33,11 @@ choice MATTER_LOG_LEVEL_CHOICE
 	default MATTER_LOG_LEVEL_DBG
 endchoice
 
+config CHIP_APP_LOG_LEVEL
+    default 4 # debug
+
 config LOG_DEFAULT_LEVEL
-    default 2
+    default 2 # warning
 
 config CHIP_LOG_SIZE_OPTIMIZATION
     default y

--- a/src/platform/nrfconnect/CHIPPlatformConfig.h
+++ b/src/platform/nrfconnect/CHIPPlatformConfig.h
@@ -93,7 +93,6 @@
 #define CHIP_CONFIG_LOG_MODULE_AppServer_DETAIL 0
 #define CHIP_CONFIG_LOG_MODULE_Support_DETAIL 0
 #define CHIP_CONFIG_LOG_MODULE_Support_PROGRESS 0
-#define CHIP_CONFIG_LOG_MODULE_DeviceLayer_DETAIL 0
 #endif
 
 // Set MRP retry intervals for Thread and Wi-Fi to test-proven values.


### PR DESCRIPTION
Debug logs from DeviceLayer and applications are not visible because configured log level is too high. Changed log level for both modules to detailed.
