### PR TITLE
Implemented Feature Flag to Enable/Disable Global EventList Attribute

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -40,6 +40,8 @@ declare_args() {
 
   # By default, the resources used by each fabric is unlimited if they are allocated on heap. This flag is for checking the resource usage even when they are allocated on heap to increase code coverage in integration tests.
   chip_im_force_fabric_quota_check = false
+
+  enable_eventlist_attribute = false
 }
 
 buildconfig_header("app_buildconfig") {
@@ -52,6 +54,7 @@ buildconfig_header("app_buildconfig") {
     "CHIP_CONFIG_ENABLE_SESSION_RESUMPTION=${chip_enable_session_resumption}",
     "CHIP_CONFIG_ACCESS_CONTROL_POLICY_LOGGING_VERBOSITY=${chip_access_control_policy_logging_verbosity}",
     "CHIP_CONFIG_PERSIST_SUBSCRIPTIONS=${chip_persist_subscriptions}",
+    "CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE=${enable_eventlist_attribute}",
   ]
 }
 

--- a/src/app/GlobalAttributes.h
+++ b/src/app/GlobalAttributes.h
@@ -31,7 +31,9 @@ namespace app {
 constexpr AttributeId GlobalAttributesNotInMetadata[] = {
     Clusters::Globals::Attributes::GeneratedCommandList::Id,
     Clusters::Globals::Attributes::AcceptedCommandList::Id,
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
     Clusters::Globals::Attributes::EventList::Id,
+#endif // CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
     Clusters::Globals::Attributes::AttributeList::Id,
 };
 

--- a/src/app/tests/TestAttributePathExpandIterator.cpp
+++ b/src/app/tests/TestAttributePathExpandIterator.cpp
@@ -49,20 +49,26 @@ void TestAllWildcard(nlTestSuite * apSuite, void * apContext)
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint1, MockClusterId(2), MockAttributeId(1) },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
@@ -70,7 +76,9 @@ void TestAllWildcard(nlTestSuite * apSuite, void * apContext)
         { kMockEndpoint2, MockClusterId(2), MockAttributeId(2) },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::FeatureMap::Id },
@@ -79,14 +87,18 @@ void TestAllWildcard(nlTestSuite * apSuite, void * apContext)
         { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint3, MockClusterId(1), MockAttributeId(1) },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
@@ -96,19 +108,25 @@ void TestAllWildcard(nlTestSuite * apSuite, void * apContext)
         { kMockEndpoint3, MockClusterId(2), MockAttributeId(4) },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::AttributeList::Id },
     };
 
@@ -214,7 +232,9 @@ void TestWildcardAttribute(nlTestSuite * apSuite, void * apContext)
         { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AttributeList::Id },
     };
 
@@ -287,20 +307,26 @@ void TestMultipleClusInfo(nlTestSuite * apSuite, void * apContext)
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint1, MockClusterId(2), MockAttributeId(1) },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
@@ -308,7 +334,9 @@ void TestMultipleClusInfo(nlTestSuite * apSuite, void * apContext)
         { kMockEndpoint2, MockClusterId(2), MockAttributeId(2) },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::FeatureMap::Id },
@@ -317,14 +345,18 @@ void TestMultipleClusInfo(nlTestSuite * apSuite, void * apContext)
         { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint3, MockClusterId(1), MockAttributeId(1) },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
@@ -334,19 +366,25 @@ void TestMultipleClusInfo(nlTestSuite * apSuite, void * apContext)
         { kMockEndpoint3, MockClusterId(2), MockAttributeId(4) },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
@@ -360,7 +398,9 @@ void TestMultipleClusInfo(nlTestSuite * apSuite, void * apContext)
         { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AcceptedCommandList::Id },
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::EventList::Id },
+#endif
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
     };

--- a/src/app/tests/suites/TestBasicInformation.yaml
+++ b/src/app/tests/suites/TestBasicInformation.yaml
@@ -79,7 +79,6 @@ tests:
                   19,
                   0xFFF8, # GeneratedCommandList
                   0xFFF9, # AcceptedCommandList
-                  0xFFFA, # EventList
                   0xFFFB, # AttributeList
                   0xFFFC, # FeatureMap
                   0xFFFD, # ClusterRevision

--- a/src/app/tests/suites/certification/Test_TC_ACL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 2, 3, 4, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 2, 3, 4, 65528, 65529, 65531, 65532, 65533]
 
     - label: "TH reads optional attribute (Extension) in AttributeList"
       PICS: ACL.S.A0001

--- a/src/app/tests/suites/certification/Test_TC_ACT_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACT_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the optional attribute(SetupURL) in AttributeList"
       PICS: ACT.S.A0002

--- a/src/app/tests/suites/certification/Test_TC_ALOGIN_1_12.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ALOGIN_1_12.yaml
@@ -55,7 +55,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the global attribute: AcceptedCommandList"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_APBSC_1_10.yaml
+++ b/src/app/tests/suites/certification/Test_TC_APBSC_1_10.yaml
@@ -55,8 +55,7 @@ tests:
       response:
           constraints:
               type: list
-              contains:
-                  [2, 4, 5, 6, 7, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [2, 4, 5, 6, 7, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the optional attribute(VendorName) in AttributeList"
       PICS: APBSC.S.A0000

--- a/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_1_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_1_3.yaml
@@ -65,7 +65,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the optional attribute(CatalogList) in AttributeList"
       PICS: APPLAUNCHER.S.A0000

--- a/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_1_8.yaml
+++ b/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_1_8.yaml
@@ -56,7 +56,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the global attribute: AcceptedCommandList"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_BIND_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BIND_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 65528, 65529, 65531, 65532, 65533]
 
     - label: "TH reads AcceptedCommandList from DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_BOOL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BOOL_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the global attribute: AcceptedCommandList"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_BRBINFO_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BRBINFO_1_1.yaml
@@ -56,7 +56,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [17, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [17, 65528, 65529, 65531, 65532, 65533]
 
     - label: "TH reads optional attribute(VendorName) in AttributeList"
       PICS: BRBINFO.S.A0001

--- a/src/app/tests/suites/certification/Test_TC_CC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_1_1.yaml
@@ -99,19 +99,7 @@ tests:
       response:
           constraints:
               type: list
-              contains:
-                  [
-                      8,
-                      15,
-                      16385,
-                      16394,
-                      65528,
-                      65529,
-                      65530,
-                      65531,
-                      65532,
-                      65533,
-                  ]
+              contains: [8, 15, 16385, 16394, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the optional attribute(CurrentHue) in AttributeList"
       PICS: CC.S.A0000

--- a/src/app/tests/suites/certification/Test_TC_CGEN_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CGEN_1_1.yaml
@@ -53,8 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains:
-                  [0, 1, 2, 3, 4, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 2, 3, 4, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the global attribute: AcceptedCommandList"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_CHANNEL_1_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CHANNEL_1_6.yaml
@@ -73,7 +73,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the optional attribute(ChannelList): AttributeList"
       PICS: CHANNEL.S.A0000

--- a/src/app/tests/suites/certification/Test_TC_CNET_1_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CNET_1_3.yaml
@@ -75,7 +75,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [65528, 65529, 65531, 65532, 65533]
 
     - label:
           "Read mandatory attributes in AttributeList if

--- a/src/app/tests/suites/certification/Test_TC_CONTENTLAUNCHER_1_11.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CONTENTLAUNCHER_1_11.yaml
@@ -76,7 +76,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the optional attribute(AcceptHeader): AttributeList"
       PICS: CONTENTLAUNCHER.S.A0000

--- a/src/app/tests/suites/certification/Test_TC_DESC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DESC_1_1.yaml
@@ -54,7 +54,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 2, 3, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the global attribute: AcceptedCommandList"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_DGETH_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DGETH_1_1.yaml
@@ -73,7 +73,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [65528, 65529, 65531, 65532, 65533]
 
     - label: "TH reads optional attribute(PHYRate) in AttributeList"
       PICS: DGETH.S.A0000

--- a/src/app/tests/suites/certification/Test_TC_DGGEN_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DGGEN_1_1.yaml
@@ -54,7 +54,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 8, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 8, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read optional attribute(UpTime) in AttributeList"
       PICS: DGGEN.S.A0002

--- a/src/app/tests/suites/certification/Test_TC_DGSW_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DGSW_1_1.yaml
@@ -66,7 +66,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [65528, 65529, 65531, 65532, 65533]
 
     - label: "TH reads optional attribute(ThreadMetrics) in AttributeList"
       PICS: DGSW.S.A0000

--- a/src/app/tests/suites/certification/Test_TC_DGWIFI_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DGWIFI_1_1.yaml
@@ -76,8 +76,7 @@ tests:
       response:
           constraints:
               type: list
-              contains:
-                  [0, 1, 2, 3, 4, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 2, 3, 4, 65528, 65529, 65531, 65532, 65533]
 
     - label:
           "TH reads Feature dependent(DGWIFI.S.F00) attributes in attributeList

--- a/src/app/tests/suites/certification/Test_TC_DLOG_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DLOG_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [65528, 65529, 65531, 65532, 65533]
 
     - label: "TH reads AcceptedCommandList from DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_DRLK_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_1_1.yaml
@@ -148,8 +148,7 @@ tests:
       response:
           constraints:
               type: list
-              contains:
-                  [0, 1, 2, 37, 38, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 2, 37, 38, 65528, 65529, 65531, 65532, 65533]
 
     - label:
           "TH reads Feature dependent(DRLK.S.F05) attributes in AttributeList"

--- a/src/app/tests/suites/certification/Test_TC_FLABEL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FLABEL_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 65528, 65529, 65531, 65532, 65533]
 
     - label: "TH reads AcceptedCommandList from DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_FLW_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FLW_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 2, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 2, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the optional attribute(Tolerance) in AttributeList"
       PICS: FLW.S.A0003

--- a/src/app/tests/suites/certification/Test_TC_G_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_G_1_1.yaml
@@ -63,7 +63,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 65528, 65529, 65531, 65532, 65533]
 
     - label: "TH reads AcceptedCommandList from DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_ILL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ILL_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 2, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 2, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the optional attribute(Tolerance) in AttributeList"
       PICS: ILL.S.A0003

--- a/src/app/tests/suites/certification/Test_TC_I_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_I_1_1.yaml
@@ -63,7 +63,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the global attribute: AcceptedCommandList"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_KEYPADINPUT_1_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_KEYPADINPUT_1_2.yaml
@@ -83,7 +83,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the global attribute: AcceptedCommandList"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_LCFG_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LCFG_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 65528, 65529, 65531, 65532, 65533]
 
     - label: "TH reads AcceptedCommandList from DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_LOWPOWER_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LOWPOWER_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       command: "readAttribute"
       attribute: "AttributeList"
       response:
-          value: [65528, 65529, 65530, 65531, 65532, 65533]
+          value: [65528, 65529, 65531, 65532, 65533]
           constraints:
               type: list
 

--- a/src/app/tests/suites/certification/Test_TC_LTIME_1_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LTIME_1_2.yaml
@@ -57,7 +57,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 65528, 65529, 65531, 65532, 65533]
 
     - label:
           "TH reads optional attribute(ActiveCalendarType) in AttributeList from

--- a/src/app/tests/suites/certification/Test_TC_LUNIT_1_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LUNIT_1_2.yaml
@@ -65,7 +65,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [65528, 65529, 65531, 65532, 65533]
 
     - label:
           "TH reads Feature dependent(LUNIT.S.F00) attribute in AttributeList"

--- a/src/app/tests/suites/certification/Test_TC_LVL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_1_1.yaml
@@ -81,7 +81,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 15, 17, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 15, 17, 65528, 65529, 65531, 65532, 65533]
 
     - label:
           "Read the optional attribute(StartUpCurrentLevel and RemainingTime) in

--- a/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_1_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_1_4.yaml
@@ -65,7 +65,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the optional attribute(InputList) in AttributeList"
       PICS: MEDIAINPUT.S.A0000

--- a/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_1_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_1_7.yaml
@@ -76,7 +76,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the optional attribute(StartTime) in AttributeList"
       PICS: MEDIAPLAYBACK.S.A0001

--- a/src/app/tests/suites/certification/Test_TC_MOD_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MOD_1_1.yaml
@@ -63,7 +63,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 2, 3, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533]
 
     - label:
           "TH reads the optional attribute(StartUpMode) in AttributeList from

--- a/src/app/tests/suites/certification/Test_TC_OCC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OCC_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 2, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 2, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the global attribute: AcceptedCommandList"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_OO_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OO_1_1.yaml
@@ -63,7 +63,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the feature dependent(OO.S.F00) attribute in AttributeList"
       PICS: OO.S.F00

--- a/src/app/tests/suites/certification/Test_TC_PCC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PCC_1_1.yaml
@@ -122,21 +122,7 @@ tests:
           constraints:
               type: list
               contains:
-                  [
-                      0,
-                      1,
-                      2,
-                      17,
-                      18,
-                      19,
-                      32,
-                      65528,
-                      65529,
-                      65530,
-                      65531,
-                      65532,
-                      65533,
-                  ]
+                  [0, 1, 2, 17, 18, 19, 32, 65528, 65529, 65531, 65532, 65533]
 
     - label:
           "TH reads optional attribute(MinConstPressure) attribute in

--- a/src/app/tests/suites/certification/Test_TC_PRS_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PRS_1_1.yaml
@@ -63,7 +63,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 2, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 2, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the optional attribute(ScaledValue) in AttributeList"
       PICS: PRS.S.A0010

--- a/src/app/tests/suites/certification/Test_TC_PSCFG_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PSCFG_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 65528, 65529, 65531, 65532, 65533]
 
     - label: "TH reads the AcceptedCommandList attribute from the DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_PS_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PS_1_1.yaml
@@ -90,7 +90,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 2, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 2, 65528, 65529, 65531, 65532, 65533]
 
     - label:
           "Read the Feature dependent(PS.S.F00-WIRED) attribute in AttributeList"

--- a/src/app/tests/suites/certification/Test_TC_RH_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_RH_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 2, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 2, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the optional attribute(Tolerance) in AttributeList"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_SWTCH_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SWTCH_1_1.yaml
@@ -109,7 +109,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 2, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 2, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the global attribute: AttributeList"
       PICS: "!SWTCH.S.F04"
@@ -118,7 +118,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the global attribute: AcceptedCommandList"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_TGTNAV_1_9.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TGTNAV_1_9.yaml
@@ -55,7 +55,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the optional attribute(CurrentTarget) in AttributeList"
       PICS: TGTNAV.S.A0001

--- a/src/app/tests/suites/certification/Test_TC_TMP_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TMP_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 2, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 2, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the optional attribute(Tolerance) in AttributeList"
       PICS: TMP.S.A0003

--- a/src/app/tests/suites/certification/Test_TC_TSTAT_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_1_1.yaml
@@ -110,7 +110,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 27, 28, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 27, 28, 65528, 65529, 65531, 65532, 65533]
 
     - label:
           "Read the Feature dependent(TSTAT.S.F00(HEAT)) attribute in

--- a/src/app/tests/suites/certification/Test_TC_TSUIC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSUIC_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 1, 2, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 1, 2, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the global attribute: AcceptedCommandList"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_ULABEL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ULABEL_1_1.yaml
@@ -53,7 +53,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 65528, 65529, 65531, 65532, 65533]
 
     - label: "Read the global attribute: AcceptedCommandList"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_WAKEONLAN_1_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WAKEONLAN_1_5.yaml
@@ -55,7 +55,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [65528, 65529, 65530, 65531, 65531, 65533]
+              contains: [65528, 65529, 65531, 65531, 65533]
 
     - label: "Read the optional attribute(MACAddress) in AttributeList"
       PICS: WAKEONLAN.S.A0000

--- a/src/app/tests/suites/certification/Test_TC_WNCV_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_1_1.yaml
@@ -107,8 +107,7 @@ tests:
       response:
           constraints:
               type: list
-              contains:
-                  [0, 7, 10, 13, 23, 65528, 65529, 65530, 65531, 65532, 65533]
+              contains: [0, 7, 10, 13, 23, 65528, 65529, 65531, 65532, 65533]
 
     - label: "TH reads optional attribute(SafetyStatus) in AttributeList"
       PICS: WNCV.S.Afffb && WNCV.S.A001a

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -330,10 +330,15 @@ CHIP_ERROR GlobalAttributeReader::Read(const ConcreteReadAttributePath & aPath, 
             {
                 AttributeId id              = mCluster->attributes[i].attributeId;
                 constexpr auto lastGlobalId = GlobalAttributesNotInMetadata[ArraySize(GlobalAttributesNotInMetadata) - 1];
-                // We are relying on GlobalAttributesNotInMetadata not having
-                // any gaps in their ids here.
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
+                // The GlobalAttributesNotInMetadata shouldn't have any gaps in their ids here.
                 static_assert(lastGlobalId - GlobalAttributesNotInMetadata[0] == ArraySize(GlobalAttributesNotInMetadata) - 1,
                               "Ids in GlobalAttributesNotInMetadata not consecutive");
+#else
+                // If EventList is not supported. The GlobalAttributesNotInMetadata is missing one id here.
+                static_assert(lastGlobalId - GlobalAttributesNotInMetadata[0] == ArraySize(GlobalAttributesNotInMetadata),
+                              "Ids in GlobalAttributesNotInMetadata not consecutive (except EventList)");
+#endif // CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
                 if (!addedExtraGlobals && id > lastGlobalId)
                 {
                     for (const auto & globalId : GlobalAttributesNotInMetadata)
@@ -353,6 +358,7 @@ CHIP_ERROR GlobalAttributeReader::Read(const ConcreteReadAttributePath & aPath, 
             }
             return CHIP_NO_ERROR;
         });
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
     case EventList::Id:
         return aEncoder.EncodeList([this](const auto & encoder) {
             for (size_t i = 0; i < mCluster->eventCount; ++i)
@@ -361,6 +367,7 @@ CHIP_ERROR GlobalAttributeReader::Read(const ConcreteReadAttributePath & aPath, 
             }
             return CHIP_NO_ERROR;
         });
+#endif // CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
     case AcceptedCommandList::Id:
         return EncodeCommandList(aPath, aEncoder, &CommandHandlerInterface::EnumerateAcceptedCommands,
                                  mCluster->acceptedCommandList);

--- a/src/controller/tests/TestEventChunking.cpp
+++ b/src/controller/tests/TestEventChunking.cpp
@@ -26,12 +26,14 @@
 #include <app/BufferedReadCallback.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/EventLogging.h>
+#include <app/GlobalAttributes.h>
 #include <app/InteractionModelEngine.h>
 #include <app/data-model/Decode.h>
 #include <app/tests/AppTestContext.h>
 #include <app/util/DataModelHandler.h>
 #include <app/util/attribute-storage.h>
 #include <controller/InvokeInteraction.h>
+#include <lib/core/CHIPCore.h>
 #include <lib/support/CHIPCounter.h>
 #include <lib/support/ErrorStr.h>
 #include <lib/support/TimeUtils.h>
@@ -196,10 +198,12 @@ void TestReadCallback::OnAttributeData(const app::ConcreteDataAttributePath & aP
         NL_TEST_ASSERT(gSuite, v.ComputeSize(&arraySize) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(gSuite, arraySize == 0);
     }
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
     else if (aPath.mAttributeId == Globals::Attributes::EventList::Id)
     {
         // Nothing to check for this one; depends on the endpoint.
     }
+#endif // CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
     else if (aPath.mAttributeId == Globals::Attributes::AttributeList::Id)
     {
         // Nothing to check for this one; depends on the endpoint.
@@ -428,12 +432,10 @@ void TestReadEvents::TestMixedEventsAndAttributesChunking(nlTestSuite * apSuite,
         ctx.DrainAndServiceIO();
 
         //
-        // Always returns the same number of attributes read (5 + revision +
-        // AttributeList + ClientGeneratedCommandList +
-        // ServerGeneratedCommandList = 9).
+        // Always returns the same number of attributes read (5 + revision + GlobalAttributesNotInMetadata).
         //
         NL_TEST_ASSERT(apSuite, readCallback.mOnReportEnd);
-        NL_TEST_ASSERT(apSuite, readCallback.mAttributeCount == 10);
+        NL_TEST_ASSERT(apSuite, readCallback.mAttributeCount == 6 + ArraySize(GlobalAttributesNotInMetadata));
         NL_TEST_ASSERT(apSuite, readCallback.mEventCount == static_cast<uint32_t>(lastEventNumber - firstEventNumber + 1));
 
         NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);

--- a/src/controller/tests/TestReadChunking.cpp
+++ b/src/controller/tests/TestReadChunking.cpp
@@ -25,6 +25,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/BufferedReadCallback.h>
 #include <app/CommandHandlerInterface.h>
+#include <app/GlobalAttributes.h>
 #include <app/InteractionModelEngine.h>
 #include <app/data-model/Decode.h>
 #include <app/tests/AppTestContext.h>
@@ -174,10 +175,12 @@ void TestReadCallback::OnAttributeData(const app::ConcreteDataAttributePath & aP
         NL_TEST_ASSERT(gSuite, v.ComputeSize(&arraySize) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(gSuite, arraySize == 0);
     }
+#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
     else if (aPath.mAttributeId == Globals::Attributes::EventList::Id)
     {
         // Nothing to check for this one; depends on the endpoint.
     }
+#endif // CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
     else if (aPath.mAttributeId == Globals::Attributes::AttributeList::Id)
     {
         // Nothing to check for this one; depends on the endpoint.
@@ -407,11 +410,9 @@ void TestReadChunking::TestChunking(nlTestSuite * apSuite, void * apContext)
         NL_TEST_ASSERT(apSuite, readCallback.mOnReportEnd);
 
         //
-        // Always returns the same number of attributes read (5 + revision +
-        // AttributeList + EventList + AcceptedCommandList +
-        // GeneratedCommandList = 10).
+        // Always returns the same number of attributes read (5 + revision + GlobalAttributesNotInMetadata).
         //
-        NL_TEST_ASSERT(apSuite, readCallback.mAttributeCount == 10);
+        NL_TEST_ASSERT(apSuite, readCallback.mAttributeCount == 6 + ArraySize(GlobalAttributesNotInMetadata));
         readCallback.mAttributeCount = 0;
 
         NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
@@ -585,9 +586,10 @@ void TestReadChunking::TestDynamicEndpoint(nlTestSuite * apSuite, void * apConte
         ctx.DrainAndServiceIO();
 
         // Ensure we have received the report, we do not care about the initial report here.
-        // AcceptedCommandList / GeneratedCommandList / EventList / AttributeList attribute are not included in
-        // testClusterAttrsOnEndpoint4.
-        NL_TEST_ASSERT(apSuite, readCallback.mAttributeCount == ArraySize(testClusterAttrsOnEndpoint4) + 4);
+        // GlobalAttributesNotInMetadata attributes are not included in testClusterAttrsOnEndpoint4.
+        NL_TEST_ASSERT(apSuite,
+                       readCallback.mAttributeCount ==
+                           ArraySize(testClusterAttrsOnEndpoint4) + ArraySize(GlobalAttributesNotInMetadata));
 
         // We have received all report data.
         NL_TEST_ASSERT(apSuite, readCallback.mOnReportEnd);
@@ -611,9 +613,10 @@ void TestReadChunking::TestDynamicEndpoint(nlTestSuite * apSuite, void * apConte
         ctx.DrainAndServiceIO();
 
         // Ensure we have received the report, we do not care about the initial report here.
-        // AcceptedCommandList / GeneratedCommandList / EventList / AttributeList attribute are not included in
-        // testClusterAttrsOnEndpoint4.
-        NL_TEST_ASSERT(apSuite, readCallback.mAttributeCount == ArraySize(testClusterAttrsOnEndpoint4) + 4);
+        // GlobalAttributesNotInMetadata attributes are not included in testClusterAttrsOnEndpoint4.
+        NL_TEST_ASSERT(apSuite,
+                       readCallback.mAttributeCount ==
+                           ArraySize(testClusterAttrsOnEndpoint4) + ArraySize(GlobalAttributesNotInMetadata));
 
         // We have received all report data.
         NL_TEST_ASSERT(apSuite, readCallback.mOnReportEnd);


### PR DESCRIPTION
The feature is disabled by default. To enable global EventList attribute use feature flag as follow:
`gn gen out/host --args='enable_eventlist_attribute=true'`

Note to reviewers:
To minimize complexity and implementation of this feature flag, this PR doesn't change *.zap, *.matter and auto generated files, which still list and implement logic associated with EventList attribute. However, this logic will never be used if `enable_eventlist_attribute == false`.

Fixes #25231 
