### PR TITLE
[chip-tool] Clean up ComplexArguments once a command is done

### DIFF
--- a/examples/chip-tool/commands/clusters/ComplexArgument.h
+++ b/examples/chip-tool/commands/clusters/ComplexArgument.h
@@ -369,6 +369,8 @@ public:
     virtual ~ComplexArgument() {}
 
     virtual CHIP_ERROR Parse(const char * label, const char * json) = 0;
+
+    virtual void Reset() = 0;
 };
 
 template <typename T>
@@ -401,6 +403,8 @@ public:
 
         return ComplexArgumentParser::Setup(label, *mRequest, value);
     }
+
+    void Reset() { *mRequest = T(); }
 
 private:
     T * mRequest;

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -1018,6 +1018,11 @@ void Command::ResetArguments()
                 }
                 vectorArgument->clear();
             }
+            else if (type == ArgumentType::Complex)
+            {
+                auto argument = static_cast<ComplexArgument *>(arg.value);
+                argument->Reset();
+            }
         }
     }
 }


### PR DESCRIPTION
#### Problem

`ComplexArguments` are not cleanup up properly in `chip-tool` interactive mode.
