### PR TITLE
Android/tv-casting-app: Adding defensive checks in Discovery/record parsing

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/NsdDiscoveryListener.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/NsdDiscoveryListener.java
@@ -111,7 +111,6 @@ public class NsdDiscoveryListener implements NsdManager.DiscoveryListener {
     failureCallback.handle(
         new MatterError(
             3, "NsdDiscoveryListener Discovery failed to start: Nsd Error code:" + errorCode));
-    nsdManager.stopServiceDiscovery(this);
   }
 
   @Override
@@ -123,6 +122,5 @@ public class NsdDiscoveryListener implements NsdManager.DiscoveryListener {
     failureCallback.handle(
         new MatterError(
             3, "NsdDiscoveryListener Discovery failed to stop: Nsd Error code:" + errorCode));
-    nsdManager.stopServiceDiscovery(this);
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -137,7 +137,9 @@ public class TvCastingApp {
               public void run() {
                 Log.d(TAG, "TvCastingApp stopping Video Player commissioner discovery");
                 nsdManager.stopServiceDiscovery(nsdDiscoveryListener);
-                multicastLock.release();
+                if (multicastLock.isHeld()) {
+                  multicastLock.release();
+                }
               }
             },
             discoveryDurationSeconds,


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/25463

### Change summary
* Added defensive check in logic to parse TXT records in DiscoveredNodeData.
* Added defensive checks to see if the multicastLock isHeld() before release()ing it.
* Stopped trying to stopDiscovery if it is not ongoing in the first place.

### Testing
Tested with the Android tv-casting-app running against the Linux tv-app

