### PR TITLE
[Silabs] efr32 wifi provisioning build args

### DIFF
--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -33,12 +33,6 @@ declare_args() {
   # Argument to force enable WPA3 security on rs91x
   rs91x_wpa3_only = false
 
-  #default WiFi SSID
-  chip_default_wifi_ssid = ""
-
-  #default Wifi Password
-  chip_default_wifi_psk = ""
-
   # Use default handler to negotiate subscription max interval
   chip_config_use_icd_subscription_callbacks = enable_sleepy_device
 }
@@ -206,18 +200,6 @@ config("efr32-common-config") {
 config("silabs-wifi-config") {
   defines = []
   include_dirs = []
-
-  if (chip_default_wifi_ssid != "") {
-    defines += [
-      "CHIP_ONNETWORK_PAIRING=1",
-      "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
-    ]
-  }
-  if (chip_default_wifi_psk != "") {
-    assert(chip_default_wifi_ssid != "",
-           "ssid can't be null if psk is provided")
-    defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
-  }
 
   if (sl_wfx_config_softap) {
     defines += [ "SL_WFX_CONFIG_SOFTAP" ]

--- a/src/platform/silabs/efr32/BUILD.gn
+++ b/src/platform/silabs/efr32/BUILD.gn
@@ -19,14 +19,6 @@ import("${chip_root}/src/crypto/crypto.gni")
 import("${chip_root}/src/platform/device.gni")
 import("${chip_root}/third_party/silabs/silabs_board.gni")
 
-declare_args() {
-  #default WiFi SSID
-  chip_default_wifi_ssid = ""
-
-  #default Wifi Password
-  chip_default_wifi_psk = ""
-}
-
 silabs_platform_dir = "${chip_root}/src/platform/silabs"
 
 assert(chip_device_platform == "efr32")
@@ -42,18 +34,6 @@ if (chip_crypto == "platform") {
 config("efr32-platform-wifi-config") {
   include_dirs = [ "wifi" ]
   defines = []
-
-  if (chip_default_wifi_ssid != "") {
-    defines += [
-      "CHIP_ONNETWORK_PAIRING=1",
-      "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
-    ]
-  }
-  if (chip_default_wifi_psk != "") {
-    assert(chip_default_wifi_ssid != "",
-           "ssid can't be null if psk is provided")
-    defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
-  }
 
   if (use_rs9116 && use_rs911x_sockets) {
     include_dirs += [ "wifi/rsi-sockets" ]

--- a/src/platform/silabs/efr32/BUILD.gn
+++ b/src/platform/silabs/efr32/BUILD.gn
@@ -19,6 +19,14 @@ import("${chip_root}/src/crypto/crypto.gni")
 import("${chip_root}/src/platform/device.gni")
 import("${chip_root}/third_party/silabs/silabs_board.gni")
 
+declare_args() {
+  #default WiFi SSID
+  chip_default_wifi_ssid = ""
+
+  #default Wifi Password
+  chip_default_wifi_psk = ""
+}
+
 silabs_platform_dir = "${chip_root}/src/platform/silabs"
 
 assert(chip_device_platform == "efr32")
@@ -34,6 +42,18 @@ if (chip_crypto == "platform") {
 config("efr32-platform-wifi-config") {
   include_dirs = [ "wifi" ]
   defines = []
+
+  if (chip_default_wifi_ssid != "") {
+    defines += [
+      "CHIP_ONNETWORK_PAIRING=1",
+      "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
+    ]
+  }
+  if (chip_default_wifi_psk != "") {
+    assert(chip_default_wifi_ssid != "",
+           "ssid can't be null if psk is provided")
+    defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
+  }
 
   if (use_rs9116 && use_rs911x_sockets) {
     include_dirs += [ "wifi/rsi-sockets" ]

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -49,6 +49,12 @@ declare_args() {
 
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
+
+  #default WiFi SSID
+  chip_default_wifi_ssid = ""
+
+  #default Wifi Password
+  chip_default_wifi_psk = ""
 }
 
 assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")
@@ -200,6 +206,17 @@ template("efr32_sdk") {
     }
 
     if (defined(invoker.chip_enable_wifi) && invoker.chip_enable_wifi) {
+      if (chip_default_wifi_ssid != "") {
+        defines += [
+          "CHIP_ONNETWORK_PAIRING=1",
+          "CHIP_WIFI_SSID=\"${chip_default_wifi_ssid}\"",
+        ]
+      }
+      if (chip_default_wifi_psk != "") {
+        assert(chip_default_wifi_ssid != "",
+               "ssid can't be null if psk is provided")
+        defines += [ "CHIP_WIFI_PSK=\"${chip_default_wifi_psk}\"" ]
+      }
       if (chip_enable_wifi_ipv4) {
         defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4=1" ]
       }


### PR DESCRIPTION
What is being Added?

Fix to provide the Wi-Fi credentials (ssid, psk) in build command.

Testing:

Manually tested sanity (commissioning, unicast)on below apps for all combos successfully,
MG12/MG24+RS9116(lighting)
MG12/MG24+WF200 (lighting)

Build below apps for all combos successfully,
MG12/MG24+RS9116(lighting)
MG12/MG24+WF200 (lighting)