### PR TITLE
[python tests] Add to flake8 in workflow and fix python files (part #25193)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -109,12 +109,6 @@ exclude = third_party
           src/controller/python/chip/yaml/__init__.py
           src/controller/python/chip/yaml/format_converter.py
           src/controller/python/chip/yaml/runner.py
-          src/controller/python/test/test_scripts/base.py
-          src/controller/python/test/test_scripts/cluster_objects.py
-          src/controller/python/test/test_scripts/mobile-device-test.py
-          src/controller/python/test/test_scripts/network_commissioning.py
-          src/controller/python/test/unit_tests/test_cluster_objects.py
-          src/controller/python/test/unit_tests/test_tlv.py
           src/lib/asn1/gen_asn1oid.py
           src/pybindings/pycontroller/build-chip-wheel.py
           src/pybindings/pycontroller/pychip/__init__.py

--- a/.flake8
+++ b/.flake8
@@ -36,17 +36,14 @@ exclude = third_party
           scripts/build/builders/imx.py
           scripts/build/builders/infineon.py
           scripts/build/builders/nrf.py
-          scripts/build/test.py
           scripts/codegen.py
           scripts/codepregen.py
           scripts/error_table.py
           scripts/examples/gn_to_cmakelists.py
-          scripts/examples/tests/test.py
           scripts/flashing/bouffalolab_firmware_utils.py
           scripts/flashing/cyw30739_firmware_utils.py
           scripts/flashing/nrfconnect_firmware_utils.py
           scripts/gen_chip_version.py
-          scripts/gen_test_driver.py
           scripts/helpers/bloat_check.py
           scripts/pregenerate/using_codegen.py
           scripts/pregenerate/using_zap.py
@@ -63,16 +60,7 @@ exclude = third_party
           scripts/py_matter_yamltests/test_yaml_parser.py
           scripts/run-clang-tidy-on-compile-commands.py
           scripts/setup/nrfconnect/update_ncs.py
-          scripts/tests/chiptest/__init__.py
-          scripts/tests/chiptest/runner.py
-          scripts/tests/chiptest/test_definition.py
           scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
-          scripts/tests/java/base.py
-          scripts/tests/java/commissioning_test.py
-          scripts/tests/java/discover_test.py
-          scripts/tests/run_java_test.py
-          scripts/tests/run_python_test.py
-          scripts/tests/run_test_suite.py
           scripts/tools/check_zcl_file_sync.py
           scripts/tools/convert_ini.py
           scripts/tools/generate_esp32_chip_factory_bin.py
@@ -88,12 +76,10 @@ exclude = third_party
           scripts/tools/telink/mfg_tool.py
           scripts/tools/zap/generate.py
           scripts/tools/zap/prune_outputs.py
-          scripts/tools/zap/test_generate.py
           scripts/tools/zap/version_update.py
           scripts/tools/zap/zap_download.py
           scripts/tools/zap_convert_all.py
           src/app/ota_image_tool.py
-          src/app/tests/suites/certification/information.py
           src/app/zap_cluster_list.py
           src/controller/python/build-chip-wheel.py
           src/controller/python/chip-device-ctrl.py
@@ -132,14 +118,4 @@ exclude = third_party
           src/lib/asn1/gen_asn1oid.py
           src/pybindings/pycontroller/build-chip-wheel.py
           src/pybindings/pycontroller/pychip/__init__.py
-          src/python_testing/TC_ACE_1_3.py
-          src/python_testing/TC_ACE_1_4.py
-          src/python_testing/TC_CGEN_2_4.py
-          src/python_testing/TC_DA_1_7.py
-          src/python_testing/TC_RR_1_1.py
-          src/python_testing/TC_SC_3_6.py
-          src/python_testing/TC_TestEventTrigger.py
-          src/python_testing/hello_test.py
-          src/python_testing/matter_testing_support.py
           src/setup_payload/python/generate_setup_payload.py
-          src/setup_payload/tests/run_python_setup_payload_gen_test.py

--- a/build/chip/java/tests/test.py
+++ b/build/chip/java/tests/test.py
@@ -18,7 +18,6 @@ Test for GN Java build rules. This test should be executed using ninja.
 
 import json
 import os
-import subprocess
 import unittest
 from os import path
 

--- a/scripts/build/test.py
+++ b/scripts/build/test.py
@@ -26,8 +26,8 @@ SCRIPT_ROOT = os.path.dirname(__file__)
 
 def build_expected_output(source: str, root: str, out: str) -> List[str]:
     with open(os.path.join(SCRIPT_ROOT, source), 'rt') as f:
-        for l in f.readlines():
-            yield l.replace("{root}", root).replace("{out}", out)
+        for line in f.readlines():
+            yield line.replace("{root}", root).replace("{out}", out)
 
 
 def build_actual_output(root: str, out: str, args: List[str]) -> List[str]:
@@ -57,7 +57,7 @@ def build_actual_output(root: str, out: str, args: List[str]) -> List[str]:
         '--out-prefix', out,
     ] + args, stdout=subprocess.PIPE, check=True, encoding='UTF-8', env=runenv)
 
-    result = [l + '\n' for l in retval.stdout.split('\n')]
+    result = [line + '\n' for line in retval.stdout.split('\n')]
 
     # ensure a single terminating newline: easier to edit since autoformat
     # often strips ending double newlines on text files
@@ -73,22 +73,22 @@ class TestBuilder(unittest.TestCase):
         ROOT = '/TEST/BUILD/ROOT'
         OUT = '/OUTPUT/DIR'
 
-        expected = [l for l in build_expected_output(expected_file, ROOT, OUT)]
-        actual = [l for l in build_actual_output(ROOT, OUT, args)]
+        expected = [line for line in build_expected_output(expected_file, ROOT, OUT)]
+        actual = [line for line in build_actual_output(ROOT, OUT, args)]
 
         diffs = [line for line in difflib.unified_diff(expected, actual)]
 
         if diffs:
             reference = os.path.basename(expected_file) + '.actual'
             with open(reference, 'wt') as fo:
-                for l in build_actual_output(ROOT, OUT, args):
-                    fo.write(l.replace(ROOT, '{root}').replace(OUT, '{out}'))
+                for line in build_actual_output(ROOT, OUT, args):
+                    fo.write(line.replace(ROOT, '{root}').replace(OUT, '{out}'))
 
             msg = "DIFFERENCE between expected and generated output in %s\n" % expected_file
             msg += "Expected file can be found in %s" % reference
-            for l in diffs:
-                msg += ("\n   " + l.replace(ROOT,
-                                            '{root}').replace(OUT, '{out}').strip())
+            for line in diffs:
+                msg += ("\n   " + line.replace(ROOT,
+                                               '{root}').replace(OUT, '{out}').strip())
             self.fail(msg)
 
     @unittest.skipUnless(sys.platform == 'linux', 'Build on linux test')

--- a/scripts/examples/tests/test.py
+++ b/scripts/examples/tests/test.py
@@ -27,9 +27,9 @@ SCRIPT_ROOT = os.path.dirname(__file__)
 
 
 def build_expected_output(root: str, out: str) -> List[str]:
-    with open(os.path.join(SCRIPT_ROOT, 'expected_test_cmakelists.txt'), 'rt') as f:
-        for l in f.readlines():
-            yield l.replace("{root}", root).replace("{out}", out)
+    with open(os.path.join(SCRIPT_ROOT, 'expected_test_cmakelists.txt'), 'rt') as file:
+        for line in file.readlines():
+            yield line.replace("{root}", root).replace("{out}", out)
 
 
 def build_actual_output(root: str, out: str) -> List[str]:
@@ -37,14 +37,14 @@ def build_actual_output(root: str, out: str) -> List[str]:
     binary = os.path.join(SCRIPT_ROOT, '../gn_to_cmakelists.py')
     project = os.path.join(SCRIPT_ROOT, "test_project.json")
     cmake = os.path.join(SCRIPT_ROOT, "../../../out/CMakeLists.txt")
-    retval = subprocess.run([
+    subprocess.run([
         binary,
         project,
     ], stdout=subprocess.PIPE, check=True, encoding='UTF-8', )
 
     with open(cmake, 'rt') as f:
-        for l in f.readlines():
-            yield l
+        for line in f.readlines():
+            yield line
 
 
 def main():
@@ -54,15 +54,15 @@ def main():
     ROOT = '/TEST/BUILD/ROOT'
     OUT = '/OUTPUT/DIR'
 
-    expected = [l for l in build_expected_output(ROOT, OUT)]
-    actual = [l for l in build_actual_output(ROOT, OUT)]
+    expected = [line for line in build_expected_output(ROOT, OUT)]
+    actual = [line for line in build_actual_output(ROOT, OUT)]
 
     diffs = [line for line in difflib.unified_diff(expected, actual)]
 
     if diffs:
         logging.error("DIFFERENCE between expected and generated output")
-        for l in diffs:
-            logging.warning("  " + l.strip())
+        for line in diffs:
+            logging.warning("  " + line.strip())
         sys.exit(1)
 
 

--- a/scripts/gen_test_driver.py
+++ b/scripts/gen_test_driver.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python
 
 # Copyright (c) 2020 Project CHIP Authors
@@ -74,8 +73,8 @@ def main(argv):
     TEST_SUITE_RE = re.compile(r'\s*CHIP_REGISTER_TEST_SUITE\(([^)]*)\)')
 
     with open(options.input_file, 'r') as input_file:
-        for l in input_file.readlines():
-            match = TEST_SUITE_RE.match(l)
+        for line in input_file.readlines():
+            match = TEST_SUITE_RE.match(line)
             if not match:
                 continue
 

--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Iterator, Set
 
 from . import linux, runner
-from .test_definition import ApplicationPaths, TestDefinition, TestRunTime, TestTag, TestTarget
+from .test_definition import ApplicationPaths, TestDefinition, TestTag, TestTarget
 
 _DEFAULT_CHIP_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", ".."))
@@ -149,7 +149,13 @@ def _AllYamlTests():
 
 
 def target_for_name(name: str):
-    if name.startswith("TV_") or name.startswith("Test_TC_MC_") or name.startswith("Test_TC_LOWPOWER_") or name.startswith("Test_TC_KEYPADINPUT_") or name.startswith("Test_TC_APPLAUNCHER_") or name.startswith("Test_TC_MEDIAINPUT_") or name.startswith("Test_TC_WAKEONLAN_") or name.startswith("Test_TC_CHANNEL_") or name.startswith("Test_TC_MEDIAPLAYBACK_") or name.startswith("Test_TC_AUDIOOUTPUT_") or name.startswith("Test_TC_TGTNAV_") or name.startswith("Test_TC_APBSC_") or name.startswith("Test_TC_CONTENTLAUNCHER_") or name.startswith("Test_TC_ALOGIN_"):
+    if (name.startswith("TV_") or name.startswith("Test_TC_MC_") or
+            name.startswith("Test_TC_LOWPOWER_") or name.startswith("Test_TC_KEYPADINPUT_") or
+            name.startswith("Test_TC_APPLAUNCHER_") or name.startswith("Test_TC_MEDIAINPUT_") or
+            name.startswith("Test_TC_WAKEONLAN_") or name.startswith("Test_TC_CHANNEL_") or
+            name.startswith("Test_TC_MEDIAPLAYBACK_") or name.startswith("Test_TC_AUDIOOUTPUT_") or
+            name.startswith("Test_TC_TGTNAV_") or name.startswith("Test_TC_APBSC_") or
+            name.startswith("Test_TC_CONTENTLAUNCHER_") or name.startswith("Test_TC_ALOGIN_")):
         return TestTarget.TV
     if name.startswith("DL_") or name.startswith("Test_TC_DRLK_"):
         return TestTarget.LOCK

--- a/scripts/tests/chiptest/runner.py
+++ b/scripts/tests/chiptest/runner.py
@@ -56,8 +56,8 @@ class LogPipe(threading.Thread):
         return False, len(self.captured_logs)
 
     def FindLastMatchingLine(self, matcher):
-        for l in reversed(self.captured_logs):
-            match = re.match(matcher, l)
+        for line in reversed(self.captured_logs):
+            match = re.match(matcher, line)
             if match:
                 return match
         return None

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -15,14 +15,12 @@
 
 import logging
 import os
-import sys
 import threading
 import time
 import typing
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, auto
-from random import randrange
 
 TEST_NODE_ID = '0x12344321'
 
@@ -94,7 +92,7 @@ class App:
             if self.killed:
                 return 0
             # If the App was never started, wait cannot be called on the process
-            if self.process == None:
+            if self.process is None:
                 time.sleep(0.1)
                 continue
             code = self.process.wait(timeout)
@@ -169,7 +167,8 @@ class ApplicationPaths:
     chip_tool_with_python_cmd: typing.List[str]
 
     def items(self):
-        return [self.chip_tool, self.all_clusters_app, self.lock_app, self.ota_provider_app, self.ota_requestor_app, self.tv_app, self.bridge_app, self.chip_repl_yaml_tester_cmd, self.chip_tool_with_python_cmd]
+        return [self.chip_tool, self.all_clusters_app, self.lock_app, self.ota_provider_app, self.ota_requestor_app,
+                self.tv_app, self.bridge_app, self.chip_repl_yaml_tester_cmd, self.chip_tool_with_python_cmd]
 
 
 @dataclass
@@ -253,7 +252,8 @@ class TestDefinition:
         """Get a human readable list of tags applied to this test"""
         return ", ".join([t.to_s() for t in self.tags])
 
-    def Run(self, runner, apps_register, paths: ApplicationPaths, pics_file: str, timeout_seconds: typing.Optional[int], dry_run=False, test_runtime: TestRunTime = TestRunTime.CHIP_TOOL_BUILTIN):
+    def Run(self, runner, apps_register, paths: ApplicationPaths, pics_file: str,
+            timeout_seconds: typing.Optional[int], dry_run=False, test_runtime: TestRunTime = TestRunTime.CHIP_TOOL_BUILTIN):
         """
         Executes the given test case using the provided runner for execution.
         """

--- a/scripts/tests/java/base.py
+++ b/scripts/tests/java/base.py
@@ -17,11 +17,8 @@
 #    limitations under the License.
 #
 
-import asyncio
 import datetime
 # Commissioning test.
-import logging
-import os
 import queue
 import subprocess
 import sys
@@ -39,7 +36,7 @@ def EnqueueLogOutput(fp, tag, q):
             try:
                 timestamp = float(line[1:18].decode())
                 line = line[19:]
-            except Exception as ex:
+            except Exception:
                 pass
         sys.stdout.buffer.write(
             (f"[{datetime.datetime.fromtimestamp(timestamp).isoformat(sep=' ')}]").encode() + tag + line)

--- a/scripts/tests/java/commissioning_test.py
+++ b/scripts/tests/java/commissioning_test.py
@@ -18,12 +18,9 @@
 #
 
 import argparse
-import asyncio
 import logging
-import os
 import queue
 import subprocess
-import sys
 import threading
 import typing
 
@@ -46,7 +43,8 @@ class CommissioningTest:
         parser.add_argument('-s', '--setup-payload', dest='setup_payload',
                             help="Setup Payload (manual pairing code or QR code content)")
         parser.add_argument('-c', '--setup-pin-code', dest='setup_pin_code',
-                            help="Setup PIN code which can be used for password-authenticated session establishment (PASE) with the Commissionee")
+                            help=("Setup PIN code which can be used for password-authenticated "
+                                  "session establishment (PASE) with the Commissionee"))
         parser.add_argument('-n', '--nodeid', help="The Node ID issued to the device", default='1')
         parser.add_argument('-d', '--discriminator', help="Discriminator of the device", default='3840')
         parser.add_argument('-u', '--paa-trust-store-path', dest='paa_trust_store_path',

--- a/scripts/tests/java/discover_test.py
+++ b/scripts/tests/java/discover_test.py
@@ -18,12 +18,9 @@
 #
 
 import argparse
-import asyncio
 import logging
-import os
 import queue
 import subprocess
-import sys
 import threading
 import typing
 

--- a/scripts/tests/run_java_test.py
+++ b/scripts/tests/run_java_test.py
@@ -16,8 +16,6 @@
 
 import logging
 import os
-import pathlib
-import pty
 import queue
 import re
 import shlex
@@ -34,12 +32,18 @@ from java.discover_test import DiscoverTest
 
 
 @click.command()
-@click.option("--app", type=click.Path(exists=True), default=None, help='Path to local application to use, omit to use external apps.')
-@click.option("--app-args", type=str, default='', help='The extra arguments passed to the device.')
-@click.option("--tool-path", type=click.Path(exists=True), default=None, help='Path to java-matter-controller.')
-@click.option("--tool-cluster", type=str, default='pairing', help='The cluster name passed to the java-matter-controller.')
-@click.option("--tool-args", type=str, default='', help='The arguments passed to the java-matter-controller.')
-@click.option("--factoryreset", is_flag=True, help='Remove app configs (/tmp/chip*) before running the tests.')
+@click.option("--app", type=click.Path(exists=True), default=None,
+              help='Path to local application to use, omit to use external apps.')
+@click.option("--app-args", type=str, default='',
+              help='The extra arguments passed to the device.')
+@click.option("--tool-path", type=click.Path(exists=True), default=None,
+              help='Path to java-matter-controller.')
+@click.option("--tool-cluster", type=str, default='pairing',
+              help='The cluster name passed to the java-matter-controller.')
+@click.option("--tool-args", type=str, default='',
+              help='The arguments passed to the java-matter-controller.')
+@click.option("--factoryreset", is_flag=True,
+              help='Remove app configs (/tmp/chip*) before running the tests.')
 def main(app: str, app_args: str, tool_path: str, tool_cluster: str, tool_args: str, factoryreset: bool):
     logging.info("Execute: {script_command}")
 

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -44,7 +44,7 @@ def EnqueueLogOutput(fp, tag, q):
             try:
                 timestamp = float(line[1:18].decode())
                 line = line[19:]
-            except Exception as ex:
+            except Exception:
                 pass
         sys.stdout.buffer.write(
             (f"[{datetime.datetime.fromtimestamp(timestamp).isoformat(sep=' ')}]").encode() + tag + line)
@@ -67,12 +67,23 @@ def DumpProgramOutputToQueue(thread_list: typing.List[threading.Thread], tag: st
 
 
 @click.command()
-@click.option("--app", type=click.Path(exists=True), default=None, help='Path to local application to use, omit to use external apps.')
-@click.option("--factoryreset", is_flag=True, help='Remove app config and repl configs (/tmp/chip* and /tmp/repl*) before running the tests.')
-@click.option("--app-args", type=str, default='', help='The extra arguments passed to the device.')
-@click.option("--script", type=click.Path(exists=True), default=os.path.join(DEFAULT_CHIP_ROOT, 'src', 'controller', 'python', 'test', 'test_scripts', 'mobile-device-test.py'), help='Test script to use.')
-@click.option("--script-args", type=str, default='', help='Path to the test script to use, omit to use the default test script (mobile-device-test.py).')
-@click.option("--script-gdb", is_flag=True, help='Run script through gdb')
+@click.option("--app", type=click.Path(exists=True), default=None,
+              help='Path to local application to use, omit to use external apps.')
+@click.option("--factoryreset", is_flag=True,
+              help='Remove app config and repl configs (/tmp/chip* and /tmp/repl*) before running the tests.')
+@click.option("--app-args", type=str, default='',
+              help='The extra arguments passed to the device.')
+@click.option("--script", type=click.Path(exists=True), default=os.path.join(DEFAULT_CHIP_ROOT,
+                                                                             'src',
+                                                                             'controller',
+                                                                             'python',
+                                                                             'test',
+                                                                             'test_scripts',
+                                                                             'mobile-device-test.py'), help='Test script to use.')
+@click.option("--script-args", type=str, default='',
+              help='Path to the test script to use, omit to use the default test script (mobile-device-test.py).')
+@click.option("--script-gdb", is_flag=True,
+              help='Run script through gdb')
 def main(app: str, factoryreset: bool, app_args: str, script: str, script_args: str, script_gdb: bool):
     if factoryreset:
         # Remove native app config
@@ -123,10 +134,12 @@ def main(app: str, factoryreset: bool, app_args: str, script: str, script_args: 
 
     if script_gdb:
         #
-        # When running through Popen, we need to preserve some space-delimited args to GDB as a single logical argument. To do that, let's use '|' as a placeholder
-        # for the space character so that the initial split will not tokenize them, and then replace that with the space char there-after.
+        # When running through Popen, we need to preserve some space-delimited args to GDB as a single logical argument.
+        # To do that, let's use '|' as a placeholder for the space character so that the initial split will not tokenize them,
+        # and then replace that with the space char there-after.
         #
-        script_command = "gdb -batch -return-child-result -q -ex run -ex thread|apply|all|bt --args python3".split() + script_command
+        script_command = ("gdb -batch -return-child-result -q -ex run -ex "
+                          "thread|apply|all|bt --args python3".split() + script_command)
     else:
         script_command = "/usr/bin/env python3".split() + script_command
 

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -52,7 +52,6 @@ def FindBinaryPath(name: str):
         else:
             del cache[name]
 
-    start = time.time()
     for path in Path(DEFAULT_CHIP_ROOT).rglob(name):
         if not path.is_file():
             continue
@@ -289,7 +288,8 @@ def cmd_list(context):
     type=int,
     help='If provided, fail if a test runs for longer than this time')
 @click.pass_context
-def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, ota_requestor_app, tv_app, bridge_app, chip_repl_yaml_tester, chip_tool_with_python, pics_file, keep_going, test_timeout_seconds):
+def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, ota_requestor_app,
+            tv_app, bridge_app, chip_repl_yaml_tester, chip_tool_with_python, pics_file, keep_going, test_timeout_seconds):
     runner = chiptest.runner.Runner()
 
     if all_clusters_app is None:

--- a/scripts/tools/zap/test_generate.py
+++ b/scripts/tools/zap/test_generate.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import glob
-import logging
 import os
 import shutil
 import subprocess
@@ -116,7 +115,7 @@ class GeneratorTest:
 
                     try:
                         subprocess.check_call(["diff", actual, expected])
-                    except:
+                    except subprocess.CalledProcessError:
                         if self.context.regenerate_golden:
                             print(
                                 f"Copying updated golden image from {actual} to {expected}")

--- a/src/app/tests/suites/certification/information.py
+++ b/src/app/tests/suites/certification/information.py
@@ -55,7 +55,6 @@ def checkPythonVersion():
 def parseTestPlans(filepath):
     tests_names = []
     tests_statuses = []
-    rv = []
 
     for name, test_plan in parseYaml(filepath)['Test Plans'].items():
         for section, tests in test_plan['tests'].items():
@@ -81,12 +80,12 @@ def parseTestPlan(filepath):
 
     for test_definition in parseYaml(filepath)['tests']:
         if 'disabled' in test_definition:
-            if is_pending_test == False:
+            if is_pending_test is False:
                 return TestStatus.partial
         else:
             is_pending_test = False
 
-    if is_pending_test == True:
+    if is_pending_test is True:
         return TestStatus.pending
 
     return TestStatus.complete

--- a/src/controller/python/test/test_scripts/cluster_objects.py
+++ b/src/controller/python/test/test_scripts/cluster_objects.py
@@ -57,7 +57,8 @@ def VerifyDecodeSuccess(values):
                             f"Ignoring attribute decode failure for path {endpoint}/{attribute}")
                     else:
                         raise AssertionError(
-                            f"Cannot decode value for path {endpoint}/{attribute}, got error: '{str(v.Reason)}', raw TLV data: '{v.TLVValue}'")
+                            f"Cannot decode value for path {endpoint}/{attribute}, "
+                            f"got error: '{str(v.Reason)}', raw TLV data: '{v.TLVValue}'")
 
     for endpoint in values:
         for cluster in values[endpoint]:
@@ -104,7 +105,7 @@ class ClusterObjectTests:
         req = Clusters.OnOff.Commands.On()
         try:
             await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=233, payload=req)
-            raise ValueError(f"Failure expected")
+            raise ValueError("Failure expected")
         except chip.interaction_model.InteractionModelError as ex:
             logger.info(f"Recevied {ex} from server.")
             return
@@ -156,11 +157,16 @@ class ClusterObjectTests:
             raise AssertionError("Write returned unexpected result.")
 
         logger.info("2: Write chunked list")
-        res = await devCtrl.WriteAttribute(nodeid=NODE_ID,
-                                           attributes=[(1, Clusters.UnitTesting.Attributes.ListLongOctetString([b"0123456789abcdef" * 32] * 5))])
+        res = await devCtrl.WriteAttribute(
+            nodeid=NODE_ID,
+            attributes=[
+                (1, Clusters.UnitTesting.Attributes.ListLongOctetString([b"0123456789abcdef" * 32] * 5))
+            ]
+        )
         expectedRes = [
             AttributeStatus(Path=AttributePath(
-                EndpointId=1, Attribute=Clusters.UnitTesting.Attributes.ListLongOctetString), Status=chip.interaction_model.Status.Success),
+                EndpointId=1,
+                Attribute=Clusters.UnitTesting.Attributes.ListLongOctetString), Status=chip.interaction_model.Status.Success),
         ]
 
         logger.info(f"Received WriteResponse: {res}")
@@ -198,15 +204,19 @@ class ClusterObjectTests:
     @ base.test_case
     async def TestSubscribeZeroMinInterval(cls, devCtrl):
         '''
-        This validates receiving subscription reports for two attributes at a time in quick succession after issuing a command that results in attribute side-effects.
-        Specifically, it relies on the fact that the second attribute is changed in a different execution context than the first. This ensures that we pick-up the first
-        attribute change and generate a notification, and validating that shortly after that, we generate a second report for the second change.
+        This validates receiving subscription reports for two attributes at a time in quick succession after
+        issuing a command that results in attribute side-effects. Specifically, it relies on the fact that the second attribute
+        is changed in a different execution context than the first. This ensures that we pick-up the first
+        attribute change and generate a notification, and validating that shortly after that,
+        we generate a second report for the second change.
 
-        This is done using subscriptions with a min reporting interval of 0 to ensure timely notification of the above. An On() command is sent to the OnOff cluster
+        This is done using subscriptions with a min reporting interval of 0 to ensure timely notification of the above.
+        An On() command is sent to the OnOff cluster
         which should simultaneously set the state to On as well as set the level to 254.
         '''
         logger.info("Test Subscription With MinInterval of 0")
-        sub = await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=[Clusters.OnOff, Clusters.LevelControl], reportInterval=(0, 60))
+        sub = await devCtrl.ReadAttribute(nodeid=NODE_ID,
+                                          attributes=[Clusters.OnOff, Clusters.LevelControl], reportInterval=(0, 60))
         data = sub.GetAttributes()
 
         logger.info("Sending off command")
@@ -297,17 +307,21 @@ class ClusterObjectTests:
         if res[1][Clusters.UnitTesting][Clusters.UnitTesting.Attributes.ListLongOctetString] != [b'0123456789abcdef' * 32] * 4:
             raise AssertionError("Unexpected read result")
 
-        logger.info("*: Getting current fabric index")
-        res = await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=[(0, Clusters.OperationalCredentials.Attributes.CurrentFabricIndex)])
-        fabricIndex = res[0][Clusters.OperationalCredentials][Clusters.OperationalCredentials.Attributes.CurrentFabricIndex]
-
         # Note: ListFabricScoped is an empty list for now. We should re-enable this test after we make it return expected data.
+        # logger.info("*: Getting current fabric index")
+        # res = await devCtrl.ReadAttribute(nodeid=NODE_ID,
+        #                                   attributes=[(0, Clusters.OperationalCredentials.Attributes.CurrentFabricIndex)])
+        # fabricIndex = res[0][Clusters.OperationalCredentials][Clusters.OperationalCredentials.Attributes.CurrentFabricIndex]
+        #
         # logger.info("8: Read without fabric filter")
-        # res = await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=[(1, Clusters.UnitTesting.Attributes.ListFabricScoped)], fabricFiltered=False)
+        # res = await devCtrl.ReadAttribute(nodeid=NODE_ID,
+        #                                   attributes=[(1, Clusters.UnitTesting.Attributes.ListFabricScoped)],
+        #                                                fabricFiltered=False)
         # if len(res[1][Clusters.UnitTesting][Clusters.UnitTesting.Attributes.ListFabricScoped]) == 1:
         #     raise AssertionError("Expect more elements in the response")
         # logger.info("9: Read with fabric filter")
-        # res = await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=[(1, Clusters.UnitTesting.Attributes.ListFabricScoped)], fabricFiltered=True)
+        # res = await devCtrl.ReadAttribute(nodeid=NODE_ID,
+        #                                   attributes=[(1, Clusters.UnitTesting.Attributes.ListFabricScoped)], fabricFiltered=True)
         # if len(res[1][Clusters.UnitTesting][Clusters.UnitTesting.Attributes.ListFabricScoped]) != 1:
         #     raise AssertionError("Expect exact one element in the response")
         # if res[1][Clusters.UnitTesting][Clusters.UnitTesting.Attributes.ListFabricScoped][0].fabricIndex != fabricIndex:
@@ -317,9 +331,12 @@ class ClusterObjectTests:
     @ classmethod
     async def _TriggerEvent(cls, devCtrl):
         # We trigger sending an event a couple of times just to be safe.
-        await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=Clusters.UnitTesting.Commands.TestEmitTestEventRequest())
-        await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=Clusters.UnitTesting.Commands.TestEmitTestEventRequest())
-        return await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=Clusters.UnitTesting.Commands.TestEmitTestEventRequest())
+        await devCtrl.SendCommand(nodeid=NODE_ID,
+                                  endpoint=1, payload=Clusters.UnitTesting.Commands.TestEmitTestEventRequest())
+        await devCtrl.SendCommand(nodeid=NODE_ID,
+                                  endpoint=1, payload=Clusters.UnitTesting.Commands.TestEmitTestEventRequest())
+        return await devCtrl.SendCommand(nodeid=NODE_ID,
+                                         endpoint=1, payload=Clusters.UnitTesting.Commands.TestEmitTestEventRequest())
 
     @ classmethod
     async def _RetryForContent(cls, request, until, retryCount=10, intervalSeconds=1):
@@ -351,20 +368,30 @@ class ClusterObjectTests:
                 return False
             return True
 
-        await cls._RetryForContent(request=lambda: devCtrl.ReadEvent(nodeid=NODE_ID, events=req, eventNumberFilter=current_event_filter), until=validate_got_expected_event)
+        await cls._RetryForContent(request=lambda: devCtrl.ReadEvent(
+            nodeid=NODE_ID,
+            events=req,
+            eventNumberFilter=current_event_filter
+        ), until=validate_got_expected_event)
 
         def validate_got_no_event(events):
             return len(events) == 0
 
-        await cls._RetryForContent(request=lambda: devCtrl.ReadEvent(nodeid=NODE_ID, events=req, eventNumberFilter=(current_event_filter + 1)), until=validate_got_no_event)
+        await cls._RetryForContent(request=lambda: devCtrl.ReadEvent(
+            nodeid=NODE_ID,
+            events=req,
+            eventNumberFilter=(current_event_filter + 1)
+        ), until=validate_got_no_event)
 
     @ classmethod
     @ base.test_case
     async def TestGenerateUndefinedFabricScopedEventRequests(cls, devCtrl):
         logger.info("Running TestGenerateUndefinedFabricScopedEventRequests")
         try:
-            res = await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=Clusters.UnitTesting.Commands.TestEmitTestFabricScopedEventRequest(arg1=0))
-            raise ValueError(f"Unexpected Failure")
+            res = await devCtrl.SendCommand(nodeid=NODE_ID,
+                                            endpoint=1,
+                                            payload=Clusters.UnitTesting.Commands.TestEmitTestFabricScopedEventRequest(arg1=0))
+            raise ValueError("Unexpected Failure")
         except chip.interaction_model.InteractionModelError as ex:
             logger.info(f"Recevied {ex} from server.")
         res = await devCtrl.ReadEvent(nodeid=NODE_ID, events=[
@@ -518,13 +545,15 @@ class ClusterObjectTests:
         req = [
             (0, Clusters.BasicInformation.Attributes.VendorName),
         ]
-        res = await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=req, dataVersionFilters=[(0, Clusters.BasicInformation, data_version)])
+        res = await devCtrl.ReadAttribute(nodeid=NODE_ID,
+                                          attributes=req, dataVersionFilters=[(0, Clusters.BasicInformation, data_version)])
         VerifyDecodeSuccess(res)
         new_data_version = res[0][Clusters.BasicInformation][DataVersion]
         if (data_version + 1) != new_data_version:
             raise AssertionError("Version mistmatch happens.")
 
-        res = await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=req, dataVersionFilters=[(0, Clusters.BasicInformation, new_data_version)])
+        res = await devCtrl.ReadAttribute(nodeid=NODE_ID,
+                                          attributes=req, dataVersionFilters=[(0, Clusters.BasicInformation, new_data_version)])
         VerifyDecodeSuccess(res)
 
         res = await devCtrl.WriteAttribute(nodeid=NODE_ID,
@@ -590,7 +619,10 @@ class ClusterObjectTests:
                 logging.info(
                     f"{testCount}: Reading mixed Attributes({attributes[0]}) Events({events[0]})")
                 await cls._TriggerEvent(devCtrl)
-                res = await cls._RetryForContent(request=lambda: devCtrl.Read(nodeid=NODE_ID, attributes=attributes[1], events=events[1]), until=lambda res: res != 0)
+                res = await cls._RetryForContent(request=lambda: devCtrl.Read(
+                    nodeid=NODE_ID,
+                    attributes=attributes[1],
+                    events=events[1]), until=lambda res: res != 0)
                 VerifyDecodeSuccess(res.attributes)
 
     @ classmethod

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -195,19 +195,59 @@ def do_tests(controller_nodeid, device_nodeid, address, timeout, discriminator, 
 
 
 @click.command()
-@click.option("--controller-nodeid", default=TEST_CONTROLLER_NODE_ID, type=int, help="NodeId of the controller.")
-@click.option("--device-nodeid", default=TEST_DEVICE_NODE_ID, type=int, help="NodeId of the device.")
-@click.option("--address", "-a", default='', type=str, help="Skip commissionee discovery, commission the device with the IP directly.")
-@click.option("--timeout", "-t", default=240, type=int, help="The program will return with timeout after specified seconds.")
-@click.option("--discriminator", default=TEST_DISCRIMINATOR, type=int, help="Discriminator of the device.")
-@click.option("--setup-pin", default=TEST_SETUPPIN, type=int, help="Setup pincode of the device.")
-@click.option('--enable-test', default=['all'], type=str, multiple=True, help='The tests to be executed. By default, all tests will be executed, use this option to run a specific set of tests. Use --print-test-list for a list of appliable tests.')
-@click.option('--disable-test', default=[], type=str, multiple=True, help='The tests to be excluded from the set of enabled tests. Use --print-test-list for a list of appliable tests.')
-@click.option('--log-level', default='WARN', type=click.Choice(['ERROR', 'WARN', 'INFO', 'DEBUG']), help="The log level of the test.")
-@click.option('--log-format', default=None, type=str, help="Override logging format")
-@click.option('--print-test-list', is_flag=True, help="Print a list of test cases and test sets that can be toggled via --enable-test and --disable-test, then exit")
-@click.option('--paa-trust-store-path', default='', type=str, help="Path that contains valid and trusted PAA Root Certificates.")
-def run(controller_nodeid, device_nodeid, address, timeout, discriminator, setup_pin, enable_test, disable_test, log_level, log_format, print_test_list, paa_trust_store_path):
+@click.option("--controller-nodeid",
+              default=TEST_CONTROLLER_NODE_ID,
+              type=int,
+              help="NodeId of the controller.")
+@click.option("--device-nodeid",
+              default=TEST_DEVICE_NODE_ID,
+              type=int,
+              help="NodeId of the device.")
+@click.option("--address", "-a",
+              default='',
+              type=str,
+              help="Skip commissionee discovery, commission the device with the IP directly.")
+@click.option("--timeout", "-t",
+              default=240,
+              type=int,
+              help="The program will return with timeout after specified seconds.")
+@click.option("--discriminator",
+              default=TEST_DISCRIMINATOR,
+              type=int,
+              help="Discriminator of the device.")
+@click.option("--setup-pin",
+              default=TEST_SETUPPIN,
+              type=int,
+              help="Setup pincode of the device.")
+@click.option('--enable-test',
+              default=['all'],
+              type=str,
+              multiple=True,
+              help='The tests to be executed. By default, all tests will be executed, use this option to run a '
+              'specific set of tests. Use --print-test-list for a list of appliable tests.')
+@click.option('--disable-test',
+              default=[],
+              type=str,
+              multiple=True,
+              help='The tests to be excluded from the set of enabled tests. Use --print-test-list for a list of '
+              'appliable tests.')
+@click.option('--log-level',
+              default='WARN',
+              type=click.Choice(['ERROR', 'WARN', 'INFO', 'DEBUG']),
+              help="The log level of the test.")
+@click.option('--log-format',
+              default=None,
+              type=str,
+              help="Override logging format")
+@click.option('--print-test-list',
+              is_flag=True,
+              help="Print a list of test cases and test sets that can be toggled via --enable-test and --disable-test, then exit")
+@click.option('--paa-trust-store-path',
+              default='',
+              type=str,
+              help="Path that contains valid and trusted PAA Root Certificates.")
+def run(controller_nodeid, device_nodeid, address, timeout, discriminator, setup_pin, enable_test, disable_test, log_level,
+        log_format, print_test_list, paa_trust_store_path):
     coloredlogs.install(level=log_level, fmt=log_format, logger=logger)
 
     if print_test_list:

--- a/src/controller/python/test/test_scripts/network_commissioning.py
+++ b/src/controller/python/test/test_scripts/network_commissioning.py
@@ -58,11 +58,16 @@ class NetworkCommissioningTests:
         self._last_breadcrumb = random.randint(1, 1 << 48)
 
     async def must_verify_breadcrumb(self):
-        res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(0, Clusters.GeneralCommissioning.Attributes.Breadcrumb)], returnClusterObject=True)
+        res = await self._devCtrl.ReadAttribute(
+            nodeid=self._nodeid,
+            attributes=[(0, Clusters.GeneralCommissioning.Attributes.Breadcrumb)],
+            returnClusterObject=True
+        )
         if self._last_breadcrumb is not None:
             if self._last_breadcrumb != res[0][Clusters.GeneralCommissioning].breadcrumb:
                 raise AssertionError(
-                    f"Breadcrumb attribute mismatch! Expect {self._last_breadcrumb} got {res[0][Clusters.GeneralCommissioning].breadcrumb}")
+                    f"Breadcrumb attribute mismatch! Expect {self._last_breadcrumb} "
+                    f"got {res[0][Clusters.GeneralCommissioning].breadcrumb}")
 
     def with_breadcrumb(self) -> int:
         self._last_breadcrumb += 1
@@ -78,9 +83,13 @@ class NetworkCommissioningTests:
             f"The feature map of this endpoint is {values.featureMap}.")
 
     async def readLastNetworkingStateAttributes(self, endpointId):
-        res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.LastConnectErrorValue),
-                                                                                 (endpointId, Clusters.NetworkCommissioning.Attributes.LastNetworkID),
-                                                                                 (endpointId, Clusters.NetworkCommissioning.Attributes.LastNetworkingStatus)], returnClusterObject=True)
+        res = await self._devCtrl.ReadAttribute(
+            nodeid=self._nodeid,
+            attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.LastConnectErrorValue),
+                        (endpointId, Clusters.NetworkCommissioning.Attributes.LastNetworkID),
+                        (endpointId, Clusters.NetworkCommissioning.Attributes.LastNetworkingStatus)],
+            returnClusterObject=True
+        )
         values = res[endpointId][Clusters.NetworkCommissioning]
         logger.info(f"Got values: {values}")
         return values
@@ -91,7 +100,7 @@ class NetworkCommissioningTests:
 
         try:
             logger.info(
-                f"1. Send ConnectNetwork command with a illegal network id")
+                "1. Send ConnectNetwork command with a illegal network id")
             req = Clusters.NetworkCommissioning.Commands.ConnectNetwork(
                 networkID=b'0' * 254, breadcrumb=0)
             res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
@@ -99,10 +108,10 @@ class NetworkCommissioningTests:
         except chip.interaction_model.InteractionModelError as ex:
             logger.info(f"Received {ex} from server.")
 
-        logger.info(f"Finished negative test cases.")
+        logger.info("Finished negative test cases.")
 
     async def test_wifi(self, endpointId):
-        logger.info(f"Get basic information of the endpoint")
+        logger.info("Get basic information of the endpoint")
         res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[
             (endpointId,
              Clusters.NetworkCommissioning.Attributes.ConnectMaxTimeSeconds),
@@ -115,7 +124,7 @@ class NetworkCommissioningTests:
             returnClusterObject=True)
         self.log_interface_basic_info(
             res[endpointId][Clusters.NetworkCommissioning])
-        logger.info(f"Finished getting basic information of the endpoint")
+        logger.info("Finished getting basic information of the endpoint")
 
         if res[endpointId][Clusters.NetworkCommissioning].acceptedCommandList != [
                 Clusters.NetworkCommissioning.Commands.ScanNetworks.command_id,
@@ -123,45 +132,54 @@ class NetworkCommissioningTests:
                 Clusters.NetworkCommissioning.Commands.RemoveNetwork.command_id,
                 Clusters.NetworkCommissioning.Commands.ConnectNetwork.command_id,
                 Clusters.NetworkCommissioning.Commands.ReorderNetwork.command_id]:
-            raise AssertionError(f"Unexpected accepted command list for Thread interface")
+            raise AssertionError("Unexpected accepted command list for Thread interface")
 
         if res[endpointId][Clusters.NetworkCommissioning].generatedCommandList != [
                 Clusters.NetworkCommissioning.Commands.ScanNetworksResponse.command_id,
                 Clusters.NetworkCommissioning.Commands.NetworkConfigResponse.command_id,
                 Clusters.NetworkCommissioning.Commands.ConnectNetworkResponse.command_id]:
-            raise AssertionError(f"Unexpected generated command list for Thread interface")
+            raise AssertionError("Unexpected generated command list for Thread interface")
 
         # Read Last* attributes
-        logger.info(f"Read Last* attributes")
+        logger.info("Read Last* attributes")
         res = await self.readLastNetworkingStateAttributes(endpointId=endpointId)
         if (res.lastNetworkID != NullValue) or (res.lastNetworkingStatus != NullValue) or (res.lastConnectErrorValue != NullValue):
             raise AssertionError(
-                f"LastNetworkID, LastNetworkingStatus and LastConnectErrorValue should be Null")
+                "LastNetworkID, LastNetworkingStatus and LastConnectErrorValue should be Null")
 
         # Scan networks
-        logger.info(f"Scan networks")
+        logger.info("Scan networks")
         req = Clusters.NetworkCommissioning.Commands.ScanNetworks(
             ssid=b'', breadcrumb=self.with_breadcrumb())
         interactionTimeoutMs = self._devCtrl.ComputeRoundTripTimeout(self._nodeid, upperLayerProcessingTimeoutMs=30000)
-        res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req, interactionTimeoutMs=interactionTimeoutMs)
+        res = await self._devCtrl.SendCommand(
+            nodeid=self._nodeid,
+            endpoint=endpointId,
+            payload=req,
+            interactionTimeoutMs=interactionTimeoutMs
+        )
         logger.info(f"Received response: {res}")
         if res.networkingStatus != Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatus.kSuccess:
             raise AssertionError(f"Unexpected result: {res.networkingStatus}")
         await self.must_verify_breadcrumb()
 
         # Arm the failsafe before making network config changes
-        logger.info(f"Arming the failsafe")
+        logger.info("Arming the failsafe")
         req = Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=900)
         res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
         logger.info(f"Received response: {res}")
 
         # Remove existing network
-        logger.info(f"Check network list")
-        res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
+        logger.info("Check network list")
+        res = await self._devCtrl.ReadAttribute(
+            nodeid=self._nodeid,
+            attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)],
+            returnClusterObject=True
+        )
         networkList = res[endpointId][Clusters.NetworkCommissioning].networks
         logger.info(f"Got network list: {networkList}")
         if len(networkList) != 0:
-            logger.info(f"Removing existing network")
+            logger.info("Removing existing network")
             req = Clusters.NetworkCommissioning.Commands.RemoveNetwork(
                 networkID=networkList[0].networkID, breadcrumb=self.with_breadcrumb())
             res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
@@ -172,7 +190,7 @@ class NetworkCommissioningTests:
             await self.must_verify_breadcrumb()
 
         # Add first network
-        logger.info(f"Adding first test network")
+        logger.info("Adding first test network")
         req = Clusters.NetworkCommissioning.Commands.AddOrUpdateWiFiNetwork(
             ssid=TEST_WIFI_SSID.encode(), credentials=TEST_WIFI_PASS.encode(), breadcrumb=self.with_breadcrumb())
         res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
@@ -184,8 +202,12 @@ class NetworkCommissioningTests:
                 f"Unexpected result: {res.networkIndex} (should be 0)")
         await self.must_verify_breadcrumb()
 
-        logger.info(f"Check network list")
-        res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
+        logger.info("Check network list")
+        res = await self._devCtrl.ReadAttribute(
+            nodeid=self._nodeid,
+            attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)],
+            returnClusterObject=True
+        )
         networkList = res[endpointId][Clusters.NetworkCommissioning].networks
         logger.info(f"Got network list: {networkList}")
         if len(networkList) != 1:
@@ -195,28 +217,38 @@ class NetworkCommissioningTests:
             raise AssertionError(
                 f"Unexpected result: first network ID should be 'TestSSID' got {networkList[0].networkID}")
 
-        logger.info(f"Connect to a network")
+        logger.info("Connect to a network")
         req = Clusters.NetworkCommissioning.Commands.ConnectNetwork(
             networkID=TEST_WIFI_SSID.encode(), breadcrumb=self.with_breadcrumb())
         interactionTimeoutMs = self._devCtrl.ComputeRoundTripTimeout(self._nodeid, upperLayerProcessingTimeoutMs=30000)
-        res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req, interactionTimeoutMs=interactionTimeoutMs)
+        res = await self._devCtrl.SendCommand(
+            nodeid=self._nodeid,
+            endpoint=endpointId,
+            payload=req,
+            interactionTimeoutMs=interactionTimeoutMs
+        )
         logger.info(f"Got response: {res}")
         if res.networkingStatus != Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatus.kSuccess:
             raise AssertionError(f"Unexpected result: {res.networkingStatus}")
-        logger.info(f"Device connected to a network.")
+        logger.info("Device connected to a network.")
         await self.must_verify_breadcrumb()
 
         # Disarm the failsafe
-        logger.info(f"Disarming the failsafe")
+        logger.info("Disarming the failsafe")
         req = Clusters.GeneralCommissioning.Commands.CommissioningComplete()
         res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
         logger.info(f"Received response: {res}")
 
-        # Note: On Linux, when connecting to a connected network, it will return immediately, however, it will try a reconnect. This will make the below attribute read return false negative values.
+        # Note: On Linux, when connecting to a connected network, it will return immediately, however, it will try a reconnect.
+        # This will make the below attribute read return false negative values.
         await asyncio.sleep(5)
 
-        logger.info(f"Check network is connected")
-        res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
+        logger.info("Check network is connected")
+        res = await self._devCtrl.ReadAttribute(
+            nodeid=self._nodeid,
+            attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)],
+            returnClusterObject=True
+        )
         networkList = res[endpointId][Clusters.NetworkCommissioning].networks
         logger.info(f"Got network list: {networkList}")
         if len(networkList) != 1:
@@ -227,17 +259,18 @@ class NetworkCommissioningTests:
                 f"Unexpected result: first network ID should be 'TestSSID' got {networkList[0].networkID}")
         if not networkList[0].connected:
             raise AssertionError(
-                f"Unexpected result: network is not marked as connected")
+                "Unexpected result: network is not marked as connected")
 
         # Verify Last* attributes
-        logger.info(f"Read Last* attributes")
+        logger.info("Read Last* attributes")
         res = await self.readLastNetworkingStateAttributes(endpointId=endpointId)
         if (res.lastNetworkID == NullValue) or (res.lastNetworkingStatus == NullValue) or (res.lastConnectErrorValue != NullValue):
             raise AssertionError(
-                f"LastNetworkID, LastNetworkingStatus should not be Null, LastConnectErrorValue should be Null for a successful network provision.")
+                "LastNetworkID, LastNetworkingStatus should not be Null, "
+                "LastConnectErrorValue should be Null for a successful network provision.")
 
     async def test_thread(self, endpointId):
-        logger.info(f"Get basic information of the endpoint")
+        logger.info("Get basic information of the endpoint")
         res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[
             (endpointId,
              Clusters.NetworkCommissioning.Attributes.ConnectMaxTimeSeconds),
@@ -257,47 +290,54 @@ class NetworkCommissioningTests:
                 Clusters.NetworkCommissioning.Commands.RemoveNetwork.command_id,
                 Clusters.NetworkCommissioning.Commands.ConnectNetwork.command_id,
                 Clusters.NetworkCommissioning.Commands.ReorderNetwork.command_id]:
-            raise AssertionError(f"Unexpected accepted command list for Thread interface")
+            raise AssertionError("Unexpected accepted command list for Thread interface")
 
         if res[endpointId][Clusters.NetworkCommissioning].generatedCommandList != [
                 Clusters.NetworkCommissioning.Commands.ScanNetworksResponse.command_id,
                 Clusters.NetworkCommissioning.Commands.NetworkConfigResponse.command_id,
                 Clusters.NetworkCommissioning.Commands.ConnectNetworkResponse.command_id]:
-            raise AssertionError(f"Unexpected generated command list for Thread interface")
+            raise AssertionError("Unexpected generated command list for Thread interface")
 
-        logger.info(f"Finished getting basic information of the endpoint")
+        logger.info("Finished getting basic information of the endpoint")
 
         # Read Last* attributes
-        logger.info(f"Read Last* attributes")
+        logger.info("Read Last* attributes")
         res = await self.readLastNetworkingStateAttributes(endpointId=endpointId)
         if (res.lastNetworkID != NullValue) or (res.lastNetworkingStatus != NullValue) or (res.lastConnectErrorValue != NullValue):
             raise AssertionError(
-                f"LastNetworkID, LastNetworkingStatus and LastConnectErrorValue should be Null")
+                "LastNetworkID, LastNetworkingStatus and LastConnectErrorValue should be Null")
 
         # Scan networks
-        logger.info(f"Scan networks")
+        logger.info("Scan networks")
         req = Clusters.NetworkCommissioning.Commands.ScanNetworks(
             ssid=b'', breadcrumb=self.with_breadcrumb())
         interactionTimeoutMs = self._devCtrl.ComputeRoundTripTimeout(self._nodeid, upperLayerProcessingTimeoutMs=30000)
-        res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req, interactionTimeoutMs=interactionTimeoutMs)
+        res = await self._devCtrl.SendCommand(nodeid=self._nodeid,
+                                              endpoint=endpointId,
+                                              payload=req,
+                                              interactionTimeoutMs=interactionTimeoutMs)
         logger.info(f"Received response: {res}")
         if res.networkingStatus != Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatus.kSuccess:
             raise AssertionError(f"Unexpected result: {res.networkingStatus}")
         await self.must_verify_breadcrumb()
 
         # Arm the failsafe before making network config changes
-        logger.info(f"Arming the failsafe")
+        logger.info("Arming the failsafe")
         req = Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=900)
         res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
         logger.info(f"Received response: {res}")
 
         # Remove existing network
-        logger.info(f"Check network list")
-        res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
+        logger.info("Check network list")
+        res = await self._devCtrl.ReadAttribute(
+            nodeid=self._nodeid,
+            attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)],
+            returnClusterObject=True
+        )
         networkList = res[endpointId][Clusters.NetworkCommissioning].networks
         logger.info(f"Got network list: {networkList}")
         if len(networkList) != 0:
-            logger.info(f"Removing existing network")
+            logger.info("Removing existing network")
             req = Clusters.NetworkCommissioning.Commands.RemoveNetwork(
                 networkID=networkList[0].networkID, breadcrumb=self.with_breadcrumb())
             res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
@@ -308,7 +348,7 @@ class NetworkCommissioningTests:
             await self.must_verify_breadcrumb()
 
         # Add first network
-        logger.info(f"Adding first test network")
+        logger.info("Adding first test network")
         req = Clusters.NetworkCommissioning.Commands.AddOrUpdateThreadNetwork(
             operationalDataset=TEST_THREAD_NETWORK_DATASET_TLVS[0], breadcrumb=self.with_breadcrumb())
         res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
@@ -320,8 +360,12 @@ class NetworkCommissioningTests:
                 f"Unexpected result: {res.networkIndex} (should be 0)")
         await self.must_verify_breadcrumb()
 
-        logger.info(f"Check network list")
-        res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
+        logger.info("Check network list")
+        res = await self._devCtrl.ReadAttribute(
+            nodeid=self._nodeid,
+            attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)],
+            returnClusterObject=True
+        )
         networkList = res[endpointId][Clusters.NetworkCommissioning].networks
         logger.info(f"Got network list: {networkList}")
         if len(networkList) != 1:
@@ -331,32 +375,40 @@ class NetworkCommissioningTests:
             raise AssertionError(
                 f"Unexpected result: first network ID should be {TEST_THREAD_NETWORK_IDS[0]} got {networkList[0].networkID}")
 
-        logger.info(f"Connect to a network")
+        logger.info("Connect to a network")
         req = Clusters.NetworkCommissioning.Commands.ConnectNetwork(
             networkID=TEST_THREAD_NETWORK_IDS[0], breadcrumb=self.with_breadcrumb())
         interactionTimeoutMs = self._devCtrl.ComputeRoundTripTimeout(self._nodeid, upperLayerProcessingTimeoutMs=30000)
-        res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req, interactionTimeoutMs=interactionTimeoutMs)
+        res = await self._devCtrl.SendCommand(nodeid=self._nodeid,
+                                              endpoint=endpointId,
+                                              payload=req,
+                                              interactionTimeoutMs=interactionTimeoutMs)
         logger.info(f"Got response: {res}")
         if res.networkingStatus != Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatus.kSuccess:
             raise AssertionError(f"Unexpected result: {res.networkingStatus}")
-        logger.info(f"Device connected to a network.")
+        logger.info("Device connected to a network.")
         await self.must_verify_breadcrumb()
 
         # Disarm the failsafe
-        logger.info(f"Disarming the failsafe")
+        logger.info("Disarming the failsafe")
         req = Clusters.GeneralCommissioning.Commands.CommissioningComplete()
         res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
         logger.info(f"Received response: {res}")
 
         # Verify Last* attributes
-        logger.info(f"Read Last* attributes")
+        logger.info("Read Last* attributes")
         res = await self.readLastNetworkingStateAttributes(endpointId=endpointId)
         if (res.lastNetworkID == NullValue) or (res.lastNetworkingStatus == NullValue) or (res.lastConnectErrorValue != NullValue):
             raise AssertionError(
-                f"LastNetworkID, LastNetworkingStatus should not be Null, LastConnectErrorValue should be Null for a successful network provision.")
+                "LastNetworkID, LastNetworkingStatus should not be Null, "
+                "LastConnectErrorValue should be Null for a successful network provision.")
 
-        logger.info(f"Check network list")
-        res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
+        logger.info("Check network list")
+        res = await self._devCtrl.ReadAttribute(
+            nodeid=self._nodeid,
+            attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)],
+            returnClusterObject=True
+        )
         networkList = res[endpointId][Clusters.NetworkCommissioning].networks
         logger.info(f"Got network list: {networkList}")
         if len(networkList) != 1:
@@ -367,16 +419,24 @@ class NetworkCommissioningTests:
                 f"Unexpected result: first network ID should be {TEST_THREAD_NETWORK_IDS[0]} got {networkList[0].networkID}")
         if not networkList[0].connected:
             raise AssertionError(
-                f"Unexpected result: network is not marked as connected")
+                "Unexpected result: network is not marked as connected")
 
     @base.test_case
     async def Test(self):
-        clusters = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(Clusters.Descriptor.Attributes.ServerList)], returnClusterObject=True)
+        clusters = await self._devCtrl.ReadAttribute(
+            nodeid=self._nodeid,
+            attributes=[(Clusters.Descriptor.Attributes.ServerList)],
+            returnClusterObject=True
+        )
         if Clusters.NetworkCommissioning.id not in clusters[0][Clusters.Descriptor].serverList:
             logger.info(
-                f"Network commissioning cluster {endpoint} is not enabled on this device.")
+                "Network commissioning cluster is not enabled on this device.")
             return
-        endpoints = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(Clusters.NetworkCommissioning.Attributes.FeatureMap)], returnClusterObject=True)
+        endpoints = await self._devCtrl.ReadAttribute(
+            nodeid=self._nodeid,
+            attributes=[(Clusters.NetworkCommissioning.Attributes.FeatureMap)],
+            returnClusterObject=True
+        )
         logger.info(endpoints)
         for endpoint, obj in endpoints.items():
             clus = obj[Clusters.NetworkCommissioning]
@@ -398,5 +458,5 @@ class NetworkCommissioningTests:
         try:
             await self.Test()
             return True
-        except Exception as ex:
+        except Exception:
             return False

--- a/src/controller/python/test/unit_tests/test_cluster_objects.py
+++ b/src/controller/python/test/unit_tests/test_cluster_objects.py
@@ -27,7 +27,9 @@ def _encode_attribute_and_then_decode_to_native(data, type: ClusterObjects.Clust
     return TLVReader(type.ToTLV(None, data)).get()['Any']
 
 
-def _encode_from_native_and_then_decode(data, cls: typing.Union[ClusterObjects.ClusterObject, ClusterObjects.ClusterAttributeDescriptor]):
+def _encode_from_native_and_then_decode(data,
+                                        cls: typing.Union[ClusterObjects.ClusterObject,
+                                                          ClusterObjects.ClusterAttributeDescriptor]):
     tlv = TLVWriter()
     tlv.put(None, data)
     return cls.FromTLV(bytes(tlv.encoding))

--- a/src/controller/python/test/unit_tests/test_tlv.py
+++ b/src/controller/python/test/unit_tests/test_tlv.py
@@ -149,9 +149,11 @@ class TestTLVReader(unittest.TestCase):
 
     def test_structure(self):
         test_cases = [
-            (b'\x15\x36\x01\x15\x35\x01\x26\x00\xBF\xA2\x55\x16\x37\x01\x24\x02\x00\x24\x03\x28\x24\x04\x00\x18\x24\x02\x01\x18\x18\x18\x18',
+            (b'\x15\x36\x01\x15\x35\x01\x26\x00\xBF\xA2\x55\x16\x37\x01\x24'
+             b'\x02\x00\x24\x03\x28\x24\x04\x00\x18\x24\x02\x01\x18\x18\x18\x18',
              {1: [{1: {0: 374710975, 1: [0, 40, 0], 2: 1}}]}),
-            (b'\x156\x01\x155\x01&\x00\xBF\xA2U\x167\x01$\x02\x00$\x03($\x04\x01\x18,\x02\x18Nordic Semiconductor ASA\x18\x18\x18\x18',
+            (b'\x156\x01\x155\x01&\x00\xBF\xA2U\x167\x01$\x02\x00$\x03($\x04\x01'
+             b'\x18,\x02\x18Nordic Semiconductor ASA\x18\x18\x18\x18',
              {1: [{1: {0: 374710975, 1: [0, 40, 1], 2: 'Nordic Semiconductor ASA'}}]}),
             (b"\0256\001\0255\001&\000\031\346x\2077\001$\002\001$\003\006$\004\000\030(\002\030\030\030\030",
              {1: [{1: {0: 2272847385, 1: [1, 6, 0], 2: False}}]})

--- a/src/python_testing/TC_ACE_1_3.py
+++ b/src/python_testing/TC_ACE_1_3.py
@@ -18,7 +18,7 @@
 import logging
 
 import chip.clusters as Clusters
-from chip.interaction_model import InteractionModelError, Status
+from chip.interaction_model import Status
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main
 from mobly import asserts
 
@@ -43,7 +43,8 @@ class TC_ACE_1_3(MatterBaseTest):
     async def read_descriptor_expect_unsupported_access(self, th):
         cluster = Clusters.Objects.Descriptor
         attribute = Clusters.Descriptor.Attributes.DeviceTypeList
-        await self.read_single_attribute_expect_error(dev_ctrl=th, endpoint=0, cluster=cluster, attribute=attribute, error=Status.UnsupportedAccess)
+        await self.read_single_attribute_expect_error(
+            dev_ctrl=th, endpoint=0, cluster=cluster, attribute=attribute, error=Status.UnsupportedAccess)
 
     @async_test_body
     async def test_TC_ACE_1_3(self):
@@ -60,6 +61,8 @@ class TC_ACE_1_3(MatterBaseTest):
 
         self.print_step(1, "Commissioning, already done")
         TH0 = self.default_controller
+        # _ = TH0 Hack for flake8 F841 local variable 'TH0' is assigned to but never used
+        _ = TH0
         fabric_admin = self.certificate_authority_manager.activeCaList[0].adminList[0]
 
         TH0_nodeid = self.matter_test_config.controller_node_id
@@ -78,14 +81,16 @@ class TC_ACE_1_3(MatterBaseTest):
                                          catTags=[cat1v1, cat2v2])
 
         self.print_step(2, "TH0 writes ACL all view on PIXIT.ACE.TESTENDPOINT")
-        TH0_admin_acl = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kAdminister,
-                                                                                authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                                subjects=[TH0_nodeid],
-                                                                                targets=[Clusters.AccessControl.Structs.Target(endpoint=0, cluster=0x001f)])
-        all_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                           authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                           subjects=[],
-                                                                           targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
+        TH0_admin_acl = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kAdminister,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[TH0_nodeid],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0, cluster=0x001f)])
+        all_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
         acl = [TH0_admin_acl, all_view]
         await self.write_acl(acl)
 
@@ -99,10 +104,11 @@ class TC_ACE_1_3(MatterBaseTest):
         await self.read_descriptor_expect_success(TH3)
 
         self.print_step(6, "TH0 writes ACL TH1 view on EP0")
-        th1_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                           authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                           subjects=[TH1_nodeid],
-                                                                           targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
+        th1_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[TH1_nodeid],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
         acl = [TH0_admin_acl, th1_view]
         await self.write_acl(acl)
         self.print_step(7, "TH1 reads EP0 descriptor - expect SUCCESS")
@@ -115,10 +121,11 @@ class TC_ACE_1_3(MatterBaseTest):
         await self.read_descriptor_expect_unsupported_access(TH3)
 
         self.print_step(10, "TH0 writes ACL TH2 view on EP0")
-        th2_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                           authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                           subjects=[TH2_nodeid],
-                                                                           targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
+        th2_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[TH2_nodeid],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
 
         acl = [TH0_admin_acl, th2_view]
         await self.write_acl(acl)
@@ -132,10 +139,11 @@ class TC_ACE_1_3(MatterBaseTest):
         await self.read_descriptor_expect_unsupported_access(TH3)
 
         self.print_step(14, "TH0 writes ACL TH3 view on EP0")
-        th3_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                           authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                           subjects=[TH3_nodeid],
-                                                                           targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
+        th3_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[TH3_nodeid],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
 
         acl = [TH0_admin_acl, th3_view]
         await self.write_acl(acl)
@@ -149,10 +157,11 @@ class TC_ACE_1_3(MatterBaseTest):
         await self.read_descriptor_expect_success(TH3)
 
         self.print_step(18, "TH0 writes ACL TH1 TH2 view on EP0")
-        th12_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                            subjects=[TH1_nodeid, TH2_nodeid],
-                                                                            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
+        th12_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[TH1_nodeid, TH2_nodeid],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
 
         acl = [TH0_admin_acl, th12_view]
         await self.write_acl(acl)
@@ -166,10 +175,11 @@ class TC_ACE_1_3(MatterBaseTest):
         await self.read_descriptor_expect_unsupported_access(TH3)
 
         self.print_step(22, "TH0 writes ACL TH1 TH3 view on EP0")
-        th13_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                            subjects=[TH1_nodeid, TH3_nodeid],
-                                                                            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
+        th13_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[TH1_nodeid, TH3_nodeid],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
 
         acl = [TH0_admin_acl, th13_view]
         await self.write_acl(acl)
@@ -183,10 +193,11 @@ class TC_ACE_1_3(MatterBaseTest):
         await self.read_descriptor_expect_success(TH3)
 
         self.print_step(26, "TH0 writes ACL TH2 TH3 view on EP0")
-        th23_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                            subjects=[TH2_nodeid, TH3_nodeid],
-                                                                            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
+        th23_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[TH2_nodeid, TH3_nodeid],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
 
         acl = [TH0_admin_acl, th23_view]
         await self.write_acl(acl)
@@ -200,10 +211,11 @@ class TC_ACE_1_3(MatterBaseTest):
         await self.read_descriptor_expect_success(TH3)
 
         self.print_step(30, "TH0 writes ACL TH1 TH2 TH3 view on EP0")
-        th123_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                             authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                             subjects=[TH1_nodeid, TH2_nodeid, TH3_nodeid],
-                                                                             targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
+        th123_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[TH1_nodeid, TH2_nodeid, TH3_nodeid],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
 
         acl = [TH0_admin_acl, th123_view]
         await self.write_acl(acl)
@@ -217,10 +229,11 @@ class TC_ACE_1_3(MatterBaseTest):
         await self.read_descriptor_expect_success(TH3)
 
         self.print_step(34, "TH0 writes ACL cat1v1 view on EP0")
-        cat1v1_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                              authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                              subjects=[acl_subject(cat1v1)],
-                                                                              targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
+        cat1v1_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[acl_subject(cat1v1)],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
         acl = [TH0_admin_acl, cat1v1_view]
         await self.write_acl(acl)
 
@@ -234,10 +247,11 @@ class TC_ACE_1_3(MatterBaseTest):
         await self.read_descriptor_expect_success(TH3)
 
         self.print_step(38, "TH0 writes ACL cat1v2 view on EP0")
-        cat1v2_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                              authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                              subjects=[acl_subject(cat1v2)],
-                                                                              targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
+        cat1v2_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[acl_subject(cat1v2)],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
 
         acl = [TH0_admin_acl, cat1v2_view]
         await self.write_acl(acl)
@@ -252,10 +266,11 @@ class TC_ACE_1_3(MatterBaseTest):
         await self.read_descriptor_expect_unsupported_access(TH3)
 
         self.print_step(42, "TH0 writes ACL cat1v3 view on EP0")
-        cat1v3_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                              authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                              subjects=[acl_subject(cat1v3)],
-                                                                              targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
+        cat1v3_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[acl_subject(cat1v3)],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
 
         acl = [TH0_admin_acl, cat1v3_view]
         await self.write_acl(acl)
@@ -270,10 +285,11 @@ class TC_ACE_1_3(MatterBaseTest):
         await self.read_descriptor_expect_unsupported_access(TH3)
 
         self.print_step(46, "TH0 writes ACL cat2v1 view on EP0")
-        cat2v1_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                              authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                              subjects=[acl_subject(cat2v1)],
-                                                                              targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
+        cat2v1_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[acl_subject(cat2v1)],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
 
         acl = [TH0_admin_acl, cat2v1_view]
         await self.write_acl(acl)
@@ -288,10 +304,11 @@ class TC_ACE_1_3(MatterBaseTest):
         await self.read_descriptor_expect_success(TH3)
 
         self.print_step(50, "TH0 writes ACL cat2v2 view on EP0")
-        cat2v2_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                              authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                              subjects=[acl_subject(cat2v2)],
-                                                                              targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
+        cat2v2_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[acl_subject(cat2v2)],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
 
         acl = [TH0_admin_acl, cat2v2_view]
         await self.write_acl(acl)
@@ -306,10 +323,11 @@ class TC_ACE_1_3(MatterBaseTest):
         await self.read_descriptor_expect_success(TH3)
 
         self.print_step(54, "TH0 writes ACL cat2v3 view on EP0")
-        cat2v3_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                              authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                              subjects=[acl_subject(cat2v3)],
-                                                                              targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
+        cat2v3_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[acl_subject(cat2v3)],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0)])
 
         acl = [TH0_admin_acl, cat2v3_view]
         await self.write_acl(acl)

--- a/src/python_testing/TC_ACE_1_4.py
+++ b/src/python_testing/TC_ACE_1_4.py
@@ -15,12 +15,10 @@
 #    limitations under the License.
 #
 
-import logging
 import sys
 
 import chip.clusters as Clusters
-import chip.clusters.Objects
-from chip.interaction_model import InteractionModelError, Status
+from chip.interaction_model import Status
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main
 from mobly import asserts
 
@@ -53,13 +51,15 @@ class TC_ACE_1_4(MatterBaseTest):
     async def read_descriptor_expect_unsupported_access(self, endpoint: int) -> None:
         cluster = Clusters.Objects.Descriptor
         attribute = Clusters.Descriptor.Attributes.DeviceTypeList
-        await self.read_single_attribute_expect_error(endpoint=endpoint, cluster=cluster, attribute=attribute, error=Status.UnsupportedAccess)
+        await self.read_single_attribute_expect_error(
+            endpoint=endpoint, cluster=cluster, attribute=attribute, error=Status.UnsupportedAccess)
 
     async def read_appcluster_expect_success(self) -> None:
         await self.read_single_attribute_check_success(endpoint=self.endpoint, cluster=self.cluster, attribute=self.attribute)
 
     async def read_appcluster_expect_unsupported_access(self) -> None:
-        await self.read_single_attribute_expect_error(endpoint=self.endpoint, cluster=self.cluster, attribute=self.attribute, error=Status.UnsupportedAccess)
+        await self.read_single_attribute_expect_error(
+            endpoint=self.endpoint, cluster=self.cluster, attribute=self.attribute, error=Status.UnsupportedAccess)
 
     async def read_wildcard_endpoint(self, attribute: object) -> object:
         return await self.default_controller.ReadAttribute(self.dut_node_id, [(attribute)])
@@ -80,13 +80,17 @@ class TC_ACE_1_4(MatterBaseTest):
     async def test_TC_ACE_1_4(self):
         # TODO: Guard these on the PICS
         asserts.assert_true('PIXIT.ACE.APPENDPOINT' in self.matter_test_config.global_test_params,
-                            "PIXIT.ACE.APPENDPOINT must be included on the command line in the --int-arg flag as PIXIT.ACE.APPENDPOINT:<endpoint>")
+                            "PIXIT.ACE.APPENDPOINT must be included on the command line in "
+                            "the --int-arg flag as PIXIT.ACE.APPENDPOINT:<endpoint>")
         asserts.assert_true('PIXIT.ACE.APPCLUSTER' in self.matter_test_config.global_test_params,
-                            "PIXIT.ACE.APPCLUSTER must be included on the command line in the --string-arg flag as PIXIT.ACE.APPCLUSTER:<cluster_name>")
+                            "PIXIT.ACE.APPCLUSTER must be included on the command line in "
+                            "the --string-arg flag as PIXIT.ACE.APPCLUSTER:<cluster_name>")
         asserts.assert_true('PIXIT.ACE.APPATTRIBUTE' in self.matter_test_config.global_test_params,
-                            "PIXIT.ACE.APPATTRIBUTE must be included on the command line in the --string-arg flag as PIXIT.ACE.APPATTRIBUTE:<attribute_name>")
+                            "PIXIT.ACE.APPATTRIBUTE must be included on the command line in "
+                            "the --string-arg flag as PIXIT.ACE.APPATTRIBUTE:<attribute_name>")
         asserts.assert_true('PIXIT.ACE.APPDEVTYPEID' in self.matter_test_config.global_test_params,
-                            "PIXIT.ACE.APPDEVTYPEID must be included on the command line in the --int-arg flag as PIXIT.ACE.APPDEVTYPEID:<device_type_id>")
+                            "PIXIT.ACE.APPDEVTYPEID must be included on the command line in "
+                            "the --int-arg flag as PIXIT.ACE.APPDEVTYPEID:<device_type_id>")
 
         cluster_str = self.matter_test_config.global_test_params['PIXIT.ACE.APPCLUSTER']
         attribute_str = self.matter_test_config.global_test_params['PIXIT.ACE.APPATTRIBUTE']
@@ -102,14 +106,16 @@ class TC_ACE_1_4(MatterBaseTest):
         self.print_step(1, "Commissioning, already done")
 
         self.print_step(2, "TH1 writes ACL all clusters view on all endpoints")
-        admin_acl = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kAdminister,
-                                                                            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                            subjects=[],
-                                                                            targets=[Clusters.AccessControl.Structs.Target(endpoint=0, cluster=Clusters.AccessControl.id)])
-        all_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
-                                                                           authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                                                                           subjects=[],
-                                                                           targets=[])
+        admin_acl = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kAdminister,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[],
+            targets=[Clusters.AccessControl.Structs.Target(endpoint=0, cluster=Clusters.AccessControl.id)])
+        all_view = Clusters.AccessControl.Structs.AccessControlEntryStruct(
+            privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kView,
+            authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+            subjects=[],
+            targets=[])
         acl = [admin_acl, all_view]
         await self.write_acl(acl)
 

--- a/src/python_testing/TC_CGEN_2_4.py
+++ b/src/python_testing/TC_CGEN_2_4.py
@@ -15,19 +15,13 @@
 #    limitations under the License.
 #
 
-import asyncio
 import logging
-import queue
 import time
-from threading import Event
 
 import chip.CertificateAuthority
 import chip.clusters as Clusters
 import chip.FabricAdmin
 from chip import ChipDeviceCtrl
-from chip.clusters.Attribute import SubscriptionTransaction, TypedAttributePath
-from chip.interaction_model import InteractionModelError
-from chip.utils import CommissioningBuildingBlocks
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main
 from mobly import asserts
 
@@ -45,15 +39,18 @@ class TC_CGEN_2_4(MatterBaseTest):
             logging.exception('Error running OpenCommissioningWindow %s', e)
             asserts.assert_true(False, 'Failed to open commissioning window')
 
-    async def CommissionToStageSendCompleteAndCleanup(self, stage: int, expectedErrorPart: chip.native.ErrorSDKPart, expectedErrCode: int):
+    async def CommissionToStageSendCompleteAndCleanup(
+            self, stage: int, expectedErrorPart: chip.native.ErrorSDKPart, expectedErrCode: int):
 
         logging.info("-----------------Fail on step {}-------------------------".format(stage))
         pin, code = self.OpenCommissioningWindow()
         self.th2.ResetTestCommissioner()
-        # This will run the commissioning up to the point where stage x is run and the response is sent before the test commissioner simulates a failure
+        # This will run the commissioning up to the point where stage x is run and the
+        # response is sent before the test commissioner simulates a failure
         self.th2.SetTestCommissionerPrematureCompleteAfter(stage)
         success, errcode = self.th2.CommissionOnNetwork(
-            nodeId=self.dut_node_id, setupPinCode=pin, filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=self.matter_test_config.discriminator)
+            nodeId=self.dut_node_id, setupPinCode=pin,
+            filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=self.matter_test_config.discriminator)
         logging.info('Commissioning complete done. Successful? {}, errorcode = {}'.format(success, errcode))
         asserts.assert_false(success, 'Commissioning complete did not error as expected')
         asserts.assert_true(errcode.sdk_part == expectedErrorPart, 'Unexpected error type returned from CommissioningComplete')
@@ -92,7 +89,8 @@ class TC_CGEN_2_4(MatterBaseTest):
         logging.info('Step 16 - TH2 fully commissions the DUT')
         self.th2.ResetTestCommissioner()
         success, errcode = self.th2.CommissionOnNetwork(
-            nodeId=self.dut_node_id, setupPinCode=pin, filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=self.matter_test_config.discriminator)
+            nodeId=self.dut_node_id, setupPinCode=pin,
+            filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=self.matter_test_config.discriminator)
         logging.info('Commissioning complete done. Successful? {}, errorcode = {}'.format(success, errcode))
 
         logging.info('Step 17 - TH1 sends an arm failsafe')
@@ -109,11 +107,15 @@ class TC_CGEN_2_4(MatterBaseTest):
             newloc = Clusters.GeneralCommissioning.Enums.RegulatoryLocationType.kIndoor
         else:
             # TODO: figure out how to use the extender
-            #newloc = MatterIntEnum.extend_enum_if_value_doesnt_exist(Clusters.GeneralCommissioning.Enums.RegulatoryLocationType, 3)
-            newlog = cap
+            # newloc = MatterIntEnum.extend_enum_if_value_doesnt_exist(
+            #     Clusters.GeneralCommissioning.Enums.RegulatoryLocationType, 3)
+            newloc = cap
+
+        _ = newloc
 
         logging.info('Step 19 Send SetRgulatoryConfig with incorrect location')
-        #cmd = Clusters.GeneralCommissioning.Commands.SetRegulatoryConfig(newRegulatoryConfig=newloc, countryCode="XX", breadcrumb=0)
+        # cmd = Clusters.GeneralCommissioning.Commands.SetRegulatoryConfig(
+        #     newRegulatoryConfig=newloc, countryCode="XX", breadcrumb=0)
         # try:
         #    await self.th1.SendCommand(nodeid=self.dut_node_id, endpoint=0, payload=cmd)
         # except InteractionModelError as ex:

--- a/src/python_testing/TC_DA_1_7.py
+++ b/src/python_testing/TC_DA_1_7.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from typing import Optional
 
 import chip.clusters as Clusters
-from chip.interaction_model import Status
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -79,13 +78,15 @@ class TC_DA_1_7(MatterBaseTest):
         dev_ctrl = self.default_controller
 
         logging.info("Step 2: Get PAI of DUT1 with certificate chain request")
-        result = await dev_ctrl.SendCommand(self.dut_node_id, 0, Clusters.OperationalCredentials.Commands.CertificateChainRequest(2))
+        result = await dev_ctrl.SendCommand(self.dut_node_id, 0,
+                                            Clusters.OperationalCredentials.Commands.CertificateChainRequest(2))
         pai_1 = result.certificate
         asserts.assert_less_equal(len(pai_1), 600, "PAI cert must be at most 600 bytes")
         self.record_data({"pai_1": hex_from_bytes(pai_1)})
 
         logging.info("Step 3: Get DAC of DUT1 with certificate chain request")
-        result = await dev_ctrl.SendCommand(self.dut_node_id, 0, Clusters.OperationalCredentials.Commands.CertificateChainRequest(1))
+        result = await dev_ctrl.SendCommand(self.dut_node_id, 0,
+                                            Clusters.OperationalCredentials.Commands.CertificateChainRequest(1))
         dac_1 = result.certificate
         asserts.assert_less_equal(len(dac_1), 600, "DAC cert must be at most 600 bytes")
         self.record_data({"dac_1": hex_from_bytes(dac_1)})

--- a/src/python_testing/TC_TestEventTrigger.py
+++ b/src/python_testing/TC_TestEventTrigger.py
@@ -15,11 +15,8 @@
 #    limitations under the License.
 #
 
-import logging
-from imaplib import Commands
-
 import chip.clusters as Clusters
-from chip.interaction_model import InteractionModelError, Status
+from chip.interaction_model import InteractionModelError
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main
 from mobly import asserts
 
@@ -40,35 +37,78 @@ class TestEventTrigger(MatterBaseTest):
     @async_test_body
     async def test_all_zeros_key(self):
         dev_ctrl = self.default_controller
-        with asserts.assert_raises_regex(InteractionModelError, "ConstraintError", "All-zero TestEventTrigger key must return ConstraintError"):
-            await dev_ctrl.SendCommand(self.dut_node_id, endpoint=0, payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kAllZerosKey, eventTrigger=kValidEventTrigger))
+        with asserts.assert_raises_regex(InteractionModelError,
+                                         "ConstraintError", "All-zero TestEventTrigger key must return ConstraintError"):
+            await dev_ctrl.SendCommand(
+                                self.dut_node_id,
+                                endpoint=0,
+                                payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kAllZerosKey,
+                                                                                              eventTrigger=kValidEventTrigger)
+                            )
 
     @async_test_body
     async def test_incorrect_key(self):
         dev_ctrl = self.default_controller
-        test_event_triggers_enabled = await self.read_single_attribute(dev_ctrl, self.dut_node_id, endpoint=0, attribute=Clusters.GeneralDiagnostics.Attributes.TestEventTriggersEnabled)
+        test_event_triggers_enabled = await self.read_single_attribute(
+                                                    dev_ctrl,
+                                                    self.dut_node_id,
+                                                    endpoint=0,
+                                                    attribute=Clusters.GeneralDiagnostics.Attributes.TestEventTriggersEnabled
+                                                )
         asserts.assert_true(test_event_triggers_enabled, "This test expects Test Event Triggers are Enabled")
 
-        with asserts.assert_raises_regex(InteractionModelError, "ConstraintError", "Bad TestEventTrigger key must return ConstraintError"):
-            await dev_ctrl.SendCommand(self.dut_node_id, endpoint=0, payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kBadKey, eventTrigger=kValidEventTrigger))
+        with asserts.assert_raises_regex(InteractionModelError,
+                                         "ConstraintError", "Bad TestEventTrigger key must return ConstraintError"):
+            await dev_ctrl.SendCommand(
+                    self.dut_node_id,
+                    endpoint=0,
+                    payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kBadKey,
+                                                                                  eventTrigger=kValidEventTrigger)
+                )
 
     @async_test_body
     async def test_correct_key_valid_code(self):
         dev_ctrl = self.default_controller
-        test_event_triggers_enabled = await self.read_single_attribute(dev_ctrl, self.dut_node_id, endpoint=0, attribute=Clusters.GeneralDiagnostics.Attributes.TestEventTriggersEnabled)
+        test_event_triggers_enabled = await self.read_single_attribute(
+                                                    dev_ctrl,
+                                                    self.dut_node_id,
+                                                    endpoint=0,
+                                                    attribute=Clusters.GeneralDiagnostics.Attributes.TestEventTriggersEnabled
+                                                )
         asserts.assert_true(test_event_triggers_enabled, "This test expects Test Event Triggers are Enabled")
 
         # No response to command --> Success yields "None".
-        asserts.assert_is_none(await dev_ctrl.SendCommand(self.dut_node_id, endpoint=0, payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kExpectedKey, eventTrigger=kValidEventTrigger)))
+        asserts.assert_is_none(
+            await dev_ctrl.SendCommand(
+                    self.dut_node_id,
+                    endpoint=0,
+                    payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kExpectedKey,
+                                                                                  eventTrigger=kValidEventTrigger)
+                )
+            )
 
     @async_test_body
     async def test_correct_key_invalid_code(self):
         dev_ctrl = self.default_controller
-        test_event_triggers_enabled = await self.read_single_attribute(dev_ctrl, self.dut_node_id, endpoint=0, attribute=Clusters.GeneralDiagnostics.Attributes.TestEventTriggersEnabled)
+        test_event_triggers_enabled = await self.read_single_attribute(
+                                                    dev_ctrl,
+                                                    self.dut_node_id,
+                                                    endpoint=0,
+                                                    attribute=Clusters.GeneralDiagnostics.Attributes.TestEventTriggersEnabled
+                                                )
         asserts.assert_true(test_event_triggers_enabled, "This test expects Test Event Triggers are Enabled")
 
-        with asserts.assert_raises_regex(InteractionModelError, "InvalidCommand", "Unsupported EventTrigger must return InvalidCommand"):
-            await dev_ctrl.SendCommand(self.dut_node_id, endpoint=0, payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kExpectedKey, eventTrigger=kInvalidEventTrigger))
+        with asserts.assert_raises_regex(InteractionModelError,
+                                         "InvalidCommand",
+                                         "Unsupported EventTrigger must return InvalidCommand"):
+            await dev_ctrl.SendCommand(
+                        self.dut_node_id,
+                        endpoint=0,
+                        payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(
+                            enableKey=kExpectedKey,
+                            eventTrigger=kInvalidEventTrigger
+                        )
+                    )
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_TestEventTrigger.py
+++ b/src/python_testing/TC_TestEventTrigger.py
@@ -40,75 +40,75 @@ class TestEventTrigger(MatterBaseTest):
         with asserts.assert_raises_regex(InteractionModelError,
                                          "ConstraintError", "All-zero TestEventTrigger key must return ConstraintError"):
             await dev_ctrl.SendCommand(
-                                self.dut_node_id,
-                                endpoint=0,
-                                payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kAllZerosKey,
-                                                                                              eventTrigger=kValidEventTrigger)
-                            )
+                self.dut_node_id,
+                endpoint=0,
+                payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kAllZerosKey,
+                                                                              eventTrigger=kValidEventTrigger)
+            )
 
     @async_test_body
     async def test_incorrect_key(self):
         dev_ctrl = self.default_controller
         test_event_triggers_enabled = await self.read_single_attribute(
-                                                    dev_ctrl,
-                                                    self.dut_node_id,
-                                                    endpoint=0,
-                                                    attribute=Clusters.GeneralDiagnostics.Attributes.TestEventTriggersEnabled
-                                                )
+            dev_ctrl,
+            self.dut_node_id,
+            endpoint=0,
+            attribute=Clusters.GeneralDiagnostics.Attributes.TestEventTriggersEnabled
+        )
         asserts.assert_true(test_event_triggers_enabled, "This test expects Test Event Triggers are Enabled")
 
         with asserts.assert_raises_regex(InteractionModelError,
                                          "ConstraintError", "Bad TestEventTrigger key must return ConstraintError"):
             await dev_ctrl.SendCommand(
-                    self.dut_node_id,
-                    endpoint=0,
-                    payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kBadKey,
-                                                                                  eventTrigger=kValidEventTrigger)
-                )
+                self.dut_node_id,
+                endpoint=0,
+                payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kBadKey,
+                                                                              eventTrigger=kValidEventTrigger)
+            )
 
     @async_test_body
     async def test_correct_key_valid_code(self):
         dev_ctrl = self.default_controller
         test_event_triggers_enabled = await self.read_single_attribute(
-                                                    dev_ctrl,
-                                                    self.dut_node_id,
-                                                    endpoint=0,
-                                                    attribute=Clusters.GeneralDiagnostics.Attributes.TestEventTriggersEnabled
-                                                )
+            dev_ctrl,
+            self.dut_node_id,
+            endpoint=0,
+            attribute=Clusters.GeneralDiagnostics.Attributes.TestEventTriggersEnabled
+        )
         asserts.assert_true(test_event_triggers_enabled, "This test expects Test Event Triggers are Enabled")
 
         # No response to command --> Success yields "None".
         asserts.assert_is_none(
             await dev_ctrl.SendCommand(
-                    self.dut_node_id,
-                    endpoint=0,
-                    payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kExpectedKey,
-                                                                                  eventTrigger=kValidEventTrigger)
-                )
+                self.dut_node_id,
+                endpoint=0,
+                payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kExpectedKey,
+                                                                              eventTrigger=kValidEventTrigger)
             )
+        )
 
     @async_test_body
     async def test_correct_key_invalid_code(self):
         dev_ctrl = self.default_controller
         test_event_triggers_enabled = await self.read_single_attribute(
-                                                    dev_ctrl,
-                                                    self.dut_node_id,
-                                                    endpoint=0,
-                                                    attribute=Clusters.GeneralDiagnostics.Attributes.TestEventTriggersEnabled
-                                                )
+            dev_ctrl,
+            self.dut_node_id,
+            endpoint=0,
+            attribute=Clusters.GeneralDiagnostics.Attributes.TestEventTriggersEnabled
+        )
         asserts.assert_true(test_event_triggers_enabled, "This test expects Test Event Triggers are Enabled")
 
         with asserts.assert_raises_regex(InteractionModelError,
                                          "InvalidCommand",
                                          "Unsupported EventTrigger must return InvalidCommand"):
             await dev_ctrl.SendCommand(
-                        self.dut_node_id,
-                        endpoint=0,
-                        payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(
-                            enableKey=kExpectedKey,
-                            eventTrigger=kInvalidEventTrigger
-                        )
-                    )
+                self.dut_node_id,
+                endpoint=0,
+                payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(
+                    enableKey=kExpectedKey,
+                    eventTrigger=kInvalidEventTrigger
+                )
+            )
 
 
 if __name__ == "__main__":

--- a/src/python_testing/hello_test.py
+++ b/src/python_testing/hello_test.py
@@ -27,7 +27,12 @@ class HelloTest(MatterBaseTest):
     @async_test_body
     async def test_names_as_expected(self):
         dev_ctrl = self.default_controller
-        vendor_name = await self.read_single_attribute(dev_ctrl, self.dut_node_id, 0, Clusters.BasicInformation.Attributes.VendorName)
+        vendor_name = await self.read_single_attribute(
+                                dev_ctrl,
+                                self.dut_node_id,
+                                0,
+                                Clusters.BasicInformation.Attributes.VendorName
+                            )
 
         logging.info("Found VendorName: %s" % (vendor_name))
         asserts.assert_equal(vendor_name, "TEST_VENDOR", "VendorName must be TEST_VENDOR!")
@@ -35,7 +40,12 @@ class HelloTest(MatterBaseTest):
     @async_test_body
     async def test_failure_on_wrong_endpoint(self):
         dev_ctrl = self.default_controller
-        result = await self.read_single_attribute(dev_ctrl, self.dut_node_id, 9999, Clusters.BasicInformation.Attributes.ProductName)
+        result = await self.read_single_attribute(
+                            dev_ctrl,
+                            self.dut_node_id,
+                            9999,
+                            Clusters.BasicInformation.Attributes.ProductName
+                        )
         asserts.assert_true(isinstance(result, Clusters.Attribute.ValueDecodeFailure), "Should fail to read on endpoint 9999")
         asserts.assert_equal(result.Reason.status, Status.UnsupportedEndpoint, "Failure reason should be UnsupportedEndpoint")
 

--- a/src/python_testing/hello_test.py
+++ b/src/python_testing/hello_test.py
@@ -28,11 +28,11 @@ class HelloTest(MatterBaseTest):
     async def test_names_as_expected(self):
         dev_ctrl = self.default_controller
         vendor_name = await self.read_single_attribute(
-                                dev_ctrl,
-                                self.dut_node_id,
-                                0,
-                                Clusters.BasicInformation.Attributes.VendorName
-                            )
+            dev_ctrl,
+            self.dut_node_id,
+            0,
+            Clusters.BasicInformation.Attributes.VendorName
+        )
 
         logging.info("Found VendorName: %s" % (vendor_name))
         asserts.assert_equal(vendor_name, "TEST_VENDOR", "VendorName must be TEST_VENDOR!")
@@ -41,11 +41,11 @@ class HelloTest(MatterBaseTest):
     async def test_failure_on_wrong_endpoint(self):
         dev_ctrl = self.default_controller
         result = await self.read_single_attribute(
-                            dev_ctrl,
-                            self.dut_node_id,
-                            9999,
-                            Clusters.BasicInformation.Attributes.ProductName
-                        )
+            dev_ctrl,
+            self.dut_node_id,
+            9999,
+            Clusters.BasicInformation.Attributes.ProductName
+        )
         asserts.assert_true(isinstance(result, Clusters.Attribute.ValueDecodeFailure), "Should fail to read on endpoint 9999")
         asserts.assert_equal(result.Reason.status, Status.UnsupportedEndpoint, "Failure reason should be UnsupportedEndpoint")
 

--- a/src/setup_payload/tests/run_python_setup_payload_gen_test.py
+++ b/src/setup_payload/tests/run_python_setup_payload_gen_test.py
@@ -15,14 +15,13 @@
 # limitations under the License.
 
 import os
-import random
 import re
 import subprocess
 import sys
 
 CHIP_TOPDIR = os.path.dirname(os.path.realpath(__file__))[:-len(os.path.join('src', 'setup_payload', 'tests'))]
 sys.path.insert(0, os.path.join(CHIP_TOPDIR, 'src', 'setup_payload', 'python'))
-from generate_setup_payload import INVALID_PASSCODES, CommissioningFlow, SetupPayload  # noqa: E402
+from generate_setup_payload import CommissioningFlow, SetupPayload  # noqa: E402
 
 
 def payload_param_dict():

--- a/src/tools/chip-cert/gen_com_dut_test_vectors.py
+++ b/src/tools/chip-cert/gen_com_dut_test_vectors.py
@@ -123,7 +123,8 @@ CERT_STRUCT_TEST_CASES = [
         "is_success_case": 'false',
     },
     {
-        "description": "Certificate Basic Constraint extension PathLen field presence is wrong (present for DAC not present for PAI)",
+        "description": "Certificate Basic Constraint extension PathLen field presence is wrong "
+        "(present for DAC not present for PAI)",
         "test_folder": 'ext_basic_pathlen_presence_wrong',
         "error_flag": 'ext-basic-pathlen-presence-wrong',
         "is_success_case": 'false',
@@ -165,7 +166,8 @@ CERT_STRUCT_TEST_CASES = [
         "is_success_case": 'false',
     },
     {
-        "description": "Certificate Key Usage extension diginalSignature field is wrong (not present for DAC and present for PAI, which is OK as optional)",
+        "description": "Certificate Key Usage extension diginalSignature field is wrong "
+        "(not present for DAC and present for PAI, which is OK as optional)",
         "test_folder": 'ext_key_usage_dig_sig_wrong',
         "error_flag": 'ext-key-usage-dig-sig',
         "is_success_case": 'false',
@@ -229,7 +231,8 @@ VIDPID_FALLBACK_ENCODING_TEST_CASES = [
         "is_success_case": 'true',
     },
     {
-        "description": 'Fallback VID and PID encoding example from spec: valid example showing that order or separators are not considered at all for the overall validity of the embedded fields',
+        "description": 'Fallback VID and PID encoding example from spec: valid example showing that '
+        'order or separators are not considered at all for the overall validity of the embedded fields',
         "common_name": 'Mpid:00B1,ACME Matter Devel DAC 5CDA9899,Mvid:FFF1',
         "test_folder": 'vidpid_fallback_encoding_03',
         "is_success_case": 'true',
@@ -241,31 +244,36 @@ VIDPID_FALLBACK_ENCODING_TEST_CASES = [
         "is_success_case": 'true',
     },
     {
-        "description": 'Fallback VID and PID encoding example from spec: valid, but highly discouraged, since embedding of substrings within other substrings may be confusing to human readers',
+        "description": 'Fallback VID and PID encoding example from spec: valid, but highly discouraged, '
+        'since embedding of substrings within other substrings may be confusing to human readers',
         "common_name": 'Mvid:FFF1ACME Matter Devel DAC 5CDAMpid:00B19899',
         "test_folder": 'vidpid_fallback_encoding_05',
         "is_success_case": 'true',
     },
     {
-        "description": 'Fallback VID and PID encoding example from spec: invalid, since substring following Mvid: is not exactly 4 uppercase hexadecimal digits',
+        "description": 'Fallback VID and PID encoding example from spec: invalid, '
+        'since substring following Mvid: is not exactly 4 uppercase hexadecimal digits',
         "common_name": 'ACME Matter Devel DAC 5CDA9899 Mvid:FF1 Mpid:00B1',
         "test_folder": 'vidpid_fallback_encoding_06',
         "is_success_case": 'false',
     },
     {
-        "description": 'Fallback VID and PID encoding example from spec: invalid, since substring following Mvid: is not exactly 4 uppercase hexadecimal digits',
+        "description": 'Fallback VID and PID encoding example from spec: invalid, '
+        'since substring following Mvid: is not exactly 4 uppercase hexadecimal digits',
         "common_name": 'ACME Matter Devel DAC 5CDA9899 Mvid:fff1 Mpid:00B1',
         "test_folder": 'vidpid_fallback_encoding_07',
         "is_success_case": 'false',
     },
     {
-        "description": 'Fallback VID and PID encoding example from spec: invalid, since substring following Mpid: is not exactly 4 uppercase hexadecimal digits',
+        "description": 'Fallback VID and PID encoding example from spec: invalid, '
+        'since substring following Mpid: is not exactly 4 uppercase hexadecimal digits',
         "common_name": 'ACME Matter Devel DAC 5CDA9899 Mvid:FFF1 Mpid:B1',
         "test_folder": 'vidpid_fallback_encoding_08',
         "is_success_case": 'false',
     },
     {
-        "description": 'Fallback VID and PID encoding example from spec: invalid, since substring following Mpid: is not exactly 4 uppercase hexadecimal digits',
+        "description": 'Fallback VID and PID encoding example from spec: invalid, '
+        'since substring following Mpid: is not exactly 4 uppercase hexadecimal digits',
         "common_name": 'ACME Matter Devel DAC 5CDA9899 Mpid: Mvid:FFF1',
         "test_folder": 'vidpid_fallback_encoding_09',
         "is_success_case": 'false',
@@ -303,7 +311,8 @@ VIDPID_FALLBACK_ENCODING_TEST_CASES = [
     },
     # Examples with both fallback encoding in the common name and using Matter specific OIDs
     {
-        "description": 'Mix of Fallback and Matter OID encoding for VID and PID: valid, Matter OIDs are used and wrong values in the common-name are ignored',
+        "description": 'Mix of Fallback and Matter OID encoding for VID and PID: valid, '
+        'Matter OIDs are used and wrong values in the common-name are ignored',
         "common_name": 'ACME Matter Devel DAC 5CDA9899 Mvid:FFF2 Mpid:00B2',
         "vid": 0xFFF1,
         "pid": 0x00B1,
@@ -311,7 +320,8 @@ VIDPID_FALLBACK_ENCODING_TEST_CASES = [
         "is_success_case": 'true',
     },
     {
-        "description": 'Mix of Fallback and Matter OID encoding for VID and PID: wrong, Correct values encoded in the common-name are ignored',
+        "description": 'Mix of Fallback and Matter OID encoding for VID and PID: wrong, '
+        'Correct values encoded in the common-name are ignored',
         "common_name": 'ACME Matter Devel DAC 5CDA9899 Mvid:FFF1 Mpid:00B1',
         "vid": 0xFFF2,
         "pid": 0x00B2,
@@ -319,7 +329,8 @@ VIDPID_FALLBACK_ENCODING_TEST_CASES = [
         "is_success_case": 'false',
     },
     {
-        "description": 'Mix of Fallback and Matter OID encoding for VID and PID: invalid, PID is using Matter OID then VID must also use Matter OID',
+        "description": 'Mix of Fallback and Matter OID encoding for VID and PID: invalid, '
+        'PID is using Matter OID then VID must also use Matter OID',
         "common_name": 'Mvid:FFF1',
         "pid": 0x00B1,
         "test_folder": 'vidpid_fallback_encoding_17',
@@ -413,7 +424,8 @@ CD_STRUCT_TEST_CASES = [
         "is_success_case": 'false',
     },
     {
-        "description": "The device_type_id field doesn't match the device_type_id value in the DCL entries associated with the VID and PID.",
+        "description": "The device_type_id field doesn't match the device_type_id value in the DCL entries "
+        "associated with the VID and PID.",
         "test_folder": 'device_type_id_mismatch',
         "error_flag": 'device-type-id-mismatch',
         "is_success_case": 'false',
@@ -467,13 +479,15 @@ CD_STRUCT_TEST_CASES = [
         "is_success_case": 'false',
     },
     {
-        "description": 'The version_number field matches the VID and PID used in a DeviceSoftwareVersionModel entry in the DCL matching the certification record associated with the product presenting this CD.',
+        "description": 'The version_number field matches the VID and PID used in a DeviceSoftwareVersionModel '
+        'entry in the DCL matching the certification record associated with the product presenting this CD.',
         "test_folder": 'version_number_match',
         "error_flag": 'no-error',
         "is_success_case": 'true',
     },
     {
-        "description": "The version_number field doesn't match the VID and PID used in a DeviceSoftwareVersionModel entry in the DCL matching the certification record associated with the product presenting this CD.",
+        "description": "The version_number field doesn't match the VID and PID used in a DeviceSoftwareVersionModel "
+        "entry in the DCL matching the certification record associated with the product presenting this CD.",
         "test_folder": 'version_number_wrong',
         "error_flag": 'version-number-wrong',
         "is_success_case": 'false',
@@ -509,19 +523,22 @@ CD_STRUCT_TEST_CASES = [
         "is_success_case": 'false',
     },
     {
-        "description": 'The dac_origin_vendor_id and dac_origin_product_id fields present and contain the VID and PID values that match the VID and PID found in the DAC Subject DN.',
+        "description": 'The dac_origin_vendor_id and dac_origin_product_id fields present and contain '
+        'the VID and PID values that match the VID and PID found in the DAC Subject DN.',
         "test_folder": 'dac_origin_vid_pid_present_match',
         "error_flag": 'dac-origin-vid-pid-present',
         "is_success_case": 'true',
     },
     {
-        "description": "The dac_origin_vendor_id and dac_origin_product_id fields present and the VID value doesn't match the VID found in the DAC Subject DN.",
+        "description": "The dac_origin_vendor_id and dac_origin_product_id fields present and the VID value "
+        "doesn't match the VID found in the DAC Subject DN.",
         "test_folder": 'dac_origin_vid_pid_present_vid_mismatch',
         "error_flag": 'dac-origin-vid-mismatch',
         "is_success_case": 'false',
     },
     {
-        "description": "The dac_origin_vendor_id and dac_origin_product_id fields present and the PID value doesn't match the PID found in the DAC Subject DN.",
+        "description": "The dac_origin_vendor_id and dac_origin_product_id fields present and the PID value "
+        "doesn't match the PID found in the DAC Subject DN.",
         "test_folder": 'dac_origin_vid_pid_present_pid_mismatch',
         "error_flag": 'dac-origin-pid-mismatch',
         "is_success_case": 'false',
@@ -663,7 +680,8 @@ class Names:
 
 
 class DevCertBuilder:
-    def __init__(self, cert_type: CertType, error_type: str, paa_path: str, test_case_out_dir: str, chip_cert: str, vid: int, pid: int, custom_cn_attribute: str, valid_from: str):
+    def __init__(self, cert_type: CertType, error_type: str, paa_path: str, test_case_out_dir: str, chip_cert: str, vid: int,
+                 pid: int, custom_cn_attribute: str, valid_from: str):
         self.vid = vid
         self.pid = pid
         self.cert_type = cert_type
@@ -710,8 +728,9 @@ class DevCertBuilder:
         else:
             return
 
-        cmd = self.chipcert + ' gen-att-cert ' + type_flag + error_type_flag + ' -c "' + subject_name + '" -C ' + self.signer.cert_pem + ' -K ' + \
-            self.signer.key_pem + vid_flag + pid_flag + validity_flags + ' -o ' + self.own.cert_pem + ' -O ' + self.own.key_pem
+        cmd = self.chipcert + ' gen-att-cert ' + type_flag + error_type_flag + ' -c "' + subject_name + '" -C ' + \
+            self.signer.cert_pem + ' -K ' + self.signer.key_pem + vid_flag + pid_flag + \
+            validity_flags + ' -o ' + self.own.cert_pem + ' -O ' + self.own.key_pem
         subprocess.run(cmd, shell=True)
         cmd = 'openssl x509 -inform pem -in ' + self.own.cert_pem + \
             ' -out ' + self.own.cert_der + ' -outform DER'
@@ -762,7 +781,11 @@ def generate_test_case_vector_json(test_case_out_dir: str, test_cert: str, test_
         json_dict["description"] = test_cert.upper() + " Test Vector: " + test_case["description"]
     if "is_success_case" in test_case:
         # These test cases are expected to fail when error injected in DAC but expected to pass when error injected in PAI
-        if (test_cert == 'pai') and (test_case["test_folder"] in ['ext_basic_pathlen0', 'vidpid_fallback_encoding_08', 'vidpid_fallback_encoding_09', 'ext_key_usage_dig_sig_wrong']):
+        if (test_cert == 'pai') and (test_case["test_folder"] in ['ext_basic_pathlen0',
+                                                                  'vidpid_fallback_encoding_08',
+                                                                  'vidpid_fallback_encoding_09',
+                                                                  'ext_key_usage_dig_sig_wrong'
+                                                                  ]):
             json_dict["is_success_case"] = "true"
         else:
             json_dict["is_success_case"] = test_case["is_success_case"]
@@ -944,13 +967,18 @@ def main():
         if test_case["error_flag"] == 'dac-origin-pid-present' or test_case["error_flag"] == 'dac-origin-vid-pid-present':
             dac_origin_flag += ' -r 0x{:X}'.format(pid)
 
-        if test_case["error_flag"] == 'authorized-paa-list-count0' or test_case["error_flag"] == 'authorized-paa-list-count1-valid' or test_case["error_flag"] == 'authorized-paa-list-count2-valid' or test_case["error_flag"] == 'authorized-paa-list-count3-invalid' or test_case["error_flag"] == 'authorized-paa-list-count10-valid' or test_case["error_flag"] == 'authorized-paa-list-count10-invalid':
+        if test_case["error_flag"] == 'authorized-paa-list-count0' or test_case["error_flag"] == 'authorized-paa-list-count1-valid'\
+                or test_case["error_flag"] == 'authorized-paa-list-count2-valid'\
+                or test_case["error_flag"] == 'authorized-paa-list-count3-invalid'\
+                or test_case["error_flag"] == 'authorized-paa-list-count10-valid'\
+                or test_case["error_flag"] == 'authorized-paa-list-count10-invalid':
             authorized_paa_flag = ' -a ' + args.paapath + 'Cert.pem'
         else:
             authorized_paa_flag = ''
 
-        cmd = chipcert + ' gen-cd -I -E ' + test_case["error_flag"] + ' -K ' + cd_key + ' -C ' + cd_cert + ' -O ' + test_case_out_dir + '/cd.der' + \
-            ' -f 1 ' + vid_flag + pid_flag + dac_origin_flag + authorized_paa_flag + ' -d 0x1234 -c "ZIG20141ZB330001-24" -l 0 -i 0 -n 9876 -t 0'
+        cmd = chipcert + ' gen-cd -I -E ' + test_case["error_flag"] + ' -K ' + cd_key + ' -C ' + cd_cert + ' -O ' + \
+            test_case_out_dir + '/cd.der' + ' -f 1 ' + vid_flag + pid_flag + dac_origin_flag + authorized_paa_flag + \
+            ' -d 0x1234 -c "ZIG20141ZB330001-24" -l 0 -i 0 -n 9876 -t 0'
         subprocess.run(cmd, shell=True)
 
         # Generate Test Case Data Container in JSON Format

--- a/src/tools/chip-cert/gen_op_cert_test_vectors.py
+++ b/src/tools/chip-cert/gen_op_cert_test_vectors.py
@@ -376,7 +376,8 @@ CHIP_TLV_CERT_ERROR_TEST_CASES = [
         "is_get_cert_type_expected_to_fail": False,
     },
     {
-        "description": "Certificate Key Usage extension diginalSignature field is wrong (not present for NOC and present for ICAC/RCAC)",
+        "description": "Certificate Key Usage extension diginalSignature field is wrong "
+        "(not present for NOC and present for ICAC/RCAC)",
         "test_name": 'Ext-KeyUsage-DigSig-Wrong',
         "error_flag": 'ext-key-usage-dig-sig',
         "is_chip_to_x509_expected_to_fail": False,
@@ -512,7 +513,8 @@ class Names:
 
 
 class OpCertBuilder:
-    def __init__(self, cert_type: CertType, cert_form: CertFormat, signer_cert: str, signer_key: str, error_type: str, test_name: str, test_case_out_dir: str, chip_cert: str):
+    def __init__(self, cert_type: CertType, cert_form: CertFormat, signer_cert: str, signer_key: str, error_type: str,
+                 test_name: str, test_case_out_dir: str, chip_cert: str):
         self.cert_type = cert_type
         self.cert_form = cert_form
         self.error_type = error_type
@@ -616,7 +618,8 @@ def main():
             for test_case in DER_CERT_ERROR_TEST_CASES:
                 for cert_type in [CertType.NOC, CertType.ICAC, CertType.RCAC]:
                     # The following error cases are applicable only for NOC
-                    if (test_case["error_flag"] == 'subject-node-id-invalid' or test_case["error_flag"] == 'ext-basic-pathlen-presence-wrong') and cert_type != CertType.NOC:
+                    if (test_case["error_flag"] == 'subject-node-id-invalid' or
+                            test_case["error_flag"] == 'ext-basic-pathlen-presence-wrong') and cert_type != CertType.NOC:
                         break
 
                     if cert_type == CertType.NOC:
@@ -658,7 +661,8 @@ def main():
                         break
 
                     # The following error cases are applicable only for NOC
-                    if (test_case["error_flag"] == 'subject-node-id-invalid' or test_case["error_flag"] == 'subject-fabric-id-missing') and cert_type != CertType.NOC:
+                    if (test_case["error_flag"] == 'subject-node-id-invalid'
+                            or test_case["error_flag"] == 'subject-fabric-id-missing') and cert_type != CertType.NOC:
                         break
 
                     if cert_type == CertType.NOC:
@@ -685,7 +689,8 @@ def main():
                     if test_case["is_validate_chip_rcac_expected_to_fail"]:
                         c_validate_chip_rcac_error_cases += builder.add_cert_to_error_cases()
                         validate_chip_rcac_error_cases_count += 1
-                    if test_case["is_get_cert_type_expected_to_fail"] and not (test_case["error_flag"] == 'subject-cat-twice' and cert_type == CertType.NOC):
+                    if test_case["is_get_cert_type_expected_to_fail"] and not (test_case["error_flag"] == 'subject-cat-twice'
+                                                                               and cert_type == CertType.NOC):
                         c_get_cert_type_error_cases += builder.add_cert_to_error_cases()
                         get_cert_type_error_cases_count += 1
 


### PR DESCRIPTION
This pull request is a part of #25193 ( part fix python files in python tests )

### Problem

Python files need prevent things like syntax errors, typos, bad style, etc... it saves time for reviewing your code. Many python files needed bug fixes.

### Changes

Fix all python files in python tests where linter find problem. Adding python tests to check with flake8.

### Testing

CI will test and maybe some another manual testing

