### PR TITLE
Cleanup external content link prefixes ... only current dir is needed…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,10 +71,5 @@ external_content_contents = [
 ]
 external_content_link_prefixes = [
     ".",
-    "src/",
-    r"\.vscode/",
-    "CONTRIBUTING",
-    "scripts/",
-    "examples/android/",
 ]
 external_content_link_extensions = [".md", ".png", ".jpg", ".svg"]


### PR DESCRIPTION
… it seems

the `CONTRIBUTING` seemed wrong and vscode was not encoded correctly, the others don't seem needed. Generally I tried `make html` in docs and only `.` is required (and it is required because top level README.md references `./docs/README.md` so that link is relative to top.
