### PR TITLE
Generate WrongCodeEntryLimit DoorLockAlarm event when lockout is engaged

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -255,6 +255,8 @@ bool DoorLockServer::engageLockout(chip::EndpointId endpointId)
 
     emberAfDoorLockClusterPrintln("Lockout engaged [endpointId=%d,lockoutTimeout=%d]", endpointId, lockoutTimeout);
 
+    SendLockAlarmEvent(endpointId, AlarmCodeEnum::kWrongCodeEntryLimit);
+
     emberAfPluginDoorLockLockoutStarted(endpointId, endpointContext->lockoutEndTimestamp);
 
     return true;

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -237,6 +237,8 @@ bool DoorLockServer::engageLockout(chip::EndpointId endpointId)
 
     emberAfDoorLockClusterPrintln("Lockout engaged [endpointId=%d,lockoutTimeout=%d]", endpointId, lockoutTimeout);
 
+    SendLockAlarmEvent(endpointId, AlarmCodeEnum::kWrongCodeEntryLimit);
+
     emberAfPluginDoorLockLockoutStarted(endpointId, endpointContext->lockoutEndTimestamp);
 
     return true;

--- a/src/app/tests/suites/DL_LockUnlock.yaml
+++ b/src/app/tests/suites/DL_LockUnlock.yaml
@@ -292,6 +292,17 @@ tests:
       response:
           error: FAILURE
 
+    - label:
+          "Read the DoorLockAlarm event list; verify WrongEntryCodeLimit alarm
+          has been generated"
+      command: "readEvent"
+      event: "DoorLockAlarm"
+      response:
+          value:
+              {
+                  "AlarmCode": 4,
+              }
+
     - label: "Wait for the lockout to end"
       cluster: "DelayCommands"
       command: "WaitForMs"

--- a/src/app/tests/suites/DL_LockUnlock.yaml
+++ b/src/app/tests/suites/DL_LockUnlock.yaml
@@ -394,6 +394,17 @@ tests:
       response:
           error: FAILURE
 
+    - label:
+          "Read the DoorLockAlarm event list; verify WrongEntryCodeLimit alarm
+          has been generated"
+      command: "readEvent"
+      event: "DoorLockAlarm"
+      response:
+          value:
+              {
+                  "AlarmCode": 4,
+              }
+
     - label: "Wait for the lockout to end"
       cluster: "DelayCommands"
       command: "WaitForMs"

--- a/src/app/tests/suites/DL_LockUnlock.yaml
+++ b/src/app/tests/suites/DL_LockUnlock.yaml
@@ -298,10 +298,7 @@ tests:
       command: "readEvent"
       event: "DoorLockAlarm"
       response:
-          value:
-              {
-                  "AlarmCode": 4,
-              }
+          value: { "AlarmCode": 4 }
 
     - label: "Wait for the lockout to end"
       cluster: "DelayCommands"

--- a/src/app/tests/suites/DL_LockUnlock.yaml
+++ b/src/app/tests/suites/DL_LockUnlock.yaml
@@ -400,10 +400,7 @@ tests:
       command: "readEvent"
       event: "DoorLockAlarm"
       response:
-          value:
-              {
-                  "AlarmCode": 4,
-              }
+          value: { "AlarmCode": 4 }
 
     - label: "Wait for the lockout to end"
       cluster: "DelayCommands"


### PR DESCRIPTION
Generate WrongCodeEntryLimit DoorLockAlarm event when lockout is engaged (#25420)

Add DoorLockAlarm[WrongCodeEntryLimit] event generation to door-lock-server.
Update `DL_LockUnlock.yaml` test to test for event.

Fixes #25420 


