### PR TITLE
Using latest DNS SD entry if there are duplicates

### DIFF
--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissionerDiscoveryViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissionerDiscoveryViewModel.swift
@@ -69,7 +69,9 @@ class CommissionerDiscoveryViewModel: ObservableObject {
                     if(commissioner != nil){
                         if(self.commissioners.contains(commissioner!))
                         {
-                            self.Log.info("Skipping previously discovered commissioner \(commissioner!.description)")
+                            var index = self.commissioners.firstIndex(of: commissioner!)
+                            self.commissioners[index!] = commissioner!
+                            self.Log.info("Updating previously discovered commissioner \(commissioner!.description)")
                         }
                         else
                         {

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -514,7 +514,8 @@ void ResolveContext::OnNewInterface(uint32_t interfaceId, const char * fullname,
     // same interface has been updated then it will not be reflected in the list of interfaces. In this case, remove
     // the existing entry in the map since the resolve seems to store it in sequential order and the last entry is
     // the most up to date.
-    if ((interfaces.find(interfaceId)) != interfaces.end()) {
+    if ((interfaces.find(interfaceId)) != interfaces.end())
+    {
         interfaces.erase(interfaceId);
     }
     interfaces.insert(std::make_pair(interfaceId, std::move(interface)));

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -510,6 +510,13 @@ void ResolveContext::OnNewInterface(uint32_t interfaceId, const char * fullname,
     // resolving.
     interface.fullyQualifiedDomainName = hostnameWithDomain;
 
+    // DNSServiceResolve caches old entries with the same interface ID. This means that when the broadcast with the
+    // same interface has been updated then it will not be reflected in the list of interfaces. In this case, remove
+    // the existing entry in the map since the resolve seems to store it in sequential order and the last entry is
+    // the most up to date.
+    if ((interfaces.find(interfaceId)) != interfaces.end()) {
+        interfaces.erase(interfaceId);
+    }
     interfaces.insert(std::make_pair(interfaceId, std::move(interface)));
 }
 


### PR DESCRIPTION
The DNSServiceResolve function in Darwin seems to cache DNS SD entries. It returns them in sequential order and the SDK holds a map of the entries keyed off the interface ID. This change updates it so that we always use the latest entry returned by the callback.
