### PR TITLE
[chip-tool] Some CHIP_ERROR returned values are ignored

### DIFF
--- a/examples/chip-tool/commands/clusters/CustomArgument.h
+++ b/examples/chip-tool/commands/clusters/CustomArgument.h
@@ -279,7 +279,7 @@ public:
     {
         chip::TLV::TLVReader reader;
         reader.Init(mData, mDataLen);
-        reader.Next();
+        ReturnErrorOnFailure(reader.Next());
 
         return writer.CopyElement(tag, reader);
     }

--- a/examples/chip-tool/commands/clusters/DataModelLogger.h
+++ b/examples/chip-tool/commands/clusters/DataModelLogger.h
@@ -103,26 +103,20 @@ private:
     template <typename X, typename std::enable_if_t<std::is_enum<X>::value, int> = 0>
     static CHIP_ERROR LogValue(const char * label, size_t indent, X value)
     {
-        DataModelLogger::LogValue(label, indent, chip::to_underlying(value));
-        return CHIP_NO_ERROR;
+        return DataModelLogger::LogValue(label, indent, chip::to_underlying(value));
     }
 
     template <typename X>
     static CHIP_ERROR LogValue(const char * label, size_t indent, chip::BitFlags<X> value)
     {
-        DataModelLogger::LogValue(label, indent, value.Raw());
-        return CHIP_NO_ERROR;
+        return DataModelLogger::LogValue(label, indent, value.Raw());
     }
 
     template <typename T>
     static CHIP_ERROR LogValue(const char * label, size_t indent, const chip::app::DataModel::DecodableList<T> & value)
     {
-        size_t count   = 0;
-        CHIP_ERROR err = value.ComputeSize(&count);
-        if (err != CHIP_NO_ERROR)
-        {
-            return err;
-        }
+        size_t count = 0;
+        ReturnErrorOnFailure(value.ComputeSize(&count));
         DataModelLogger::LogString(label, indent, std::to_string(count) + " entries");
 
         auto iter = value.begin();
@@ -146,13 +140,10 @@ private:
         if (value.IsNull())
         {
             DataModelLogger::LogString(label, indent, "null");
-        }
-        else
-        {
-            DataModelLogger::LogValue(label, indent, value.Value());
+            return CHIP_NO_ERROR;
         }
 
-        return CHIP_NO_ERROR;
+        return DataModelLogger::LogValue(label, indent, value.Value());
     }
 
     template <typename T>
@@ -160,7 +151,7 @@ private:
     {
         if (value.HasValue())
         {
-            DataModelLogger::LogValue(label, indent, value.Value());
+            return DataModelLogger::LogValue(label, indent, value.Value());
         }
 
         return CHIP_NO_ERROR;

--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -169,48 +169,51 @@ CHIP_ERROR LogDiscoveredNodeData(const chip::Dnssd::DiscoveredNodeData & nodeDat
 {
     VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
 
-    if (!chip::CanCastTo<uint8_t>(nodeData.resolutionData.numIPs))
+    auto & resolutionData = nodeData.resolutionData;
+    auto & commissionData = nodeData.commissionData;
+
+    if (!chip::CanCastTo<uint8_t>(resolutionData.numIPs))
     {
         ChipLogError(chipTool, "Too many ips.");
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    if (!chip::CanCastTo<uint64_t>(nodeData.commissionData.rotatingIdLen))
+    if (!chip::CanCastTo<uint64_t>(commissionData.rotatingIdLen))
     {
         ChipLogError(chipTool, "Can not convert rotatingId to json format.");
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
     char rotatingId[chip::Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
-    chip::Encoding::BytesToUppercaseHexString(nodeData.commissionData.rotatingId, nodeData.commissionData.rotatingIdLen, rotatingId,
-                                              sizeof(rotatingId));
+    ReturnErrorOnFailure(chip::Encoding::BytesToUppercaseHexString(commissionData.rotatingId, commissionData.rotatingIdLen,
+                                                                   rotatingId, sizeof(rotatingId)));
 
     Json::Value value;
-    value["hostName"]           = nodeData.resolutionData.hostName;
-    value["instanceName"]       = nodeData.commissionData.instanceName;
-    value["longDiscriminator"]  = nodeData.commissionData.longDiscriminator;
-    value["shortDiscriminator"] = ((nodeData.commissionData.longDiscriminator >> 8) & 0x0F);
-    value["vendorId"]           = nodeData.commissionData.vendorId;
-    value["productId"]          = nodeData.commissionData.productId;
-    value["commissioningMode"]  = nodeData.commissionData.commissioningMode;
-    value["deviceType"]         = nodeData.commissionData.deviceType;
-    value["deviceName"]         = nodeData.commissionData.deviceName;
+    value["hostName"]           = resolutionData.hostName;
+    value["instanceName"]       = commissionData.instanceName;
+    value["longDiscriminator"]  = commissionData.longDiscriminator;
+    value["shortDiscriminator"] = ((commissionData.longDiscriminator >> 8) & 0x0F);
+    value["vendorId"]           = commissionData.vendorId;
+    value["productId"]          = commissionData.productId;
+    value["commissioningMode"]  = commissionData.commissioningMode;
+    value["deviceType"]         = commissionData.deviceType;
+    value["deviceName"]         = commissionData.deviceName;
     value["rotatingId"]         = rotatingId;
-    value["rotatingIdLen"]      = static_cast<uint64_t>(nodeData.commissionData.rotatingIdLen);
-    value["pairingHint"]        = nodeData.commissionData.pairingHint;
-    value["pairingInstruction"] = nodeData.commissionData.pairingInstruction;
-    value["supportsTcp"]        = nodeData.resolutionData.supportsTcp;
-    value["port"]               = nodeData.resolutionData.port;
-    value["numIPs"]             = static_cast<uint8_t>(nodeData.resolutionData.numIPs);
+    value["rotatingIdLen"]      = static_cast<uint64_t>(commissionData.rotatingIdLen);
+    value["pairingHint"]        = commissionData.pairingHint;
+    value["pairingInstruction"] = commissionData.pairingInstruction;
+    value["supportsTcp"]        = resolutionData.supportsTcp;
+    value["port"]               = resolutionData.port;
+    value["numIPs"]             = static_cast<uint8_t>(resolutionData.numIPs);
 
-    if (nodeData.resolutionData.mrpRetryIntervalIdle.HasValue())
+    if (resolutionData.mrpRetryIntervalIdle.HasValue())
     {
-        value["mrpRetryIntervalIdle"] = nodeData.resolutionData.mrpRetryIntervalIdle.Value().count();
+        value["mrpRetryIntervalIdle"] = resolutionData.mrpRetryIntervalIdle.Value().count();
     }
 
-    if (nodeData.resolutionData.mrpRetryIntervalActive.HasValue())
+    if (resolutionData.mrpRetryIntervalActive.HasValue())
     {
-        value["mrpRetryIntervalActive"] = nodeData.resolutionData.mrpRetryIntervalActive.Value().count();
+        value["mrpRetryIntervalActive"] = resolutionData.mrpRetryIntervalActive.Value().count();
     }
 
     Json::Value rootValue;

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
@@ -30,8 +30,8 @@ void DiscoverCommissionablesCommandBase::OnDiscoveredDevice(const chip::Dnssd::D
     if (mDiscoverOnce.ValueOr(true))
     {
         mCommissioner->RegisterDeviceDiscoveryDelegate(nullptr);
-        mCommissioner->StopCommissionableDiscovery();
-        SetCommandExitStatus(CHIP_NO_ERROR);
+        auto err = mCommissioner->StopCommissionableDiscovery();
+        SetCommandExitStatus(err);
     }
 }
 

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -306,7 +306,10 @@ bool InteractiveCommand::ParseCommand(char * command, int * status)
 {
     if (strcmp(command, kInteractiveModeStopCommand) == 0)
     {
-        chip::DeviceLayer::PlatformMgr().ScheduleWork(ExecuteDeferredCleanups, 0);
+        // If scheduling the cleanup fails, there is not much we can do.
+        // But if something went wrong while the application is leaving it could be because things have
+        // not been cleaned up properly, so it is still useful to log the failure.
+        LogErrorOnFailure(chip::DeviceLayer::PlatformMgr().ScheduleWork(ExecuteDeferredCleanups, 0));
         return false;
     }
 

--- a/examples/chip-tool/commands/payload/SetupPayloadGenerateCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadGenerateCommand.cpp
@@ -118,12 +118,12 @@ CHIP_ERROR SetupPayloadGenerateQRCodeCommand::PopulatePayloadTLVFromBytes(SetupP
 {
     // First clear out all the existing TVL bits from the payload.  Ignore
     // errors here, because we don't care if those bits are not present.
-    payload.removeSerialNumber();
+    (void) payload.removeSerialNumber();
 
     auto existingVendorData = payload.getAllOptionalVendorData();
     for (auto & data : existingVendorData)
     {
-        payload.removeOptionalVendorData(data.tag);
+        (void) payload.removeOptionalVendorData(data.tag);
     }
 
     if (tlvBytes.empty())

--- a/examples/common/websocket-server/WebSocketServer.cpp
+++ b/examples/common/websocket-server/WebSocketServer.cpp
@@ -200,9 +200,8 @@ bool WebSocketServer::OnWebSocketMessageReceived(char * msg)
     return shouldContinue;
 }
 
-CHIP_ERROR WebSocketServer::Send(const char * msg)
+void WebSocketServer::Send(const char * msg)
 {
     std::lock_guard<std::mutex> lock(gMutex);
     gMessageQueue.push_back(msg);
-    return CHIP_NO_ERROR;
 }

--- a/examples/common/websocket-server/WebSocketServer.h
+++ b/examples/common/websocket-server/WebSocketServer.h
@@ -29,7 +29,7 @@ class WebSocketServer : public WebSocketServerDelegate
 {
 public:
     CHIP_ERROR Run(chip::Optional<uint16_t> port, WebSocketServerDelegate * delegate);
-    CHIP_ERROR Send(const char * msg);
+    void Send(const char * msg);
 
     bool OnWebSocketMessageReceived(char * msg) override;
 

--- a/examples/placeholder/linux/InteractiveServer.cpp
+++ b/examples/placeholder/linux/InteractiveServer.cpp
@@ -226,7 +226,7 @@ bool InteractiveServer::Command(const chip::app::ConcreteCommandPath & path)
 
     auto valueStr = JsonToString(value);
     gInteractiveServerResult.MaybeAddResult(valueStr.c_str());
-    LogErrorOnFailure(mWebSocketServer.Send(gInteractiveServerResult.AsJsonString().c_str()));
+    mWebSocketServer.Send(gInteractiveServerResult.AsJsonString().c_str());
     gInteractiveServerResult.Reset();
     return mIsReady;
 }
@@ -243,7 +243,7 @@ bool InteractiveServer::ReadAttribute(const chip::app::ConcreteAttributePath & p
 
     auto valueStr = JsonToString(value);
     gInteractiveServerResult.MaybeAddResult(valueStr.c_str());
-    LogErrorOnFailure(mWebSocketServer.Send(gInteractiveServerResult.AsJsonString().c_str()));
+    mWebSocketServer.Send(gInteractiveServerResult.AsJsonString().c_str());
     gInteractiveServerResult.Reset();
     return mIsReady;
 }
@@ -260,7 +260,7 @@ bool InteractiveServer::WriteAttribute(const chip::app::ConcreteAttributePath & 
 
     auto valueStr = JsonToString(value);
     gInteractiveServerResult.MaybeAddResult(valueStr.c_str());
-    LogErrorOnFailure(mWebSocketServer.Send(gInteractiveServerResult.AsJsonString().c_str()));
+    mWebSocketServer.Send(gInteractiveServerResult.AsJsonString().c_str());
     gInteractiveServerResult.Reset();
     return mIsReady;
 }
@@ -273,6 +273,6 @@ void InteractiveServer::CommissioningComplete()
     Json::Value value = Json::objectValue;
     auto valueStr     = JsonToString(value);
     gInteractiveServerResult.MaybeAddResult(valueStr.c_str());
-    LogErrorOnFailure(mWebSocketServer.Send(gInteractiveServerResult.AsJsonString().c_str()));
+    mWebSocketServer.Send(gInteractiveServerResult.AsJsonString().c_str());
     gInteractiveServerResult.Reset();
 }


### PR DESCRIPTION
#### Problem

Some `CHIP_ERROR` returned values are ignored in `chip-tool`.  This PR adds handling for them, or in the case of `WebSocketServer::Send` removed the returned value since it does not seems useful.
