### PR TITLE
Switch back to 6.44 for cloudbuild as nrf NCS revision is not matching

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.44"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               git submodule update --init --recursive
       id: Submodules
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.44"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -22,7 +22,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.44"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -40,7 +40,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.44"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -61,7 +61,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.44"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -83,7 +83,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.44"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -143,7 +143,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.44"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
Fixes cloudbuild errors after #25443 

```
...
Traceback (most recent call last):
2023-03-03 21:14:32 ERROR   Failed to validate ZEPHYR_BASE status
2023-03-03 21:14:32 INFO    ################################################################################
2023-03-03 21:14:32 INFO    # /workspace/scripts/setup/nrfconnect/update_ncs.py --update                   #
2023-03-03 21:14:32 INFO    # Consider updating NCS to the recommended revision, by calling:               #
2023-03-03 21:14:32 INFO    # Please be aware that it may lead to encountering unexpected problems.        #
...
```