### PR TITLE
[Silabs] [EFR32] Adds translation between spec WiFi Security Types

### DIFF
--- a/examples/platform/silabs/SiWx917/SiWx917/rsi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/rsi_if.c
@@ -75,7 +75,6 @@ extern rsi_semaphore_handle_t sl_rs_ble_init_sem;
  */
 static uint8_t wfx_rsi_drv_buf[WFX_RSI_BUF_SZ];
 wfx_wifi_scan_ext_t * temp_reset;
-uint8_t security;
 
 /******************************************************************
  * @fn   int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t *ap)
@@ -89,7 +88,7 @@ int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap)
 {
     int32_t status;
     uint8_t rssi;
-    ap->security = security;
+    ap->security = wfx_rsi.sec.security;
     ap->chan     = wfx_rsi.ap_chan;
     memcpy(&ap->bssid[0], &wfx_rsi.ap_mac.octet[0], BSSID_MAX_STR_LEN);
     status = rsi_wlan_get(RSI_RSSI, &rssi, sizeof(rssi));
@@ -381,21 +380,32 @@ static void wfx_rsi_save_ap_info()
     }
     else
     {
-        wfx_rsi.sec.security = rsp.scan_info->security_mode;
+        wfx_rsi.sec.security = WFX_SEC_UNSPECIFIED;
         wfx_rsi.ap_chan      = rsp.scan_info->rf_channel;
         memcpy(&wfx_rsi.ap_mac.octet[0], &rsp.scan_info->bssid[0], BSSID_MAX_STR_LEN);
     }
-    if ((wfx_rsi.sec.security == RSI_WPA) || (wfx_rsi.sec.security == RSI_WPA2))
+    switch (rsp.scan_info->security_mode)
     {
-        // saving the security before changing into mixed mode
-        security             = wfx_rsi.sec.security;
-        wfx_rsi.sec.security = RSI_WPA_WPA2_MIXED;
-    }
-    if (wfx_rsi.sec.security == SME_WPA3)
-    {
-        // returning 3 for WPA3 when DGWIFI read security-type is called
-        security             = WPA3_SECURITY;
-        wfx_rsi.sec.security = RSI_WPA3;
+    case SME_OPEN:
+        wfx_rsi.sec.security = WFX_SEC_NONE;
+        break;
+    case SME_WPA:
+    case SME_WPA_ENTERPRISE:
+        wfx_rsi.sec.security = WFX_SEC_WPA;
+        break;
+    case SME_WPA2:
+    case SME_WPA2_ENTERPRISE:
+        wfx_rsi.sec.security = WFX_SEC_WPA2;
+        break;
+    case SME_WEP:
+        wfx_rsi.sec.security = WFX_SEC_WEP;
+        break;
+    case SME_WPA3:
+    case SME_WPA3_TRANSITION:
+        wfx_rsi.sec.security = WFX_SEC_WPA3;
+        break;
+    default:
+        wfx_rsi.sec.security = WFX_SEC_UNSPECIFIED;
     }
     WFX_RSI_LOG("%s: WLAN: connecting to %s==%s, sec=%d, status=%02x", __func__, &wfx_rsi.sec.ssid[0], &wfx_rsi.sec.passkey[0],
                 wfx_rsi.sec.security, status);
@@ -418,6 +428,26 @@ static void wfx_rsi_do_join(void)
     }
     else
     {
+        switch (wfx_rsi.sec.security)
+        {
+        case WFX_SEC_WEP:
+            connect_security_mode = RSI_WEP;
+            break;
+        case WFX_SEC_WPA:
+        case WFX_SEC_WPA2:
+            connect_security_mode = RSI_WPA_WPA2_MIXED;
+            break;
+        case WFX_SEC_WPA3:
+            connect_security_mode = RSI_WPA3;
+            break;
+        case WFX_SEC_NONE:
+            connect_security_mode = RSI_OPEN;
+            break;
+        default:
+            WFX_RSI_LOG("%s: error: unknown security type.");
+            return;
+        }
+
         WFX_RSI_LOG("%s: WLAN: connecting to %s==%s, sec=%d", __func__, &wfx_rsi.sec.ssid[0], &wfx_rsi.sec.passkey[0],
                     wfx_rsi.sec.security);
         /*

--- a/examples/platform/silabs/SiWx917/SiWx917/rsi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/rsi_if.c
@@ -406,6 +406,7 @@ static void wfx_rsi_save_ap_info()
         break;
     default:
         wfx_rsi.sec.security = WFX_SEC_UNSPECIFIED;
+        break;
     }
     WFX_RSI_LOG("%s: WLAN: connecting to %s==%s, sec=%d, status=%02x", __func__, &wfx_rsi.sec.ssid[0], &wfx_rsi.sec.passkey[0],
                 wfx_rsi.sec.security, status);

--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -492,7 +492,7 @@ static void wfx_rsi_save_ap_info() // transalation
 static void wfx_rsi_do_join(void)
 {
     int32_t status;
-    rsi_security_mode_t connect_security_mode = RSI_OPEN;
+    rsi_security_mode_t connect_security_mode;
 
     if (wfx_rsi.dev_state & (WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED))
     {
@@ -545,8 +545,8 @@ static void wfx_rsi_do_join(void)
             /* Call rsi connect call with given ssid and password
              * And check there is a success
              */
-            if ((status = rsi_wlan_connect_async((int8_t *) &wfx_rsi.sec.ssid[0], (rsi_security_mode_t) wfx_rsi.sec.security,
-                                                 &wfx_rsi.sec.passkey[0], wfx_rsi_join_cb)) != RSI_SUCCESS)
+            if ((status = rsi_wlan_connect_async((int8_t *) &wfx_rsi.sec.ssid[0], connect_security_mode, &wfx_rsi.sec.passkey[0],
+                                                 wfx_rsi_join_cb)) != RSI_SUCCESS)
             {
 
                 wfx_rsi.dev_state &= ~WFX_RSI_ST_STA_CONNECTING;

--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -476,6 +476,7 @@ static void wfx_rsi_save_ap_info() // transalation
         break;
     default:
         wfx_rsi.sec.security = WFX_SEC_UNSPECIFIED;
+        break;
     }
 
     WFX_RSI_LOG("%s: WLAN: connecting to %s==%s, sec=%d, status=%02x", __func__, &wfx_rsi.sec.ssid[0], &wfx_rsi.sec.passkey[0],

--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -434,7 +434,7 @@ void wfx_show_err(char * msg)
  * @return
  *       None
  *******************************************************************************************/
-static void wfx_rsi_save_ap_info() // transalation
+static void wfx_rsi_save_ap_info() // translation
 {
     int32_t status;
     rsi_rsp_scan_t rsp;

--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -82,7 +82,6 @@ extern rsi_semaphore_handle_t sl_rs_ble_init_sem;
  */
 static uint8_t wfx_rsi_drv_buf[WFX_RSI_BUF_SZ];
 wfx_wifi_scan_ext_t * temp_reset;
-uint8_t security;
 
 /******************************************************************
  * @fn   int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t *ap)
@@ -96,7 +95,7 @@ int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap)
 {
     int32_t status;
     uint8_t rssi;
-    ap->security = security;
+    ap->security = wfx_rsi.sec.security;
     ap->chan     = wfx_rsi.ap_chan;
     memcpy(&ap->bssid[0], &wfx_rsi.ap_mac.octet[0], BSSID_MAX_STR_LEN);
     status = rsi_wlan_get(RSI_RSSI, &rssi, sizeof(rssi));
@@ -435,7 +434,7 @@ void wfx_show_err(char * msg)
  * @return
  *       None
  *******************************************************************************************/
-static void wfx_rsi_save_ap_info()
+static void wfx_rsi_save_ap_info() // transalation
 {
     int32_t status;
     rsi_rsp_scan_t rsp;
@@ -450,22 +449,35 @@ static void wfx_rsi_save_ap_info()
     }
     else
     {
-        wfx_rsi.sec.security = rsp.scan_info->security_mode;
+        wfx_rsi.sec.security = WFX_SEC_UNSPECIFIED;
         wfx_rsi.ap_chan      = rsp.scan_info->rf_channel;
         memcpy(&wfx_rsi.ap_mac.octet[0], &rsp.scan_info->bssid[0], BSSID_MAX_STR_LEN);
     }
-    if ((wfx_rsi.sec.security == RSI_WPA) || (wfx_rsi.sec.security == RSI_WPA2))
+
+    switch (rsp.scan_info->security_mode)
     {
-        // saving the security before changing into mixed mode
-        security             = wfx_rsi.sec.security;
-        wfx_rsi.sec.security = RSI_WPA_WPA2_MIXED;
+    case SME_OPEN:
+        wfx_rsi.sec.security = WFX_SEC_NONE;
+        break;
+    case SME_WPA:
+    case SME_WPA_ENTERPRISE:
+        wfx_rsi.sec.security = WFX_SEC_WPA;
+        break;
+    case SME_WPA2:
+    case SME_WPA2_ENTERPRISE:
+        wfx_rsi.sec.security = WFX_SEC_WPA2;
+        break;
+    case SME_WEP:
+        wfx_rsi.sec.security = WFX_SEC_WEP;
+        break;
+    case SME_WPA3:
+    case SME_WPA3_TRANSITION:
+        wfx_rsi.sec.security = WFX_SEC_WPA3;
+        break;
+    default:
+        wfx_rsi.sec.security = WFX_SEC_UNSPECIFIED;
     }
-    if (wfx_rsi.sec.security == SME_WPA3)
-    {
-        // returning 3 for WPA3 when DGWIFI read security-type is called
-        security             = WPA3_SECURITY;
-        wfx_rsi.sec.security = RSI_WPA3;
-    }
+
     WFX_RSI_LOG("%s: WLAN: connecting to %s==%s, sec=%d, status=%02x", __func__, &wfx_rsi.sec.ssid[0], &wfx_rsi.sec.passkey[0],
                 wfx_rsi.sec.security, status);
 }
@@ -480,6 +492,7 @@ static void wfx_rsi_save_ap_info()
 static void wfx_rsi_do_join(void)
 {
     int32_t status;
+    rsi_security_mode_t connect_security_mode;
 
     if (wfx_rsi.dev_state & (WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED))
     {
@@ -487,6 +500,27 @@ static void wfx_rsi_do_join(void)
     }
     else
     {
+
+        switch (wfx_rsi.sec.security)
+        {
+        case WFX_SEC_WEP:
+            connect_security_mode = RSI_WEP;
+            break;
+        case WFX_SEC_WPA:
+        case WFX_SEC_WPA2:
+            connect_security_mode = RSI_WPA_WPA2_MIXED;
+            break;
+        case WFX_SEC_WPA3:
+            connect_security_mode = RSI_WPA3;
+            break;
+        case WFX_SEC_NONE:
+            connect_security_mode = RSI_OPEN;
+            break;
+        default:
+            WFX_RSI_LOG("%s: error: unknown security type.");
+            return;
+        }
+
         WFX_RSI_LOG("%s: WLAN: connecting to %s==%s, sec=%d", __func__, &wfx_rsi.sec.ssid[0], &wfx_rsi.sec.passkey[0],
                     wfx_rsi.sec.security);
 

--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -492,7 +492,7 @@ static void wfx_rsi_save_ap_info() // transalation
 static void wfx_rsi_do_join(void)
 {
     int32_t status;
-    rsi_security_mode_t connect_security_mode;
+    rsi_security_mode_t connect_security_mode = RSI_OPEN;
 
     if (wfx_rsi.dev_state & (WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED))
     {

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -149,7 +149,7 @@ CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, 
     wfx_wifi_provision_t wifiConfig = {};
     memcpy(wifiConfig.ssid, ssid, ssidLen);
     memcpy(wifiConfig.passkey, key, keyLen);
-    wifiConfig.security = WFX_SEC_WPA_WPA2_MIXED;
+    wifiConfig.security = WFX_SEC_WPA2;
 
     ChipLogProgress(NetworkProvisioning, "Setting up connection for WiFi SSID: %.*s", static_cast<int>(ssidLen), ssid);
     // Configure the WFX WiFi interface.

--- a/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
+++ b/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
@@ -131,7 +131,6 @@
 #define BG_SCAN_RES_SIZE 500
 
 #define SPI_CONFIG_SUCCESS 0
-#define WPA3_SECURITY 3
 
 typedef enum
 {
@@ -149,28 +148,19 @@ typedef enum
 /* Note that these are same as RSI_security */
 typedef enum
 {
-    WFX_SEC_NONE           = 0,
-    WFX_SEC_WPA            = 1,
-    WFX_SEC_WPA2           = 2,
-    WFX_SEC_WEP            = 3,
-    WFX_SEC_WPA_EAP        = 4,
-    WFX_SEC_WPA2_EAP       = 5,
-    WFX_SEC_WPA_WPA2_MIXED = 6,
-    WFX_SEC_WPA_PMK        = 7,
-    WFX_SEC_WPA2_PMK       = 8,
-    WFX_SEC_WPS_PIN        = 9,
-    WFX_SEC_GEN_WPS_PIN    = 10,
-    WFX_SEC_PUSH_BTN       = 11,
-    WFX_SEC_WPA3           = 11,
+    WFX_SEC_UNSPECIFIED = 0,
+    WFX_SEC_NONE        = 1,
+    WFX_SEC_WEP         = 2,
+    WFX_SEC_WPA         = 3,
+    WFX_SEC_WPA2        = 4,
+    WFX_SEC_WPA3        = 5
 } wfx_sec_t;
-
-#define WPA3_SECURITY 3
 
 typedef struct
 {
     char ssid[32 + 1];
     char passkey[64 + 1];
-    uint8_t security;
+    wfx_sec_t security;
 } wfx_wifi_provision_t;
 
 typedef enum
@@ -185,7 +175,7 @@ typedef enum
 typedef struct wfx_wifi_scan_result
 {
     char ssid[32 + 1];
-    uint8_t security;
+    wfx_sec_t security;
     uint8_t bssid[6];
     uint8_t chan;
     int16_t rssi; /* I suspect this is in dBm - so signed */

--- a/src/platform/silabs/efr32/wifi/wfx_host_events.h
+++ b/src/platform/silabs/efr32/wifi/wfx_host_events.h
@@ -220,7 +220,6 @@ typedef struct __attribute__((__packed__)) sl_wfx_mib_req_s
 #define BG_SCAN_RES_SIZE 500
 
 #define SPI_CONFIG_SUCESS 0
-#define WPA3_SECURITY 3
 
 typedef enum
 {
@@ -238,28 +237,19 @@ typedef enum
 /* Note that these are same as RSI_security */
 typedef enum
 {
-    WFX_SEC_NONE           = 0,
-    WFX_SEC_WPA            = 1,
-    WFX_SEC_WPA2           = 2,
-    WFX_SEC_WEP            = 3,
-    WFX_SEC_WPA_EAP        = 4,
-    WFX_SEC_WPA2_EAP       = 5,
-    WFX_SEC_WPA_WPA2_MIXED = 6,
-    WFX_SEC_WPA_PMK        = 7,
-    WFX_SEC_WPA2_PMK       = 8,
-    WFX_SEC_WPS_PIN        = 9,
-    WFX_SEC_GEN_WPS_PIN    = 10,
-    WFX_SEC_PUSH_BTN       = 11,
-    WFX_SEC_WPA3           = 11,
+    WFX_SEC_UNSPECIFIED = 0,
+    WFX_SEC_NONE        = 1,
+    WFX_SEC_WEP         = 2,
+    WFX_SEC_WPA         = 3,
+    WFX_SEC_WPA2        = 4,
+    WFX_SEC_WPA3        = 5
 } wfx_sec_t;
-
-#define WPA3_SECURITY 3
 
 typedef struct
 {
     char ssid[32 + 1];
     char passkey[64 + 1];
-    uint8_t security;
+    wfx_sec_t security;
 } wfx_wifi_provision_t;
 
 typedef enum
@@ -274,7 +264,7 @@ typedef enum
 typedef struct wfx_wifi_scan_result
 {
     char ssid[32 + 1];
-    uint8_t security;
+    wfx_sec_t security;
     uint8_t bssid[6];
     uint8_t chan;
     int16_t rssi; /* I suspect this is in dBm - so signed */


### PR DESCRIPTION
Fixes #25118 

Encoding the enum provided by driver in scan result callback to CHIP spec based enum, decoding them back to driver based enum on the connect API.