### PR TITLE
Add the explicit request to generate eventList and eventCount

### DIFF
--- a/src/app/zap-templates/templates/app/endpoint_config.zapt
+++ b/src/app/zap-templates/templates/app/endpoint_config.zapt
@@ -52,7 +52,7 @@
 // This is an array of EmberAfCluster structures.
 #define GENERATED_CLUSTER_COUNT {{endpoint_cluster_count}}
 // clang-format off
-#define GENERATED_CLUSTERS {{chip_endpoint_cluster_list}}
+#define GENERATED_CLUSTERS {{chip_endpoint_cluster_list order="clusterId,attributes,attributeCount,clusterSize,mask,functions,acceptedCommandList,generatedCommandList,eventList,eventCount"}}
 // clang-format on
 
 #define ZAP_FIXED_ENDPOINT_DATA_VERSION_COUNT {{chip_endpoint_data_version_count}}


### PR DESCRIPTION
Recent changes to ZAP and the Matter template have broken backwards compatibility: latest zap was no longer able to operate against older versions of Matter SDK code.

This change addresses this problem:

1. It puts the elements of endpoint config cluster struct under control of the template.
2. It sets the default (inside Zap), to how it was before any of these changes happened.

This allows template creator to change the order of the fields or add new fields without breaking backwards compatibility, and at the same time allows older SDKs to be used with newest zap.

This should go hand it hand with the PR:
  https://github.com/project-chip/zap/pull/948

If ZAP PR gets merged first, Matter will stay broken with latest zap until this commit is merge in. Matter, however, can merge this commit first without ill effect, and use older zap if it chooses.

