### PR TITLE
Added Darwin support for Java examples

### DIFF
--- a/build/chip/java/config.gni
+++ b/build/chip/java/config.gni
@@ -17,10 +17,16 @@ declare_args() {
   java_matter_controller_dependent_paths = []
   build_java_matter_controller = false
   if (java_path != "") {
-    java_matter_controller_dependent_paths += [
-      "${java_path}/include/",
-      "${java_path}/include/linux/",
-    ]
+    java_matter_controller_dependent_paths += [ "${java_path}/include/" ]
+
+    if (current_os == "mac") {
+      java_matter_controller_dependent_paths +=
+          [ "${java_path}/include/darwin/" ]
+    } else {
+      java_matter_controller_dependent_paths +=
+          [ "${java_path}/include/linux/" ]
+    }
+
     build_java_matter_controller = true
   }
 }

--- a/src/controller/data_model/BUILD.gn
+++ b/src/controller/data_model/BUILD.gn
@@ -199,7 +199,11 @@ if (current_os == "android" || build_java_matter_controller) {
     ]
 
     if (build_java_matter_controller) {
-      deps += [ "${chip_root}/src/platform/Linux" ]
+      if (current_os == "mac") {
+        deps += [ "${chip_root}/src/platform/Darwin" ]
+      } else {
+        deps += [ "${chip_root}/src/platform/Linux" ]
+      }
     } else {
       deps += [ "${chip_root}/src/platform/android" ]
     }

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -25,6 +25,10 @@ if (!build_java_matter_controller) {
 shared_library("jni") {
   output_name = "libCHIPController"
 
+  if (current_os == "mac") {
+    output_extension = "dylib"
+  }
+
   sources = [
     "AndroidCallbacks-JNI.cpp",
     "AndroidCallbacks.cpp",
@@ -54,12 +58,7 @@ shared_library("jni") {
     "zap-generated/CHIPReadCallbacks.cpp",
     "zap-generated/CHIPReadCallbacks.h",
   ]
-  if (build_java_matter_controller) {
-    sources += [
-      "${chip_root}/src/controller/ExamplePersistentStorage.cpp",
-      "${chip_root}/src/controller/ExamplePersistentStorage.h",
-    ]
-  }
+
   deps = [
     "${chip_root}/src/controller/data_model",
     "${chip_root}/src/controller/data_model:java-jni-sources",
@@ -70,13 +69,22 @@ shared_library("jni") {
     "${chip_root}/src/platform",
   ]
 
-  public_configs = [ "${chip_root}/src:includes" ]
-
   if (build_java_matter_controller) {
     defines = [ "JAVA_MATTER_CONTROLLER_TEST" ]
-    include_dirs = java_matter_controller_dependent_paths
 
-    deps += [ "${chip_root}/src/platform/Linux" ]
+    sources += [
+      "${chip_root}/src/controller/ExamplePersistentStorage.cpp",
+      "${chip_root}/src/controller/ExamplePersistentStorage.h",
+    ]
+
+    include_dirs = java_matter_controller_dependent_paths
+    deps += [ "${chip_root}/third_party/inipp" ]
+
+    if (current_os == "mac") {
+      deps += [ "${chip_root}/src/platform/Darwin" ]
+    } else {
+      deps += [ "${chip_root}/src/platform/Linux" ]
+    }
 
     cflags = [ "-Wno-unknown-pragmas" ]
 
@@ -87,7 +95,13 @@ shared_library("jni") {
     output_dir = "${root_out_dir}/lib/jni/${android_abi}"
   }
 
-  ldflags = [ "-Wl,--gc-sections" ]
+  if (current_os == "mac") {
+    ldflags = [ "-Wl,-dead_strip" ]
+  } else {
+    ldflags = [ "-Wl,--gc-sections" ]
+  }
+
+  public_configs = [ "${chip_root}/src:includes" ]
 }
 
 if (chip_link_tests) {
@@ -105,8 +119,11 @@ if (chip_link_tests) {
     if (build_java_matter_controller) {
       defines = [ "JAVA_MATTER_CONTROLLER_TEST" ]
       include_dirs = java_matter_controller_dependent_paths
-
-      deps += [ "${chip_root}/src/platform/Linux" ]
+      if (current_os == "mac") {
+        deps += [ "${chip_root}/src/platform/Darwin" ]
+      } else {
+        deps += [ "${chip_root}/src/platform/Linux" ]
+      }
 
       cflags = [ "-Wno-unknown-pragmas" ]
 


### PR DESCRIPTION
When testing the `darwin-arm64-java-matter-controller` target, I found that the Java examples were not compatible with OSX. It appeared that only Linux environment had been configured and support for the Java packages.

JDK8 was required to avoid compilation warnings (that became errors) related to the deprecation of `finalize()`.

When building for Darwin arm64, the resulting shared object was compiled for "Mach-O 64-bit dynamically linked shared library arm64". To successfully run the project I was required to use a java runtime that was compiled for the same architecture.

https://corretto.aws/downloads/latest/amazon-corretto-8-aarch64-macos-jdk.pkg

* Build Projects

```
source ./scripts/activate.sh

export JAVA_PATH=/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/
export PATH=$JAVA_PATH/bin:$PATH

./scripts/build/build_examples.py --target darwin-arm64-java-matter-controller build
./scripts/build/build_examples.py --target darwin-arm64-chip-tool build
./scripts/build/build_examples.py --target darwin-arm64-all-clusters build
```

* Terminal 1

```
cd out/darwin-arm64-all-clusters/

rm /tmp/chip*
./chip-all-clusters-app
```

* Terminal 2

```
cd out/darwin-arm64-java-matter-controller/

java -verbose:jni -Xcheck:jni -Djava.library.path=lib/jni/ \
  -jar bin/java-matter-controller \
  pairing onnetwork-long 1 20202021 3840 1000
```

