### PR TITLE
Replace kotlinx.android.parcel package with kotlinx.parcelize

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/QrCodeInfo.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/QrCodeInfo.kt
@@ -2,9 +2,10 @@ package com.google.chip.chiptool.setuppayloadscanner
 
 import android.os.Parcelable
 import chip.setuppayload.OptionalQRCodeInfo.OptionalQRCodeInfoType
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
-@Parcelize data class QrCodeInfo(
+@Parcelize 
+data class QrCodeInfo(
     val tag: Int,
     val type: OptionalQRCodeInfoType,
     val data: String,


### PR DESCRIPTION
We have following warning when build Android CHIPTool:

`2023-02-27 19:04:33 INFO    w: /home/yufengw/connectedhomeip/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/QrCodeInfo.kt: (7, 1): Parcelize annotations from package 'kotlinx.android.parcel' are deprecated. Change package to 'kotlinx.parcelize'`

The kotlinx.android.parcel package has been deprecated in favor of kotlinx.parcelize. kotlinx.parcelize provides a more efficient and flexible way to serialize and deserialize Kotlin classes, and is not limited to just Android use cases. It uses code generation to create Parcelable implementations at compile time, instead of relying on reflection at runtime like kotlinx.android.parcel did.