### PR TITLE
[nrfconnect] Bump nRF Connect SDK version in Docker

### DIFF
--- a/integrations/docker/images/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrf-platform/Dockerfile
@@ -6,7 +6,7 @@ ARG VERSION=latest
 
 FROM connectedhomeip/chip-build:${VERSION} as build
 # Compatible Nordic Connect SDK revision.
-ARG NCS_REVISION=v2.2.0
+ARG NCS_REVISION=v2.3.0
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /opt/NordicSemiconductor/nRF5_tools

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.45 Version bump reason: [Telink] Update Telink Docker image (Zephyr update)
+0.6.46 Version bump reason: [nrfconnect] Update nRF Connect SDK version.


### PR DESCRIPTION
Regular update of nRF Connect SDK to 2.3.0 version



