### PR TITLE
[Telink] Add missed client side for THREAD_NETWORK_DIAGNOSTICS_CLUSTER

### DIFF
--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -1161,6 +1161,8 @@ server cluster ThreadNetworkDiagnostics = 53 {
   readonly attribute attrib_id attributeList[] = 65531;
   readonly attribute bitmap32 featureMap = 65532;
   readonly attribute int16u clusterRevision = 65533;
+
+  command ResetCounts(): DefaultSuccess = 0;
 }
 
 server cluster WiFiNetworkDiagnostics = 54 {

--- a/examples/thermostat/thermostat-common/thermostat.zap
+++ b/examples/thermostat/thermostat-common/thermostat.zap
@@ -3030,6 +3030,42 @@
           "code": 53,
           "mfgCode": null,
           "define": "THREAD_NETWORK_DIAGNOSTICS_CLUSTER",
+          "side": "client",
+          "enabled": 0,
+          "commands": [
+            {
+              "name": "ResetCounts",
+              "code": 0,
+              "mfgCode": null,
+              "source": "client",
+              "incoming": 1,
+              "outgoing": 0
+            }
+          ],
+          "attributes": [
+            {
+              "name": "ClusterRevision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "client",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "1",
+              "reportable": 1,
+              "minInterval": 0,
+              "maxInterval": 65344,
+              "reportableChange": 0
+            }
+          ]
+        },
+        {
+          "name": "Thread Network Diagnostics",
+          "code": 53,
+          "mfgCode": null,
+          "define": "THREAD_NETWORK_DIAGNOSTICS_CLUSTER",
           "side": "server",
           "enabled": 1,
           "attributes": [


### PR DESCRIPTION
**Problem**

Thermostat fails Test_TC_DGTHREAD_1_1 because client side is missed for THREAD_NETWORK_DIAGNOSTICS_CLUSTER in "examples/thermostat/thermostat-common/thermostat.zap"

**Change overview**

Add missed client side for THREAD_NETWORK_DIAGNOSTICS_CLUSTER

**Testing**

Perform Thermostat Test_TC_DGTHREAD_1_1