### PR TITLE
Bump timeout in Java Tests - Linux

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -521,7 +521,7 @@ jobs:
 
     java_tests_linux:
         name: Java Tests - Linux
-        timeout-minutes: 130
+        timeout-minutes: 135
 
         env:
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
@@ -614,7 +614,7 @@ jobs:
                      --factoryreset \
                   '
             - name: Run Pairing Address-PaseOnly Test
-              timeout-minutes: 10
+              timeout-minutes: 15
               run: |
                   scripts/run_in_build_env.sh \
                   './scripts/tests/run_java_test.py \


### PR DESCRIPTION
### Problem
Tests often fail due to insufficient timeout  in Pairing Address-PaseOnly Test (Error: The action has timed out.)

### Changes
timeout for Java Tests - Linux was bumped up from 130 to 135 minutes and test Pairing Address-PaseOnly Test from 10 to 15 minutes