### PR TITLE
[darwin] Data race when accessing onConnectionComplete

### DIFF
--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -182,23 +182,19 @@ namespace DeviceLayer {
 // All our callback dispatch must happen on _chipWorkQueue
 - (void)dispatchConnectionError:(CHIP_ERROR)error
 {
-    if (self.onConnectionError == nil) {
-        return;
-    }
-
     dispatch_async(_chipWorkQueue, ^{
-        self.onConnectionError(self.appState, error);
+        if (self.onConnectionError != nil) {
+            self.onConnectionError(self.appState, error);
+        }
     });
 }
 
 - (void)dispatchConnectionComplete:(CBPeripheral *)peripheral
 {
-    if (self.onConnectionComplete == nil) {
-        return;
-    }
-
     dispatch_async(_chipWorkQueue, ^{
-        self.onConnectionComplete(self.appState, (__bridge void *) peripheral);
+        if (self.onConnectionComplete != nil) {
+            self.onConnectionComplete(self.appState, (__bridge void *) peripheral);
+        }
     });
 }
 


### PR DESCRIPTION
#### Problem

Found while working on #25374 
```
WARNING: ThreadSanitizer: data race (pid=3721)
  Read of size 8 at 0x7b1c00003a10 by thread T4:
    #0 -[BleConnection onConnectionComplete] BleConnectionDelegateImpl.mm:58 (chip-tool:x86_64+0x100fa0b89)
    #1 -[BleConnection dispatchConnectionComplete:] BleConnectionDelegateImpl.mm:238 (chip-tool:x86_64+0x100f9823f)
    #2 -[BleConnection peripheral:didDiscoverCharacteristicsForService:error:] BleConnectionDelegateImpl.mm:370 (chip-tool:x86_64+0x100f9b892)
    #3 -[CBPeripheral handleAttributeEvent:args:attributeSelector:delegateSelector:delegateFlag:] <null>:2 (CoreBluetooth:x86_64+0x346a9)
    #4 _dispatch_client_callout <null>:2 (libdispatch.dylib:x86_64+0x2a43)

  Previous write of size 8 at 0x7b1c00003a10 by thread T3:
    #0 -[BleConnection setOnConnectionComplete:] BleConnectionDelegateImpl.mm (chip-tool:x86_64+0x100fa0bfd)
    #1 chip::DeviceLayer::Internal::BleConnectionDelegateImpl::NewConnection(chip::Ble::BleLayer*, void*, void*) BleConnectionDelegateImpl.mm:121 (chip-tool:x86_64+0x100f966f8)
    #2 chip::Ble::BleLayer::NewBleConnectionByObject(void*, void*, void (*)(void*, void*), void (*)(void*, chip::ChipError)) BleLayer.cpp:403 (chip-tool:x86_64+0x100dacd68)
    #3 chip::Controller::SetUpCodePairer::PairDevice(unsigned long long, unsigned int, void*, chip::Controller::SetupCodePairerBehaviour) SetUpCodePairer.cpp:150 (chip-tool:x86_64+0x1011b2c4b)
    #4 chip::Controller::DeviceCommissioner::EstablishPASEConnection(unsigned long long, unsigned int, void*) CHIPDeviceController.cpp:646 (chip-tool:x86_64+0x1010a1007)
    #5 DiscoverCommissionablesPairCommand::RunCommand() DiscoverCommissionablesCommand.cpp:202 (chip-tool:x86_64+0x100cbed60)
    #6 CHIPCommand::RunQueuedCommand(long) CHIPCommand.cpp:473 (chip-tool:x86_64+0x100c4bc44)
    #7 chip::DeviceLayer::Internal::GenericPlatformManagerImpl<chip::DeviceLayer::PlatformManagerImpl>::_DispatchEvent(chip::DeviceLayer::ChipDeviceEvent const*) GenericPlatformManagerImpl.ipp:290 (chip-tool:x86_64+0x100f8ca72)
    #8 chip::DeviceLayer::PlatformManager::DispatchEvent(chip::DeviceLayer::ChipDeviceEvent const*) PlatformManager.h:505 (chip-tool:x86_64+0x100f8d999)
    #9 invocation function for block in chip::DeviceLayer::PlatformManagerImpl::_PostEvent(chip::DeviceLayer::ChipDeviceEvent const*) PlatformManagerImpl.cpp:150 (chip-tool:x86_64+0x100f8d90a)
    #10 __tsan::invoke_and_release_block(void*) <null>:3 (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x7f44b)
    #11 _dispatch_client_callout <null>:2 (libdispatch.dylib:x86_64+0x2a43)

  Location is heap block of size 112 at 0x7b1c000039c0 allocated by thread T2:
    #0 calloc <null>:3 (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x554b4)
    #1 _objc_rootAllocWithZone <null>:3 (libobjc.A.dylib:x86_64h+0xbef8)
    #2 chip::DeviceLayer::Internal::BLEManagerImpl::PrepareConnection(chip::DeviceLayer::PrepareCommissioningDelegate*) BLEManagerImpl.cpp:95 (chip-tool:x86_64+0x100f579de)
    #3 chip::DeviceLayer::PlatformManagerImpl::PrepareCommissioning(chip::DeviceLayer::PrepareCommissioningDelegate*) PlatformManagerImpl.cpp:167 (chip-tool:x86_64+0x100f8daa5)
    #4 chip::Controller::SetUpCodePairer::StartDiscoverDevices(chip::Controller::SetUpCodePairerDiscoveryDelegate*, chip::Controller::DiscoveryType) SetUpCodePairer.cpp:53 (chip-tool:x86_64+0x1011b0eef)
    #5 chip::Controller::DeviceCommissioner::StartDiscoverDevices(chip::Controller::SetUpCodePairerDiscoveryDelegate*, chip::Controller::DiscoveryType) CHIPDeviceController.cpp:584 (chip-tool:x86_64+0x10109f114)
    #6 DiscoverCommissionablesStartCommand::RunCommand() DiscoverCommissionablesCommand.cpp:115 (chip-tool:x86_64+0x100cbd804)
    #7 CHIPCommand::RunQueuedCommand(long) CHIPCommand.cpp:473 (chip-tool:x86_64+0x100c4bc44)
    #8 chip::DeviceLayer::Internal::GenericPlatformManagerImpl<chip::DeviceLayer::PlatformManagerImpl>::_DispatchEvent(chip::DeviceLayer::ChipDeviceEvent const*) GenericPlatformManagerImpl.ipp:290 (chip-tool:x86_64+0x100f8ca72)
    #9 chip::DeviceLayer::PlatformManager::DispatchEvent(chip::DeviceLayer::ChipDeviceEvent const*) PlatformManager.h:505 (chip-tool:x86_64+0x100f8d999)
    #10 invocation function for block in chip::DeviceLayer::PlatformManagerImpl::_PostEvent(chip::DeviceLayer::ChipDeviceEvent const*) PlatformManagerImpl.cpp:150 (chip-tool:x86_64+0x100f8d90a)
    #11 __tsan::invoke_and_release_block(void*) <null>:3 (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x7f44b)
    #12 _dispatch_client_callout <null>:2 (libdispatch.dylib:x86_64+0x2a43)
```
