### PR TITLE
Bugfix: Required to enabled EFR32_ATTESTATION_CREDENTIALS.

### DIFF
--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -319,7 +319,7 @@ source_set("efr32-common") {
 
   # Attestation Credentials
   if (chip_build_platform_attestation_credentials_provider) {
-    deps += [ ":efr32-attestation-credentials" ]
+    public_deps += [ ":efr32-attestation-credentials" ]
   }
 
   # Factory Data Provider


### PR DESCRIPTION
Required to use custom credentials.

Tested on EFR32MG12, and EFR32MG24.

