### PR TITLE
Remove unused event.

### DIFF
--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -3064,7 +3064,6 @@ endpoint 0 {
 
   server cluster AccessControl {
     emits event AccessControlEntryChanged;
-    emits event AccessControlExtensionChanged;
     callback attribute acl;
     callback attribute subjectsPerAccessControlEntry;
     callback attribute targetsPerAccessControlEntry;

--- a/examples/placeholder/linux/apps/app1/config.zap
+++ b/examples/placeholder/linux/apps/app1/config.zap
@@ -608,7 +608,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "included": 1
+              "included": 0
             }
           ]
         },

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -3033,7 +3033,6 @@ endpoint 0 {
 
   server cluster AccessControl {
     emits event AccessControlEntryChanged;
-    emits event AccessControlExtensionChanged;
     callback attribute acl;
     callback attribute subjectsPerAccessControlEntry;
     callback attribute targetsPerAccessControlEntry;

--- a/examples/placeholder/linux/apps/app2/config.zap
+++ b/examples/placeholder/linux/apps/app2/config.zap
@@ -608,7 +608,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "included": 1
+              "included": 0
             }
           ]
         },


### PR DESCRIPTION
Remove AccessControlExtensionChanged from ACL cluster in the simulated app.