### PR TITLE
Correct the Advertised data length for bluedroid on esp32

### DIFF
--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -652,7 +652,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     advData[index++] = 0x02;                            // length
     advData[index++] = CHIP_ADV_DATA_TYPE_FLAGS;        // AD type : flags
     advData[index++] = CHIP_ADV_DATA_FLAGS;             // AD value
-    advData[index++] = 0x0A;                            // length
+    advData[index++] = 0x0B;                            // length
     advData[index++] = CHIP_ADV_DATA_TYPE_SERVICE_DATA; // AD type: (Service Data - 16-bit UUID)
     advData[index++] = ShortUUID_CHIPoBLEService[0];    // AD value
     advData[index++] = ShortUUID_CHIPoBLEService[1];    // AD value


### PR DESCRIPTION
### Problem
 - The length of advertised data over bluedroid is not correct
 - So the configured data for advertisement is incorrect and device doesnot get scanned as a CHIP Device and commissioning fails
 - setting length = 0x0B solves the issue

### Testing
- Tested Commissioning and control over bluedroid

