### PR TITLE
[Silabs][EFR32] Fixed the improper channel result issue in the scan results of network

### DIFF
--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -737,6 +737,7 @@ void wfx_rsi_task(void * arg)
                             WFX_RSI_LOG("Inside else");
                             ap.security = scan->security_mode;
                             ap.rssi     = (-1) * scan->rssi_val;
+                            ap.chan     = scan->rf_channel;
                             memcpy(&ap.bssid[0], &scan->bssid[0], BSSID_MAX_STR_LEN);
                             (*wfx_rsi.scan_cb)(&ap);
                         }


### PR DESCRIPTION
In the scan results of network, it showing below values:
```
{
    Security: 2
    Ssid: 56475F4150
    Bssid: 7C10C9620F80
    Channel: 165
    WiFiBand: 0
    Rssi: -25
}
```
From the above values, channel value is improper (AP configured at channel 1) . This fix will resolve the issue.

Tested it on below combinations:

MG24(BRD4186C) + RS9116




