### PR TITLE
[Telink] Update Telink Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/chip-build-telink/Dockerfile
@@ -23,7 +23,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=3da02564e056033ef184081b0ca15e8e00e40bc9
+ARG ZEPHYR_REVISION=bc0f7ba490a45f58610cc2df25f4cadff2d6820b
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.44 Version bump reason: [Java] update kotlin compiler version to 1.8.10
+0.6.45 Version bump reason: [Telink] Update Telink Docker image (Zephyr update)


### PR DESCRIPTION
**Change overview**

- Use latest Telink Zephyr
- BLE PM improvements
- Support HW flow control
- CSL unblocking transmission
- Update net packet during tx
- Fix GPIO functionality
- Disable USB SWI by default
- Start PWM from device tree
- Fix PWM during suspend
- Set 4-wire SPI by default
- Update systicks max sleep value

**Testing**
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully