### PR TITLE
tv-casting-app: Fixing caching logic and app crashes

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/DiscoveredNodeData.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/DiscoveredNodeData.java
@@ -52,6 +52,9 @@ public class DiscoveredNodeData {
   public DiscoveredNodeData(NsdServiceInfo serviceInfo) {
     Map<String, byte[]> attributes = serviceInfo.getAttributes();
     this.deviceName = new String(attributes.get(KEY_DEVICE_NAME), StandardCharsets.UTF_8);
+    if (serviceInfo.getHost() != null) {
+      this.hostName = serviceInfo.getHost().getHostName();
+    }
     this.deviceType =
         Long.parseLong(new String(attributes.get(KEY_DEVICE_TYPE), StandardCharsets.UTF_8));
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/VideoPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/VideoPlayer.java
@@ -37,6 +37,7 @@ public class VideoPlayer {
 
   private int numIPs;
   private List<InetAddress> ipAddresses;
+  private String hostName;
 
   private boolean isInitialized = false;
 
@@ -50,6 +51,7 @@ public class VideoPlayer {
       List<ContentApp> contentApps,
       int numIPs,
       List<InetAddress> ipAddresses,
+      String hostName,
       boolean isConnected) {
     this.nodeId = nodeId;
     this.fabricIndex = fabricIndex;
@@ -61,6 +63,7 @@ public class VideoPlayer {
     this.isConnected = isConnected;
     this.numIPs = numIPs;
     this.ipAddresses = ipAddresses;
+    this.hostName = hostName;
     this.isInitialized = true;
   }
 
@@ -68,6 +71,11 @@ public class VideoPlayer {
     // return false because 'this' VideoPlayer is not null
     if (discoveredNodeData == null) {
       return false;
+    }
+
+    // return true if hostNames match
+    if (Objects.equals(hostName, discoveredNodeData.getHostName())) {
+      return true;
     }
 
     // return false because deviceNames are different
@@ -133,6 +141,9 @@ public class VideoPlayer {
         + ", ipAddresses="
         + ipAddresses
         + ", isInitialized="
+        + ", hostName='"
+        + hostName
+        + '\''
         + isInitialized
         + '}';
   }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -209,7 +209,7 @@ JNI_METHOD(jboolean, verifyOrEstablishConnection)
         [](CHIP_ERROR err) { TvCastingAppJNIMgr().getOnConnectionFailureHandler(true).Handle(err); },
         [](TargetEndpointInfo * endpoint) { TvCastingAppJNIMgr().getOnNewOrUpdatedEndpointHandler(true).Handle(endpoint); });
     VerifyOrExit(CHIP_NO_ERROR == err,
-                 ChipLogError(AppServer, "CastingServer::OpenBasicCommissioningWindow failed: %" CHIP_ERROR_FORMAT, err.Format()));
+                 ChipLogError(AppServer, "CastingServer::verifyOrEstablishConnection failed: %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
     return (err == CHIP_NO_ERROR);

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -622,7 +622,8 @@
             self->_previouslyConnectedVideoPlayer->Initialize(currentTargetVideoPlayerInfo->GetNodeId(),
                 currentTargetVideoPlayerInfo->GetFabricIndex(), nullptr, nullptr, currentTargetVideoPlayerInfo->GetVendorId(),
                 currentTargetVideoPlayerInfo->GetProductId(), currentTargetVideoPlayerInfo->GetDeviceType(),
-                currentTargetVideoPlayerInfo->GetDeviceName(), currentTargetVideoPlayerInfo->GetNumIPs(),
+                currentTargetVideoPlayerInfo->GetDeviceName(), currentTargetVideoPlayerInfo->GetHostName(),
+                currentTargetVideoPlayerInfo->GetNumIPs(),
                 const_cast<chip::Inet::IPAddress *>(currentTargetVideoPlayerInfo->GetIpAddresses()));
 
             TargetEndpointInfo * prevEndpoints = self->_previouslyConnectedVideoPlayer->GetEndpoints();

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/ConversionUtils.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/ConversionUtils.mm
@@ -54,16 +54,22 @@
     outDiscoveredNodeData.commissionData.longDiscriminator = objCDiscoveredNodeData.longDiscriminator;
     outDiscoveredNodeData.commissionData.commissioningMode = objCDiscoveredNodeData.commissioningMode;
     outDiscoveredNodeData.commissionData.pairingHint = objCDiscoveredNodeData.pairingHint;
-    chip::Platform::CopyString(outDiscoveredNodeData.commissionData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
-        [objCDiscoveredNodeData.deviceName UTF8String]);
+    memset(outDiscoveredNodeData.commissionData.deviceName, '\0', sizeof(outDiscoveredNodeData.commissionData.deviceName));
+    if (objCDiscoveredNodeData.deviceName != nullptr) {
+        chip::Platform::CopyString(outDiscoveredNodeData.commissionData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
+            [objCDiscoveredNodeData.deviceName UTF8String]);
+    }
     outDiscoveredNodeData.commissionData.rotatingIdLen = objCDiscoveredNodeData.rotatingIdLen;
     memcpy(
         outDiscoveredNodeData.commissionData.rotatingId, objCDiscoveredNodeData.rotatingId, objCDiscoveredNodeData.rotatingIdLen);
 
     // setting CommonResolutionData
     outDiscoveredNodeData.resolutionData.port = objCDiscoveredNodeData.port;
-    chip::Platform::CopyString(outDiscoveredNodeData.resolutionData.hostName, chip::Dnssd::kHostNameMaxLength + 1,
-        [objCDiscoveredNodeData.hostName UTF8String]);
+    memset(outDiscoveredNodeData.resolutionData.hostName, '\0', sizeof(outDiscoveredNodeData.resolutionData.hostName));
+    if (objCDiscoveredNodeData.hostName != nullptr) {
+        chip::Platform::CopyString(outDiscoveredNodeData.resolutionData.hostName, chip::Dnssd::kHostNameMaxLength + 1,
+            [objCDiscoveredNodeData.hostName UTF8String]);
+    }
     outDiscoveredNodeData.resolutionData.interfaceId = chip::Inet::InterfaceId(objCDiscoveredNodeData.platformInterface);
     outDiscoveredNodeData.resolutionData.numIPs = objCDiscoveredNodeData.numIPs;
     for (size_t i = 0; i < objCDiscoveredNodeData.numIPs; i++) {

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -97,6 +97,7 @@ public:
                                            std::function<void(CHIP_ERROR)> onConnectionFailure,
                                            std::function<void(TargetEndpointInfo *)> onNewOrUpdatedEndpoint);
 
+    void LogCachedVideoPlayers();
     CHIP_ERROR PurgeVideoPlayerCache();
 
     /**

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -438,6 +438,7 @@ private:
     uint16_t mTargetVideoPlayerProductId                                  = 0;
     chip::DeviceTypeId mTargetVideoPlayerDeviceType                       = 0;
     char mTargetVideoPlayerDeviceName[chip::Dnssd::kMaxDeviceNameLen + 1] = {};
+    char mTargetVideoPlayerHostName[chip::Dnssd::kHostNameMaxLength + 1]  = {};
     size_t mTargetVideoPlayerNumIPs                                       = 0; // number of valid IP addresses
     chip::Inet::IPAddress mTargetVideoPlayerIpAddress[chip::Dnssd::CommonResolutionData::kMaxIPAddresses];
 

--- a/examples/tv-casting-app/tv-casting-common/include/PersistenceManager.h
+++ b/examples/tv-casting-app/tv-casting-common/include/PersistenceManager.h
@@ -49,6 +49,7 @@ private:
         kVideoPlayerProductIdTag,
         kVideoPlayerDeviceTypeIdTag,
         kVideoPlayerDeviceNameTag,
+        kVideoPlayerHostNameTag,
         kVideoPlayerNumIPsTag,
         kVideoPlayerIPAddressTag,
         kIpAddressesContainerTag,

--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -41,10 +41,11 @@ public:
     chip::NodeId GetNodeId() const { return mNodeId; }
     chip::FabricIndex GetFabricIndex() const { return mFabricIndex; }
     const char * GetDeviceName() const { return mDeviceName; }
+    const char * GetHostName() const { return mHostName; }
     size_t GetNumIPs() const { return mNumIPs; }
     const chip::Inet::IPAddress * GetIpAddresses() const { return mIpAddress; }
     bool IsSameAs(const chip::Dnssd::DiscoveredNodeData * discoveredNodeData);
-    bool IsSameAs(const char * deviceName, size_t numIPs, const chip::Inet::IPAddress * ipAddresses);
+    bool IsSameAs(const char * hostName, const char * deviceName, size_t numIPs, const chip::Inet::IPAddress * ipAddresses);
 
     chip::OperationalDeviceProxy * GetOperationalDeviceProxy()
     {
@@ -58,8 +59,8 @@ public:
     CHIP_ERROR Initialize(chip::NodeId nodeId, chip::FabricIndex fabricIndex,
                           std::function<void(TargetVideoPlayerInfo *)> onConnectionSuccess,
                           std::function<void(CHIP_ERROR)> onConnectionFailure, uint16_t vendorId = 0, uint16_t productId = 0,
-                          chip::DeviceTypeId deviceType = 0, const char * deviceName = {}, size_t numIPs = 0,
-                          chip::Inet::IPAddress * ipAddressList = nullptr);
+                          chip::DeviceTypeId deviceType = 0, const char * deviceName = {}, const char * hostName = {},
+                          size_t numIPs = 0, chip::Inet::IPAddress * ipAddressList = nullptr);
     CHIP_ERROR FindOrEstablishCASESession(std::function<void(TargetVideoPlayerInfo *)> onConnectionSuccess,
                                           std::function<void(CHIP_ERROR)> onConnectionFailure);
     TargetEndpointInfo * GetOrAddEndpoint(chip::EndpointId endpointId);
@@ -110,6 +111,7 @@ private:
     uint16_t mProductId                                  = 0;
     chip::DeviceTypeId mDeviceType                       = 0;
     char mDeviceName[chip::Dnssd::kMaxDeviceNameLen + 1] = {};
+    char mHostName[chip::Dnssd::kHostNameMaxLength + 1]  = {};
     size_t mNumIPs                                       = 0; // number of valid IP addresses
     chip::Inet::IPAddress mIpAddress[chip::Dnssd::CommonResolutionData::kMaxIPAddresses];
 

--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -25,12 +25,46 @@
 
 constexpr size_t kMaxNumberOfEndpoints = 5;
 
+class TargetVideoPlayerInfo;
+class VideoPlayerConnectionContext
+{
+public:
+    VideoPlayerConnectionContext(TargetVideoPlayerInfo * targetVideoPlayerInfo, chip::OnDeviceConnected handleDeviceConnected,
+                                 chip::OnDeviceConnectionFailure handleConnectionFailure,
+                                 std::function<void(TargetVideoPlayerInfo *)> onConnectionSuccess,
+                                 std::function<void(CHIP_ERROR)> onConnectionFailure)
+    {
+        mTargetVideoPlayerInfo       = targetVideoPlayerInfo;
+        mOnConnectedCallback         = new chip::Callback::Callback<chip::OnDeviceConnected>(handleDeviceConnected, this);
+        mOnConnectionFailureCallback = new chip::Callback::Callback<chip::OnDeviceConnectionFailure>(handleConnectionFailure, this);
+        mOnConnectionSuccessClientCallback = onConnectionSuccess;
+        mOnConnectionFailureClientCallback = onConnectionFailure;
+    }
+
+    ~VideoPlayerConnectionContext()
+    {
+        if (mOnConnectedCallback != nullptr)
+        {
+            delete mOnConnectedCallback;
+        }
+
+        if (mOnConnectionFailureCallback != nullptr)
+        {
+            delete mOnConnectionFailureCallback;
+        }
+    }
+
+    TargetVideoPlayerInfo * mTargetVideoPlayerInfo;
+    chip::Callback::Callback<chip::OnDeviceConnected> * mOnConnectedCallback                 = nullptr;
+    chip::Callback::Callback<chip::OnDeviceConnectionFailure> * mOnConnectionFailureCallback = nullptr;
+    std::function<void(TargetVideoPlayerInfo *)> mOnConnectionSuccessClientCallback          = {};
+    std::function<void(CHIP_ERROR)> mOnConnectionFailureClientCallback                       = {};
+};
+
 class TargetVideoPlayerInfo
 {
 public:
-    TargetVideoPlayerInfo() :
-        mOnConnectedCallback(HandleDeviceConnected, this), mOnConnectionFailureCallback(HandleDeviceConnectionFailure, this)
-    {}
+    TargetVideoPlayerInfo() {}
 
     bool operator==(const TargetVideoPlayerInfo & other) { return this->mNodeId == other.mNodeId; }
 
@@ -49,9 +83,9 @@ public:
 
     chip::OperationalDeviceProxy * GetOperationalDeviceProxy()
     {
-        if (mDeviceProxy.ConnectionReady())
+        if (mDeviceProxy != nullptr && mDeviceProxy->ConnectionReady())
         {
-            return &mDeviceProxy;
+            return mDeviceProxy;
         }
         return nullptr;
     }
@@ -73,19 +107,33 @@ private:
     static void HandleDeviceConnected(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
                                       const chip::SessionHandle & sessionHandle)
     {
-        TargetVideoPlayerInfo * _this = static_cast<TargetVideoPlayerInfo *>(context);
-        _this->mDeviceProxy           = chip::OperationalDeviceProxy(&exchangeMgr, sessionHandle);
-        _this->mInitialized           = true;
+        ChipLogProgress(AppServer, "tmplog: HandleDeviceConnected called");
+        VideoPlayerConnectionContext * connectionContext = static_cast<VideoPlayerConnectionContext *>(context);
+        if (connectionContext == nullptr || connectionContext->mTargetVideoPlayerInfo == nullptr)
+        {
+            ChipLogError(AppServer, "HandleDeviceConnected called with null context or null context.targetVideoPlayerInfo");
+            return;
+        }
+        if (connectionContext->mTargetVideoPlayerInfo->mDeviceProxy != nullptr)
+        {
+            ChipLogProgress(AppServer, "HandleDeviceConnected deleting mDeviceProxy");
+            delete connectionContext->mTargetVideoPlayerInfo->mDeviceProxy;
+            ChipLogProgress(AppServer, "HandleDeviceConnected deleted mDeviceProxy");
+        }
+        connectionContext->mTargetVideoPlayerInfo->mDeviceProxy = new chip::OperationalDeviceProxy(&exchangeMgr, sessionHandle);
+        connectionContext->mTargetVideoPlayerInfo->mInitialized = true;
         ChipLogProgress(AppServer,
                         "HandleDeviceConnected created an instance of OperationalDeviceProxy for nodeId: 0x" ChipLogFormatX64
                         ", fabricIndex: %d",
-                        ChipLogValueX64(_this->GetNodeId()), _this->GetFabricIndex());
+                        ChipLogValueX64(connectionContext->mTargetVideoPlayerInfo->GetNodeId()),
+                        connectionContext->mTargetVideoPlayerInfo->GetFabricIndex());
 
-        if (_this->mOnConnectionSuccessClientCallback)
+        if (connectionContext->mOnConnectionSuccessClientCallback)
         {
             ChipLogProgress(AppServer, "HandleDeviceConnected calling mOnConnectionSuccessClientCallback");
-            _this->mOnConnectionSuccessClientCallback(_this);
+            connectionContext->mOnConnectionSuccessClientCallback(connectionContext->mTargetVideoPlayerInfo);
         }
+        delete connectionContext;
     }
 
     static void HandleDeviceConnectionFailure(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error)
@@ -94,19 +142,29 @@ private:
                      "HandleDeviceConnectionFailure called for peerId.nodeId: 0x" ChipLogFormatX64
                      ", peer.fabricIndex: %d with error: %" CHIP_ERROR_FORMAT,
                      ChipLogValueX64(peerId.GetNodeId()), peerId.GetFabricIndex(), error.Format());
-        TargetVideoPlayerInfo * _this = static_cast<TargetVideoPlayerInfo *>(context);
-        _this->mDeviceProxy           = chip::OperationalDeviceProxy();
-        if (_this->mOnConnectionFailureClientCallback)
+        VideoPlayerConnectionContext * connectionContext = static_cast<VideoPlayerConnectionContext *>(context);
+        if (connectionContext == nullptr || connectionContext->mTargetVideoPlayerInfo == nullptr)
+        {
+            ChipLogError(AppServer, "HandleDeviceConnectionFailure called with null context");
+            return;
+        }
+        if (connectionContext->mTargetVideoPlayerInfo->mDeviceProxy != nullptr)
+        {
+            delete connectionContext->mTargetVideoPlayerInfo->mDeviceProxy;
+        }
+        connectionContext->mTargetVideoPlayerInfo->mDeviceProxy = new chip::OperationalDeviceProxy();
+        if (connectionContext->mOnConnectionFailureClientCallback)
         {
             ChipLogProgress(AppServer, "HandleDeviceConnectionFailure calling mOnConnectionFailureClientCallback");
-            _this->mOnConnectionFailureClientCallback(error);
+            connectionContext->mOnConnectionFailureClientCallback(error);
         }
+        delete connectionContext;
     }
 
     TargetEndpointInfo mEndpoints[kMaxNumberOfEndpoints];
     chip::NodeId mNodeId;
     chip::FabricIndex mFabricIndex;
-    chip::OperationalDeviceProxy mDeviceProxy;
+    chip::OperationalDeviceProxy * mDeviceProxy          = nullptr;
     uint16_t mVendorId                                   = 0;
     uint16_t mProductId                                  = 0;
     chip::DeviceTypeId mDeviceType                       = 0;
@@ -114,11 +172,5 @@ private:
     char mHostName[chip::Dnssd::kHostNameMaxLength + 1]  = {};
     size_t mNumIPs                                       = 0; // number of valid IP addresses
     chip::Inet::IPAddress mIpAddress[chip::Dnssd::CommonResolutionData::kMaxIPAddresses];
-
-    chip::Callback::Callback<chip::OnDeviceConnected> mOnConnectedCallback;
-    chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnConnectionFailureCallback;
-    std::function<void(TargetVideoPlayerInfo *)> mOnConnectionSuccessClientCallback;
-    std::function<void(CHIP_ERROR)> mOnConnectionFailureClientCallback;
-
     bool mInitialized = false;
 };

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -162,6 +162,8 @@ CHIP_ERROR CastingServer::SendUserDirectedCommissioningRequest(Dnssd::Discovered
     }
     chip::Platform::CopyString(mTargetVideoPlayerDeviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
                                selectedCommissioner->commissionData.deviceName);
+    chip::Platform::CopyString(mTargetVideoPlayerHostName, chip::Dnssd::kHostNameMaxLength + 1,
+                               selectedCommissioner->resolutionData.hostName);
     return CHIP_NO_ERROR;
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
@@ -412,7 +414,8 @@ void CastingServer::DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * eve
             CastingServer::GetInstance()->mOnConnectionFailureClientCallback,
             CastingServer::GetInstance()->mTargetVideoPlayerVendorId, CastingServer::GetInstance()->mTargetVideoPlayerProductId,
             CastingServer::GetInstance()->mTargetVideoPlayerDeviceType, CastingServer::GetInstance()->mTargetVideoPlayerDeviceName,
-            CastingServer::GetInstance()->mTargetVideoPlayerNumIPs, CastingServer::GetInstance()->mTargetVideoPlayerIpAddress);
+            CastingServer::GetInstance()->mTargetVideoPlayerHostName, CastingServer::GetInstance()->mTargetVideoPlayerNumIPs,
+            CastingServer::GetInstance()->mTargetVideoPlayerIpAddress);
 
         if (err != CHIP_NO_ERROR)
         {

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -295,11 +295,22 @@ TargetVideoPlayerInfo * CastingServer::ReadCachedTargetVideoPlayerInfos()
     return mCachedTargetVideoPlayerInfo;
 }
 
+void CastingServer::LogCachedVideoPlayers()
+{
+    ChipLogProgress(AppServer, "CastingServer:LogCachedVideoPlayers dumping any/all cached video players.");
+    for (size_t i = 0; i < kMaxCachedVideoPlayers && mCachedTargetVideoPlayerInfo[i].IsInitialized(); i++)
+    {
+        mCachedTargetVideoPlayerInfo[i].PrintInfo();
+    }
+}
+
 CHIP_ERROR CastingServer::VerifyOrEstablishConnection(TargetVideoPlayerInfo & targetVideoPlayerInfo,
                                                       std::function<void(TargetVideoPlayerInfo *)> onConnectionSuccess,
                                                       std::function<void(CHIP_ERROR)> onConnectionFailure,
                                                       std::function<void(TargetEndpointInfo *)> onNewOrUpdatedEndpoint)
 {
+    LogCachedVideoPlayers();
+
     if (!targetVideoPlayerInfo.IsInitialized())
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -316,7 +327,8 @@ CHIP_ERROR CastingServer::VerifyOrEstablishConnection(TargetVideoPlayerInfo & ta
         prevDeviceProxy->Disconnect();
     }
 
-    return targetVideoPlayerInfo.FindOrEstablishCASESession(
+    CastingServer::GetInstance()->mActiveTargetVideoPlayerInfo = targetVideoPlayerInfo;
+    return CastingServer::GetInstance()->mActiveTargetVideoPlayerInfo.FindOrEstablishCASESession(
         [](TargetVideoPlayerInfo * videoPlayer) {
             ChipLogProgress(AppServer, "CastingServer::OnConnectionSuccess lambda called");
             CastingServer::GetInstance()->mActiveTargetVideoPlayerInfo = *videoPlayer;

--- a/examples/tv-casting-app/tv-casting-common/src/PersistenceManager.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/PersistenceManager.cpp
@@ -98,6 +98,10 @@ CHIP_ERROR PersistenceManager::WriteAllVideoPlayers(TargetVideoPlayerInfo videoP
             ReturnErrorOnFailure(tlvWriter.PutBytes(TLV::ContextTag(kVideoPlayerDeviceNameTag),
                                                     (const uint8_t *) videoPlayer->GetDeviceName(),
                                                     static_cast<uint32_t>(strlen(videoPlayer->GetDeviceName()) + 1)));
+            ReturnErrorOnFailure(tlvWriter.PutBytes(TLV::ContextTag(kVideoPlayerHostNameTag),
+                                                    (const uint8_t *) videoPlayer->GetHostName(),
+                                                    static_cast<uint32_t>(strlen(videoPlayer->GetHostName()) + 1)));
+
             ReturnErrorOnFailure(
                 tlvWriter.Put(TLV::ContextTag(kVideoPlayerNumIPsTag), static_cast<uint64_t>(videoPlayer->GetNumIPs())));
             const Inet::IPAddress * ipAddress = videoPlayer->GetIpAddresses();
@@ -205,6 +209,7 @@ CHIP_ERROR PersistenceManager::ReadAllVideoPlayers(TargetVideoPlayerInfo outVide
     uint16_t productId                                  = 0;
     uint16_t deviceType                                 = 0;
     char deviceName[chip::Dnssd::kMaxDeviceNameLen + 1] = {};
+    char hostName[chip::Dnssd::kHostNameMaxLength + 1]  = {};
     size_t numIPs                                       = 0;
     Inet::IPAddress ipAddress[chip::Dnssd::CommonResolutionData::kMaxIPAddresses];
     CHIP_ERROR err;
@@ -251,6 +256,12 @@ CHIP_ERROR PersistenceManager::ReadAllVideoPlayers(TargetVideoPlayerInfo outVide
         if (videoPlayersContainerTagNum == kVideoPlayerDeviceNameTag)
         {
             ReturnErrorOnFailure(reader.GetBytes(reinterpret_cast<uint8_t *>(deviceName), chip::Dnssd::kMaxDeviceNameLen + 1));
+            continue;
+        }
+
+        if (videoPlayersContainerTagNum == kVideoPlayerHostNameTag)
+        {
+            ReturnErrorOnFailure(reader.GetBytes(reinterpret_cast<uint8_t *>(hostName), chip::Dnssd::kHostNameMaxLength + 1));
             continue;
         }
 
@@ -301,7 +312,7 @@ CHIP_ERROR PersistenceManager::ReadAllVideoPlayers(TargetVideoPlayerInfo outVide
         if (videoPlayersContainerTagNum == kContentAppEndpointsContainerTag)
         {
             outVideoPlayers[videoPlayerIndex].Initialize(nodeId, fabricIndex, nullptr, nullptr, vendorId, productId, deviceType,
-                                                         deviceName, numIPs, ipAddress);
+                                                         deviceName, hostName, numIPs, ipAddress);
             // Entering Content App Endpoints container
             TLV::TLVType contentAppEndpointArrayContainerType = TLV::kTLVType_Array;
             ReturnErrorOnFailure(reader.EnterContainer(contentAppEndpointArrayContainerType));


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/25377 and https://github.com/project-chip/connectedhomeip/issues/25379

### Change summary
1. Caching key change (3bd389f3f2e3300bbf48cfc6e540041cf1139a8a) - The first commit here changes the caching logic to prioritize hostnames to do the matching with previously discovered TV records.
2. The second commit (f869bc4723b686e606dcc4e3881135e672cf3ccf) changes the way we pass in the context to the FindOrEstablishSession API and when mActiveTargetVideoPlayerInfo was set in the CastingServer::verifyOrEstablishConnection() API. That fixes crashes we were observing earlier.

### Testing
Tested with the Android/iOS tv-casting-apps against the Linux tv-app