### PR TITLE
Revert "Remove some java test timeouts: it consistently times out on …

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -549,12 +549,14 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
+              timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
                       .environment
                       build_overrides/pigweed_environment.gni
             - name: Bootstrap
+              timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v3
@@ -566,6 +568,7 @@ jobs:
                       .environment/pigweed-venv/*.log
 
             - name: Build Java Matter Controller and all clusters app
+              timeout-minutes: 50
               run: |
                   scripts/run_in_build_env.sh './scripts/build_python.sh --install_wheel build-env'
                   ./scripts/run_in_build_env.sh \
@@ -575,6 +578,7 @@ jobs:
                       build \
                    "
             - name: Run Discover Commissionables Test
+              timeout-minutes: 10
               run: |
                   scripts/run_in_build_env.sh \
                   './scripts/tests/run_java_test.py \
@@ -586,6 +590,7 @@ jobs:
                      --factoryreset \
                   '
             - name: Run Pairing Onnetwork Test
+              timeout-minutes: 10
               run: |
                   scripts/run_in_build_env.sh \
                   './scripts/tests/run_java_test.py \
@@ -597,6 +602,7 @@ jobs:
                      --factoryreset \
                   '
             - name: Run Pairing AlreadyDiscovered Test
+              timeout-minutes: 10
               run: |
                   scripts/run_in_build_env.sh \
                   './scripts/tests/run_java_test.py \
@@ -608,6 +614,7 @@ jobs:
                      --factoryreset \
                   '
             - name: Run Pairing Address-PaseOnly Test
+              timeout-minutes: 10
               run: |
                   scripts/run_in_build_env.sh \
                   './scripts/tests/run_java_test.py \


### PR DESCRIPTION
…PASE at 10m (#25341)"

This reverts commit e2fa69a63ed6839f3353dde0ae4354212530df32.


It looks like actual PASE tests in java generally are very fast (much faster than 10m) so we were not at the case of "this timeouts out because slow machines". See https://github.com/project-chip/connectedhomeip/actions/runs/4285667562/jobs/7464252021 finishing in 1s.

