### PR TITLE
Fix JNI error in tv-app

### DIFF
--- a/examples/tv-app/android/App/content-app/src/main/java/com/example/contentapp/CommandResponseHolder.java
+++ b/examples/tv-app/android/App/content-app/src/main/java/com/example/contentapp/CommandResponseHolder.java
@@ -30,7 +30,7 @@ public class CommandResponseHolder {
     setResponseValue(
         Clusters.AccountLogin.Id,
         Clusters.AccountLogin.Commands.GetSetupPIN.ID,
-        "{\"0\":\"12345678\"}");
+        "{\"0\":\"20202021\"}");
   };
 
   public static CommandResponseHolder getInstance() {

--- a/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
@@ -81,11 +81,11 @@ void ContentAppCommandDelegate::InvokeCommand(CommandHandlerInterface::HandlerCo
             env->ExceptionDescribe();
             env->ExceptionClear();
             FormatResponseData(handlerContext, "{\"value\":{}}");
-            return;
+        } else {
+            JniUtfString respStr(env, resp);
+            ChipLogProgress(Zcl, "ContentAppCommandDelegate::InvokeCommand got response %s", respStr.c_str());
+            FormatResponseData(handlerContext, respStr.c_str());
         }
-        JniUtfString respStr(env, resp);
-        ChipLogProgress(Zcl, "ContentAppCommandDelegate::InvokeCommand got response %s", respStr.c_str());
-        FormatResponseData(handlerContext, respStr.c_str());
         env->DeleteLocalRef(resp);
     }
     else

--- a/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
@@ -81,7 +81,9 @@ void ContentAppCommandDelegate::InvokeCommand(CommandHandlerInterface::HandlerCo
             env->ExceptionDescribe();
             env->ExceptionClear();
             FormatResponseData(handlerContext, "{\"value\":{}}");
-        } else {
+        }
+        else
+        {
             JniUtfString respStr(env, resp);
             ChipLogProgress(Zcl, "ContentAppCommandDelegate::InvokeCommand got response %s", respStr.c_str());
             FormatResponseData(handlerContext, respStr.c_str());


### PR DESCRIPTION
`Fixes #25330`

Change default passcode returned from account login cluster. Move use of JniUtfString in a code block so that ReleaseStringUTFChars does not happen after DeleteLocalRef.