### PR TITLE
Add dependent lib kotlin-stdlib for kotlin version of java-matter-controller

### DIFF
--- a/integrations/docker/images/chip-build-java/Dockerfile
+++ b/integrations/docker/images/chip-build-java/Dockerfile
@@ -4,7 +4,7 @@ FROM connectedhomeip/chip-build:${VERSION}
 # Download and install kotlin compiler
 RUN set -x \
     && cd /usr/lib \
-    && wget -q https://github.com/JetBrains/kotlin/releases/download/v1.3.31/kotlin-compiler-1.3.31.zip \
+    && wget -q https://github.com/JetBrains/kotlin/releases/download/v1.8.10/kotlin-compiler-1.8.10.zip \
     && unzip kotlin-compiler-*.zip \
     && rm kotlin-compiler-*.zip \
     && rm -f kotlinc/bin/*.bat \

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -64,7 +64,7 @@ RUN set -x \
 # Download and install kotlin compiler
 RUN set -x \
     && cd /usr/lib \
-    && wget -q https://github.com/JetBrains/kotlin/releases/download/v1.3.31/kotlin-compiler-1.3.31.zip \
+    && wget -q https://github.com/JetBrains/kotlin/releases/download/v1.8.10/kotlin-compiler-1.8.10.zip \
     && unzip kotlin-compiler-*.zip \
     && rm kotlin-compiler-*.zip \
     && rm -f kotlinc/bin/*.bat \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.43 Version bump reason: Update Tizen SDK version to 7.0
+0.6.44 Version bump reason: [Java] update kotlin compiler version to 1.8.10

--- a/third_party/java_deps/BUILD.gn
+++ b/third_party/java_deps/BUILD.gn
@@ -24,3 +24,7 @@ java_prebuilt("annotation") {
 java_prebuilt("json") {
   jar_path = "artifacts/json-20220924.jar"
 }
+
+java_prebuilt("kotlin-stdlib") {
+  jar_path = "artifacts/kotlin-stdlib-1.3.31.jar"
+}

--- a/third_party/java_deps/BUILD.gn
+++ b/third_party/java_deps/BUILD.gn
@@ -26,5 +26,5 @@ java_prebuilt("json") {
 }
 
 java_prebuilt("kotlin-stdlib") {
-  jar_path = "artifacts/kotlin-stdlib-1.3.31.jar"
+  jar_path = "artifacts/kotlin-stdlib-1.8.10.jar"
 }

--- a/third_party/java_deps/set_up_java_deps.sh
+++ b/third_party/java_deps/set_up_java_deps.sh
@@ -19,4 +19,4 @@
 mkdir -p third_party/java_deps/artifacts
 curl --fail --location --silent --show-error https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar -o third_party/java_deps/artifacts/jsr305-3.0.2.jar
 curl --fail --location --silent --show-error https://repo1.maven.org/maven2/org/json/json/20220924/json-20220924.jar -o third_party/java_deps/artifacts/json-20220924.jar
-curl --fail --location --silent --show-error https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.31/kotlin-stdlib-1.3.31.jar -o third_party/java_deps/artifacts/kotlin-stdlib-1.3.31.jar
+curl --fail --location --silent --show-error https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.8.10/kotlin-stdlib-1.8.10.jar -o third_party/java_deps/artifacts/kotlin-stdlib-1.8.10.jar

--- a/third_party/java_deps/set_up_java_deps.sh
+++ b/third_party/java_deps/set_up_java_deps.sh
@@ -19,3 +19,4 @@
 mkdir -p third_party/java_deps/artifacts
 curl --fail --location --silent --show-error https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar -o third_party/java_deps/artifacts/jsr305-3.0.2.jar
 curl --fail --location --silent --show-error https://repo1.maven.org/maven2/org/json/json/20220924/json-20220924.jar -o third_party/java_deps/artifacts/json-20220924.jar
+curl --fail --location --silent --show-error https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.31/kotlin-stdlib-1.3.31.jar -o third_party/java_deps/artifacts/kotlin-stdlib-1.3.31.jar


### PR DESCRIPTION
We need  kotlin-stdlib to run java-matter-controller written in kotlin, this Kotlin Standard Library provides living essentials for everyday work with Kotlin. 

There have been several major changes since 1.3. Update kotlin to the latest stable version 1.8.10.