### PR TITLE
Disallow CASE and PASE establishment attempts over existing secure sessions.

### DIFF
--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -73,7 +73,14 @@ CHIP_ERROR CASEServer::OnUnsolicitedMessageReceived(const PayloadHeader & payloa
 CHIP_ERROR CASEServer::OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
                                          System::PacketBufferHandle && payload)
 {
-    ChipLogProgress(Inet, "CASE Server received Sigma1 message. Starting handshake. EC %p", ec);
+    if (!ec->GetSessionHandle()->IsUnauthenticatedSession())
+    {
+        ChipLogError(Inet, "CASE Server received Sigma1 message %s EC %p", "over encrypted session. Ignoring.", ec);
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    ChipLogProgress(Inet, "CASE Server received Sigma1 message %s EC %p", ". Starting handshake.", ec);
+
     CHIP_ERROR err = InitCASEHandshake(ec);
     SuccessOrExit(err);
 

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -794,6 +794,13 @@ CHIP_ERROR PASESession::ValidateReceivedMessage(ExchangeContext * exchange, cons
     {
         mExchangeCtxt = exchange;
     }
+
+    if (!mExchangeCtxt->GetSessionHandle()->IsUnauthenticatedSession())
+    {
+        ChipLogError(SecureChannel, "PASESession received PBKDFParamRequest over encrypted session.  Ignoring.");
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
     mExchangeCtxt->UseSuggestedResponseTimeout(kExpectedHighProcessingTime);
 
     VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -222,6 +222,8 @@ public:
 
     bool IsSecureSession() const { return GetSessionType() == SessionType::kSecure; }
 
+    bool IsUnauthenticatedSession() const { return GetSessionType() == SessionType::kUnauthenticated; }
+
     void DispatchSessionEvent(SessionDelegate::Event event)
     {
         // Holders might remove themselves when notified.


### PR DESCRIPTION
Per spec, CASE and PASE establishment needs to happen via unauthenticated messages.  We should ignore Sigma1 or PBKDFParamsRequest received over a CASE or PASE (or group) session.
