### PR TITLE
[Android] Fallback to BLE Notification when Indication unsupported

### DIFF
--- a/src/platform/android/java/chip/platform/AndroidBleManager.java
+++ b/src/platform/android/java/chip/platform/AndroidBleManager.java
@@ -157,6 +157,9 @@ public class AndroidBleManager implements BleManager {
             if (desc.getValue() == BluetoothGattDescriptor.ENABLE_INDICATION_VALUE) {
               mPlatform.handleSubscribeComplete(
                   connId, svcIdBytes, charIdBytes, status == BluetoothGatt.GATT_SUCCESS);
+            } else if (desc.getValue() == BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE) {
+              mPlatform.handleSubscribeComplete(
+                  connId, svcIdBytes, charIdBytes, status == BluetoothGatt.GATT_SUCCESS);
             } else if (desc.getValue() == BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE) {
               mPlatform.handleUnsubscribeComplete(
                   connId, svcIdBytes, charIdBytes, status == BluetoothGatt.GATT_SUCCESS);
@@ -283,10 +286,18 @@ public class AndroidBleManager implements BleManager {
 
     BluetoothGattDescriptor descriptor =
         subscribeChar.getDescriptor(UUID.fromString(CLIENT_CHARACTERISTIC_CONFIG));
-    descriptor.setValue(BluetoothGattDescriptor.ENABLE_INDICATION_VALUE);
-    if (!bluetoothGatt.writeDescriptor(descriptor)) {
-      Log.e(TAG, "writeDescriptor failed");
-      return false;
+    if ((subscribeChar.getProperties() & BluetoothGattCharacteristic.PROPERTY_INDICATE) != 0) {
+      descriptor.setValue(BluetoothGattDescriptor.ENABLE_INDICATION_VALUE);
+      if (!bluetoothGatt.writeDescriptor(descriptor)) {
+        Log.e(TAG, "writeDescriptor failed");
+        return false;
+      }
+    } else if ((subscribeChar.getProperties() & BluetoothGattCharacteristic.PROPERTY_NOTIFY) != 0) {
+      descriptor.setValue(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE);
+      if (!bluetoothGatt.writeDescriptor(descriptor)) {
+        Log.e(TAG, "writeDescriptor failed");
+        return false;
+      }
     }
     return true;
   }


### PR DESCRIPTION
To support devices based on older revisions of the SDK that did not include the GATT Server Characteristic property change (from Notification to Indication), the GATT Characteristic properties are queried to determine if Indication and/or Notification is supported. When available, Indication is preferred.

Fixes #25442 

Example logs from device supporting only Notifications:

```
6.654011000; ATT Write Transaction (Client Characteristic Configuration: Notifications=Enabled, Indications=Disabled)                        ; 01 00; 
6.654011000;   ATT Write Request Packet (Client Characteristic Configuration: Notifications=Enabled, Indications=Disabled)                   ; 12 11 00 01 00; 
6.654011000;     L2CAP SDU (Basic, Service=ATT)                                                                                              ; 12 11 00 01 00; 
6.654011000;       L2CAP B-Frame (Service=ATT, ACL-U Flow Events)                                                                            ; 05 00 04 00 12 11 00 01 00; 
6.652025000;         HCI Number Of Completed Packets (Connection=0x0002, Packets=1)                                                          ; 13 05 01 02 00 01 00; 
6.654011000;         HCI ACL Data OUT                                                                                                        ; 02 00 09 00 05 00 04 00 12 11 00 01 00; 
6.666372000;   ATT Write Response Packet                                                                                                     ; 13; 
6.666372000;     L2CAP SDU (Basic, Service=ATT)                                                                                              ; 13; 
6.666372000;       L2CAP B-Frame (Service=ATT)                                                                                               ; 01 00 04 00 13; 
6.666372000;         HCI ACL Data IN                                                                                                         ; 02 20 05 00 01 00 04 00 13; 
```

Example logs from device supporting Indications:

```
47.677276000; ATT Write Transaction (Client Characteristic Configuration: Notifications=Disabled, Indications=Enabled)                        ; 02 00; 
47.677276000;   ATT Write Request Packet (Client Characteristic Configuration: Notifications=Disabled, Indications=Enabled)                   ; 12 0F 00 02 00; 
47.677276000;     L2CAP SDU (Basic, Service=ATT)                                                                                              ; 12 0F 00 02 00; 
47.677276000;       L2CAP B-Frame (Service=ATT, ACL-U Flow Events)                                                                            ; 05 00 04 00 12 0F 00 02 00; 
47.661667000;         HCI Number Of Completed Packets (Connection=0x0002, Packets=1)                                                          ; 13 05 01 02 00 01 00; 
47.677276000;         HCI ACL Data OUT                                                                                                        ; 02 00 09 00 05 00 04 00 12 0F 00 02 00; 
47.706433000;   ATT Write Response Packet                                                                                                     ; 13; 
47.706433000;     L2CAP SDU (Basic, Service=ATT)                                                                                              ; 13; 
47.706433000;       L2CAP B-Frame (Service=ATT)                                                                                               ; 01 00 04 00 13; 
47.706433000;         HCI ACL Data IN                                                                                                         ; 02 20 05 00 01 00 04 00 13; 
```

[device-notifications-enabled-patch-export.txt](https://github.com/project-chip/connectedhomeip/files/10876556/device-notifications-enabled-patch-export.txt)

![device-notifications-enabled-patch](https://user-images.githubusercontent.com/122404367/222582571-8d0f4a45-6a21-4cb5-97d7-6c0d89eec392.png)

[rpi-indications-enabled-patch-export.txt](https://github.com/project-chip/connectedhomeip/files/10876557/rpi-indications-enabled-patch-export.txt)

![rpi-indications-enabled-patch](https://user-images.githubusercontent.com/122404367/222582593-96e6c5d7-1c34-4915-be27-1a6811e27a3a.png)

