### PR TITLE
Update docker image to the latest for all android related builds

### DIFF
--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-android:0.6.44
+            image: connectedhomeip/chip-build-android:0.6.47
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.6.44"
+    - name: "connectedhomeip/chip-build-vscode:0.6.47"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               git submodule update --init --recursive
       id: Submodules
-    - name: "connectedhomeip/chip-build-vscode:0.6.44"
+    - name: "connectedhomeip/chip-build-vscode:0.6.47"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -22,7 +22,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.44"
+    - name: "connectedhomeip/chip-build-vscode:0.6.47"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -40,7 +40,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "connectedhomeip/chip-build-vscode:0.6.44"
+    - name: "connectedhomeip/chip-build-vscode:0.6.47"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -61,7 +61,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.44"
+    - name: "connectedhomeip/chip-build-vscode:0.6.47"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -83,7 +83,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.44"
+    - name: "connectedhomeip/chip-build-vscode:0.6.47"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -143,7 +143,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.44"
+    - name: "connectedhomeip/chip-build-vscode:0.6.47"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
We need the latest kotlinc 1.8.10 which is installed since 0.6.45 to build Matter SDK, Update docker image to the latest for all android related builds. 
