### PR TITLE
Adding preprocessor checks before using DevelopmentCerts:kDac* constants

### DIFF
--- a/src/credentials/examples/DeviceAttestationCredsExample.cpp
+++ b/src/credentials/examples/DeviceAttestationCredsExample.cpp
@@ -52,7 +52,11 @@ public:
 
 CHIP_ERROR ExampleDACProvider::GetDeviceAttestationCert(MutableByteSpan & out_dac_buffer)
 {
+#if 0x8000 <= CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID && CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID <= 0x801F
     return CopySpanToMutableSpan(DevelopmentCerts::kDacCert, out_dac_buffer);
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif // 0x8000 <= CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID && CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID <= 0x801F
 }
 
 CHIP_ERROR ExampleDACProvider::GetProductAttestationIntermediateCert(MutableByteSpan & out_pai_buffer)
@@ -122,6 +126,7 @@ CHIP_ERROR ExampleDACProvider::GetFirmwareInformation(MutableByteSpan & out_firm
 CHIP_ERROR ExampleDACProvider::SignWithDeviceAttestationKey(const ByteSpan & message_to_sign,
                                                             MutableByteSpan & out_signature_buffer)
 {
+#if 0x8000 <= CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID && CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID <= 0x801F
     Crypto::P256ECDSASignature signature;
     Crypto::P256Keypair keypair;
 
@@ -135,6 +140,9 @@ CHIP_ERROR ExampleDACProvider::SignWithDeviceAttestationKey(const ByteSpan & mes
     ReturnErrorOnFailure(keypair.ECDSA_sign_msg(message_to_sign.data(), message_to_sign.size(), signature));
 
     return CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, out_signature_buffer);
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif // 0x8000 <= CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID && CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID <= 0x801F
 }
 
 } // namespace


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/25388

### Change summary
This change adds a necessary preprocessor check in src/credentials/examples/DeviceAttestationCredsExample.cpp to allow the code to build if `CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID` is set to a value outside of the range of test values i.e. [0x8000, 0x801F]. (see `src/credentials/examples/ExampleDACs.cpp`) If we do not make this change, we end up with compilation failures like this when building an app (say the tv-casting-app) if the product id is outside the test range:

```
Undefined symbols for architecture arm64:
  "chip::DevelopmentCerts::kDacPublicKey", referenced from:
      chip::Credentials::Examples::(anonymous namespace)::ExampleDACProvider::SignWithDeviceAttestationKey(chip::Span<unsigned char const> const&, chip::Span<unsigned char>&) in libTvCastingCommon.a(libCredentials.DeviceAttestationCredsExample.cpp.o)
  "chip::DevelopmentCerts::kDacPrivateKey", referenced from:
      chip::Credentials::Examples::(anonymous namespace)::ExampleDACProvider::SignWithDeviceAttestationKey(chip::Span<unsigned char const> const&, chip::Span<unsigned char>&) in libTvCastingCommon.a(libCredentials.DeviceAttestationCredsExample.cpp.o)
  "chip::DevelopmentCerts::kDacCert", referenced from:
      chip::Credentials::Examples::(anonymous namespace)::ExampleDACProvider::GetDeviceAttestationCert(chip::Span<unsigned char>&) in libTvCastingCommon.a(libCredentials.DeviceAttestationCredsExample.cpp.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

### Testing
Successfully able to build the tv-casting-app with a CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID set to a value outside the range of test values, like 0x7FFF.