### PR TITLE
[chef] linux wpa fix

### DIFF
--- a/examples/chef/linux/main.cpp
+++ b/examples/chef/linux/main.cpp
@@ -21,6 +21,8 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app/ConcreteAttributePath.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <app/clusters/network-commissioning/network-commissioning.h>
+#include <platform/Linux/NetworkCommissioningDriver.h>
 
 #include <lib/shell/Engine.h>
 
@@ -28,8 +30,22 @@
 
 using namespace chip;
 using namespace chip::Shell;
+using namespace chip::app;
+using namespace chip::app::Clusters;
 
-void ApplicationInit() {}
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+namespace {
+DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sLinuxWiFiDriver;
+Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(0, &sLinuxWiFiDriver);
+} // namespace
+#endif
+
+void ApplicationInit()
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+    sWiFiNetworkCommissioningInstance.Init();
+#endif
+}
 
 int main(int argc, char * argv[])
 {

--- a/examples/chef/linux/main.cpp
+++ b/examples/chef/linux/main.cpp
@@ -20,8 +20,8 @@
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app/ConcreteAttributePath.h>
-#include <lib/support/logging/CHIPLogging.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
+#include <lib/support/logging/CHIPLogging.h>
 #include <platform/Linux/NetworkCommissioningDriver.h>
 
 #include <lib/shell/Engine.h>
@@ -31,7 +31,6 @@
 using namespace chip;
 using namespace chip::Shell;
 using namespace chip::app;
-using namespace chip::app::Clusters;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 namespace {


### PR DESCRIPTION
Issue: chef linux builds had a Network Commissioning Cluster with WI feature, but commands were not working.

Fix: Linux Wifi Driver is initialized.

Tested with chip-tool. Scan Network command now returns a valid status, while previously it returned INVALID_COMMAND.
