### PR TITLE
Allow for example to disable the TEST_SETUP_PARAMS flag

### DIFF
--- a/config/standalone/CHIPProjectConfig.h
+++ b/config/standalone/CHIPProjectConfig.h
@@ -39,7 +39,9 @@
 //    WARNING: This option makes it possible to circumvent basic chip security functionality.
 //    Because of this it SHOULD NEVER BE ENABLED IN PRODUCTION BUILDS.
 //
+#ifndef CHIP_DEVICE_CONFIG_ENABLE_TEST_SETUP_PARAMS
 #define CHIP_DEVICE_CONFIG_ENABLE_TEST_SETUP_PARAMS 1
+#endif
 
 // Enable reading DRBG seed data from /dev/(u)random.
 // This is needed for test applications and the CHIP device manager to function

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -33,6 +33,14 @@
 #include <lib/support/CHIPMem.h>
 #include <platform/PlatformManager.h>
 
+#ifndef CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
+#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
+#endif
+
+#ifndef CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
+#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
+#endif
+
 @interface CastingServerBridge ()
 
 @property AppParameters * appParameters;

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CommissionableDataProviderImpl.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CommissionableDataProviderImpl.mm
@@ -33,6 +33,10 @@ using namespace chip::Crypto;
 
 namespace {
 
+#ifndef CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_ITERATION_COUNT
+#define CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_ITERATION_COUNT 1000
+#endif
+
 CHIP_ERROR GeneratePaseSalt(std::vector<uint8_t> & spake2pSaltVector)
 {
     constexpr size_t kSaltLen = kSpake2p_Max_PBKDF_Salt_Length;

--- a/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
@@ -33,8 +33,6 @@
 #define CHIP_CONFIG_KVS_PATH "/tmp/chip_casting_kvs"
 #endif
 
-#include <CHIPProjectConfig.h>
-
 #define CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY 0
 
 #define CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT 1
@@ -61,3 +59,12 @@
 #define CHIP_ENABLE_ROTATING_DEVICE_ID 1
 
 #define CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID_LENGTH 128
+
+// Disable this since it should not be enabled for production setups
+#define CHIP_DEVICE_CONFIG_ENABLE_TEST_SETUP_PARAMS 0
+
+#define CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT 4
+
+// Include the CHIPProjectConfig from config/standalone
+// Add this at the end so that we can hit our #defines first
+#include <CHIPProjectConfig.h>

--- a/src/platform/android/CommissionableDataProviderImpl.cpp
+++ b/src/platform/android/CommissionableDataProviderImpl.cpp
@@ -34,6 +34,10 @@ using namespace chip::Crypto;
 
 namespace {
 
+#ifndef CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_ITERATION_COUNT
+#define CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_ITERATION_COUNT 1000
+#endif
+
 CHIP_ERROR GeneratePaseSalt(std::vector<uint8_t> & spake2pSaltVector)
 {
     constexpr size_t kSaltLen = kSpake2p_Max_PBKDF_Salt_Length;


### PR DESCRIPTION
Documentation indicates that the `CHIP_DEVICE_CONFIG_ENABLE_TEST_SETUP_PARAMS` can be dangerous to include in production use cases (see `config/standalone/CHIPProjectConfig.h`)

We should disable it where necessary
