### PR TITLE
Stop assuming spans are null-terminated in WiFi driver impls.

### DIFF
--- a/src/platform/Linux/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Linux/NetworkCommissioningWiFiDriver.cpp
@@ -156,7 +156,7 @@ void LinuxWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callb
 
     VerifyOrExit(NetworkMatch(mStagingNetwork, networkId), networkingStatus = Status::kNetworkIDNotFound);
 
-    ChipLogProgress(NetworkProvisioning, "LinuxNetworkCommissioningDelegate: SSID: %s",
+    ChipLogProgress(NetworkProvisioning, "LinuxWiFiDriver: SSID: %.*s", static_cast<int>(networkId.size()),
                     StringOrNullMarker((char *) networkId.data()));
 
     err = ConnectivityMgrImpl().ConnectWiFiNetworkAsync(ByteSpan(mStagingNetwork.ssid, mStagingNetwork.ssidLen),

--- a/src/platform/nxp/mw320/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/mw320/NetworkCommissioningWiFiDriver.cpp
@@ -160,7 +160,7 @@ void Mw320WiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callb
 
     VerifyOrExit(NetworkMatch(mStagingNetwork, networkId), networkingStatus = Status::kNetworkIDNotFound);
 
-    ChipLogProgress(NetworkProvisioning, "LinuxNetworkCommissioningDelegate: SSID: %s", networkId.data());
+    ChipLogProgress(NetworkProvisioning, "Mw320WiFiDriver: SSID: %.*s", static_cast<int>(networkId.size()), networkId.data());
 
     err = ConnectivityMgrImpl().ConnectWiFiNetworkAsync(ByteSpan(mStagingNetwork.ssid, mStagingNetwork.ssidLen),
                                                         ByteSpan(mStagingNetwork.credentials, mStagingNetwork.credentialsLen),

--- a/src/platform/webos/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/webos/NetworkCommissioningWiFiDriver.cpp
@@ -156,7 +156,7 @@ void LinuxWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callb
 
     VerifyOrExit(NetworkMatch(mStagingNetwork, networkId), networkingStatus = Status::kNetworkIDNotFound);
 
-    ChipLogProgress(NetworkProvisioning, "LinuxNetworkCommissioningDelegate: SSID: %s", networkId.data());
+    ChipLogProgress(NetworkProvisioning, "LinuxWiFiDriver: SSID: %.*s", static_cast<int>(networkId.size()), networkId.data());
 
     err = ConnectivityMgrImpl().ConnectWiFiNetworkAsync(ByteSpan(mStagingNetwork.ssid, mStagingNetwork.ssidLen),
                                                         ByteSpan(mStagingNetwork.credentials, mStagingNetwork.credentialsLen),


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/24271

