### PR TITLE
[NXP] Add to flake8 in workflow and fix python files (part #25193)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -23,7 +23,6 @@ exclude = third_party
           examples/common/pigweed/rpc_console/py/chip_rpc/console.py
           examples/lighting-app/python/lighting.py
           examples/platform/mbed/ota/generate_ota_list_image.py
-          examples/platform/nxp/k32w/k32w0/scripts/detokenizer.py
           scripts/build/build/target.py
           scripts/build/build/targets.py
           scripts/build/builders/android.py
@@ -81,9 +80,6 @@ exclude = third_party
           scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
           scripts/tools/nrfconnect/nrfconnect_generate_partition.py
           scripts/tools/nrfconnect/tests/test_generate_factory_data.py
-          scripts/tools/nxp/factory_data_generator/custom.py
-          scripts/tools/nxp/factory_data_generator/default.py
-          scripts/tools/nxp/factory_data_generator/generate.py
           scripts/tools/silabs/FactoryDataProvider.py
           scripts/tools/telink/mfg_tool.py
           scripts/tools/zap/generate.py

--- a/examples/platform/nxp/k32w/k32w0/scripts/detokenizer.py
+++ b/examples/platform/nxp/k32w/k32w0/scripts/detokenizer.py
@@ -53,7 +53,7 @@ def decode_string(tstr, detok):
         if s.find('$') == 0:
             return None
         return s
-    except:
+    except ValueError:
         return None
 
 
@@ -88,7 +88,7 @@ def decode_serial(serialport, outfile, database):
                     print(line, file=sys.stdout)
                     if output:
                         print(line, file=output)
-        except:
+        except Exception:
             print("Serial error or program closed", file=sys.stderr)
 
         if output:
@@ -120,7 +120,7 @@ def decode_file(infile, outfile, database):
                     # ascii decode line
                     # serial terminals may include non ascii characters
                     line = line.decode('ascii').strip()
-                except:
+                except Exception:
                     continue
                 # find token start and detokenize
                 idx = line.rfind(']')

--- a/scripts/tools/nxp/factory_data_generator/custom.py
+++ b/scripts/tools/nxp/factory_data_generator/custom.py
@@ -49,7 +49,7 @@ option:
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import load_der_private_key
-from default import *
+from default import StrArgument, FileArgument, IntArgument, Base64Argument
 
 
 class Verifier(Base64Argument):

--- a/scripts/tools/nxp/factory_data_generator/custom.py
+++ b/scripts/tools/nxp/factory_data_generator/custom.py
@@ -49,7 +49,7 @@ option:
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import load_der_private_key
-from default import StrArgument, FileArgument, IntArgument, Base64Argument
+from default import Base64Argument, FileArgument, IntArgument, StrArgument
 
 
 class Verifier(Base64Argument):

--- a/scripts/tools/nxp/factory_data_generator/default.py
+++ b/scripts/tools/nxp/factory_data_generator/default.py
@@ -29,7 +29,6 @@ from one of the default classes.
 
 import base64
 import logging
-import sys
 
 
 class InputArgument:

--- a/scripts/tools/nxp/factory_data_generator/generate.py
+++ b/scripts/tools/nxp/factory_data_generator/generate.py
@@ -19,11 +19,12 @@
 import argparse
 import hashlib
 import logging
-import os
 import subprocess
 import sys
 
-from custom import *
+from custom import (CertDeclaration, DacCert, DacPKey, Discriminator, HardwareVersion, HardwareVersionStr, IterationCount,
+                    ManufacturingDate, PaiCert, PartNumber, ProductId, ProductLabel, ProductName, ProductURL, Salt, SerialNum,
+                    SetupPasscode, StrArgument, UniqueId, VendorId, VendorName, Verifier)
 from default import InputArgument
 
 


### PR DESCRIPTION
This pull request is a part of #25193 ( part fix python files in NXP )

### Problem

Python files need prevent things like syntax errors, typos, bad style, etc... it saves time for reviewing your code. Many python files needed bug fixes.

### Changes

Fix all python files in NXP where linter find problem. Adding NXP to check with flake8.

### Testing

CI will test and maybe some another manual testing
