### PR TITLE
Make it easier to catch bugs in async command handling.

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -93,6 +93,8 @@ void CommandHandler::OnInvokeCommandRequest(Messaging::ExchangeContext * ec, con
         StatusResponse::Send(status, mExchangeCtx.Get(), false /*aExpectResponse*/);
         mSentStatusResponse = true;
     }
+
+    mGoneAsync = true;
 }
 
 Status CommandHandler::ProcessInvokeRequest(System::PacketBufferHandle && payload, bool isTimedInvoke)
@@ -577,6 +579,7 @@ TLV::TLVWriter * CommandHandler::GetCommandDataIBTLVWriter()
 
 FabricIndex CommandHandler::GetAccessingFabricIndex() const
 {
+    VerifyOrDie(!mGoneAsync);
     return mExchangeCtx->GetSessionHandle()->GetFabricIndex();
 }
 


### PR DESCRIPTION
If GetSubjectDescriptor or GetAccessingFabricIndex were called on a CommandHandler after the command handling had gone async, it would sometimes crash, and sometimes not, depending on whether sessions had been evicted or not.

Make that situation always crash, so that it will be caught more easily in testing.
