### PR TITLE
Add a continuous browse for Matter operational advertisements on Darwin.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -254,6 +254,17 @@ private:
     os_unfair_lock_unlock(&self->_lock);
 }
 
+- (void)nodeMayBeAdvertisingOperational
+{
+    // TODO: Figure out what to do with that information.  If we're not waiting
+    // to subscribe/resubscribe, do nothing, otherwise perhaps trigger the
+    // subscribe/resubscribe immediately?  We need to have much better tracking
+    // of our internal state for that, and may need to add something on
+    // ReadClient to cancel its outstanding timer and try to resubscribe
+    // immediately....
+    MTR_LOG_DEFAULT("%@ saw new operational advertisement", self);
+}
+
 // assume lock is held
 - (void)_changeState:(MTRDeviceState)state
 {

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -48,9 +48,12 @@
 #include <credentials/attestation_verifier/DacOnlyPartialAttestationVerifier.h>
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
+#include <platform/LockTracker.h>
 #include <platform/PlatformManager.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
 #include <system/SystemClock.h>
+
+#include <atomic>
 
 #import <os/lock.h>
 
@@ -82,7 +85,10 @@ typedef void (^SyncWorkQueueBlock)(void);
 typedef id (^SyncWorkQueueBlockWithReturnValue)(void);
 typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
 
-@interface MTRDeviceController ()
+@interface MTRDeviceController () {
+    // Atomic because it can be touched from multiple threads.
+    std::atomic<chip::FabricIndex> _storedFabricIndex;
+}
 
 // queue used to serialize all work performed by the MTRDeviceController
 @property (atomic, readonly) dispatch_queue_t chipWorkQueue;
@@ -123,6 +129,8 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
         if ([self checkForInitError:(_operationalCredentialsDelegate != nullptr) logMsg:kErrorOperationalCredentialsInit]) {
             return nil;
         }
+
+        _storedFabricIndex = chip::kUndefinedFabricIndex;
     }
     return self;
 }
@@ -152,12 +160,15 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
 // in a very specific way that only MTRDeviceControllerFactory knows about.
 - (void)shutDownCppController
 {
+    assertChipStackLockedByCurrentThread();
+
     if (_cppCommissioner) {
         auto * commissionerToShutDown = _cppCommissioner;
         // Flag ourselves as not running before we start shutting down
         // _cppCommissioner, so we're not in a state where we claim to be
         // running but are actually partially shut down.
         _cppCommissioner = nullptr;
+        _storedFabricIndex = chip::kUndefinedFabricIndex;
         commissionerToShutDown->Shutdown();
         delete commissionerToShutDown;
         if (_operationalCredentialsDelegate != nil) {
@@ -345,6 +356,7 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
             return;
         }
 
+        self->_storedFabricIndex = fabricIdx;
         commissionerInitialized = YES;
     });
 
@@ -813,17 +825,26 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
 
 - (chip::FabricIndex)fabricIndex
 {
+    return _storedFabricIndex;
+}
+
+- (nullable NSNumber *)compressedFabricID
+{
+    assertChipStackLockedByCurrentThread();
+
     if (!_cppCommissioner) {
-        return chip::kUndefinedFabricIndex;
+        return nil;
     }
 
-    return _cppCommissioner->GetFabricIndex();
+    return @(_cppCommissioner->GetCompressedFabricId());
 }
 
 - (CHIP_ERROR)isRunningOnFabric:(chip::FabricTable *)fabricTable
                     fabricIndex:(chip::FabricIndex)fabricIndex
                       isRunning:(BOOL *)isRunning
 {
+    assertChipStackLockedByCurrentThread();
+
     if (![self isRunning]) {
         *isRunning = NO;
         return CHIP_NO_ERROR;
@@ -859,6 +880,22 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
     };
 
     [self syncRunOnWorkQueue:block error:nil];
+}
+
+- (void)operationalInstanceAdded:(chip::NodeId)nodeID
+{
+    // Don't use deviceForNodeID here, because we don't want to create the
+    // device if it does not already exist.
+    os_unfair_lock_lock(&_deviceMapLock);
+    MTRDevice * device = self.nodeIDToDeviceMap[@(nodeID)];
+    os_unfair_lock_unlock(&_deviceMapLock);
+
+    if (device == nil) {
+        return;
+    }
+
+    ChipLogProgress(Controller, "Notifying device about node 0x" ChipLogFormatX64 " advertising", ChipLogValueX64(nodeID));
+    [device nodeMayBeAdvertisingOperational];
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
@@ -24,6 +24,7 @@
 #import "MTRDeviceControllerFactory.h"
 
 #include <lib/core/DataModelTypes.h>
+#include <lib/core/PeerId.h>
 
 class MTRPersistentStorageDelegateBridge;
 
@@ -46,6 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
  * Find a running controller, if any, for the given fabric index.
  */
 - (nullable MTRDeviceController *)runningControllerForFabricIndex:(chip::FabricIndex)fabricIndex;
+
+/**
+ * Notify the controller factory that a new operational instance with the given
+ * compressed fabric id and node id has been observed.
+ */
+- (void)operationalInstanceAdded:(chip::PeerId &)operationalID;
 
 @property (readonly) MTRPersistentStorageDelegateBridge * storageDelegateBridge;
 @property (readonly) chip::Credentials::GroupDataProvider * groupData;

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -62,9 +62,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Will return chip::kUndefinedFabricIndex if we do not have a fabric index.
- * This property MUST be gotten from the Matter work queue.
  */
 @property (readonly) chip::FabricIndex fabricIndex;
+
+/**
+ * Will return the compressed fabric id of the fabric if the controller is
+ * running, else nil.
+ *
+ * This property MUST be gotten from the Matter work queue.
+ */
+@property (readonly, nullable) NSNumber * compressedFabricID;
 
 /**
  * Init a newly created controller.
@@ -184,6 +191,12 @@ NS_ASSUME_NONNULL_BEGIN
  * sort of MTRBaseDevice they return.
  */
 - (MTRBaseDevice *)baseDeviceForNodeID:(NSNumber *)nodeID;
+
+/**
+ * Notify the controller that a new operational instance with the given node id
+ * and a compressed fabric id that matches this controller has been observed.
+ */
+- (void)operationalInstanceAdded:(chip::NodeId)nodeID;
 
 #pragma mark - Device-specific data and SDK access
 // DeviceController will act as a central repository for this opaque dictionary that MTRDevice manages

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -36,6 +36,11 @@ typedef void (^MTRDevicePerformAsyncBlock)(MTRBaseDevice * baseDevice);
 // called by controller to clean up and shutdown
 - (void)invalidate;
 
+// Called by controller when a new operational advertisement for what we think
+// is this device's identity has been observed.  This could have
+// false-positives, for example due to compressed fabric id collisions.
+- (void)nodeMayBeAdvertisingOperational;
+
 @property (nonatomic, readonly) MTRDeviceController * deviceController;
 @property (nonatomic, readonly, copy) NSNumber * nodeID;
 // Queue used for various internal bookkeeping work.  In general endWork calls

--- a/src/darwin/Framework/CHIP/MTROperationalBrowser.h
+++ b/src/darwin/Framework/CHIP/MTROperationalBrowser.h
@@ -1,0 +1,47 @@
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <Matter/MTRDeviceControllerFactory.h>
+#import <dns_sd.h>
+
+class MTROperationalBrowser
+{
+public:
+    // Should be created at a point when the factory starts up the event loop,
+    // and destroyed when the event loop is stopped.
+    MTROperationalBrowser(MTRDeviceControllerFactory * aFactory, dispatch_queue_t aQueue);
+
+    ~MTROperationalBrowser();
+
+private:
+    static void OnBrowse(DNSServiceRef aServiceRef, DNSServiceFlags aFlags, uint32_t aInterfaceId, DNSServiceErrorType aError,
+                         const char * aName, const char * aType, const char * aDomain, void * aContext);
+
+    void TryToStartBrowse();
+
+    MTRDeviceControllerFactory * const mDeviceControllerFactory;
+    dispatch_queue_t mQueue;
+    DNSServiceRef mBrowseRef;
+
+    // If mInitialized is true, mBrowseRef is valid.
+    bool mInitialized = false;
+
+    // If mIsDestroying is true, we're in our destructor, shutting things down.
+    bool mIsDestroying = false;
+};

--- a/src/darwin/Framework/CHIP/MTROperationalBrowser.mm
+++ b/src/darwin/Framework/CHIP/MTROperationalBrowser.mm
@@ -1,0 +1,112 @@
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MTRDeviceControllerFactory_Internal.h"
+#import "MTROperationalBrowser.h"
+
+#include <cinttypes>
+#include <lib/dnssd/ServiceNaming.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <platform/LockTracker.h>
+
+namespace {
+constexpr const char kLocalDot[] = "local.";
+constexpr const char kOperationalType[] = "_matter._tcp";
+constexpr DNSServiceFlags kBrowseFlags = 0;
+}
+
+MTROperationalBrowser::MTROperationalBrowser(MTRDeviceControllerFactory * aFactory, dispatch_queue_t aQueue)
+    : mDeviceControllerFactory(aFactory)
+    , mQueue(aQueue)
+{
+    // If we fail to start a browse, there's nothing our consumer would do
+    // differently, so we might as well do this in the constructor.
+    TryToStartBrowse();
+}
+
+void MTROperationalBrowser::TryToStartBrowse()
+{
+    assertChipStackLockedByCurrentThread();
+
+    ChipLogProgress(Controller, "Trying to start operational browse");
+
+    auto err
+        = DNSServiceBrowse(&mBrowseRef, kBrowseFlags, kDNSServiceInterfaceIndexAny, kOperationalType, kLocalDot, OnBrowse, this);
+    if (err != kDNSServiceErr_NoError) {
+        ChipLogError(Controller, "Failed to start operational browse: %" PRId32, err);
+        return;
+    }
+
+    err = DNSServiceSetDispatchQueue(mBrowseRef, mQueue);
+    if (err != kDNSServiceErr_NoError) {
+        ChipLogError(Controller, "Failed to set up dispatch queue properly");
+        DNSServiceRefDeallocate(mBrowseRef);
+        return;
+    }
+
+    mInitialized = true;
+}
+
+void MTROperationalBrowser::OnBrowse(DNSServiceRef aServiceRef, DNSServiceFlags aFlags, uint32_t aInterfaceId,
+    DNSServiceErrorType aError, const char * aName, const char * aType, const char * aDomain, void * aContext)
+{
+    assertChipStackLockedByCurrentThread();
+
+    auto self = static_cast<MTROperationalBrowser *>(aContext);
+
+    // We only expect to get notified about our type/domain.
+    if (aError != kDNSServiceErr_NoError) {
+        ChipLogError(Controller, "Operational browse failure: %" PRId32, aError);
+        DNSServiceRefDeallocate(self->mBrowseRef);
+        self->mInitialized = false;
+
+        // We shouldn't really get callbacks under our destructor, but guard
+        // against it just in case.
+        if (!self->mIsDestroying) {
+            // Try to start a new browse, so we have one going.
+            self->TryToStartBrowse();
+        }
+        return;
+    }
+
+    if (!(aFlags & kDNSServiceFlagsAdd)) {
+        // We only care about new things appearing.
+        return;
+    }
+
+    chip::PeerId peerId;
+    CHIP_ERROR err = chip::Dnssd::ExtractIdFromInstanceName(aName, &peerId);
+    if (err != CHIP_NO_ERROR) {
+        ChipLogError(Controller, "Invalid instance name: '%s'\n", aName);
+        return;
+    }
+
+    ChipLogProgress(Controller, "Notifying controller factory about new operational instance: '%s'", aName);
+    [self->mDeviceControllerFactory operationalInstanceAdded:peerId];
+}
+
+MTROperationalBrowser::~MTROperationalBrowser()
+{
+    assertChipStackLockedByCurrentThread();
+
+    mIsDestroying = true;
+
+    if (mInitialized) {
+        DNSServiceRefDeallocate(mBrowseRef);
+    }
+}

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -126,6 +126,8 @@
 		3DFCB32C29678C9500332B35 /* MTRConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DFCB32B29678C9500332B35 /* MTRConversion.h */; };
 		51029DF6293AA6100087AFB0 /* MTROperationalCertificateIssuer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51029DF5293AA6100087AFB0 /* MTROperationalCertificateIssuer.mm */; };
 		510CECA8297F72970064E0B3 /* MTROperationalCertificateIssuerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 510CECA6297F72470064E0B3 /* MTROperationalCertificateIssuerTests.m */; };
+		5117DD3829A931AE00FFA1AA /* MTROperationalBrowser.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5117DD3629A931AD00FFA1AA /* MTROperationalBrowser.mm */; };
+		5117DD3929A931AE00FFA1AA /* MTROperationalBrowser.h in Headers */ = {isa = PBXBuildFile; fileRef = 5117DD3729A931AE00FFA1AA /* MTROperationalBrowser.h */; };
 		511913FB28C100EF009235E9 /* MTRBaseSubscriptionCallback.mm in Sources */ = {isa = PBXBuildFile; fileRef = 511913F928C100EF009235E9 /* MTRBaseSubscriptionCallback.mm */; };
 		511913FC28C100EF009235E9 /* MTRBaseSubscriptionCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 511913FA28C100EF009235E9 /* MTRBaseSubscriptionCallback.h */; };
 		5129BCFD26A9EE3300122DDF /* MTRError.h in Headers */ = {isa = PBXBuildFile; fileRef = 5129BCFC26A9EE3300122DDF /* MTRError.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -401,6 +403,8 @@
 		3DFCB32B29678C9500332B35 /* MTRConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRConversion.h; sourceTree = "<group>"; };
 		51029DF5293AA6100087AFB0 /* MTROperationalCertificateIssuer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTROperationalCertificateIssuer.mm; sourceTree = "<group>"; };
 		510CECA6297F72470064E0B3 /* MTROperationalCertificateIssuerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTROperationalCertificateIssuerTests.m; sourceTree = "<group>"; };
+		5117DD3629A931AD00FFA1AA /* MTROperationalBrowser.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTROperationalBrowser.mm; sourceTree = "<group>"; };
+		5117DD3729A931AE00FFA1AA /* MTROperationalBrowser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTROperationalBrowser.h; sourceTree = "<group>"; };
 		511913F928C100EF009235E9 /* MTRBaseSubscriptionCallback.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRBaseSubscriptionCallback.mm; sourceTree = "<group>"; };
 		511913FA28C100EF009235E9 /* MTRBaseSubscriptionCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRBaseSubscriptionCallback.h; sourceTree = "<group>"; };
 		5129BCFC26A9EE3300122DDF /* MTRError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRError.h; sourceTree = "<group>"; };
@@ -998,6 +1002,8 @@
 				997DED152695343400975E97 /* MTRThreadOperationalDataset.mm */,
 				3D843710294977000070D20A /* NSDataSpanConversion.h */,
 				3D84370E294977000070D20A /* NSStringSpanConversion.h */,
+				5117DD3729A931AE00FFA1AA /* MTROperationalBrowser.h */,
+				5117DD3629A931AD00FFA1AA /* MTROperationalBrowser.mm */,
 				3D69867E29382E58007314E7 /* Resources */,
 			);
 			path = CHIP;
@@ -1098,6 +1104,7 @@
 				2CB7163B252E8A7B0026E2BB /* MTRDeviceControllerDelegateBridge.h in Headers */,
 				5ACDDD7A27CD129700EFD68A /* MTRClusterStateCacheContainer.h in Headers */,
 				5A6FEC9227B5669C00F25F42 /* MTRDeviceControllerOverXPC.h in Headers */,
+				5117DD3929A931AE00FFA1AA /* MTROperationalBrowser.h in Headers */,
 				2C1B027B2641DB4E00780EF1 /* MTROperationalCredentialsDelegate.h in Headers */,
 				3D843717294979230070D20A /* MTRClusters_Internal.h in Headers */,
 				7596A85728788557004DAE0E /* MTRClusters.h in Headers */,
@@ -1384,6 +1391,7 @@
 				511913FB28C100EF009235E9 /* MTRBaseSubscriptionCallback.mm in Sources */,
 				5ACDDD7D27CD16D200EFD68A /* MTRClusterStateCacheContainer.mm in Sources */,
 				513DDB8A2761F6F900DAA01A /* MTRAttributeTLVValueDecoder.mm in Sources */,
+				5117DD3829A931AE00FFA1AA /* MTROperationalBrowser.mm in Sources */,
 				2FD775552695557E00FF4B12 /* error-mapping.cpp in Sources */,
 				3D843757294AD25A0070D20A /* MTRCertificateInfo.mm in Sources */,
 				5A7947E427C0129600434CF2 /* MTRDeviceController+XPC.mm in Sources */,


### PR DESCRIPTION
The information is propagated to MTRDevice, but we're not making use of it there yet.

The fabricIndex changes were due to a pre-existing issue: we are in fact getting it from the wrong thread/queue in various places (MTRDevice init, MTRDevice command invocation), such that an assertChipStackLockedByCurrentThread() in the getter failed.

Lays the groundwork for fixing #25091: we now browse for operational advertisements, but do not act on them yet.

