### PR TITLE
[ColorControl] Split (Enhanced)Hue and Saturation transitions

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -364,9 +364,9 @@ bool ColorControlServer::computeNewColor16uValue(ColorControlServer::Color16uTra
     }
     else if (p->finalValue > p->initialValue)
     {
-        newValue32u = ((uint32_t) (p->finalValue - p->initialValue));
-        newValue32u *= ((uint32_t) (p->stepsRemaining));
-        newValue32u /= ((uint32_t) (p->stepsTotal));
+        newValue32u = ((uint32_t)(p->finalValue - p->initialValue));
+        newValue32u *= ((uint32_t)(p->stepsRemaining));
+        newValue32u /= ((uint32_t)(p->stepsTotal));
         p->currentValue = static_cast<uint16_t>(p->finalValue - static_cast<uint16_t>(newValue32u));
 
         if (static_cast<uint16_t>(newValue32u) > p->finalValue || p->currentValue > p->highLimit)
@@ -376,9 +376,9 @@ bool ColorControlServer::computeNewColor16uValue(ColorControlServer::Color16uTra
     }
     else
     {
-        newValue32u = ((uint32_t) (p->initialValue - p->finalValue));
-        newValue32u *= ((uint32_t) (p->stepsRemaining));
-        newValue32u /= ((uint32_t) (p->stepsTotal));
+        newValue32u = ((uint32_t)(p->initialValue - p->finalValue));
+        newValue32u *= ((uint32_t)(p->stepsRemaining));
+        newValue32u /= ((uint32_t)(p->stepsTotal));
         p->currentValue = static_cast<uint16_t>(p->finalValue + static_cast<uint16_t>(newValue32u));
 
         if (p->finalValue > UINT16_MAX - static_cast<uint16_t>(newValue32u) || p->currentValue < p->lowLimit)
@@ -1808,7 +1808,7 @@ bool ColorControlServer::moveColorCommand(app::CommandHandler * commandObj, cons
     else
     {
         colorXTransitionState->finalValue = MIN_CIE_XY_VALUE;
-        unsignedRate                      = (uint16_t) (rateX * -1);
+        unsignedRate                      = (uint16_t)(rateX * -1);
     }
     transitionTimeX                       = computeTransitionTimeFromStateAndRate(colorXTransitionState, unsignedRate);
     colorXTransitionState->stepsRemaining = transitionTimeX;
@@ -1827,7 +1827,7 @@ bool ColorControlServer::moveColorCommand(app::CommandHandler * commandObj, cons
     else
     {
         colorYTransitionState->finalValue = MIN_CIE_XY_VALUE;
-        unsignedRate                      = (uint16_t) (rateY * -1);
+        unsignedRate                      = (uint16_t)(rateY * -1);
     }
     transitionTimeY                       = computeTransitionTimeFromStateAndRate(colorYTransitionState, unsignedRate);
     colorYTransitionState->stepsRemaining = transitionTimeY;
@@ -2462,8 +2462,8 @@ void ColorControlServer::levelControlColorTempChangeCommand(EndpointId endpoint)
         else
         {
             uint32_t tempDelta = (((uint32_t) tempPhysMax - (uint32_t) tempCoupleMin) * currentLevel.Value()) /
-                (uint32_t) (MAX_CURRENT_LEVEL - MIN_CURRENT_LEVEL + 1);
-            newColorTemp = (uint16_t) ((uint32_t) tempPhysMax - tempDelta);
+                (uint32_t)(MAX_CURRENT_LEVEL - MIN_CURRENT_LEVEL + 1);
+            newColorTemp = (uint16_t)((uint32_t) tempPhysMax - tempDelta);
         }
 
         // Apply new color temp.

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -828,6 +828,12 @@ bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const 
         return true;
     }
 
+    if (rate == 0 && moveMode != EMBER_ZCL_HUE_MOVE_MODE_STOP)
+    {
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
+        return true;
+    }
+
     // New command.  Need to stop any active transitions.
     stopAllColorTransitions(endpoint);
     // now, kick off the state machine.
@@ -1263,6 +1269,12 @@ bool ColorControlServer::moveSaturationCommand(app::CommandHandler * commandObj,
     Color16uTransitionState * colorSaturationTransitionState = getSaturationTransitionState(endpoint);
     VerifyOrExit(colorSaturationTransitionState != nullptr, status = Status::UnsupportedEndpoint);
 
+    if (rate == 0 && moveMode != EMBER_ZCL_SATURATION_MOVE_MODE_STOP)
+    {
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
+        return true;
+    }
+
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
     {
         commandObj->AddStatus(commandPath, Status::Success);
@@ -1277,7 +1289,7 @@ bool ColorControlServer::moveSaturationCommand(app::CommandHandler * commandObj,
     // now, kick off the state machine.
     initSaturationTransitionState(endpoint, colorSaturationTransitionState);
 
-    if (moveMode == EMBER_ZCL_SATURATION_MOVE_MODE_STOP || rate == 0)
+    if (moveMode == EMBER_ZCL_SATURATION_MOVE_MODE_STOP)
     {
         // Per spec any hue transition must also be cancelled.
         ColorHueTransitionState * hueState = getColorHueTransitionState(endpoint);
@@ -2208,6 +2220,12 @@ bool ColorControlServer::moveColorTempCommand(app::CommandHandler * commandObj, 
     Attributes::ColorTempPhysicalMinMireds::Get(endpoint, &tempPhysicalMin);
     Attributes::ColorTempPhysicalMaxMireds::Get(endpoint, &tempPhysicalMax);
 
+    if (rate == 0 && moveMode != MOVE_MODE_STOP)
+    {
+        commandObj->AddStatus(commandPath, Status::InvalidCommand);
+        return true;
+    }
+
     // New command.  Need to stop any active transitions.
     stopAllColorTransitions(endpoint);
 
@@ -2217,11 +2235,6 @@ bool ColorControlServer::moveColorTempCommand(app::CommandHandler * commandObj, 
         return true;
     }
 
-    if (rate == 0)
-    {
-        commandObj->AddStatus(commandPath, Status::InvalidCommand);
-        return true;
-    }
 
     if (colorTemperatureMinimum < tempPhysicalMin)
     {

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -2235,7 +2235,6 @@ bool ColorControlServer::moveColorTempCommand(app::CommandHandler * commandObj, 
         return true;
     }
 
-
     if (colorTemperatureMinimum < tempPhysicalMin)
     {
         colorTemperatureMinimum = tempPhysicalMin;

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -823,6 +823,9 @@ bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const 
 
     if (moveMode == EMBER_ZCL_HUE_MOVE_MODE_STOP)
     {
+        // Per spec any staturation transition must also be cancelled.
+        Color16uTransitionState * saturationState = getSaturationTransitionState(endpoint);
+        initSaturationTransitionState(endpoint, saturationState);
         commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }
@@ -1264,6 +1267,9 @@ bool ColorControlServer::moveSaturationCommand(app::CommandHandler * commandObj,
 
     if (moveMode == EMBER_ZCL_SATURATION_MOVE_MODE_STOP || rate == 0)
     {
+        // Per spec any hue transition must also be cancelled.
+        ColorHueTransitionState * hueState = getColorHueTransitionState(endpoint);
+        initHueTransitionState(endpoint, hueState, false /*isEnhancedHue don't care*/);
         commandObj->AddStatus(commandPath, Status::Success);
         return true;
     }

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -1867,7 +1867,7 @@ bool ColorControlServer::moveColorCommand(app::CommandHandler * commandObj, cons
     else
     {
         colorYTransitionState->finalValue = MIN_CIE_XY_VALUE;
-        unsignedRate                      = (uint16_t) (rateY * -1);
+        unsignedRate                      = (uint16_t)(rateY * -1);
     }
     transitionTimeY                       = computeTransitionTimeFromStateAndRate(colorYTransitionState, unsignedRate);
     colorYTransitionState->stepsRemaining = transitionTimeY;

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -74,6 +74,19 @@ public:
         MOVE_MODE_DOWN = 0x03
     };
 
+    enum StepMode
+    {
+        STEP_MODE_STOP = 0x00,
+        STEP_MODE_UP   = 0x01,
+        STEP_MODE_DOWN = 0x03
+    };
+
+    enum ColorLoopDirection
+    {
+        DECREMENT_HUE = 0x00,
+        INCREMENT_HUE = 0x01,
+    };
+
     enum ColorMode
     {
         COLOR_MODE_HSV         = 0x00,

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -216,8 +216,8 @@ private:
     uint16_t addEnhancedHue(uint16_t hue1, uint16_t hue2);
     uint16_t subtractEnhancedHue(uint16_t hue1, uint16_t hue2);
     void startColorLoop(chip::EndpointId endpoint, uint8_t startFromStartHue);
-    void initHueSat(chip::EndpointId endpoint, ColorHueTransitionState * colorHueTransitionState,
-                    Color16uTransitionState * colorSatTransitionState);
+    void initHueTransitionState(chip::EndpointId endpoint, ColorHueTransitionState * colorHueTransitionState, bool isEnhancedHue);
+    void initSaturationTransitionState(chip::EndpointId endpoint, Color16uTransitionState * colorSatTransitionState);
     bool computeNewHueValue(ColorHueTransitionState * p);
     EmberEventControl * configureHSVEventControl(chip::EndpointId);
 #endif // EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_HSV

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -218,6 +218,7 @@ private:
     void startColorLoop(chip::EndpointId endpoint, uint8_t startFromStartHue);
     void initHueTransitionState(chip::EndpointId endpoint, ColorHueTransitionState * colorHueTransitionState, bool isEnhancedHue);
     void initSaturationTransitionState(chip::EndpointId endpoint, Color16uTransitionState * colorSatTransitionState);
+    void SetHSVRemainingTime(chip::EndpointId endpoint);
     bool computeNewHueValue(ColorHueTransitionState * p);
     EmberEventControl * configureHSVEventControl(chip::EndpointId);
 #endif // EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_HSV


### PR DESCRIPTION
fixes #25040

Hue and Saturation are part of the same color schema (HSV). Previously, a command changing only the hue would stop any active saturation transition and vice versa.

This PR reworks the use of the ColorHueTransitionState and SaturationTransitionState so each transition can continue unaffected by a command only targeted to change one of the two.
Examples
```
move-to-hue
move-saturation
enhanced-step-hue
etc.
```

The following commands affect both at the same time:
```
move-to-hue-and-saturation
enhanced-move-to-hue-and-saturation
stop-move-step
```

Per spec` move-hue`, `enhanced-move-hue` and `move-saturation` stop (`moveMode`) will stop both transitions.
https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/ColorControl.adoc#1184-effect-on-receipt

Some code clean up and changes in computeNewColor16uValue functions lead to some minor changes for XY and Temperature transition functions without affecting the behaviour.

Tested with chip-tool manually and with Test_TC_CC_X_Y (all of them) on EFR32 lighting-app

CI will also validate with the test suite.


