### PR TITLE
Check that we are on the Matter thread when we do ErrorStr.

### DIFF
--- a/src/ble/tests/BUILD.gn
+++ b/src/ble/tests/BUILD.gn
@@ -31,6 +31,7 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/ble",
     "${chip_root}/src/lib/support:testing",
+    "${chip_root}/src/platform",
     "${nlunit_test_root}:nlunit-test",
   ]
 }

--- a/src/lib/core/tests/BUILD.gn
+++ b/src/lib/core/tests/BUILD.gn
@@ -37,6 +37,7 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support:testing",
+    "${chip_root}/src/platform",
     "${nlunit_test_root}:nlunit-test",
   ]
 }

--- a/src/lib/support/ErrorStr.cpp
+++ b/src/lib/support/ErrorStr.cpp
@@ -32,6 +32,7 @@
 
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CodeUtils.h>
+#include <platform/LockTracker.h>
 
 namespace chip {
 
@@ -56,6 +57,7 @@ static ErrorFormatter * sErrorFormatterList = nullptr;
  */
 DLL_EXPORT const char * ErrorStr(CHIP_ERROR err)
 {
+    assertChipStackLockedByCurrentThread();
     char * formattedError   = sErrorStr;
     uint16_t formattedSpace = sizeof(sErrorStr);
 


### PR DESCRIPTION
This uses a single static buffer, so using it from multiple threads can race on writes to that buffer.  In the worst case, we could end up with that buffer not null-terminated in a useful way.

