### PR TITLE
Fixes for #25388 and #25389

### DIFF
--- a/src/credentials/examples/DeviceAttestationCredsExample.cpp
+++ b/src/credentials/examples/DeviceAttestationCredsExample.cpp
@@ -52,7 +52,11 @@ public:
 
 CHIP_ERROR ExampleDACProvider::GetDeviceAttestationCert(MutableByteSpan & out_dac_buffer)
 {
+#if 0x8000 <= CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID && CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID <= 0x801F
     return CopySpanToMutableSpan(DevelopmentCerts::kDacCert, out_dac_buffer);
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif // 0x8000 <= CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID && CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID <= 0x801F
 }
 
 CHIP_ERROR ExampleDACProvider::GetProductAttestationIntermediateCert(MutableByteSpan & out_pai_buffer)
@@ -122,6 +126,7 @@ CHIP_ERROR ExampleDACProvider::GetFirmwareInformation(MutableByteSpan & out_firm
 CHIP_ERROR ExampleDACProvider::SignWithDeviceAttestationKey(const ByteSpan & message_to_sign,
                                                             MutableByteSpan & out_signature_buffer)
 {
+#if 0x8000 <= CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID && CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID <= 0x801F
     Crypto::P256ECDSASignature signature;
     Crypto::P256Keypair keypair;
 
@@ -135,6 +140,9 @@ CHIP_ERROR ExampleDACProvider::SignWithDeviceAttestationKey(const ByteSpan & mes
     ReturnErrorOnFailure(keypair.ECDSA_sign_msg(message_to_sign.data(), message_to_sign.size(), signature));
 
     return CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, out_signature_buffer);
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif // 0x8000 <= CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID && CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID <= 0x801F
 }
 
 } // namespace

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -1242,6 +1242,15 @@
 #endif
 
 /**
+ * CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES
+ *
+ * Maximum number of IP Addresses stored for a discovered node
+ */
+#ifndef CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES
+#define CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES 5
+#endif
+
+/**
  * CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONABLE_DEVICE_TYPE
  *
  * Enable or disable including device type in commissionable node discovery.

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -38,8 +38,7 @@ namespace Dnssd {
 /// Node resolution data common to both operational and commissionable discovery
 struct CommonResolutionData
 {
-    // TODO: is this count OK? Sufficient space for IPv6 LL, GUA, ULA (and maybe IPv4 if enabled)
-    static constexpr unsigned kMaxIPAddresses = 5;
+    static constexpr unsigned kMaxIPAddresses = CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES;
 
     Inet::InterfaceId interfaceId;
 


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/25388 and https://github.com/project-chip/connectedhomeip/issues/25389

### Change summary
1. The first commit (1447cf3f4998db879a36fd5236dd09a1157916c7) adds a necessary preprocessor check in src/credentials/examples/DeviceAttestationCredsExample.cpp to allow the code to build if `CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID` is set to a value outside of the range of test values i.e. [0x8000, 0x801F]
2.  The second commit (fe41bbd9e70aeef0dfd53d2b42027b8a633b96b3) makes `CommonResolutionData::kMaxIPAddresses` a compile time configurable value using the new constant `CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES` (defaulting to its current value of `5` in src/include/platform/CHIPDeviceConfig.h)