### PR TITLE
[Silabs] [SiWx917] Updating qspi clock and nvm3 size for 917 SoC

### DIFF
--- a/examples/platform/silabs/SiWx917/SiWx917/hal/rsi_hal_mcu_platform_init.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/hal/rsi_hal_mcu_platform_init.c
@@ -34,7 +34,7 @@
 
 /* QSPI clock config params */
 #define INTF_PLL_500_CTRL_VALUE 0xD900
-#define INTF_PLL_CLK 160000000 /* PLL out clock 160MHz */
+#define INTF_PLL_CLK 80000000 /* PLL out clock 80 MHz */
 
 #define PMU_GOOD_TIME 31  /*Duration in us*/
 #define XTAL_GOOD_TIME 31 /*Duration in us*/

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -105,9 +105,7 @@ template("efr32_sdk") {
       "HARD_FAULT_LOG_ENABLE",
       "CORTEXM3_EFM32_MICRO",
       "SILABS_LOG_ENABLED=1",
-
-      #Matter required at least 40960 but SiWx917 SoC requires an extra 20k to resolve nvm3_open() error, Need to be checked.
-      "NVM3_DEFAULT_NVM_SIZE=73728",
+      "NVM3_DEFAULT_NVM_SIZE=40960",
       "NVM3_DEFAULT_MAX_OBJECT_SIZE=4092",
       "KVS_MAX_ENTRIES=${kvs_max_entries}",
       "EFR32_OPENTHREAD_API",


### PR DESCRIPTION
1. Reducing the Qspi clock to 40 Mhz for 917  SoC 
2. Higher Qspi clock (80 Mhz) was causing some stability issue with UART, so reduced to 40 Mhz
3. Reducing nvm3 size to 40k for SoC similar to efr


Tested locally with SiWX917 SoC.