### PR TITLE
[sphinx doc] update external link prefix list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,10 +70,10 @@ external_content_contents = [
     (MATTER_BASE, "examples/**/*.JPG"),
 ]
 external_content_link_prefixes = [
-    ".",
     "src/",
     r"\.vscode/",
-    "CONTRIBUTING",
+    "CONTRIBUTING", # cannot detect CONTRIBUTING.md
+    "README", # cannot detect README.md
     "scripts/",
     "examples/android/",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,8 +72,8 @@ external_content_contents = [
 external_content_link_prefixes = [
     "src/",
     r"\.vscode/",
-    "CONTRIBUTING", # cannot detect CONTRIBUTING.md
-    "README", # cannot detect README.md
+    "CONTRIBUTING",  # cannot detect CONTRIBUTING.md
+    "README",  # cannot detect README.md
     "scripts/",
     "examples/android/",
 ]


### PR DESCRIPTION
If including `.` as an item, we lose all internal links.
If we do not have `.` then BUILDING.md gets a stripped extension (sounds like a bug to me, but unsure why) so I added that to the list of prefixes the same like we have for CONTRIBUTING (which if removed also errors out).

This should get better documentation internal links.