### PR TITLE
[ESP32] Replace undefined variable 'type' with 'service->mType'

### DIFF
--- a/src/platform/ESP32/DnssdImpl.h
+++ b/src/platform/ESP32/DnssdImpl.h
@@ -104,7 +104,7 @@ struct ResolveContext : public GenericContext
     ResolveContext(DnssdService * service, Inet::InterfaceId ifId, mdns_search_once_t * searchHandle, DnssdResolveCallback cb,
                    void * cbCtx)
     {
-        Platform::CopyString(mType, type);
+        Platform::CopyString(mType, service->mType);
         Platform::CopyString(mInstanceName, service->mName);
         mContextType  = ContextType::Resolve;
         mProtocol     = service->mProtocol;


### PR DESCRIPTION
There is an undefined variable "type" in the code, it cause build error when use platform mdns.
So I changed the variable to "service->mType"

