### PR TITLE
[Tizen] Implement Thread SRP service remove

### DIFF
--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -532,7 +532,20 @@ CHIP_ERROR ThreadStackManagerImpl::_AddSrpService(const char * aInstanceName, co
 
     int threadErr;
 
-    threadErr = thread_srp_client_register_service(mThreadInstance, aInstanceName, aName, aPort);
+    std::vector<thread_dns_txt_entry_s> entries;
+    entries.reserve(aTxtEntries.size());
+
+    thread_dns_txt_entry_s * ee = entries.data();
+    for (auto & entry : aTxtEntries)
+    {
+        ee->key       = entry.mKey;
+        ee->value     = entry.mData;
+        ee->value_len = entry.mDataSize;
+        ee++;
+    }
+
+    threadErr =
+        thread_srp_client_register_service_full(mThreadInstance, aInstanceName, aName, aPort, 0, 0, entries.data(), entries.size());
     VerifyOrReturnError(
         threadErr == THREAD_ERROR_NONE || threadErr == THREAD_ERROR_ALREADY_DONE,
         (ChipLogError(DeviceLayer, "thread_srp_client_register_service() failed. ret: %d", threadErr), CHIP_ERROR_INTERNAL));

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -546,9 +546,8 @@ CHIP_ERROR ThreadStackManagerImpl::_AddSrpService(const char * aInstanceName, co
 
     threadErr =
         thread_srp_client_register_service_full(mThreadInstance, aInstanceName, aName, aPort, 0, 0, entries.data(), entries.size());
-    VerifyOrReturnError(
-        threadErr == THREAD_ERROR_NONE || threadErr == THREAD_ERROR_ALREADY_DONE,
-        (ChipLogError(DeviceLayer, "thread_srp_client_register_service() failed. ret: %d", threadErr), CHIP_ERROR_INTERNAL));
+    VerifyOrReturnError(threadErr == THREAD_ERROR_NONE || threadErr == THREAD_ERROR_ALREADY_DONE, CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "thread_srp_client_register_service() failed. ret: %d", threadErr));
 
     SrpClientService service;
     Platform::CopyString(service.mInstanceName, aInstanceName);
@@ -568,9 +567,8 @@ CHIP_ERROR ThreadStackManagerImpl::_RemoveSrpService(const char * aInstanceName,
     int threadErr;
 
     threadErr = thread_srp_client_remove_service(mThreadInstance, aInstanceName, aName);
-    VerifyOrReturnError(
-        threadErr == THREAD_ERROR_NONE,
-        (ChipLogError(DeviceLayer, "thread_srp_client_remove_service() failed. ret: %d", threadErr), CHIP_ERROR_INTERNAL));
+    VerifyOrReturnError(threadErr == THREAD_ERROR_NONE, CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "thread_srp_client_remove_service() failed. ret: %d", threadErr));
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -44,6 +44,7 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/dnssd/Constants.h>
 #include <lib/dnssd/platform/Dnssd.h>
+#include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Span.h>
 #include <lib/support/ThreadOperationalDataset.h>
@@ -525,40 +526,68 @@ CHIP_ERROR ThreadStackManagerImpl::_AddSrpService(const char * aInstanceName, co
                                                   const Span<const Dnssd::TextEntry> & aTxtEntries, uint32_t aLeaseInterval,
                                                   uint32_t aKeyLeaseInterval)
 {
-    ChipLogDetail(DeviceLayer, "%s +", __func__);
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int threadErr    = THREAD_ERROR_NONE;
-
     VerifyOrReturnError(mIsInitialized, CHIP_ERROR_WELL_UNINITIALIZED);
-    VerifyOrExit(aInstanceName, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(aName, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(aInstanceName != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(aName != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    int threadErr;
 
     threadErr = thread_srp_client_register_service(mThreadInstance, aInstanceName, aName, aPort);
-    VerifyOrExit(threadErr == THREAD_ERROR_NONE || threadErr == THREAD_ERROR_ALREADY_DONE, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(
+        threadErr == THREAD_ERROR_NONE || threadErr == THREAD_ERROR_ALREADY_DONE,
+        (ChipLogError(DeviceLayer, "thread_srp_client_register_service() failed. ret: %d", threadErr), CHIP_ERROR_INTERNAL));
+
+    SrpClientService service;
+    Platform::CopyString(service.mInstanceName, aInstanceName);
+    Platform::CopyString(service.mName, aName);
+    service.mPort = aPort;
+    mSrpClientServices.push_back(service);
 
     return CHIP_NO_ERROR;
-
-exit:
-    ChipLogError(DeviceLayer, "FAIL: thread_srp_client_register_service");
-    return error;
 }
 
 CHIP_ERROR ThreadStackManagerImpl::_RemoveSrpService(const char * aInstanceName, const char * aName)
 {
-    ChipLogError(DeviceLayer, "Not implemented");
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    VerifyOrReturnError(mIsInitialized, CHIP_ERROR_WELL_UNINITIALIZED);
+    VerifyOrReturnError(aInstanceName != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(aName != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    int threadErr;
+
+    threadErr = thread_srp_client_remove_service(mThreadInstance, aInstanceName, aName);
+    VerifyOrReturnError(
+        threadErr == THREAD_ERROR_NONE,
+        (ChipLogError(DeviceLayer, "thread_srp_client_remove_service() failed. ret: %d", threadErr), CHIP_ERROR_INTERNAL));
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ThreadStackManagerImpl::_InvalidateAllSrpServices()
 {
-    ChipLogError(DeviceLayer, "Not implemented");
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    for (auto & service : mSrpClientServices)
+    {
+        service.mValid = false;
+    }
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ThreadStackManagerImpl::_RemoveInvalidSrpServices()
 {
-    ChipLogError(DeviceLayer, "Not implemented");
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    for (auto it = mSrpClientServices.begin(); it != mSrpClientServices.end();)
+    {
+        if (!it->mValid)
+        {
+            auto err = _RemoveSrpService(it->mInstanceName, it->mName);
+            VerifyOrReturnError(err == CHIP_NO_ERROR, err);
+            it = mSrpClientServices.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return CHIP_NO_ERROR;
 }
 
 void ThreadStackManagerImpl::_ThreadIpAddressCb(int index, char * ipAddr, thread_ipaddr_type_e ipAddrType, void * userData)

--- a/src/platform/Tizen/ThreadStackManagerImpl.h
+++ b/src/platform/Tizen/ThreadStackManagerImpl.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <cstdint>
+#include <vector>
 
 #include <thread.h>
 
@@ -31,6 +32,7 @@
 #include <inet/IPAddress.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
+#include <lib/dnssd/platform/Dnssd.h>
 #include <lib/support/Span.h>
 #include <lib/support/ThreadOperationalDataset.h>
 #include <platform/CHIPDeviceConfig.h>
@@ -127,6 +129,19 @@ public:
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
 private:
+    static constexpr size_t kSrpServiceInstanceNameSize = Dnssd::Common::kInstanceNameMaxLength + 1; // add null-terminator
+    static constexpr size_t kSrpServiceNameSize         = Dnssd::Common::kSubTypeTotalLength + 1;    // add null-terminator
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    struct SrpClientService
+    {
+        char mInstanceName[kSrpServiceInstanceNameSize];
+        char mName[kSrpServiceNameSize];
+        uint16_t mPort;
+        bool mValid = true;
+    };
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
     static constexpr char kOpenthreadDeviceRoleDisabled[] = "disabled";
     static constexpr char kOpenthreadDeviceRoleDetached[] = "detached";
     static constexpr char kOpenthreadDeviceRoleChild[]    = "child";
@@ -153,6 +168,9 @@ private:
     bool mIsAttached;
     bool mIsInitialized;
     thread_instance_h mThreadInstance;
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    std::vector<SrpClientService> mSrpClientServices;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 };
 
 } // namespace DeviceLayer


### PR DESCRIPTION
### Problem

Currently there is no implementation for Thread SRP services remove on Tizen. This PR implements such functionality using Tizen thread API available since Tizen 7.0.

### Changes

-  implement `_RemoveSrpService()`, `_RemoveInvalidSrpServices()` and `_InvalidateAllSrpServices()`
- use new `thread_srp_client_register_service_full()` API for registering service which allows to export TXT entries

### Testing

CI will test potential build failures. Functionality tested locally on Thread-enabled Tizen device.

