### PR TITLE
[EFR32] Add to flake8 in workflow and fix python files (part #25193)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,7 +12,6 @@ exclude = third_party
           src/test_driver/mbed/*
           src/test_driver/linux-cirque/*
           src/test_driver/esp32/*
-          src/test_driver/efr32/*
           build/chip/java/tests/*
           build/chip/linux/*
           build/config/linux/*
@@ -29,7 +28,6 @@ exclude = third_party
           scripts/build/builders/android.py
           scripts/build/builders/bouffalolab.py
           scripts/build/builders/cc13x2x7_26x2x7.py
-          scripts/build/builders/efr32.py
           scripts/build/builders/esp32.py
           scripts/build/builders/genio.py
           scripts/build/builders/gn.py

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -167,16 +167,16 @@ class Efr32Builder(GnBuilder):
         if chip_build_libshell:
             self.extra_gn_options.append('chip_build_libshell=true')
 
-        if chip_logging == False:
+        if chip_logging is False:
             self.extra_gn_options.append('chip_logging=false')
 
-        if chip_openthread_ftd == False:
+        if chip_openthread_ftd is False:
             self.extra_gn_options.append('chip_openthread_ftd=false')
 
         if enable_heap_monitoring:
             self.extra_gn_options.append('enable_heap_monitoring=true')
 
-        if enable_openthread_cli == False:
+        if enable_openthread_cli is False:
             self.extra_gn_options.append('enable_openthread_cli=false')
 
         if show_qr_code:
@@ -208,7 +208,8 @@ class Efr32Builder(GnBuilder):
 
         if enable_ot_coap_lib:
             self.extra_gn_options.append(
-                'use_silabs_thread_lib=true chip_openthread_target="../silabs:ot-efr32-cert" use_thread_coap_lib=true openthread_external_platform=""')
+                'use_silabs_thread_lib=true chip_openthread_target="../silabs:ot-efr32-cert" '
+                'use_thread_coap_lib=true openthread_external_platform=""')
 
         if not no_version:
             shortCommitSha = subprocess.check_output(

--- a/src/test_driver/efr32/py/nl_test_runner/nl_test_runner.py
+++ b/src/test_driver/efr32/py/nl_test_runner/nl_test_runner.py
@@ -90,7 +90,7 @@ def get_hdlc_rpc_client(device: str, baudrate: int, output: Any, **kwargs):
 def runner(client) -> int:
     """ Run the tests"""
     def on_error_callback(call_object, error):
-        raise Exception("Error running test RPC: {}".format(status))
+        raise Exception("Error running test RPC: {}".format(error))
 
     rpc = client.client.channel(1).rpcs.chip.rpc.NlTest.Run
     invoke = rpc.invoke(rpc.request(), on_error=on_error_callback)


### PR DESCRIPTION
This pull request is a part of #25193 ( part fix python files in EFR32 )

Problem

Python files need prevent things like syntax errors, typos, bad style, etc... it saves time for reviewing your code. Many python files needed bug fixes.

Changes

Fix all python files in EFR32 where linter find problem. Adding EFR32 to check with flake8.

Testing

CI will test and maybe some another manual testing
