### PR TITLE
Fix encoding for device name

### DIFF
--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/ConversionUtils.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/ConversionUtils.mm
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020-2022 Project CHIP Authors
+ *    Copyright (c) 2020-2023 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -120,16 +120,16 @@
     objCDiscoveredNodeData.commissioningMode = cppDiscoveredNodedata->commissionData.commissioningMode;
     objCDiscoveredNodeData.pairingHint = cppDiscoveredNodedata->commissionData.pairingHint;
     objCDiscoveredNodeData.deviceName = [NSString stringWithCString:cppDiscoveredNodedata->commissionData.deviceName
-                                                           encoding:NSASCIIStringEncoding];
+                                                           encoding:NSUTF8StringEncoding];
     objCDiscoveredNodeData.rotatingIdLen = cppDiscoveredNodedata->commissionData.rotatingIdLen;
     objCDiscoveredNodeData.rotatingId = cppDiscoveredNodedata->commissionData.rotatingId;
     objCDiscoveredNodeData.instanceName = [NSString stringWithCString:cppDiscoveredNodedata->commissionData.instanceName
-                                                             encoding:NSASCIIStringEncoding];
+                                                             encoding:NSUTF8StringEncoding];
 
     // from CommonResolutionData
     objCDiscoveredNodeData.port = cppDiscoveredNodedata->resolutionData.port;
     objCDiscoveredNodeData.hostName = [NSString stringWithCString:cppDiscoveredNodedata->resolutionData.hostName
-                                                         encoding:NSASCIIStringEncoding];
+                                                         encoding:NSUTF8StringEncoding];
     objCDiscoveredNodeData.platformInterface = cppDiscoveredNodedata->resolutionData.interfaceId.GetPlatformInterface();
     objCDiscoveredNodeData.numIPs = cppDiscoveredNodedata->resolutionData.numIPs;
     if (cppDiscoveredNodedata->resolutionData.numIPs > 0) {
@@ -154,7 +154,7 @@
         objCVideoPlayer.deviceType = cppTargetVideoPlayerInfo->GetDeviceType();
         objCVideoPlayer.isConnected = (cppTargetVideoPlayerInfo->GetOperationalDeviceProxy() != nil);
         objCVideoPlayer.deviceName = [NSString stringWithCString:cppTargetVideoPlayerInfo->GetDeviceName()
-                                                        encoding:NSASCIIStringEncoding];
+                                                        encoding:NSUTF8StringEncoding];
         objCVideoPlayer.contentApps = [NSMutableArray new];
         TargetEndpointInfo * cppTargetEndpointInfos = cppTargetVideoPlayerInfo->GetEndpoints();
         for (size_t i = 0; i < kMaxNumberOfEndpoints && cppTargetEndpointInfos[i].IsInitialized(); i++) {


### PR DESCRIPTION
We should be using UTF8 encoding rather than ASCII encoding in the TV casting app
