### PR TITLE
Enable -Wconversion in a few places in examples/.

### DIFF
--- a/examples/common/tracing/BUILD.gn
+++ b/examples/common/tracing/BUILD.gn
@@ -26,6 +26,8 @@ source_set("trace_handlers") {
   deps = [ "${chip_root}/src/lib" ]
 
   public_configs = [ ":default_config" ]
+
+  cflags = [ "-Wconversion" ]
 }
 
 source_set("trace_handlers_decoder") {
@@ -47,6 +49,8 @@ source_set("trace_handlers_decoder") {
 
   deps = [ "${chip_root}/src/lib" ]
   public_deps = [ "${chip_root}/third_party/jsoncpp" ]
+
+  cflags = [ "-Wconversion" ]
 }
 
 executable("chip-trace-decoder") {
@@ -73,4 +77,6 @@ executable("chip-trace-decoder") {
     "${chip_root}/src/lib",
     "${chip_root}/third_party/jsoncpp",
   ]
+
+  cflags = [ "-Wconversion" ]
 }

--- a/examples/common/tracing/decoder/TraceDecoderProtocols.cpp
+++ b/examples/common/tracing/decoder/TraceDecoderProtocols.cpp
@@ -44,11 +44,11 @@ void ENFORCE_FORMAT(1, 2) TLVPrettyPrinter(const char * aFormat, ...)
 namespace chip {
 namespace trace {
 
-const char * ToProtocolName(uint16_t protocolId)
+const char * ToProtocolName(uint16_t vendorId, uint16_t protocolId)
 {
     const char * name = nullptr;
 
-    auto protocol = Protocols::Id(VendorId::Common, protocolId);
+    auto protocol = Protocols::Id(static_cast<VendorId>(vendorId), protocolId);
     if (protocol == Protocols::SecureChannel::Id)
     {
         name = secure_channel::ToProtocolName();
@@ -77,11 +77,11 @@ const char * ToProtocolName(uint16_t protocolId)
     return name;
 }
 
-const char * ToProtocolMessageTypeName(uint16_t protocolId, uint8_t protocolCode)
+const char * ToProtocolMessageTypeName(uint16_t vendorId, uint16_t protocolId, uint8_t protocolCode)
 {
     const char * name = nullptr;
 
-    auto protocol = Protocols::Id(VendorId::Common, protocolId);
+    auto protocol = Protocols::Id(static_cast<VendorId>(vendorId), protocolId);
     if (protocol == Protocols::SecureChannel::Id)
     {
         name = secure_channel::ToProtocolMessageTypeName(protocolCode);
@@ -110,7 +110,7 @@ const char * ToProtocolMessageTypeName(uint16_t protocolId, uint8_t protocolCode
     return name;
 }
 
-CHIP_ERROR LogAsProtocolMessage(uint16_t protocolId, uint8_t protocolCode, const char * payload, size_t len,
+CHIP_ERROR LogAsProtocolMessage(uint16_t vendorId, uint16_t protocolId, uint8_t protocolCode, const char * payload, size_t len,
                                 bool interactionModelResponse)
 {
     constexpr uint16_t kMaxPayloadLen = 2048;
@@ -120,7 +120,7 @@ CHIP_ERROR LogAsProtocolMessage(uint16_t protocolId, uint8_t protocolCode, const
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    auto protocol = Protocols::Id(VendorId::Common, protocolId);
+    auto protocol = Protocols::Id(static_cast<VendorId>(vendorId), protocolId);
     if (protocol == Protocols::SecureChannel::Id)
     {
         err = secure_channel::LogAsProtocolMessage(protocolCode, data, dataLen);

--- a/examples/common/tracing/decoder/TraceDecoderProtocols.h
+++ b/examples/common/tracing/decoder/TraceDecoderProtocols.h
@@ -26,11 +26,11 @@
 namespace chip {
 namespace trace {
 
-const char * ToProtocolName(uint16_t protocolId);
+const char * ToProtocolName(uint16_t vendorId, uint16_t protocolId);
 
-const char * ToProtocolMessageTypeName(uint16_t protocolId, uint8_t protocolCode);
+const char * ToProtocolMessageTypeName(uint16_t vendorId, uint16_t protocolId, uint8_t protocolCode);
 
-CHIP_ERROR LogAsProtocolMessage(uint16_t protocolId, uint8_t protocolCode, const char * payload, size_t len,
+CHIP_ERROR LogAsProtocolMessage(uint16_t vendorId, uint16_t protocolId, uint8_t protocolCode, const char * payload, size_t len,
                                 bool interactionModelResponse);
 
 } // namespace trace

--- a/examples/common/tracing/decoder/logging/Log.cpp
+++ b/examples/common/tracing/decoder/logging/Log.cpp
@@ -36,12 +36,12 @@ void ENFORCE_FORMAT(1, 2) LogFormatted(const char * format, ...)
 {
     char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE] = {};
 
-    uint8_t indentation = gIndentLevel * kSpacePerIndent;
+    int indentation = gIndentLevel * kSpacePerIndent;
     snprintf(buffer, sizeof(buffer), "%*s", indentation, "");
 
     va_list args;
     va_start(args, format);
-    vsnprintf(&buffer[indentation], sizeof(buffer) - indentation, format, args);
+    vsnprintf(&buffer[indentation], sizeof(buffer) - static_cast<size_t>(indentation), format, args);
     va_end(args);
 
     ChipLogDetail(DataManagement, "%s", buffer);

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -48,11 +48,11 @@ struct LinuxDeviceOptions
     bool mWiFi                 = false;
     bool mThread               = false;
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE || CHIP_DEVICE_ENABLE_PORT_PARAMS
-    uint32_t securedDevicePort         = CHIP_PORT;
-    uint32_t unsecuredCommissionerPort = CHIP_UDC_PORT;
+    uint16_t securedDevicePort         = CHIP_PORT;
+    uint16_t unsecuredCommissionerPort = CHIP_UDC_PORT;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
-    uint32_t securedCommissionerPort = CHIP_PORT + 12; // TODO: why + 12?
+    uint16_t securedCommissionerPort = CHIP_PORT + 12; // TODO: why + 12?
 #endif                                                 // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
     const char * command                = nullptr;
     const char * PICS                   = nullptr;

--- a/examples/shell/shell_common/BUILD.gn
+++ b/examples/shell/shell_common/BUILD.gn
@@ -76,4 +76,6 @@ static_library("shell_common") {
   }
 
   public_configs = [ ":shell_common_config" ]
+
+  cflags = [ "-Wconversion" ]
 }

--- a/examples/shell/shell_common/cmd_server.cpp
+++ b/examples/shell/shell_common/cmd_server.cpp
@@ -170,7 +170,7 @@ static CHIP_ERROR CmdAppServerClusters(int argc, char ** argv)
 {
     bool server = true;
 
-    for (int i = 0; i < emberAfEndpointCount(); i++)
+    for (uint16_t i = 0; i < emberAfEndpointCount(); i++)
     {
         EndpointId endpoint = emberAfEndpointFromIndex(i);
 
@@ -190,7 +190,7 @@ static CHIP_ERROR CmdAppServerClusters(int argc, char ** argv)
 
 static CHIP_ERROR CmdAppServerEndpoints(int argc, char ** argv)
 {
-    for (int i = 0; i < emberAfEndpointCount(); i++)
+    for (uint16_t i = 0; i < emberAfEndpointCount(); i++)
     {
         EndpointId endpoint = emberAfEndpointFromIndex(i);
 


### PR DESCRIPTION
Also fixes incorrect handling of vendor-prefixed protocol ids in trace decoder that was caught by the resulting errors.


