### PR TITLE
Set thread bakends for pigweed rpc builds

### DIFF
--- a/examples/chef/linux/with_pw_rpc.gni
+++ b/examples/chef/linux/with_pw_rpc.gni
@@ -32,6 +32,8 @@ pw_rpc_system_server_BACKEND = "${chip_root}/config/linux/lib/pw_rpc:pw_rpc"
 dir_pw_third_party_nanopb = "${chip_root}/third_party/nanopb/repo"
 pw_chrono_SYSTEM_CLOCK_BACKEND = "$dir_pw_chrono_stl:system_clock"
 pw_sync_MUTEX_BACKEND = "$dir_pw_sync_stl:mutex_backend"
+pw_thread_YIELD_BACKEND = "$dir_pw_thread_stl:yield"
+pw_thread_SLEEP_BACKEND = "$dir_pw_thread_stl:sleep"
 
 pw_build_LINK_DEPS = [
   "$dir_pw_assert:impl",

--- a/examples/dynamic-bridge-app/linux/with_pw_rpc.gni
+++ b/examples/dynamic-bridge-app/linux/with_pw_rpc.gni
@@ -32,6 +32,8 @@ pw_rpc_system_server_BACKEND = "${chip_root}/config/linux/lib/pw_rpc:pw_rpc"
 dir_pw_third_party_nanopb = "${chip_root}/third_party/nanopb/repo"
 pw_chrono_SYSTEM_CLOCK_BACKEND = "$dir_pw_chrono_stl:system_clock"
 pw_sync_MUTEX_BACKEND = "$dir_pw_sync_stl:mutex_backend"
+pw_thread_YIELD_BACKEND = "$dir_pw_thread_stl:yield"
+pw_thread_SLEEP_BACKEND = "$dir_pw_thread_stl:sleep"
 
 pw_build_LINK_DEPS = [
   "$dir_pw_assert:impl",

--- a/examples/lighting-app/linux/with_pw_rpc.gni
+++ b/examples/lighting-app/linux/with_pw_rpc.gni
@@ -32,6 +32,8 @@ pw_rpc_system_server_BACKEND = "${chip_root}/config/linux/lib/pw_rpc:pw_rpc"
 dir_pw_third_party_nanopb = "${chip_root}/third_party/nanopb/repo"
 pw_chrono_SYSTEM_CLOCK_BACKEND = "$dir_pw_chrono_stl:system_clock"
 pw_sync_MUTEX_BACKEND = "$dir_pw_sync_stl:mutex_backend"
+pw_thread_YIELD_BACKEND = "$dir_pw_thread_stl:yield"
+pw_thread_SLEEP_BACKEND = "$dir_pw_thread_stl:sleep"
 
 pw_build_LINK_DEPS = [
   "$dir_pw_assert:impl",


### PR DESCRIPTION
These are needed because of the sleep/yield functionality and are enforced in new pigweed builds.

They are not strictly required in current pigweed version, but will make updating to newer version easier (so just pulling latest pigweed works better).

This should fix things like:

https://github.com/project-chip/connectedhomeip/actions/runs/4280636928/jobs/7452659286

```
...
INFO    ../../examples/lighting-app/linux/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/endpoint.cc:41:15: error: static assertion failed: PW_RPC_YIELD_MODE is PW_RPC_YIELD_MODE_SLEEP (pw::this_thread::sleep_for()), but no backend is set for pw_thread:sleep. Set a pw_thread:sleep backend or use a different PW_RPC_YIELD_MODE setting.
1206
INFO       41 | static_assert(false,
1207
INFO          |               ^~~~~
1208
INFO    ../../examples/lighting-app/linux/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/endpoint.cc: In function ‘void pw::rpc::internal::YieldRpcLock()’:
1209
INFO    ../../examples/lighting-app/linux/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/endpoint.cc:85:20: error: ‘chrono’ does not name a type
1210
INFO       85 |   static constexpr chrono::SystemClock::duration kSleepDuration =
```