### PR TITLE
[placeholder] Allow applications to specify which additional sources…

### DIFF
--- a/examples/placeholder/linux/BUILD.gn
+++ b/examples/placeholder/linux/BUILD.gn
@@ -15,17 +15,8 @@
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
-import("${chip_root}/src/app/chip_data_model.gni")
-
 declare_args() {
   chip_tests_zap_config = "none"
-}
-
-chip_data_model("configuration") {
-  zap_file = "apps/${chip_tests_zap_config}/config.zap"
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/placeholder/${chip_tests_zap_config}/zap-generated"
-  is_server = true
 }
 
 config("includes") {
@@ -41,13 +32,11 @@ executable("chip-${chip_tests_zap_config}") {
     "AppOptions.cpp",
     "InteractiveServer.cpp",
     "main.cpp",
-    "src/bridged-actions-stub.cpp",
-    "static-supported-modes-manager.cpp",
   ]
 
   deps = [
-    ":configuration",
     "${chip_root}/examples/common/websocket-server",
+    "${chip_root}/examples/placeholder/linux/apps/${chip_tests_zap_config}:${chip_tests_zap_config}",
     "${chip_root}/examples/platform/linux:app-main",
     "${chip_root}/src/app/tests/suites/commands/delay",
     "${chip_root}/src/app/tests/suites/commands/discovery",

--- a/examples/placeholder/linux/apps/app1/BUILD.gn
+++ b/examples/placeholder/linux/apps/app1/BUILD.gn
@@ -1,0 +1,38 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("${chip_root}/src/app/chip_data_model.gni")
+
+chip_data_model("configuration") {
+  zap_file = "config.zap"
+
+  zap_pregenerated_dir =
+      "${chip_root}/zzz_generated/placeholder/app1/zap-generated"
+  is_server = true
+}
+
+source_set("app1") {
+  include_dirs = [
+    ".",
+    "../../include",
+  ]
+
+  sources = [
+    "../../src/bridged-actions-stub.cpp",
+    "../../static-supported-modes-manager.cpp",
+  ]
+
+  public_deps = [ ":configuration" ]
+}

--- a/examples/placeholder/linux/apps/app2/BUILD.gn
+++ b/examples/placeholder/linux/apps/app2/BUILD.gn
@@ -1,0 +1,38 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("${chip_root}/src/app/chip_data_model.gni")
+
+chip_data_model("configuration") {
+  zap_file = "config.zap"
+
+  zap_pregenerated_dir =
+      "${chip_root}/zzz_generated/placeholder/app2/zap-generated"
+  is_server = true
+}
+
+source_set("app2") {
+  include_dirs = [
+    ".",
+    "../../include",
+  ]
+
+  sources = [
+    "../../src/bridged-actions-stub.cpp",
+    "../../static-supported-modes-manager.cpp",
+  ]
+
+  public_deps = [ ":configuration" ]
+}


### PR DESCRIPTION
… to build

#### Problem

`examples/placeholder/apps/` applications can not specify custom files to be built.

This PR try to do what #25315 is doing with a little narrower scope.