### PR TITLE
Backwards Compatibility Issue for released Matter SDKs

### DIFF
--- a/src/app/zap-templates/templates/app/endpoint_config.zapt
+++ b/src/app/zap-templates/templates/app/endpoint_config.zapt
@@ -26,7 +26,7 @@
 
 // This is an array of EmberAfAttributeMetadata structures.
 #define GENERATED_ATTRIBUTE_COUNT {{endpoint_attribute_count}}
-#define GENERATED_ATTRIBUTES {{ endpoint_attribute_list }}
+#define GENERATED_ATTRIBUTES {{ endpoint_attribute_list order='default,id,size,type,mask'}}
 
 // clang-format off
 #define GENERATED_EVENT_COUNT {{ chip_endpoint_generated_event_count }}


### PR DESCRIPTION
Mentioning the new order for GENERATED_ATTRIBUTES in the current template such that default can be the old order within zap and it will not break earlier Matter sdk releases.

JIRA: ZAPP-1081

