### PR TITLE
[ICD] Subscription resumption should respect min interval on startup

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1660,8 +1660,6 @@ void InteractionModelEngine::ResumeSubscriptionsTimerCallback(System::Layer * ap
     }
     iterator->Release();
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
-
-    return;
 }
 
 } // namespace app

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -536,6 +536,8 @@ private:
     void ShutdownMatchingSubscriptions(const Optional<FabricIndex> & aFabricIndex = NullOptional,
                                        const Optional<NodeId> & aPeerNodeId       = NullOptional);
 
+    CHIP_ERROR ResumeSubscriptionsTimerCallback();
+
     template <typename T, size_t N>
     void ReleasePool(ObjectList<T> *& aObjectList, ObjectPool<ObjectList<T>, N> & aObjectPool);
     template <typename T, size_t N>

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -536,7 +536,7 @@ private:
     void ShutdownMatchingSubscriptions(const Optional<FabricIndex> & aFabricIndex = NullOptional,
                                        const Optional<NodeId> & aPeerNodeId       = NullOptional);
 
-    CHIP_ERROR ResumeSubscriptionsTimerCallback();
+    static void ResumeSubscriptionsTimerCallback(System::Layer * apSystemLayer, void * apAppState);
 
     template <typename T, size_t N>
     void ReleasePool(ObjectList<T> *& aObjectList, ObjectPool<ObjectList<T>, N> & aObjectPool);


### PR DESCRIPTION
Addresses https://github.com/CHIP-Specifications/chip-test-plans/issues/2445

This adds a delay to resume subscriptions based on the largest min interval of the persisted subscriptions.