### PR TITLE
Correct copied path for kotlinc for vscode image

### DIFF
--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=nrf /opt/NordicSemiconductor/nrfconnect /opt/NordicSemiconductor/nrf
 
 COPY --from=android /opt/android/sdk /opt/android/sdk
 COPY --from=android /opt/android/android-ndk-r21b /opt/android/android-ndk-r21b
-COPY --from=android /usr/lib/kotlinc/bin /usr/lib/kotlinc/bin
+COPY --from=android /usr/lib/kotlinc /usr/lib/kotlinc
 
 COPY --from=mbedos /opt/openocd/ /opt/openocd/
 

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.47 Version bump reason: [nrfconnect] Update nRF Connect SDK version.
+0.6.48 Version bump reason: [android] Correct kotlinc path for vscode image


### PR DESCRIPTION
Only the "bin" path was copied before, however that is insufficient. Copy the entire tree.