### PR TITLE
Fix java im sub crash

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
@@ -129,8 +129,8 @@ class OnOffClientFragment : Fragment() {
         showReportMessage(message)
       }
 
-      override fun onSubscriptionEstablished() {
-        val message = "Subscription for on/off established"
+      override fun onSubscriptionEstablished(subscriptionId: Long) {
+        val message = "Subscription for on/off established with subscriptionId: $subscriptionId"
         Log.v(TAG, message)
         showMessage(message)
       }

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
@@ -181,7 +181,7 @@ class SensorClientFragment : Fragment() {
       return
 
     try {
-      ChipClient.getDeviceController(requireContext()).shutdownSubscriptions(null, null, null)
+      ChipClient.getDeviceController(requireContext()).shutdownSubscriptions()
       subscribedDevicePtr = 0
     } catch (ex: Exception) {
       showMessage(R.string.sensor_client_unsubscribe_error_text, ex.toString())

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
@@ -181,7 +181,7 @@ class SensorClientFragment : Fragment() {
       return
 
     try {
-      ChipClient.getDeviceController(requireContext()).shutdownSubscriptions(subscribedDevicePtr)
+      ChipClient.getDeviceController(requireContext()).shutdownSubscriptions(null, null, null)
       subscribedDevicePtr = 0
     } catch (ex: Exception) {
       showMessage(R.string.sensor_client_unsubscribe_error_text, ex.toString())

--- a/examples/chip-tool/commands/clusters/SubscriptionsCommands.h
+++ b/examples/chip-tool/commands/clusters/SubscriptionsCommands.h
@@ -30,7 +30,7 @@ public:
         CHIPCommand("shutdown-one", credsIssuerConfig,
                     "Shut down a single subscription, identified by its subscription id and target node id.")
     {
-        AddArgument("subscription-id", 0, UINT64_MAX, &mSubscriptionId);
+        AddArgument("subscription-id", 0, UINT32_MAX, &mSubscriptionId);
         AddArgument("node-id", 0, UINT64_MAX, &mNodeId,
                     "The node id, scoped to the commissioner name the command is running under.");
     }

--- a/examples/java-matter-controller/BUILD.gn
+++ b/examples/java-matter-controller/BUILD.gn
@@ -69,6 +69,7 @@ kotlin_binary("java-matter-controller") {
     "java/src/com/matter/controller/commands/pairing/PairOnNetworkInstanceNameCommand.kt",
     "java/src/com/matter/controller/commands/pairing/PairOnNetworkLongCommand.kt",
     "java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImInvokeCommand.kt",
+    "java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImSubscribeCommand.kt",
     "java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImWriteCommand.kt",
     "java/src/com/matter/controller/commands/pairing/PairOnNetworkShortCommand.kt",
     "java/src/com/matter/controller/commands/pairing/PairOnNetworkVendorCommand.kt",

--- a/examples/java-matter-controller/args.gni
+++ b/examples/java-matter-controller/args.gni
@@ -23,4 +23,4 @@ chip_system_project_config_include = "<SystemProjectConfig.h>"
 chip_project_config_include_dirs =
     [ "${chip_root}/examples/java-matter-controller/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
-chip_stack_lock_tracking = "none"
+chip_stack_lock_tracking = "fatal"

--- a/examples/java-matter-controller/java/src/com/matter/controller/Main.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/Main.kt
@@ -62,6 +62,7 @@ private fun getImCommands(
   credentialsIssuer: CredentialsIssuer
 ): List<Command> {
   return listOf(
+    PairOnNetworkLongImSubscribeCommand(controller, credentialsIssuer),
     PairOnNetworkLongImWriteCommand(controller, credentialsIssuer),
     PairOnNetworkLongImInvokeCommand(controller, credentialsIssuer),
   )

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImSubscribeCommand.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImSubscribeCommand.kt
@@ -1,0 +1,98 @@
+package com.matter.controller.commands.pairing
+
+import chip.devicecontroller.ChipDeviceController
+import chip.devicecontroller.GetConnectedDeviceCallbackJni.GetConnectedDeviceCallback
+import chip.devicecontroller.ReportCallback
+import chip.devicecontroller.SubscriptionEstablishedCallback
+import chip.devicecontroller.ResubscriptionAttemptCallback
+import chip.devicecontroller.model.NodeState
+import chip.devicecontroller.model.ChipAttributePath
+import chip.devicecontroller.model.ChipEventPath
+import com.matter.controller.commands.common.CredentialsIssuer
+import java.util.Collections
+import java.util.logging.Level
+import java.util.logging.Logger
+
+class PairOnNetworkLongImSubscribeCommand(
+  controller: ChipDeviceController, credsIssue: CredentialsIssuer?
+) : PairingCommand(
+  controller,
+  "onnetwork-long-im-subscribe",
+  credsIssue,
+  PairingModeType.ON_NETWORK,
+  PairingNetworkType.NONE,
+  DiscoveryFilterType.LONG_DISCRIMINATOR
+) {
+  private var devicePointer: Long = 0
+  private var subscriptionId: Long = 0
+
+  private inner class InternalReportCallback : ReportCallback {
+    override fun onError(attributePath: ChipAttributePath?, eventPath: ChipEventPath?, e: Exception) {
+      logger.log(Level.INFO, "Subscribe receive onError")
+      setFailure("write failure")
+    }
+
+    override fun onReport(nodeState: NodeState) {
+      logger.log(Level.INFO, "Subscribe receve onReport")
+    }
+  }
+
+  private inner class InternalGetConnectedDeviceCallback : GetConnectedDeviceCallback {
+    override fun onDeviceConnected(devicePointer: Long) {
+      this@PairOnNetworkLongImSubscribeCommand.devicePointer = devicePointer
+      logger.log(Level.INFO, "onDeviceConnected")
+    }
+
+    override fun onConnectionFailure(nodeId: Long, error: Exception?) {
+      logger.log(Level.INFO, "onConnectionFailure")
+    }
+  }
+
+  private inner class InternalSubscriptionEstablishedCallback : SubscriptionEstablishedCallback {
+    override fun onSubscriptionEstablished(subscriptionId: Long) {
+      this@PairOnNetworkLongImSubscribeCommand.subscriptionId = subscriptionId
+      logger.log(Level.INFO, "onSubscriptionEstablished with Id" + subscriptionId)
+      setSuccess()
+    }
+  }
+
+  private inner class InternalResubscriptionAttemptCallback : ResubscriptionAttemptCallback {
+    override fun onResubscriptionAttempt(terminationCause: Int, nextResubscribeIntervalMsec: Int) {
+      logger.log(Level.INFO, "ResubscriptionAttemptCallback");
+    }
+  }
+
+  override fun runCommand() {
+    val attributePathList = listOf(ChipAttributePath.newInstance(
+        /* endpointId= */ 0, CLUSTER_ID_BASIC, ATTR_ID_LOCAL_CONFIG_DISABLED))
+
+    currentCommissioner()
+      .pairDeviceWithAddress(
+        getNodeId(),
+        getRemoteAddr().getHostAddress(),
+        MATTER_PORT,
+        getDiscriminator(),
+        getSetupPINCode(),
+        null
+      )
+    currentCommissioner().setCompletionListener(this)
+    waitCompleteMs(getTimeoutMillis())
+    currentCommissioner()
+      .getConnectedDevicePointer(getNodeId(), InternalGetConnectedDeviceCallback())
+    clear()
+    currentCommissioner()
+      .subscribeToPath(InternalSubscriptionEstablishedCallback(), InternalResubscriptionAttemptCallback(), InternalReportCallback(), devicePointer, attributePathList, Collections.emptyList(), 0, 5, false, false)
+    waitCompleteMs(getTimeoutMillis())
+    currentCommissioner().shutdownSubscriptions(currentCommissioner().getFabricIndex(), getNodeId(), subscriptionId);
+  }
+
+  companion object {
+    private val logger = Logger.getLogger(
+      PairOnNetworkLongImSubscribeCommand::class.java.name
+    )
+
+    private const val MATTER_PORT = 5540
+    private const val CLUSTER_ID_BASIC = 0x0028L
+    private const val ATTR_ID_LOCAL_CONFIG_DISABLED = 16L
+  }
+}

--- a/examples/tv-casting-app/linux/CastingUtils.cpp
+++ b/examples/tv-casting-app/linux/CastingUtils.cpp
@@ -160,7 +160,7 @@ void OnCurrentStateReadResponseFailure(void * context, CHIP_ERROR err)
     ChipLogProgress(AppServer, "OnCurrentStateReadResponseFailure called with %" CHIP_ERROR_FORMAT, err.Format());
 }
 
-void OnCurrentStateSubscriptionEstablished(void * context)
+void OnCurrentStateSubscriptionEstablished(void * context, SubscriptionId aSubscriptionId)
 {
     ChipLogProgress(AppServer, "OnCurrentStateSubscriptionEstablished called");
     if (context != nullptr)

--- a/src/app/DeviceProxy.h
+++ b/src/app/DeviceProxy.h
@@ -46,8 +46,6 @@ public:
 
     virtual NodeId GetDeviceId() const = 0;
 
-    virtual void ShutdownSubscriptions() = 0;
-
     virtual CHIP_ERROR SendCommands(app::CommandSender * commandObj, chip::Optional<System::Clock::Timeout> timeout = NullOptional);
 
     virtual Messaging::ExchangeManager * GetExchangeManager() const = 0;

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -84,8 +84,6 @@ public:
     {}
     OperationalDeviceProxy() {}
 
-    // Recommended to use InteractionModelEngine::ShutdownSubscriptions directly.
-    void ShutdownSubscriptions() override { VerifyOrDie(false); } // Currently not implemented.
     void Disconnect() override
     {
         if (IsSecureConnected())

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -50,7 +50,7 @@ template <typename T>
 using ReadResponseSuccessCallback     = void (*)(void * context, T responseData);
 using ReadResponseFailureCallback     = void (*)(void * context, CHIP_ERROR err);
 using ReadDoneCallback                = void (*)(void * context);
-using SubscriptionEstablishedCallback = void (*)(void * context);
+using SubscriptionEstablishedCallback = void (*)(void * context, SubscriptionId subscriptionId);
 using ResubscriptionAttemptCallback   = void (*)(void * context, CHIP_ERROR aError, uint32_t aNextResubscribeIntervalMsec);
 using SubscriptionOnDoneCallback      = std::function<void(void)>;
 
@@ -298,10 +298,11 @@ public:
             }
         };
 
-        auto onSubscriptionEstablishedCb = [context, subscriptionEstablishedCb](const app::ReadClient & readClient) {
+        auto onSubscriptionEstablishedCb = [context, subscriptionEstablishedCb](const app::ReadClient & readClient,
+                                                                                SubscriptionId subscriptionId) {
             if (subscriptionEstablishedCb != nullptr)
             {
-                subscriptionEstablishedCb(context);
+                subscriptionEstablishedCb(context, subscriptionId);
             }
         };
 
@@ -377,10 +378,11 @@ public:
             }
         };
 
-        auto onSubscriptionEstablishedCb = [context, subscriptionEstablishedCb](const app::ReadClient & readClient) {
+        auto onSubscriptionEstablishedCb = [context, subscriptionEstablishedCb](const app::ReadClient & readClient,
+                                                                                SubscriptionId subscriptionId) {
             if (subscriptionEstablishedCb != nullptr)
             {
-                subscriptionEstablishedCb(context);
+                subscriptionEstablishedCb(context, subscriptionId);
             }
         };
 

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -133,7 +133,6 @@ public:
     bool IsSessionSetupInProgress() const { return mState == ConnectionState::Connecting; }
 
     NodeId GetDeviceId() const override { return mPeerId.GetNodeId(); }
-    void ShutdownSubscriptions() override {}
     PeerId GetPeerId() const { return mPeerId; }
     CHIP_ERROR SetPeerId(ByteSpan rcac, ByteSpan noc) override;
     const Transport::PeerAddress & GetPeerAddress() const { return mDeviceAddress; }

--- a/src/controller/TypedReadCallback.h
+++ b/src/controller/TypedReadCallback.h
@@ -52,7 +52,8 @@ public:
         std::function<void(const app::ConcreteDataAttributePath & aPath, const DecodableAttributeType & aData)>;
     using OnErrorCallbackType = std::function<void(const app::ConcreteDataAttributePath * aPath, CHIP_ERROR aError)>;
     using OnDoneCallbackType  = std::function<void(TypedReadAttributeCallback * callback)>;
-    using OnSubscriptionEstablishedCallbackType = std::function<void(const app::ReadClient & readClient)>;
+    using OnSubscriptionEstablishedCallbackType =
+        std::function<void(const app::ReadClient & readClient, SubscriptionId aSubscriptionId)>;
     using OnResubscriptionAttemptCallbackType =
         std::function<void(const app::ReadClient & readClient, CHIP_ERROR aError, uint32_t aNextResubscribeIntervalMsec)>;
     TypedReadAttributeCallback(ClusterId aClusterId, AttributeId aAttributeId, OnSuccessCallbackType aOnSuccess,
@@ -127,7 +128,7 @@ private:
     {
         if (mOnSubscriptionEstablished)
         {
-            mOnSubscriptionEstablished(*mReadClient.get());
+            mOnSubscriptionEstablished(*mReadClient.get(), aSubscriptionId);
         }
     }
 
@@ -175,7 +176,8 @@ public:
     using OnSuccessCallbackType = std::function<void(const app::EventHeader & aEventHeader, const DecodableEventType & aData)>;
     using OnErrorCallbackType   = std::function<void(const app::EventHeader * apEventHeader, CHIP_ERROR aError)>;
     using OnDoneCallbackType    = std::function<void(app::ReadClient * apReadClient)>;
-    using OnSubscriptionEstablishedCallbackType = std::function<void(const app::ReadClient & aReadClient)>;
+    using OnSubscriptionEstablishedCallbackType =
+        std::function<void(const app::ReadClient & aReadClient, SubscriptionId aSubscriptionId)>;
     using OnResubscriptionAttemptCallbackType =
         std::function<void(const app::ReadClient & aReadClient, CHIP_ERROR aError, uint32_t aNextResubscribeIntervalMsec)>;
 
@@ -260,7 +262,7 @@ private:
     {
         if (mOnSubscriptionEstablished)
         {
-            mOnSubscriptionEstablished(*mReadClient.get());
+            mOnSubscriptionEstablished(*mReadClient.get(), aSubscriptionId);
         }
     }
 

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -510,13 +510,16 @@ void ReportCallback::OnDone(app::ReadClient *)
     err = JniReferences::GetInstance().FindMethod(env, mReportCallbackRef, "onDone", "()V", &onDoneMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Could not find onDone method"));
 
+    if (mReadClient != nullptr)
+    {
+        Platform::Delete(mReadClient);
+    }
+    mReadClient = nullptr;
+
     DeviceLayer::StackUnlock unlock;
     env->CallVoidMethod(mReportCallbackRef, onDoneMethod);
     VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
     JniReferences::GetInstance().GetEnvForCurrentThread()->DeleteGlobalRef(mWrapperCallbackRef);
-
-    Platform::Delete(mReadClient);
-    mReadClient = nullptr;
 }
 
 void ReportCallback::OnSubscriptionEstablished(SubscriptionId aSubscriptionId)

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 #include "AndroidCallbacks.h"
-
 #include <controller/java/AndroidClusterExceptions.h>
 #include <controller/java/CHIPAttributeTLVValueDecoder.h>
 #include <controller/java/CHIPEventTLVValueDecoder.h>
@@ -515,11 +514,15 @@ void ReportCallback::OnDone(app::ReadClient *)
     env->CallVoidMethod(mReportCallbackRef, onDoneMethod);
     VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
     JniReferences::GetInstance().GetEnvForCurrentThread()->DeleteGlobalRef(mWrapperCallbackRef);
+
+    Platform::Delete(mReadClient);
+    mReadClient = nullptr;
 }
 
 void ReportCallback::OnSubscriptionEstablished(SubscriptionId aSubscriptionId)
 {
-    JniReferences::GetInstance().CallSubscriptionEstablished(mSubscriptionEstablishedCallbackRef);
+    DeviceLayer::StackUnlock unlock;
+    JniReferences::GetInstance().CallSubscriptionEstablished(mSubscriptionEstablishedCallbackRef, aSubscriptionId);
 }
 
 CHIP_ERROR ReportCallback::OnResubscriptionNeeded(app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause)
@@ -771,7 +774,8 @@ void ReportEventCallback::OnDone(app::ReadClient *)
 
 void ReportEventCallback::OnSubscriptionEstablished(SubscriptionId aSubscriptionId)
 {
-    JniReferences::GetInstance().CallSubscriptionEstablished(mSubscriptionEstablishedCallbackRef);
+    chip::DeviceLayer::StackUnlock unlock;
+    JniReferences::GetInstance().CallSubscriptionEstablished(mSubscriptionEstablishedCallbackRef, aSubscriptionId);
 }
 
 CHIP_ERROR ReportEventCallback::OnResubscriptionNeeded(app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause)

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -958,19 +958,52 @@ JNI_METHOD(void, releaseOperationalDevicePointer)(JNIEnv * env, jobject self, jl
     }
 }
 
-JNI_METHOD(void, shutdownSubscriptions)(JNIEnv * env, jobject self, jlong handle, jlong devicePtr)
+JNI_METHOD(jint, getFabricIndex)(JNIEnv * env, jobject self, jlong handle)
 {
     chip::DeviceLayer::StackLock lock;
 
-    DeviceProxy * device = reinterpret_cast<DeviceProxy *>(devicePtr);
+    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
 
-    //
-    // We should move away from this model of shutting down subscriptions in this manner and instead,
-    // have Java own the ReadClient objects directly and manage their lifetimes.
-    //
-    // #13163 tracks this issue.
-    //
-    device->ShutdownSubscriptions();
+    return wrapper->Controller()->GetFabricIndex();
+}
+
+JNI_METHOD(void, shutdownSubscriptions)
+(JNIEnv * env, jobject self, jobject handle, jobject fabricIndex, jobject peerNodeId, jobject subscriptionId)
+{
+    chip::DeviceLayer::StackLock lock;
+    if (fabricIndex == nullptr && peerNodeId == nullptr && subscriptionId == nullptr)
+    {
+        app::InteractionModelEngine::GetInstance()->ShutdownAllSubscriptions();
+        return;
+    }
+
+    if (fabricIndex != nullptr && peerNodeId != nullptr && subscriptionId == nullptr)
+    {
+        jint jFabricIndex = chip::JniReferences::GetInstance().IntegerToPrimitive(fabricIndex);
+        jlong jPeerNodeId = chip::JniReferences::GetInstance().LongToPrimitive(peerNodeId);
+        app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(static_cast<chip::FabricIndex>(jFabricIndex),
+                                                                          static_cast<chip::NodeId>(jPeerNodeId));
+        return;
+    }
+
+    if (fabricIndex != nullptr && peerNodeId == nullptr && subscriptionId == nullptr)
+    {
+        jint jFabricIndex = chip::JniReferences::GetInstance().IntegerToPrimitive(fabricIndex);
+        app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(static_cast<chip::FabricIndex>(jFabricIndex));
+        return;
+    }
+
+    if (fabricIndex != nullptr && peerNodeId != nullptr && subscriptionId != nullptr)
+    {
+        jint jFabricIndex     = chip::JniReferences::GetInstance().IntegerToPrimitive(fabricIndex);
+        jlong jPeerNodeId     = chip::JniReferences::GetInstance().LongToPrimitive(peerNodeId);
+        jlong jSubscriptionId = chip::JniReferences::GetInstance().LongToPrimitive(subscriptionId);
+        app::InteractionModelEngine::GetInstance()->ShutdownSubscription(
+            chip::ScopedNodeId(static_cast<chip::NodeId>(jPeerNodeId), static_cast<chip::FabricIndex>(jFabricIndex)),
+            static_cast<chip::SubscriptionId>(jSubscriptionId));
+        return;
+    }
+    ChipLogError(Controller, "Failed to shutdown subscriptions with correct input paramemeter");
 }
 
 JNI_METHOD(jstring, getIpAddress)(JNIEnv * env, jobject self, jlong handle, jlong deviceId)

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -492,10 +492,40 @@ public class ChipDeviceController {
     return getFabricIndex(deviceControllerPtr);
   }
 
-  /* Shutdown the subscriptions based upon peerNodeId, fabricIndex, and subscriptionId */
-  public void shutdownSubscriptions(
-      @Nullable Integer fabricIndex, @Nullable Long peerNodeId, @Nullable Long subscriptionId) {
-    shutdownSubscriptions(deviceControllerPtr, fabricIndex, peerNodeId, subscriptionId);
+  /* Shuts down all active subscriptions. */
+  public void shutdownSubscriptions() {
+    shutdownSubscriptions(deviceControllerPtr, null, null, null);
+  }
+
+  /* Shuts down all active subscriptions for the fabric at the given fabricIndex */
+  public void shutdownSubscriptions(int fabricIndex) {
+    shutdownSubscriptions(deviceControllerPtr, new Integer(fabricIndex), null, null);
+  }
+
+  /**
+   * Shuts down all subscriptions for a particular node.
+   *
+   * @param fabricIndex the fabric index of to which the node belongs
+   * @param peerNodeId the node ID of the device for which subscriptions should be canceled
+   */
+  public void shutdownSubscriptions(int fabricIndex, long peerNodeId) {
+    shutdownSubscriptions(
+        deviceControllerPtr, new Integer(fabricIndex), new Long(peerNodeId), null);
+  }
+
+  /**
+   * Shuts down all subscriptions for a particular node.
+   *
+   * @param fabricIndex the fabric index of to which the node belongs
+   * @param peerNodeId the node ID of the device for which subscriptions should be canceled
+   * @param subscriptionId the ID of the subscription on the node which should be canceled
+   */
+  public void shutdownSubscriptions(int fabricIndex, long peerNodeId, long subscriptionId) {
+    shutdownSubscriptions(
+        deviceControllerPtr,
+        new Integer(fabricIndex),
+        new Long(peerNodeId),
+        new Long(subscriptionId));
   }
 
   /**

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -488,9 +488,14 @@ public class ChipDeviceController {
         deviceControllerPtr, devicePtr, duration, iteration, discriminator, setupPinCode, callback);
   }
 
-  /* Shutdown all cluster attribute subscriptions for a given device */
-  public void shutdownSubscriptions(long devicePtr) {
-    shutdownSubscriptions(deviceControllerPtr, devicePtr);
+  public int getFabricIndex() {
+    return getFabricIndex(deviceControllerPtr);
+  }
+
+  /* Shutdown the subscriptions based upon peerNodeId, fabricIndex, and subscriptionId */
+  public void shutdownSubscriptions(
+      @Nullable Integer fabricIndex, @Nullable Long peerNodeId, @Nullable Long subscriptionId) {
+    shutdownSubscriptions(deviceControllerPtr, fabricIndex, peerNodeId, subscriptionId);
   }
 
   /**
@@ -833,7 +838,13 @@ public class ChipDeviceController {
 
   private native int onNOCChainGeneration(long deviceControllerPtr, ControllerParams params);
 
-  private native void shutdownSubscriptions(long deviceControllerPtr, long devicePtr);
+  private native int getFabricIndex(long deviceControllerPtr);
+
+  private native void shutdownSubscriptions(
+      long deviceControllerPtr,
+      @Nullable Integer fabricIndex,
+      @Nullable Long peerNodeId,
+      @Nullable Long subscriptionId);
 
   private native void shutdownCommissioning(long deviceControllerPtr);
 

--- a/src/controller/java/src/chip/devicecontroller/SubscriptionEstablishedCallback.java
+++ b/src/controller/java/src/chip/devicecontroller/SubscriptionEstablishedCallback.java
@@ -18,5 +18,5 @@
 package chip.devicecontroller;
 
 public interface SubscriptionEstablishedCallback {
-  void onSubscriptionEstablished();
+  void onSubscriptionEstablished(long subscriptionId);
 }

--- a/src/controller/java/templates/CHIPReadCallbacks.zapt
+++ b/src/controller/java/templates/CHIPReadCallbacks.zapt
@@ -24,8 +24,8 @@ public:
     }
 
     static void CallbackFn(void * context, {{chipCallback.type}} value);
-    static void OnSubscriptionEstablished(void * context) {
-        CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(reinterpret_cast<CHIP{{chipCallback.name}}AttributeCallback *>(context)->javaCallbackRef);
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId) {
+        CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(reinterpret_cast<CHIP{{chipCallback.name}}AttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -56,8 +56,8 @@ public:
     }
 
     static void CallbackFn(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} {{#if isArray}}list{{else}}value{{/if}});
-    static void OnSubscriptionEstablished(void * context) {
-        CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(reinterpret_cast<CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback *>(context)->javaCallbackRef);
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId) {
+        CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(reinterpret_cast<CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -21,44 +21,44 @@ public class ChipClusters {
     void onSuccess(String value);
     void onError(Exception error);
     {{! TODO: use SubscriptionEstablishedCallback instead, here and below. }}
-    default void onSubscriptionEstablished() {}
+    default void onSubscriptionEstablished(long subscriptionId) {}
   }
 
   public interface OctetStringAttributeCallback {
     /** Indicates a successful read for an OCTET_STRING attribute. */
     void onSuccess(byte[] value);
     void onError(Exception error);
-    default void onSubscriptionEstablished() {}
+    default void onSubscriptionEstablished(long subscriptionId) {}
   }
 
   public interface IntegerAttributeCallback {
     void onSuccess(int value);
     void onError(Exception error);
-    default void onSubscriptionEstablished() {}
+    default void onSubscriptionEstablished(long subscriptionId) {}
   }
 
   public interface LongAttributeCallback {
     void onSuccess(long value);
     void onError(Exception error);
-    default void onSubscriptionEstablished() {}
+    default void onSubscriptionEstablished(long subscriptionId) {}
   }
 
   public interface BooleanAttributeCallback {
     void onSuccess(boolean value);
     void onError(Exception error);
-    default void onSubscriptionEstablished() {}
+    default void onSubscriptionEstablished(long subscriptionId) {}
   }
 
   public interface FloatAttributeCallback {
     void onSuccess(float value);
     void onError(Exception error);
-    default void onSubscriptionEstablished() {}
+    default void onSubscriptionEstablished(long subscriptionId) {}
   }
 
   public interface DoubleAttributeCallback {
     void onSuccess(double value);
     void onError(Exception error);
-    default void onSubscriptionEstablished() {}
+    default void onSubscriptionEstablished(long subscriptionId) {}
   }
 
   public static abstract class BaseChipCluster {
@@ -152,13 +152,13 @@ public class ChipClusters {
       public interface {{asUpperCamelCase name}}AttributeCallback {
         void onSuccess({{#if isNullable}}@Nullable{{/if}} List<{{>asJavaTypeForEntry isArray=false}}> valueList);
         void onError(Exception ex);
-        default void onSubscriptionEstablished() {}
+        default void onSubscriptionEstablished(long subscriptionId) {}
       }
     {{else}}
       public interface {{asUpperCamelCase name}}AttributeCallback {
         void onSuccess({{#if isNullable}}@Nullable{{/if}} {{>asJavaTypeForEntry isArray=false}} value);
         void onError(Exception ex);
-        default void onSubscriptionEstablished() {}
+        default void onSubscriptionEstablished(long subscriptionId) {}
       }
     {{/if}}
   {{/if_basic_global_response}}

--- a/src/controller/java/zap-generated/CHIPReadCallbacks.h
+++ b/src/controller/java/zap-generated/CHIPReadCallbacks.h
@@ -41,10 +41,10 @@ public:
     }
 
     static void CallbackFn(void * context, bool value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBooleanAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBooleanAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -69,10 +69,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::CharSpan value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPCharStringAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPCharStringAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -97,10 +97,10 @@ public:
     }
 
     static void CallbackFn(void * context, double value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDoubleAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDoubleAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -125,10 +125,10 @@ public:
     }
 
     static void CallbackFn(void * context, float value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFloatAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFloatAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -153,10 +153,10 @@ public:
     }
 
     static void CallbackFn(void * context, int8_t value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPInt8sAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPInt8sAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -181,10 +181,10 @@ public:
     }
 
     static void CallbackFn(void * context, uint8_t value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPInt8uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPInt8uAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -209,10 +209,10 @@ public:
     }
 
     static void CallbackFn(void * context, int16_t value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPInt16sAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPInt16sAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -237,10 +237,10 @@ public:
     }
 
     static void CallbackFn(void * context, uint16_t value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPInt16uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPInt16uAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -265,10 +265,10 @@ public:
     }
 
     static void CallbackFn(void * context, int32_t value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPInt32sAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPInt32sAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -293,10 +293,10 @@ public:
     }
 
     static void CallbackFn(void * context, uint32_t value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPInt32uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPInt32uAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -321,10 +321,10 @@ public:
     }
 
     static void CallbackFn(void * context, int64_t value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPInt64sAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPInt64sAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -349,10 +349,10 @@ public:
     }
 
     static void CallbackFn(void * context, uint64_t value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPInt64uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPInt64uAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -377,10 +377,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::ByteSpan value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOctetStringAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOctetStringAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -407,10 +407,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPIdentifyGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPIdentifyGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -437,10 +437,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPIdentifyAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPIdentifyAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -466,10 +466,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPIdentifyEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPIdentifyEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -496,10 +496,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPIdentifyAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPIdentifyAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -526,10 +526,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGroupsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGroupsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -556,10 +556,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGroupsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGroupsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -585,10 +585,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGroupsEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGroupsEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -615,10 +615,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGroupsAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGroupsAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -644,10 +644,10 @@ public:
     }
 
     static void CallbackFn(void * context, chip::GroupId value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPScenesCurrentGroupAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPScenesCurrentGroupAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -674,10 +674,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPScenesGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPScenesGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -704,10 +704,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPScenesAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPScenesAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -733,10 +733,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPScenesEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPScenesEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -763,10 +763,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPScenesAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPScenesAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -793,10 +793,10 @@ public:
 
     static void CallbackFn(void * context,
                            const chip::app::DataModel::Nullable<chip::app::Clusters::OnOff::OnOffStartUpOnOff> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOnOffStartUpOnOffAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOnOffStartUpOnOffAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -823,10 +823,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOnOffGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOnOffGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -853,10 +853,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOnOffAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOnOffAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -882,10 +882,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOnOffEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOnOffEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -911,10 +911,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOnOffAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOnOffAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -941,10 +941,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOnOffSwitchConfigurationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOnOffSwitchConfigurationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -971,10 +972,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOnOffSwitchConfigurationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOnOffSwitchConfigurationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1001,10 +1003,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOnOffSwitchConfigurationEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOnOffSwitchConfigurationEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1031,10 +1033,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOnOffSwitchConfigurationAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOnOffSwitchConfigurationAttributeListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1061,10 +1064,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLevelControlCurrentLevelAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLevelControlCurrentLevelAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1091,10 +1094,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLevelControlOnLevelAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLevelControlOnLevelAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1121,10 +1124,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLevelControlOnTransitionTimeAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLevelControlOnTransitionTimeAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1151,10 +1154,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLevelControlOffTransitionTimeAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLevelControlOffTransitionTimeAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1181,10 +1184,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLevelControlDefaultMoveRateAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLevelControlDefaultMoveRateAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1211,10 +1214,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLevelControlStartUpCurrentLevelAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLevelControlStartUpCurrentLevelAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1241,10 +1244,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLevelControlGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLevelControlGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1271,10 +1274,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLevelControlAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLevelControlAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1301,10 +1304,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLevelControlEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLevelControlEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1331,10 +1334,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLevelControlAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLevelControlAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1361,10 +1364,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBinaryInputBasicGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBinaryInputBasicGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1391,10 +1395,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBinaryInputBasicAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBinaryInputBasicAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1421,10 +1425,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBinaryInputBasicEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBinaryInputBasicEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1451,10 +1455,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBinaryInputBasicAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBinaryInputBasicAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1484,10 +1488,10 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::Descriptor::Structs::DeviceTypeStruct::DecodableType> &
             list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDescriptorDeviceTypeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDescriptorDeviceTypeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1514,10 +1518,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::ClusterId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDescriptorServerListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDescriptorServerListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1544,10 +1548,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::ClusterId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDescriptorClientListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDescriptorClientListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1574,10 +1578,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EndpointId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDescriptorPartsListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDescriptorPartsListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1604,10 +1608,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDescriptorGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDescriptorGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1634,10 +1638,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDescriptorAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDescriptorAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1664,10 +1668,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDescriptorEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDescriptorEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1694,10 +1698,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDescriptorAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDescriptorAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1725,10 +1729,10 @@ public:
     static void CallbackFn(
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::Binding::Structs::TargetStruct::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBindingBindingAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBindingBindingAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1755,10 +1759,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBindingGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBindingGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1785,10 +1789,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBindingAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBindingAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1814,10 +1818,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBindingEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBindingEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1844,10 +1848,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBindingAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBindingAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1875,10 +1879,10 @@ public:
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::AccessControl::Structs::AccessControlEntryStruct::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAccessControlAclAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAccessControlAclAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1907,10 +1911,10 @@ public:
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::AccessControl::Structs::AccessControlExtensionStruct::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAccessControlExtensionAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAccessControlExtensionAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1937,10 +1941,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAccessControlGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAccessControlGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1967,10 +1971,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAccessControlAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAccessControlAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -1997,10 +2001,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAccessControlEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAccessControlEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2027,10 +2031,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAccessControlAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAccessControlAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2058,10 +2062,10 @@ public:
     static void CallbackFn(
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::Actions::Structs::ActionStruct::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPActionsActionListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPActionsActionListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2090,10 +2094,10 @@ public:
     static void CallbackFn(
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::Actions::Structs::EndpointListStruct::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPActionsEndpointListsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPActionsEndpointListsAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2120,10 +2124,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPActionsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPActionsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2150,10 +2154,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPActionsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPActionsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2179,10 +2183,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPActionsEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPActionsEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2209,10 +2213,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPActionsAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPActionsAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2239,10 +2243,10 @@ public:
     }
 
     static void CallbackFn(void * context, chip::VendorId value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBasicInformationVendorIDAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBasicInformationVendorIDAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2269,10 +2273,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBasicInformationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBasicInformationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2299,10 +2304,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBasicInformationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBasicInformationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2329,10 +2334,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBasicInformationEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBasicInformationEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2359,10 +2364,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBasicInformationAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBasicInformationAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2389,10 +2394,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOtaSoftwareUpdateProviderGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOtaSoftwareUpdateProviderGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2419,10 +2425,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOtaSoftwareUpdateProviderAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOtaSoftwareUpdateProviderAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2449,10 +2456,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOtaSoftwareUpdateProviderEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOtaSoftwareUpdateProviderEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2479,10 +2486,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOtaSoftwareUpdateProviderAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOtaSoftwareUpdateProviderAttributeListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2511,10 +2519,11 @@ public:
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOtaSoftwareUpdateRequestorDefaultOTAProvidersAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOtaSoftwareUpdateRequestorDefaultOTAProvidersAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2541,10 +2550,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOtaSoftwareUpdateRequestorUpdateStateProgressAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOtaSoftwareUpdateRequestorUpdateStateProgressAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2571,10 +2581,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOtaSoftwareUpdateRequestorGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOtaSoftwareUpdateRequestorGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2601,10 +2612,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOtaSoftwareUpdateRequestorAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOtaSoftwareUpdateRequestorAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2631,10 +2643,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOtaSoftwareUpdateRequestorEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOtaSoftwareUpdateRequestorEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2661,10 +2673,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOtaSoftwareUpdateRequestorAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOtaSoftwareUpdateRequestorAttributeListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2691,10 +2704,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CharSpan> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLocalizationConfigurationSupportedLocalesAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLocalizationConfigurationSupportedLocalesAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2721,10 +2735,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLocalizationConfigurationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLocalizationConfigurationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2751,10 +2766,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLocalizationConfigurationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLocalizationConfigurationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2781,10 +2797,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLocalizationConfigurationEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLocalizationConfigurationEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2811,10 +2827,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLocalizationConfigurationAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLocalizationConfigurationAttributeListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2843,10 +2860,11 @@ public:
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::DecodableList<chip::app::Clusters::TimeFormatLocalization::CalendarTypeEnum> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTimeFormatLocalizationSupportedCalendarTypesAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTimeFormatLocalizationSupportedCalendarTypesAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2873,10 +2891,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTimeFormatLocalizationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTimeFormatLocalizationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2903,10 +2922,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTimeFormatLocalizationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTimeFormatLocalizationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2933,10 +2953,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTimeFormatLocalizationEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTimeFormatLocalizationEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2963,10 +2983,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTimeFormatLocalizationAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTimeFormatLocalizationAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -2993,10 +3013,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitLocalizationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitLocalizationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3023,10 +3044,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitLocalizationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitLocalizationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3053,10 +3074,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitLocalizationEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitLocalizationEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3083,10 +3104,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitLocalizationAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitLocalizationAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3113,10 +3134,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<uint8_t> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceConfigurationSourcesAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceConfigurationSourcesAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3143,10 +3164,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceConfigurationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceConfigurationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3173,10 +3195,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceConfigurationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceConfigurationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3203,10 +3226,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceConfigurationEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceConfigurationEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3233,10 +3256,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceConfigurationAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceConfigurationAttributeListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3263,10 +3287,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceWiredAssessedInputVoltageAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceWiredAssessedInputVoltageAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3293,10 +3318,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceWiredAssessedInputFrequencyAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceWiredAssessedInputFrequencyAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3323,10 +3349,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceWiredAssessedCurrentAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceWiredAssessedCurrentAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3354,10 +3380,10 @@ public:
 
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<chip::app::Clusters::PowerSource::WiredFaultEnum> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceActiveWiredFaultsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceActiveWiredFaultsAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3384,10 +3410,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceBatVoltageAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceBatVoltageAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3414,10 +3440,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceBatPercentRemainingAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceBatPercentRemainingAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3444,10 +3470,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceBatTimeRemainingAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceBatTimeRemainingAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3475,10 +3501,10 @@ public:
 
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<chip::app::Clusters::PowerSource::BatFaultEnum> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceActiveBatFaultsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceActiveBatFaultsAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3505,10 +3531,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceBatTimeToFullChargeAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceBatTimeToFullChargeAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3535,10 +3561,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceBatChargingCurrentAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceBatChargingCurrentAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3566,10 +3592,10 @@ public:
 
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<chip::app::Clusters::PowerSource::BatChargeFaultEnum> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceActiveBatChargeFaultsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceActiveBatChargeFaultsAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3596,10 +3622,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3626,10 +3652,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3656,10 +3682,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3686,10 +3712,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPowerSourceAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPowerSourceAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3716,10 +3742,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGeneralCommissioningGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGeneralCommissioningGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3746,10 +3773,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGeneralCommissioningAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGeneralCommissioningAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3776,10 +3804,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGeneralCommissioningEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGeneralCommissioningEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3806,10 +3834,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGeneralCommissioningAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGeneralCommissioningAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3839,10 +3867,10 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::NetworkCommissioning::Structs::NetworkInfo::DecodableType> &
             list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPNetworkCommissioningNetworksAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPNetworkCommissioningNetworksAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3871,10 +3899,11 @@ public:
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::Nullable<chip::app::Clusters::NetworkCommissioning::NetworkCommissioningStatus> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPNetworkCommissioningLastNetworkingStatusAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPNetworkCommissioningLastNetworkingStatusAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3901,10 +3930,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<chip::ByteSpan> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPNetworkCommissioningLastNetworkIDAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPNetworkCommissioningLastNetworkIDAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3931,10 +3960,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPNetworkCommissioningLastConnectErrorValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPNetworkCommissioningLastConnectErrorValueAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3961,10 +3991,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPNetworkCommissioningGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPNetworkCommissioningGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -3991,10 +4022,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPNetworkCommissioningAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPNetworkCommissioningAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4021,10 +4053,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPNetworkCommissioningEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPNetworkCommissioningEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4051,10 +4083,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPNetworkCommissioningAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPNetworkCommissioningAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4081,10 +4113,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDiagnosticLogsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDiagnosticLogsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4111,10 +4143,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDiagnosticLogsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDiagnosticLogsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4141,10 +4173,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDiagnosticLogsEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDiagnosticLogsEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4171,10 +4203,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDiagnosticLogsAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDiagnosticLogsAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4203,10 +4235,10 @@ public:
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::GeneralDiagnostics::Structs::NetworkInterface::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4235,10 +4267,11 @@ public:
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::DecodableList<chip::app::Clusters::GeneralDiagnostics::HardwareFaultEnum> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGeneralDiagnosticsActiveHardwareFaultsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGeneralDiagnosticsActiveHardwareFaultsAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4267,10 +4300,10 @@ public:
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::DecodableList<chip::app::Clusters::GeneralDiagnostics::RadioFaultEnum> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGeneralDiagnosticsActiveRadioFaultsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGeneralDiagnosticsActiveRadioFaultsAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4299,10 +4332,11 @@ public:
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::DecodableList<chip::app::Clusters::GeneralDiagnostics::NetworkFaultEnum> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGeneralDiagnosticsActiveNetworkFaultsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGeneralDiagnosticsActiveNetworkFaultsAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4329,10 +4363,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGeneralDiagnosticsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGeneralDiagnosticsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4359,10 +4394,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGeneralDiagnosticsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGeneralDiagnosticsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4389,10 +4425,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGeneralDiagnosticsEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGeneralDiagnosticsEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4419,10 +4455,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGeneralDiagnosticsAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGeneralDiagnosticsAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4451,10 +4487,10 @@ public:
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::SoftwareDiagnostics::Structs::ThreadMetricsStruct::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPSoftwareDiagnosticsThreadMetricsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPSoftwareDiagnosticsThreadMetricsAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4481,10 +4517,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPSoftwareDiagnosticsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPSoftwareDiagnosticsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4511,10 +4548,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPSoftwareDiagnosticsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPSoftwareDiagnosticsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4541,10 +4579,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPSoftwareDiagnosticsEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPSoftwareDiagnosticsEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4571,10 +4609,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPSoftwareDiagnosticsAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPSoftwareDiagnosticsAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4601,10 +4639,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsChannelAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsChannelAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4633,10 +4671,10 @@ public:
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::Nullable<chip::app::Clusters::ThreadNetworkDiagnostics::RoutingRole> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsRoutingRoleAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsRoutingRoleAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4663,10 +4701,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<chip::CharSpan> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsNetworkNameAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsNetworkNameAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4693,10 +4731,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsPanIdAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsPanIdAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4723,10 +4761,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsExtendedPanIdAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsExtendedPanIdAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4753,10 +4792,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<chip::ByteSpan> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsMeshLocalPrefixAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsMeshLocalPrefixAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4785,10 +4825,11 @@ public:
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::ThreadNetworkDiagnostics::Structs::NeighborTable::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsNeighborTableAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsNeighborTableAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4817,10 +4858,10 @@ public:
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::ThreadNetworkDiagnostics::Structs::RouteTable::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsRouteTableAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsRouteTableAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4847,10 +4888,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsPartitionIdAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsPartitionIdAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4877,10 +4918,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsWeightingAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsWeightingAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4907,10 +4948,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsDataVersionAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsDataVersionAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4937,10 +4978,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsStableDataVersionAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsStableDataVersionAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4967,10 +5009,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsLeaderRouterIdAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsLeaderRouterIdAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -4997,10 +5040,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsActiveTimestampAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsActiveTimestampAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5027,10 +5071,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsPendingTimestampAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsPendingTimestampAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5057,10 +5102,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsDelayAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsDelayAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5087,10 +5132,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<chip::ByteSpan> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsChannelPage0MaskAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsChannelPage0MaskAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5119,10 +5165,11 @@ public:
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::DecodableList<chip::app::Clusters::ThreadNetworkDiagnostics::NetworkFault> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5149,10 +5196,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5179,10 +5227,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5209,10 +5258,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5239,10 +5288,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThreadNetworkDiagnosticsAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThreadNetworkDiagnosticsAttributeListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5269,10 +5319,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<chip::ByteSpan> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsBssidAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsBssidAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5301,10 +5351,10 @@ public:
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::Nullable<chip::app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsSecurityTypeAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsSecurityTypeAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5333,10 +5383,10 @@ public:
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::Nullable<chip::app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsWiFiVersionAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsWiFiVersionAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5363,10 +5413,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsChannelNumberAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsChannelNumberAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5393,10 +5443,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsRssiAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsRssiAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5423,10 +5473,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsBeaconLostCountAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsBeaconLostCountAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5453,10 +5504,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsBeaconRxCountAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsBeaconRxCountAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5483,10 +5534,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsPacketMulticastRxCountAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsPacketMulticastRxCountAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5513,10 +5565,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsPacketMulticastTxCountAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsPacketMulticastTxCountAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5543,10 +5596,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsPacketUnicastRxCountAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsPacketUnicastRxCountAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5573,10 +5627,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsPacketUnicastTxCountAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsPacketUnicastTxCountAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5603,10 +5658,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsCurrentMaxRateAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsCurrentMaxRateAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5633,10 +5689,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsOverrunCountAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsOverrunCountAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5663,10 +5719,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5693,10 +5750,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5723,10 +5781,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5753,10 +5811,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWiFiNetworkDiagnosticsAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWiFiNetworkDiagnosticsAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5785,10 +5843,10 @@ public:
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::Nullable<chip::app::Clusters::EthernetNetworkDiagnostics::PHYRateEnum> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPEthernetNetworkDiagnosticsPHYRateAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPEthernetNetworkDiagnosticsPHYRateAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5815,10 +5873,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<bool> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPEthernetNetworkDiagnosticsFullDuplexAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPEthernetNetworkDiagnosticsFullDuplexAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5845,10 +5904,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<bool> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPEthernetNetworkDiagnosticsCarrierDetectAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPEthernetNetworkDiagnosticsCarrierDetectAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5875,10 +5935,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPEthernetNetworkDiagnosticsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPEthernetNetworkDiagnosticsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5905,10 +5966,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPEthernetNetworkDiagnosticsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPEthernetNetworkDiagnosticsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5935,10 +5997,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPEthernetNetworkDiagnosticsEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPEthernetNetworkDiagnosticsEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5965,10 +6027,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPEthernetNetworkDiagnosticsAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPEthernetNetworkDiagnosticsAttributeListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -5995,10 +6058,11 @@ public:
     }
 
     static void CallbackFn(void * context, chip::VendorId value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBridgedDeviceBasicInformationVendorIDAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBridgedDeviceBasicInformationVendorIDAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6025,10 +6089,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBridgedDeviceBasicInformationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBridgedDeviceBasicInformationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6055,10 +6120,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBridgedDeviceBasicInformationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBridgedDeviceBasicInformationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6085,10 +6151,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBridgedDeviceBasicInformationEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBridgedDeviceBasicInformationEventListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6115,10 +6182,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBridgedDeviceBasicInformationAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBridgedDeviceBasicInformationAttributeListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6145,10 +6213,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPSwitchGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPSwitchGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6175,10 +6243,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPSwitchAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPSwitchAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6204,10 +6272,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPSwitchEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPSwitchEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6234,10 +6302,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPSwitchAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPSwitchAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6264,10 +6332,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<chip::FabricIndex> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAdministratorCommissioningAdminFabricIndexAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAdministratorCommissioningAdminFabricIndexAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6294,10 +6363,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAdministratorCommissioningAdminVendorIdAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAdministratorCommissioningAdminVendorIdAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6324,10 +6394,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAdministratorCommissioningGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAdministratorCommissioningGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6354,10 +6425,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAdministratorCommissioningAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAdministratorCommissioningAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6384,10 +6456,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAdministratorCommissioningEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAdministratorCommissioningEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6414,10 +6486,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAdministratorCommissioningAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAdministratorCommissioningAttributeListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6447,10 +6520,10 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::OperationalCredentials::Structs::NOCStruct::DecodableType> &
             list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOperationalCredentialsNOCsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOperationalCredentialsNOCsAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6479,10 +6552,10 @@ public:
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptorStruct::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOperationalCredentialsFabricsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOperationalCredentialsFabricsAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6509,10 +6582,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6539,10 +6613,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOperationalCredentialsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOperationalCredentialsGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6569,10 +6644,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOperationalCredentialsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOperationalCredentialsAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6599,10 +6675,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOperationalCredentialsEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOperationalCredentialsEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6629,10 +6705,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOperationalCredentialsAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOperationalCredentialsAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6661,10 +6737,10 @@ public:
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGroupKeyManagementGroupKeyMapAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGroupKeyManagementGroupKeyMapAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6693,10 +6769,10 @@ public:
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::GroupKeyManagement::Structs::GroupInfoMapStruct::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGroupKeyManagementGroupTableAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGroupKeyManagementGroupTableAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6723,10 +6799,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGroupKeyManagementGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGroupKeyManagementGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6753,10 +6830,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGroupKeyManagementAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGroupKeyManagementAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6783,10 +6861,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGroupKeyManagementEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGroupKeyManagementEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6813,10 +6891,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPGroupKeyManagementAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPGroupKeyManagementAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6845,10 +6923,10 @@ public:
     static void CallbackFn(
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::FixedLabel::Structs::LabelStruct::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFixedLabelLabelListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFixedLabelLabelListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6875,10 +6953,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFixedLabelGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFixedLabelGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6905,10 +6983,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFixedLabelAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFixedLabelAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6935,10 +7013,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFixedLabelEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFixedLabelEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6965,10 +7043,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFixedLabelAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFixedLabelAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -6996,10 +7074,10 @@ public:
     static void CallbackFn(
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::UserLabel::Structs::LabelStruct::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUserLabelLabelListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUserLabelLabelListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7026,10 +7104,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUserLabelGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUserLabelGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7056,10 +7134,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUserLabelAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUserLabelAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7085,10 +7163,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUserLabelEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUserLabelEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7115,10 +7193,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUserLabelAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUserLabelAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7145,10 +7223,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBooleanStateGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBooleanStateGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7175,10 +7253,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBooleanStateAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBooleanStateAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7205,10 +7283,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBooleanStateEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBooleanStateEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7235,10 +7313,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBooleanStateAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBooleanStateAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7265,10 +7343,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPModeSelectStandardNamespaceAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPModeSelectStandardNamespaceAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7298,10 +7376,10 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::ModeSelect::Structs::ModeOptionStruct::DecodableType> &
             list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPModeSelectSupportedModesAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPModeSelectSupportedModesAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7328,10 +7406,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPModeSelectStartUpModeAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPModeSelectStartUpModeAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7357,10 +7435,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPModeSelectOnModeAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPModeSelectOnModeAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7387,10 +7465,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPModeSelectGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPModeSelectGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7417,10 +7495,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPModeSelectAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPModeSelectAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7447,10 +7525,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPModeSelectEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPModeSelectEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7477,10 +7555,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPModeSelectAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPModeSelectAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7507,10 +7585,10 @@ public:
 
     static void CallbackFn(void * context,
                            const chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlLockState> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDoorLockLockStateAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDoorLockLockStateAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7537,10 +7615,10 @@ public:
 
     static void CallbackFn(void * context,
                            const chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DoorStateEnum> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDoorLockDoorStateAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDoorLockDoorStateAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7567,10 +7645,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDoorLockGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDoorLockGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7597,10 +7675,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDoorLockAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDoorLockAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7626,10 +7704,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDoorLockEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDoorLockEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7656,10 +7734,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPDoorLockAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPDoorLockAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7686,10 +7764,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWindowCoveringCurrentPositionLiftAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWindowCoveringCurrentPositionLiftAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7716,10 +7794,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWindowCoveringCurrentPositionTiltAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWindowCoveringCurrentPositionTiltAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7746,10 +7824,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<chip::Percent> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWindowCoveringCurrentPositionLiftPercentageAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWindowCoveringCurrentPositionLiftPercentageAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7776,10 +7855,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<chip::Percent> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWindowCoveringCurrentPositionTiltPercentageAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWindowCoveringCurrentPositionTiltPercentageAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7806,10 +7886,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<chip::Percent100ths> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWindowCoveringTargetPositionLiftPercent100thsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWindowCoveringTargetPositionLiftPercent100thsAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7836,10 +7917,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<chip::Percent100ths> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWindowCoveringTargetPositionTiltPercent100thsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWindowCoveringTargetPositionTiltPercent100thsAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7866,10 +7948,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<chip::Percent100ths> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWindowCoveringCurrentPositionLiftPercent100thsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWindowCoveringCurrentPositionLiftPercent100thsAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7896,10 +7979,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<chip::Percent100ths> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWindowCoveringCurrentPositionTiltPercent100thsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWindowCoveringCurrentPositionTiltPercent100thsAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7926,10 +8010,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWindowCoveringGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWindowCoveringGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7956,10 +8040,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWindowCoveringAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWindowCoveringAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -7986,10 +8070,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWindowCoveringEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWindowCoveringEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8016,10 +8100,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWindowCoveringAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWindowCoveringAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8046,10 +8130,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBarrierControlGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBarrierControlGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8076,10 +8160,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBarrierControlAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBarrierControlAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8106,10 +8190,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBarrierControlEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBarrierControlEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8136,10 +8220,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBarrierControlAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBarrierControlAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8166,10 +8250,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlMaxPressureAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlMaxPressureAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8196,10 +8281,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlMaxSpeedAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlMaxSpeedAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8226,10 +8311,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlMaxFlowAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlMaxFlowAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8256,10 +8341,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlMinConstPressureAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlMinConstPressureAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8286,10 +8372,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlMaxConstPressureAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlMaxConstPressureAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8316,10 +8403,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlMinCompPressureAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlMinCompPressureAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8346,10 +8434,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlMaxCompPressureAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlMaxCompPressureAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8376,10 +8465,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlMinConstSpeedAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlMinConstSpeedAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8406,10 +8496,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlMaxConstSpeedAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlMaxConstSpeedAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8436,10 +8527,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlMinConstFlowAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlMinConstFlowAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8466,10 +8558,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlMaxConstFlowAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlMaxConstFlowAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8496,10 +8589,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlMinConstTempAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlMinConstTempAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8526,10 +8620,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlMaxConstTempAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlMaxConstTempAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8556,10 +8651,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlCapacityAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlCapacityAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8586,10 +8681,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlSpeedAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlSpeedAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8616,10 +8711,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlLifetimeRunningHoursAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlLifetimeRunningHoursAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8646,10 +8742,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlPowerAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlPowerAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8676,10 +8772,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlLifetimeEnergyConsumedAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlLifetimeEnergyConsumedAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8706,10 +8803,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8736,10 +8834,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8766,10 +8865,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlEventListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8796,10 +8896,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPumpConfigurationAndControlAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPumpConfigurationAndControlAttributeListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8826,10 +8927,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThermostatLocalTemperatureAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThermostatLocalTemperatureAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8856,10 +8957,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThermostatGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThermostatGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8886,10 +8987,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThermostatAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThermostatAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8916,10 +9017,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThermostatEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThermostatEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8946,10 +9047,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThermostatAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThermostatAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -8976,10 +9077,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFanControlPercentSettingAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFanControlPercentSettingAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9006,10 +9107,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFanControlSpeedSettingAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFanControlSpeedSettingAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9036,10 +9137,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFanControlGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFanControlGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9066,10 +9167,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFanControlAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFanControlAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9096,10 +9197,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFanControlEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFanControlEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9126,10 +9227,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFanControlAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFanControlAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9156,11 +9257,12 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
             reinterpret_cast<CHIPThermostatUserInterfaceConfigurationGeneratedCommandListAttributeCallback *>(context)
-                ->javaCallbackRef);
+                ->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9187,11 +9289,12 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
             reinterpret_cast<CHIPThermostatUserInterfaceConfigurationAcceptedCommandListAttributeCallback *>(context)
-                ->javaCallbackRef);
+                ->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9218,10 +9321,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThermostatUserInterfaceConfigurationEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThermostatUserInterfaceConfigurationEventListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9248,10 +9352,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPThermostatUserInterfaceConfigurationAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPThermostatUserInterfaceConfigurationAttributeListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9278,10 +9383,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlNumberOfPrimariesAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlNumberOfPrimariesAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9308,10 +9413,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlPrimary1IntensityAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlPrimary1IntensityAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9338,10 +9443,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlPrimary2IntensityAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlPrimary2IntensityAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9368,10 +9473,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlPrimary3IntensityAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlPrimary3IntensityAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9398,10 +9503,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlPrimary4IntensityAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlPrimary4IntensityAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9428,10 +9533,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlPrimary5IntensityAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlPrimary5IntensityAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9458,10 +9563,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlPrimary6IntensityAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlPrimary6IntensityAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9488,10 +9593,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlColorPointRIntensityAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlColorPointRIntensityAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9518,10 +9623,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlColorPointGIntensityAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlColorPointGIntensityAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9548,10 +9653,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlColorPointBIntensityAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlColorPointBIntensityAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9578,10 +9683,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlStartUpColorTemperatureMiredsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlStartUpColorTemperatureMiredsAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9608,10 +9714,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9638,10 +9744,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9668,10 +9774,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9698,10 +9804,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPColorControlAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPColorControlAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9728,10 +9834,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBallastConfigurationIntrinsicBallastFactorAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBallastConfigurationIntrinsicBallastFactorAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9758,10 +9865,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBallastConfigurationBallastFactorAdjustmentAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBallastConfigurationBallastFactorAdjustmentAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9788,10 +9896,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBallastConfigurationLampRatedHoursAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBallastConfigurationLampRatedHoursAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9818,10 +9926,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBallastConfigurationLampBurnHoursAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBallastConfigurationLampBurnHoursAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9848,10 +9956,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBallastConfigurationLampBurnHoursTripPointAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBallastConfigurationLampBurnHoursTripPointAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9878,10 +9987,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBallastConfigurationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBallastConfigurationGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9908,10 +10018,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBallastConfigurationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBallastConfigurationAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9938,10 +10049,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBallastConfigurationEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBallastConfigurationEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9968,10 +10079,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPBallastConfigurationAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPBallastConfigurationAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -9998,10 +10109,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPIlluminanceMeasurementMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPIlluminanceMeasurementMeasuredValueAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10028,10 +10139,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPIlluminanceMeasurementMinMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPIlluminanceMeasurementMinMeasuredValueAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10058,10 +10170,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPIlluminanceMeasurementMaxMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPIlluminanceMeasurementMaxMeasuredValueAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10088,10 +10201,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPIlluminanceMeasurementLightSensorTypeAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPIlluminanceMeasurementLightSensorTypeAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10118,10 +10232,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPIlluminanceMeasurementGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPIlluminanceMeasurementGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10148,10 +10263,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPIlluminanceMeasurementAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPIlluminanceMeasurementAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10178,10 +10294,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPIlluminanceMeasurementEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPIlluminanceMeasurementEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10208,10 +10324,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPIlluminanceMeasurementAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPIlluminanceMeasurementAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10238,10 +10354,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTemperatureMeasurementMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTemperatureMeasurementMeasuredValueAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10268,10 +10384,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTemperatureMeasurementMinMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTemperatureMeasurementMinMeasuredValueAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10298,10 +10415,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTemperatureMeasurementMaxMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTemperatureMeasurementMaxMeasuredValueAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10328,10 +10446,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTemperatureMeasurementGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTemperatureMeasurementGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10358,10 +10477,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTemperatureMeasurementAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTemperatureMeasurementAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10388,10 +10508,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTemperatureMeasurementEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTemperatureMeasurementEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10418,10 +10538,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTemperatureMeasurementAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTemperatureMeasurementAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10448,10 +10568,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPressureMeasurementMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPressureMeasurementMeasuredValueAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10478,10 +10598,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPressureMeasurementMinMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPressureMeasurementMinMeasuredValueAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10508,10 +10628,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPressureMeasurementMaxMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPressureMeasurementMaxMeasuredValueAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10538,10 +10658,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPressureMeasurementScaledValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPressureMeasurementScaledValueAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10568,10 +10688,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPressureMeasurementMinScaledValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPressureMeasurementMinScaledValueAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10598,10 +10718,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPressureMeasurementMaxScaledValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPressureMeasurementMaxScaledValueAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10628,10 +10748,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPressureMeasurementGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPressureMeasurementGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10658,10 +10779,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPressureMeasurementAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPressureMeasurementAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10688,10 +10810,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPressureMeasurementEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPressureMeasurementEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10718,10 +10840,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPPressureMeasurementAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPPressureMeasurementAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10748,10 +10870,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFlowMeasurementMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFlowMeasurementMeasuredValueAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10778,10 +10900,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFlowMeasurementMinMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFlowMeasurementMinMeasuredValueAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10808,10 +10930,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFlowMeasurementMaxMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFlowMeasurementMaxMeasuredValueAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10838,10 +10960,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFlowMeasurementGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFlowMeasurementGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10868,10 +10990,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFlowMeasurementAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFlowMeasurementAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10898,10 +11020,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFlowMeasurementEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFlowMeasurementEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10928,10 +11050,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPFlowMeasurementAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPFlowMeasurementAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10958,10 +11080,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPRelativeHumidityMeasurementMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPRelativeHumidityMeasurementMeasuredValueAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -10988,10 +11111,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPRelativeHumidityMeasurementMinMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPRelativeHumidityMeasurementMinMeasuredValueAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11018,10 +11142,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPRelativeHumidityMeasurementMaxMeasuredValueAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPRelativeHumidityMeasurementMaxMeasuredValueAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11048,10 +11173,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPRelativeHumidityMeasurementGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPRelativeHumidityMeasurementGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11078,10 +11204,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPRelativeHumidityMeasurementAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPRelativeHumidityMeasurementAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11108,10 +11235,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPRelativeHumidityMeasurementEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPRelativeHumidityMeasurementEventListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11138,10 +11266,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPRelativeHumidityMeasurementAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPRelativeHumidityMeasurementAttributeListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11168,10 +11297,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOccupancySensingGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOccupancySensingGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11198,10 +11328,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOccupancySensingAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOccupancySensingAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11228,10 +11358,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOccupancySensingEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOccupancySensingEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11258,10 +11388,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPOccupancySensingAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPOccupancySensingAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11288,10 +11418,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWakeOnLanGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWakeOnLanGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11318,10 +11448,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWakeOnLanAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWakeOnLanAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11347,10 +11477,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWakeOnLanEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWakeOnLanEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11377,10 +11507,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPWakeOnLanAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPWakeOnLanAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11408,10 +11538,10 @@ public:
     static void CallbackFn(
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::Channel::Structs::ChannelInfoStruct::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPChannelChannelListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPChannelChannelListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11438,10 +11568,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPChannelGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPChannelGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11468,10 +11598,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPChannelAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPChannelAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11497,10 +11627,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPChannelEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPChannelEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11527,10 +11657,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPChannelAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPChannelAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11560,10 +11690,10 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::TargetNavigator::Structs::TargetInfoStruct::DecodableType> &
             list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTargetNavigatorTargetListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTargetNavigatorTargetListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11590,10 +11720,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTargetNavigatorGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTargetNavigatorGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11620,10 +11750,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTargetNavigatorAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTargetNavigatorAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11650,10 +11780,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTargetNavigatorEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTargetNavigatorEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11680,10 +11810,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPTargetNavigatorAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPTargetNavigatorAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11710,10 +11840,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPMediaPlaybackStartTimeAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPMediaPlaybackStartTimeAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11740,10 +11870,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPMediaPlaybackDurationAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPMediaPlaybackDurationAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11770,10 +11900,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPMediaPlaybackSeekRangeEndAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPMediaPlaybackSeekRangeEndAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11800,10 +11930,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPMediaPlaybackSeekRangeStartAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPMediaPlaybackSeekRangeStartAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11830,10 +11960,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPMediaPlaybackGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPMediaPlaybackGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11860,10 +11990,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPMediaPlaybackAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPMediaPlaybackAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11890,10 +12020,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPMediaPlaybackEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPMediaPlaybackEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11920,10 +12050,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPMediaPlaybackAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPMediaPlaybackAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11952,10 +12082,10 @@ public:
     static void CallbackFn(
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::MediaInput::Structs::InputInfoStruct::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPMediaInputInputListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPMediaInputInputListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -11982,10 +12112,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPMediaInputGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPMediaInputGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12012,10 +12142,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPMediaInputAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPMediaInputAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12042,10 +12172,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPMediaInputEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPMediaInputEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12072,10 +12202,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPMediaInputAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPMediaInputAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12102,10 +12232,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLowPowerGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLowPowerGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12132,10 +12262,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLowPowerAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLowPowerAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12161,10 +12291,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLowPowerEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLowPowerEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12191,10 +12321,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPLowPowerAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPLowPowerAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12221,10 +12351,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPKeypadInputGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPKeypadInputGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12251,10 +12381,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPKeypadInputAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPKeypadInputAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12281,10 +12411,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPKeypadInputEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPKeypadInputEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12311,10 +12441,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPKeypadInputAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPKeypadInputAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12341,10 +12471,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CharSpan> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPContentLauncherAcceptHeaderAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPContentLauncherAcceptHeaderAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12371,10 +12501,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPContentLauncherGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPContentLauncherGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12401,10 +12531,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPContentLauncherAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPContentLauncherAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12431,10 +12561,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPContentLauncherEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPContentLauncherEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12461,10 +12591,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPContentLauncherAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPContentLauncherAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12494,10 +12624,10 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::AudioOutput::Structs::OutputInfoStruct::DecodableType> &
             list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAudioOutputOutputListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAudioOutputOutputListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12524,10 +12654,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAudioOutputGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAudioOutputGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12554,10 +12684,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAudioOutputAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAudioOutputAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12584,10 +12714,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAudioOutputEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAudioOutputEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12614,10 +12744,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAudioOutputAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAudioOutputAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12644,10 +12774,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<uint16_t> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPApplicationLauncherCatalogListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPApplicationLauncherCatalogListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12674,10 +12804,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPApplicationLauncherGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPApplicationLauncherGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12704,10 +12835,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPApplicationLauncherAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPApplicationLauncherAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12734,10 +12866,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPApplicationLauncherEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPApplicationLauncherEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12764,10 +12896,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPApplicationLauncherAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPApplicationLauncherAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12794,10 +12926,10 @@ public:
     }
 
     static void CallbackFn(void * context, chip::VendorId value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPApplicationBasicVendorIDAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPApplicationBasicVendorIDAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12824,10 +12956,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::VendorId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPApplicationBasicAllowedVendorListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPApplicationBasicAllowedVendorListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12854,10 +12986,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPApplicationBasicGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPApplicationBasicGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12884,10 +13017,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPApplicationBasicAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPApplicationBasicAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12914,10 +13047,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPApplicationBasicEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPApplicationBasicEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12944,10 +13077,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPApplicationBasicAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPApplicationBasicAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -12974,10 +13107,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAccountLoginGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAccountLoginGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13004,10 +13137,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAccountLoginAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAccountLoginAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13034,10 +13167,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAccountLoginEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAccountLoginEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13064,10 +13197,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPAccountLoginAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPAccountLoginAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13094,10 +13227,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPElectricalMeasurementGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPElectricalMeasurementGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13124,10 +13258,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPElectricalMeasurementAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPElectricalMeasurementAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13154,10 +13289,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPElectricalMeasurementEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPElectricalMeasurementEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13184,10 +13319,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPElectricalMeasurementAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPElectricalMeasurementAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13216,10 +13351,10 @@ public:
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::ClientMonitoring::Structs::MonitoringRegistration::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPClientMonitoringExpectedClientsAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPClientMonitoringExpectedClientsAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13246,10 +13381,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPClientMonitoringGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPClientMonitoringGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13276,10 +13412,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPClientMonitoringAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPClientMonitoringAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13306,10 +13442,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPClientMonitoringEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPClientMonitoringEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13336,10 +13472,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPClientMonitoringAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPClientMonitoringAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13366,10 +13502,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<uint8_t> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingListInt8uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingListInt8uAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13396,10 +13532,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingListOctetStringAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingListOctetStringAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13429,10 +13565,10 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::UnitTesting::Structs::TestListStructOctet::DecodableType> &
             list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingListStructOctetStringAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingListStructOctetStringAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13459,10 +13595,10 @@ public:
     }
 
     static void CallbackFn(void * context, chip::VendorId value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingVendorIdAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingVendorIdAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13491,10 +13627,11 @@ public:
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::UnitTesting::Structs::NullablesAndOptionalsStruct::DecodableType> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingListNullablesAndOptionalsStructAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingListNullablesAndOptionalsStructAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13521,10 +13658,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingListLongOctetStringAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingListLongOctetStringAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13554,10 +13691,10 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::UnitTesting::Structs::TestFabricScoped::DecodableType> &
             list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingListFabricScopedAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingListFabricScopedAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13584,10 +13721,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<bool> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableBooleanAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableBooleanAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13616,10 +13753,10 @@ public:
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::Nullable<chip::BitMask<chip::app::Clusters::UnitTesting::Bitmap8MaskMap>> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableBitmap8AttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableBitmap8AttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13648,10 +13785,10 @@ public:
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::Nullable<chip::BitMask<chip::app::Clusters::UnitTesting::Bitmap16MaskMap>> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableBitmap16AttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableBitmap16AttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13680,10 +13817,10 @@ public:
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::Nullable<chip::BitMask<chip::app::Clusters::UnitTesting::Bitmap32MaskMap>> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableBitmap32AttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableBitmap32AttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13712,10 +13849,10 @@ public:
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::Nullable<chip::BitMask<chip::app::Clusters::UnitTesting::Bitmap64MaskMap>> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableBitmap64AttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableBitmap64AttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13742,10 +13879,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt8uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt8uAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13772,10 +13909,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt16uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt16uAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13802,10 +13939,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt24uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt24uAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13832,10 +13969,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt32uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt32uAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13862,10 +13999,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt40uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt40uAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13892,10 +14029,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt48uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt48uAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13922,10 +14059,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt56uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt56uAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13952,10 +14089,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt64uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt64uAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -13982,10 +14119,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt8sAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt8sAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14012,10 +14149,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt16sAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt16sAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14042,10 +14179,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt24sAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt24sAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14072,10 +14209,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int32_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt32sAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt32sAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14102,10 +14239,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt40sAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt40sAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14132,10 +14269,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt48sAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt48sAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14162,10 +14299,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt56sAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt56sAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14192,10 +14329,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int64_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableInt64sAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableInt64sAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14222,10 +14359,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableEnum8AttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableEnum8AttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14252,10 +14389,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableEnum16AttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableEnum16AttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14282,10 +14419,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<float> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableFloatSingleAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableFloatSingleAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14312,10 +14449,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<double> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableFloatDoubleAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableFloatDoubleAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14342,10 +14479,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<chip::ByteSpan> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableOctetStringAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableOctetStringAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14372,10 +14509,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<chip::CharSpan> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableCharStringAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableCharStringAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14403,10 +14540,10 @@ public:
 
     static void CallbackFn(void * context,
                            const chip::app::DataModel::Nullable<chip::app::Clusters::UnitTesting::SimpleEnum> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableEnumAttrAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableEnumAttrAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14433,10 +14570,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableRangeRestrictedInt8uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableRangeRestrictedInt8uAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14463,10 +14601,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int8_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableRangeRestrictedInt8sAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableRangeRestrictedInt8sAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14493,10 +14632,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableRangeRestrictedInt16uAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableRangeRestrictedInt16uAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14523,10 +14663,11 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::Nullable<int16_t> & value);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingNullableRangeRestrictedInt16sAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingNullableRangeRestrictedInt16sAttributeCallback *>(context)->javaCallbackRef,
+            subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14553,10 +14694,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingGeneratedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14583,10 +14724,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingAcceptedCommandListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14613,10 +14754,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EventId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingEventListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingEventListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 
@@ -14643,10 +14784,10 @@ public:
     }
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & list);
-    static void OnSubscriptionEstablished(void * context)
+    static void OnSubscriptionEstablished(void * context, chip::SubscriptionId subscriptionId)
     {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
-            reinterpret_cast<CHIPUnitTestingAttributeListAttributeCallback *>(context)->javaCallbackRef);
+            reinterpret_cast<CHIPUnitTestingAttributeListAttributeCallback *>(context)->javaCallbackRef, subscriptionId);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
     };
 

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -38,7 +38,7 @@ public class ChipClusters {
 
     void onError(Exception error);
 
-    default void onSubscriptionEstablished() {}
+    default void onSubscriptionEstablished(long subscriptionId) {}
   }
 
   public interface OctetStringAttributeCallback {
@@ -47,7 +47,7 @@ public class ChipClusters {
 
     void onError(Exception error);
 
-    default void onSubscriptionEstablished() {}
+    default void onSubscriptionEstablished(long subscriptionId) {}
   }
 
   public interface IntegerAttributeCallback {
@@ -55,7 +55,7 @@ public class ChipClusters {
 
     void onError(Exception error);
 
-    default void onSubscriptionEstablished() {}
+    default void onSubscriptionEstablished(long subscriptionId) {}
   }
 
   public interface LongAttributeCallback {
@@ -63,7 +63,7 @@ public class ChipClusters {
 
     void onError(Exception error);
 
-    default void onSubscriptionEstablished() {}
+    default void onSubscriptionEstablished(long subscriptionId) {}
   }
 
   public interface BooleanAttributeCallback {
@@ -71,7 +71,7 @@ public class ChipClusters {
 
     void onError(Exception error);
 
-    default void onSubscriptionEstablished() {}
+    default void onSubscriptionEstablished(long subscriptionId) {}
   }
 
   public interface FloatAttributeCallback {
@@ -79,7 +79,7 @@ public class ChipClusters {
 
     void onError(Exception error);
 
-    default void onSubscriptionEstablished() {}
+    default void onSubscriptionEstablished(long subscriptionId) {}
   }
 
   public interface DoubleAttributeCallback {
@@ -87,7 +87,7 @@ public class ChipClusters {
 
     void onError(Exception error);
 
-    default void onSubscriptionEstablished() {}
+    default void onSubscriptionEstablished(long subscriptionId) {}
   }
 
   public abstract static class BaseChipCluster {
@@ -182,7 +182,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -190,7 +190,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -198,7 +198,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -206,7 +206,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readIdentifyTimeAttribute(IntegerAttributeCallback callback) {
@@ -494,7 +494,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -502,7 +502,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -510,7 +510,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -518,7 +518,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readNameSupportAttribute(IntegerAttributeCallback callback) {
@@ -857,7 +857,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -865,7 +865,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -873,7 +873,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -881,7 +881,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -889,7 +889,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readSceneCountAttribute(IntegerAttributeCallback callback) {
@@ -1188,7 +1188,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -1196,7 +1196,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -1204,7 +1204,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -1212,7 +1212,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -1220,7 +1220,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readOnOffAttribute(BooleanAttributeCallback callback) {
@@ -1459,7 +1459,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -1467,7 +1467,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -1475,7 +1475,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -1483,7 +1483,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readSwitchTypeAttribute(IntegerAttributeCallback callback) {
@@ -1922,7 +1922,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface OnLevelAttributeCallback {
@@ -1930,7 +1930,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface OnTransitionTimeAttributeCallback {
@@ -1938,7 +1938,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface OffTransitionTimeAttributeCallback {
@@ -1946,7 +1946,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface DefaultMoveRateAttributeCallback {
@@ -1954,7 +1954,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface StartUpCurrentLevelAttributeCallback {
@@ -1962,7 +1962,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -1970,7 +1970,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -1978,7 +1978,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -1986,7 +1986,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -1994,7 +1994,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readCurrentLevelAttribute(CurrentLevelAttributeCallback callback) {
@@ -2442,7 +2442,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -2450,7 +2450,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -2458,7 +2458,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -2466,7 +2466,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readOutOfServiceAttribute(BooleanAttributeCallback callback) {
@@ -2659,7 +2659,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ServerListAttributeCallback {
@@ -2667,7 +2667,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ClientListAttributeCallback {
@@ -2675,7 +2675,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface PartsListAttributeCallback {
@@ -2683,7 +2683,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -2691,7 +2691,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -2699,7 +2699,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -2707,7 +2707,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -2715,7 +2715,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readDeviceTypeListAttribute(DeviceTypeListAttributeCallback callback) {
@@ -2902,7 +2902,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -2910,7 +2910,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -2918,7 +2918,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -2926,7 +2926,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -2934,7 +2934,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readBindingAttribute(BindingAttributeCallback callback) {
@@ -3085,7 +3085,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ExtensionAttributeCallback {
@@ -3093,7 +3093,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -3101,7 +3101,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -3109,7 +3109,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -3117,7 +3117,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -3125,7 +3125,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readAclAttribute(AclAttributeCallback callback) {
@@ -3617,7 +3617,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EndpointListsAttributeCallback {
@@ -3625,7 +3625,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -3633,7 +3633,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -3641,7 +3641,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -3649,7 +3649,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -3657,7 +3657,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readActionListAttribute(ActionListAttributeCallback callback) {
@@ -3829,7 +3829,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -3837,7 +3837,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -3845,7 +3845,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -3853,7 +3853,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -3861,7 +3861,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readDataModelRevisionAttribute(IntegerAttributeCallback callback) {
@@ -4468,7 +4468,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -4476,7 +4476,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -4484,7 +4484,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -4492,7 +4492,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readGeneratedCommandListAttribute(GeneratedCommandListAttributeCallback callback) {
@@ -4657,7 +4657,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface UpdateStateProgressAttributeCallback {
@@ -4665,7 +4665,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -4673,7 +4673,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -4681,7 +4681,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -4689,7 +4689,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -4697,7 +4697,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readDefaultOTAProvidersAttribute(DefaultOTAProvidersAttributeCallback callback) {
@@ -4900,7 +4900,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -4908,7 +4908,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -4916,7 +4916,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -4924,7 +4924,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -4932,7 +4932,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readActiveLocaleAttribute(CharStringAttributeCallback callback) {
@@ -5101,7 +5101,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -5109,7 +5109,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -5117,7 +5117,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -5125,7 +5125,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -5133,7 +5133,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readHourFormatAttribute(IntegerAttributeCallback callback) {
@@ -5330,7 +5330,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -5338,7 +5338,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -5346,7 +5346,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -5354,7 +5354,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readTemperatureUnitAttribute(IntegerAttributeCallback callback) {
@@ -5502,7 +5502,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -5510,7 +5510,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -5518,7 +5518,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -5526,7 +5526,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -5534,7 +5534,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readSourcesAttribute(SourcesAttributeCallback callback) {
@@ -5667,7 +5667,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface WiredAssessedInputFrequencyAttributeCallback {
@@ -5675,7 +5675,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface WiredAssessedCurrentAttributeCallback {
@@ -5683,7 +5683,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ActiveWiredFaultsAttributeCallback {
@@ -5691,7 +5691,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface BatVoltageAttributeCallback {
@@ -5699,7 +5699,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface BatPercentRemainingAttributeCallback {
@@ -5707,7 +5707,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface BatTimeRemainingAttributeCallback {
@@ -5715,7 +5715,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ActiveBatFaultsAttributeCallback {
@@ -5723,7 +5723,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface BatTimeToFullChargeAttributeCallback {
@@ -5731,7 +5731,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface BatChargingCurrentAttributeCallback {
@@ -5739,7 +5739,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ActiveBatChargeFaultsAttributeCallback {
@@ -5747,7 +5747,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -5755,7 +5755,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -5763,7 +5763,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -5771,7 +5771,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -5779,7 +5779,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readStatusAttribute(IntegerAttributeCallback callback) {
@@ -6497,7 +6497,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -6505,7 +6505,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -6513,7 +6513,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -6521,7 +6521,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readBreadcrumbAttribute(LongAttributeCallback callback) {
@@ -6878,7 +6878,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface LastNetworkingStatusAttributeCallback {
@@ -6886,7 +6886,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface LastNetworkIDAttributeCallback {
@@ -6894,7 +6894,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface LastConnectErrorValueAttributeCallback {
@@ -6902,7 +6902,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -6910,7 +6910,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -6918,7 +6918,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -6926,7 +6926,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -6934,7 +6934,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readMaxNetworksAttribute(IntegerAttributeCallback callback) {
@@ -7239,7 +7239,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -7247,7 +7247,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -7255,7 +7255,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -7263,7 +7263,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readGeneratedCommandListAttribute(GeneratedCommandListAttributeCallback callback) {
@@ -7401,7 +7401,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ActiveHardwareFaultsAttributeCallback {
@@ -7409,7 +7409,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ActiveRadioFaultsAttributeCallback {
@@ -7417,7 +7417,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ActiveNetworkFaultsAttributeCallback {
@@ -7425,7 +7425,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -7433,7 +7433,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -7441,7 +7441,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -7449,7 +7449,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -7457,7 +7457,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readNetworkInterfacesAttribute(NetworkInterfacesAttributeCallback callback) {
@@ -7736,7 +7736,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -7744,7 +7744,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -7752,7 +7752,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -7760,7 +7760,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -7768,7 +7768,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readThreadMetricsAttribute(ThreadMetricsAttributeCallback callback) {
@@ -7964,7 +7964,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface RoutingRoleAttributeCallback {
@@ -7972,7 +7972,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NetworkNameAttributeCallback {
@@ -7980,7 +7980,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface PanIdAttributeCallback {
@@ -7988,7 +7988,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ExtendedPanIdAttributeCallback {
@@ -7996,7 +7996,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MeshLocalPrefixAttributeCallback {
@@ -8004,7 +8004,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NeighborTableAttributeCallback {
@@ -8012,7 +8012,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface RouteTableAttributeCallback {
@@ -8020,7 +8020,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface PartitionIdAttributeCallback {
@@ -8028,7 +8028,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface WeightingAttributeCallback {
@@ -8036,7 +8036,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface DataVersionAttributeCallback {
@@ -8044,7 +8044,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface StableDataVersionAttributeCallback {
@@ -8052,7 +8052,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface LeaderRouterIdAttributeCallback {
@@ -8060,7 +8060,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ActiveTimestampAttributeCallback {
@@ -8068,7 +8068,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface PendingTimestampAttributeCallback {
@@ -8076,7 +8076,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface DelayAttributeCallback {
@@ -8084,7 +8084,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ChannelPage0MaskAttributeCallback {
@@ -8092,7 +8092,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ActiveNetworkFaultsListAttributeCallback {
@@ -8100,7 +8100,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -8108,7 +8108,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -8116,7 +8116,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -8124,7 +8124,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -8132,7 +8132,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readChannelAttribute(ChannelAttributeCallback callback) {
@@ -9225,7 +9225,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface SecurityTypeAttributeCallback {
@@ -9233,7 +9233,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface WiFiVersionAttributeCallback {
@@ -9241,7 +9241,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ChannelNumberAttributeCallback {
@@ -9249,7 +9249,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface RssiAttributeCallback {
@@ -9257,7 +9257,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface BeaconLostCountAttributeCallback {
@@ -9265,7 +9265,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface BeaconRxCountAttributeCallback {
@@ -9273,7 +9273,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface PacketMulticastRxCountAttributeCallback {
@@ -9281,7 +9281,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface PacketMulticastTxCountAttributeCallback {
@@ -9289,7 +9289,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface PacketUnicastRxCountAttributeCallback {
@@ -9297,7 +9297,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface PacketUnicastTxCountAttributeCallback {
@@ -9305,7 +9305,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface CurrentMaxRateAttributeCallback {
@@ -9313,7 +9313,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface OverrunCountAttributeCallback {
@@ -9321,7 +9321,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -9329,7 +9329,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -9337,7 +9337,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -9345,7 +9345,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -9353,7 +9353,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readBssidAttribute(BssidAttributeCallback callback) {
@@ -9713,7 +9713,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface FullDuplexAttributeCallback {
@@ -9721,7 +9721,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface CarrierDetectAttributeCallback {
@@ -9729,7 +9729,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -9737,7 +9737,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -9745,7 +9745,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -9753,7 +9753,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -9761,7 +9761,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readPHYRateAttribute(PHYRateAttributeCallback callback) {
@@ -10020,7 +10020,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -10028,7 +10028,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -10036,7 +10036,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -10044,7 +10044,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -10052,7 +10052,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readVendorNameAttribute(CharStringAttributeCallback callback) {
@@ -10443,7 +10443,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -10451,7 +10451,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -10459,7 +10459,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -10467,7 +10467,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readNumberOfPositionsAttribute(IntegerAttributeCallback callback) {
@@ -10681,7 +10681,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AdminVendorIdAttributeCallback {
@@ -10689,7 +10689,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -10697,7 +10697,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -10705,7 +10705,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -10713,7 +10713,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -10721,7 +10721,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readWindowStatusAttribute(IntegerAttributeCallback callback) {
@@ -11080,7 +11080,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface FabricsAttributeCallback {
@@ -11089,7 +11089,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface TrustedRootCertificatesAttributeCallback {
@@ -11097,7 +11097,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -11105,7 +11105,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -11113,7 +11113,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -11121,7 +11121,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -11129,7 +11129,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readNOCsAttribute(NOCsAttributeCallback callback) {
@@ -11419,7 +11419,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GroupTableAttributeCallback {
@@ -11427,7 +11427,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -11435,7 +11435,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -11443,7 +11443,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -11451,7 +11451,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -11459,7 +11459,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readGroupKeyMapAttribute(GroupKeyMapAttributeCallback callback) {
@@ -11662,7 +11662,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -11670,7 +11670,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -11678,7 +11678,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -11686,7 +11686,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -11694,7 +11694,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readLabelListAttribute(LabelListAttributeCallback callback) {
@@ -11827,7 +11827,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -11835,7 +11835,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -11843,7 +11843,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -11851,7 +11851,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -11859,7 +11859,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readLabelListAttribute(LabelListAttributeCallback callback) {
@@ -12010,7 +12010,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -12018,7 +12018,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -12026,7 +12026,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -12034,7 +12034,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readStateValueAttribute(BooleanAttributeCallback callback) {
@@ -12182,7 +12182,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface SupportedModesAttributeCallback {
@@ -12190,7 +12190,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface StartUpModeAttributeCallback {
@@ -12198,7 +12198,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface OnModeAttributeCallback {
@@ -12206,7 +12206,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -12214,7 +12214,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -12222,7 +12222,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -12230,7 +12230,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -12238,7 +12238,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readDescriptionAttribute(CharStringAttributeCallback callback) {
@@ -12967,7 +12967,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface DoorStateAttributeCallback {
@@ -12975,7 +12975,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -12983,7 +12983,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -12991,7 +12991,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -12999,7 +12999,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -13007,7 +13007,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readLockStateAttribute(LockStateAttributeCallback callback) {
@@ -13751,7 +13751,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface CurrentPositionTiltAttributeCallback {
@@ -13759,7 +13759,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface CurrentPositionLiftPercentageAttributeCallback {
@@ -13767,7 +13767,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface CurrentPositionTiltPercentageAttributeCallback {
@@ -13775,7 +13775,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface TargetPositionLiftPercent100thsAttributeCallback {
@@ -13783,7 +13783,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface TargetPositionTiltPercent100thsAttributeCallback {
@@ -13791,7 +13791,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface CurrentPositionLiftPercent100thsAttributeCallback {
@@ -13799,7 +13799,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface CurrentPositionTiltPercent100thsAttributeCallback {
@@ -13807,7 +13807,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -13815,7 +13815,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -13823,7 +13823,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -13831,7 +13831,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -13839,7 +13839,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readTypeAttribute(IntegerAttributeCallback callback) {
@@ -14375,7 +14375,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -14383,7 +14383,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -14391,7 +14391,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -14399,7 +14399,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readBarrierMovingStateAttribute(IntegerAttributeCallback callback) {
@@ -14577,7 +14577,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MaxSpeedAttributeCallback {
@@ -14585,7 +14585,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MaxFlowAttributeCallback {
@@ -14593,7 +14593,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MinConstPressureAttributeCallback {
@@ -14601,7 +14601,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MaxConstPressureAttributeCallback {
@@ -14609,7 +14609,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MinCompPressureAttributeCallback {
@@ -14617,7 +14617,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MaxCompPressureAttributeCallback {
@@ -14625,7 +14625,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MinConstSpeedAttributeCallback {
@@ -14633,7 +14633,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MaxConstSpeedAttributeCallback {
@@ -14641,7 +14641,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MinConstFlowAttributeCallback {
@@ -14649,7 +14649,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MaxConstFlowAttributeCallback {
@@ -14657,7 +14657,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MinConstTempAttributeCallback {
@@ -14665,7 +14665,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MaxConstTempAttributeCallback {
@@ -14673,7 +14673,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface CapacityAttributeCallback {
@@ -14681,7 +14681,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface SpeedAttributeCallback {
@@ -14689,7 +14689,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface LifetimeRunningHoursAttributeCallback {
@@ -14697,7 +14697,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface PowerAttributeCallback {
@@ -14705,7 +14705,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface LifetimeEnergyConsumedAttributeCallback {
@@ -14713,7 +14713,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -14721,7 +14721,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -14729,7 +14729,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -14737,7 +14737,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -14745,7 +14745,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readMaxPressureAttribute(MaxPressureAttributeCallback callback) {
@@ -15408,7 +15408,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -15416,7 +15416,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -15424,7 +15424,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -15432,7 +15432,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -15440,7 +15440,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readLocalTemperatureAttribute(LocalTemperatureAttributeCallback callback) {
@@ -15958,7 +15958,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface SpeedSettingAttributeCallback {
@@ -15966,7 +15966,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -15974,7 +15974,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -15982,7 +15982,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -15990,7 +15990,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -15998,7 +15998,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readFanModeAttribute(IntegerAttributeCallback callback) {
@@ -16377,7 +16377,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -16385,7 +16385,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -16393,7 +16393,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -16401,7 +16401,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readTemperatureDisplayModeAttribute(IntegerAttributeCallback callback) {
@@ -17440,7 +17440,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface Primary1IntensityAttributeCallback {
@@ -17448,7 +17448,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface Primary2IntensityAttributeCallback {
@@ -17456,7 +17456,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface Primary3IntensityAttributeCallback {
@@ -17464,7 +17464,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface Primary4IntensityAttributeCallback {
@@ -17472,7 +17472,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface Primary5IntensityAttributeCallback {
@@ -17480,7 +17480,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface Primary6IntensityAttributeCallback {
@@ -17488,7 +17488,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ColorPointRIntensityAttributeCallback {
@@ -17496,7 +17496,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ColorPointGIntensityAttributeCallback {
@@ -17504,7 +17504,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ColorPointBIntensityAttributeCallback {
@@ -17512,7 +17512,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface StartUpColorTemperatureMiredsAttributeCallback {
@@ -17520,7 +17520,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -17528,7 +17528,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -17536,7 +17536,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -17544,7 +17544,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -17552,7 +17552,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readCurrentHueAttribute(IntegerAttributeCallback callback) {
@@ -18690,7 +18690,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface BallastFactorAdjustmentAttributeCallback {
@@ -18698,7 +18698,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface LampRatedHoursAttributeCallback {
@@ -18706,7 +18706,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface LampBurnHoursAttributeCallback {
@@ -18714,7 +18714,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface LampBurnHoursTripPointAttributeCallback {
@@ -18722,7 +18722,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -18730,7 +18730,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -18738,7 +18738,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -18746,7 +18746,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -18754,7 +18754,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readPhysicalMinLevelAttribute(IntegerAttributeCallback callback) {
@@ -19258,7 +19258,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MinMeasuredValueAttributeCallback {
@@ -19266,7 +19266,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MaxMeasuredValueAttributeCallback {
@@ -19274,7 +19274,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface LightSensorTypeAttributeCallback {
@@ -19282,7 +19282,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -19290,7 +19290,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -19298,7 +19298,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -19306,7 +19306,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -19314,7 +19314,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readMeasuredValueAttribute(MeasuredValueAttributeCallback callback) {
@@ -19519,7 +19519,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MinMeasuredValueAttributeCallback {
@@ -19527,7 +19527,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MaxMeasuredValueAttributeCallback {
@@ -19535,7 +19535,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -19543,7 +19543,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -19551,7 +19551,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -19559,7 +19559,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -19567,7 +19567,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readMeasuredValueAttribute(MeasuredValueAttributeCallback callback) {
@@ -19754,7 +19754,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MinMeasuredValueAttributeCallback {
@@ -19762,7 +19762,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MaxMeasuredValueAttributeCallback {
@@ -19770,7 +19770,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ScaledValueAttributeCallback {
@@ -19778,7 +19778,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MinScaledValueAttributeCallback {
@@ -19786,7 +19786,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MaxScaledValueAttributeCallback {
@@ -19794,7 +19794,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -19802,7 +19802,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -19810,7 +19810,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -19818,7 +19818,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -19826,7 +19826,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readMeasuredValueAttribute(MeasuredValueAttributeCallback callback) {
@@ -20096,7 +20096,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MinMeasuredValueAttributeCallback {
@@ -20104,7 +20104,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MaxMeasuredValueAttributeCallback {
@@ -20112,7 +20112,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -20120,7 +20120,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -20128,7 +20128,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -20136,7 +20136,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -20144,7 +20144,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readMeasuredValueAttribute(MeasuredValueAttributeCallback callback) {
@@ -20331,7 +20331,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MinMeasuredValueAttributeCallback {
@@ -20339,7 +20339,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface MaxMeasuredValueAttributeCallback {
@@ -20347,7 +20347,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -20355,7 +20355,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -20363,7 +20363,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -20371,7 +20371,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -20379,7 +20379,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readMeasuredValueAttribute(MeasuredValueAttributeCallback callback) {
@@ -20566,7 +20566,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -20574,7 +20574,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -20582,7 +20582,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -20590,7 +20590,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readOccupancyAttribute(IntegerAttributeCallback callback) {
@@ -20754,7 +20754,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -20762,7 +20762,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -20770,7 +20770,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -20778,7 +20778,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readMACAddressAttribute(CharStringAttributeCallback callback) {
@@ -20971,7 +20971,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -20979,7 +20979,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -20987,7 +20987,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -20995,7 +20995,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -21003,7 +21003,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readChannelListAttribute(ChannelListAttributeCallback callback) {
@@ -21165,7 +21165,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -21173,7 +21173,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -21181,7 +21181,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -21189,7 +21189,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -21197,7 +21197,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readTargetListAttribute(TargetListAttributeCallback callback) {
@@ -21514,7 +21514,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface DurationAttributeCallback {
@@ -21522,7 +21522,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface SeekRangeEndAttributeCallback {
@@ -21530,7 +21530,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface SeekRangeStartAttributeCallback {
@@ -21538,7 +21538,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -21546,7 +21546,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -21554,7 +21554,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -21562,7 +21562,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -21570,7 +21570,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readCurrentStateAttribute(IntegerAttributeCallback callback) {
@@ -21843,7 +21843,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -21851,7 +21851,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -21859,7 +21859,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -21867,7 +21867,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -21875,7 +21875,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readInputListAttribute(InputListAttributeCallback callback) {
@@ -22037,7 +22037,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -22045,7 +22045,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -22053,7 +22053,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -22061,7 +22061,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readGeneratedCommandListAttribute(GeneratedCommandListAttributeCallback callback) {
@@ -22200,7 +22200,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -22208,7 +22208,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -22216,7 +22216,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -22224,7 +22224,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readGeneratedCommandListAttribute(GeneratedCommandListAttributeCallback callback) {
@@ -22404,7 +22404,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -22412,7 +22412,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -22420,7 +22420,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -22428,7 +22428,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -22436,7 +22436,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readAcceptHeaderAttribute(AcceptHeaderAttributeCallback callback) {
@@ -22636,7 +22636,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -22644,7 +22644,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -22652,7 +22652,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -22660,7 +22660,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -22668,7 +22668,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readOutputListAttribute(OutputListAttributeCallback callback) {
@@ -22885,7 +22885,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -22893,7 +22893,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -22901,7 +22901,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -22909,7 +22909,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -22917,7 +22917,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readCatalogListAttribute(CatalogListAttributeCallback callback) {
@@ -23053,7 +23053,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AllowedVendorListAttributeCallback {
@@ -23061,7 +23061,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -23069,7 +23069,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -23077,7 +23077,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -23085,7 +23085,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -23093,7 +23093,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readVendorNameAttribute(CharStringAttributeCallback callback) {
@@ -23371,7 +23371,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -23379,7 +23379,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -23387,7 +23387,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -23395,7 +23395,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readGeneratedCommandListAttribute(GeneratedCommandListAttributeCallback callback) {
@@ -23513,7 +23513,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -23521,7 +23521,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -23529,7 +23529,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -23537,7 +23537,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readMeasurementTypeAttribute(LongAttributeCallback callback) {
@@ -23855,7 +23855,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -23863,7 +23863,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -23871,7 +23871,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -23879,7 +23879,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -23887,7 +23887,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readIdleModeIntervalAttribute(LongAttributeCallback callback) {
@@ -24422,7 +24422,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ListOctetStringAttributeCallback {
@@ -24430,7 +24430,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ListStructOctetStringAttributeCallback {
@@ -24438,7 +24438,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface VendorIdAttributeCallback {
@@ -24446,7 +24446,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ListNullablesAndOptionalsStructAttributeCallback {
@@ -24454,7 +24454,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ListLongOctetStringAttributeCallback {
@@ -24462,7 +24462,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface ListFabricScopedAttributeCallback {
@@ -24470,7 +24470,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableBooleanAttributeCallback {
@@ -24478,7 +24478,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableBitmap8AttributeCallback {
@@ -24486,7 +24486,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableBitmap16AttributeCallback {
@@ -24494,7 +24494,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableBitmap32AttributeCallback {
@@ -24502,7 +24502,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableBitmap64AttributeCallback {
@@ -24510,7 +24510,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt8uAttributeCallback {
@@ -24518,7 +24518,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt16uAttributeCallback {
@@ -24526,7 +24526,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt24uAttributeCallback {
@@ -24534,7 +24534,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt32uAttributeCallback {
@@ -24542,7 +24542,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt40uAttributeCallback {
@@ -24550,7 +24550,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt48uAttributeCallback {
@@ -24558,7 +24558,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt56uAttributeCallback {
@@ -24566,7 +24566,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt64uAttributeCallback {
@@ -24574,7 +24574,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt8sAttributeCallback {
@@ -24582,7 +24582,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt16sAttributeCallback {
@@ -24590,7 +24590,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt24sAttributeCallback {
@@ -24598,7 +24598,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt32sAttributeCallback {
@@ -24606,7 +24606,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt40sAttributeCallback {
@@ -24614,7 +24614,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt48sAttributeCallback {
@@ -24622,7 +24622,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt56sAttributeCallback {
@@ -24630,7 +24630,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableInt64sAttributeCallback {
@@ -24638,7 +24638,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableEnum8AttributeCallback {
@@ -24646,7 +24646,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableEnum16AttributeCallback {
@@ -24654,7 +24654,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableFloatSingleAttributeCallback {
@@ -24662,7 +24662,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableFloatDoubleAttributeCallback {
@@ -24670,7 +24670,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableOctetStringAttributeCallback {
@@ -24678,7 +24678,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableCharStringAttributeCallback {
@@ -24686,7 +24686,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableEnumAttrAttributeCallback {
@@ -24694,7 +24694,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableRangeRestrictedInt8uAttributeCallback {
@@ -24702,7 +24702,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableRangeRestrictedInt8sAttributeCallback {
@@ -24710,7 +24710,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableRangeRestrictedInt16uAttributeCallback {
@@ -24718,7 +24718,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface NullableRangeRestrictedInt16sAttributeCallback {
@@ -24726,7 +24726,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface GeneratedCommandListAttributeCallback {
@@ -24734,7 +24734,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AcceptedCommandListAttributeCallback {
@@ -24742,7 +24742,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface EventListAttributeCallback {
@@ -24750,7 +24750,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public interface AttributeListAttributeCallback {
@@ -24758,7 +24758,7 @@ public class ChipClusters {
 
       void onError(Exception ex);
 
-      default void onSubscriptionEstablished() {}
+      default void onSubscriptionEstablished(long subscriptionId) {}
     }
 
     public void readBooleanAttribute(BooleanAttributeCallback callback) {

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -1831,7 +1831,8 @@ void TestReadInteraction::TestReadHandler_MultipleSubscriptions(nlTestSuite * ap
         NL_TEST_ASSERT(apSuite, false);
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient) {
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+                                                                          chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
     };
 
@@ -1897,7 +1898,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionAppRejection(nlTestSuite *
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient) {
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+                                                                          chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
     };
 
@@ -1961,7 +1963,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest1(nl
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient) {
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient,
+                                                                                    chip::SubscriptionId aSubscriptionId) {
         uint16_t minInterval = 0, maxInterval = 0;
 
         CHIP_ERROR err = readClient.GetReportingIntervals(minInterval, maxInterval);
@@ -2036,7 +2039,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest2(nl
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient) {
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient,
+                                                                                    chip::SubscriptionId aSubscriptionId) {
         uint16_t minInterval = 0, maxInterval = 0;
 
         CHIP_ERROR err = readClient.GetReportingIntervals(minInterval, maxInterval);
@@ -2111,7 +2115,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest3(nl
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient) {
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient,
+                                                                                    chip::SubscriptionId aSubscriptionId) {
         uint16_t minInterval = 0, maxInterval = 0;
 
         CHIP_ERROR err = readClient.GetReportingIntervals(minInterval, maxInterval);
@@ -2186,7 +2191,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest4(nl
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient) {
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+                                                                          chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
     };
 
@@ -2251,7 +2257,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest5(nl
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient) {
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient,
+                                                                                    chip::SubscriptionId aSubscriptionId) {
         uint16_t minInterval = 0, maxInterval = 0;
 
         CHIP_ERROR err = readClient.GetReportingIntervals(minInterval, maxInterval);
@@ -2326,7 +2333,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest6(nl
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient) {
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient,
+                                                                                    chip::SubscriptionId aSubscriptionId) {
         uint16_t minInterval = 0, maxInterval = 0;
 
         CHIP_ERROR err = readClient.GetReportingIntervals(minInterval, maxInterval);
@@ -2401,7 +2409,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest7(nl
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient) {
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient,
+                                                                                    chip::SubscriptionId aSubscriptionId) {
         uint16_t minInterval = 0, maxInterval = 0;
 
         CHIP_ERROR err = readClient.GetReportingIntervals(minInterval, maxInterval);
@@ -2475,7 +2484,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest8(nl
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient) {
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+                                                                          chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
     };
     //
@@ -2538,7 +2548,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest9(nl
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient) {
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+                                                                          chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
     };
 
@@ -2648,7 +2659,8 @@ void TestReadInteraction::SubscribeThenReadHelper(nlTestSuite * apSuite, TestCon
     };
 
     auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite, &aCtx, aSubscribeCount, aReadCount,
-                                        &numReadSuccessCalls, &numReadFailureCalls](const app::ReadClient & readClient) {
+                                        &numReadSuccessCalls, &numReadFailureCalls](const app::ReadClient & readClient,
+                                                                                    chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
         if (numSubscriptionEstablishedCalls == aSubscribeCount)
         {
@@ -2745,7 +2757,8 @@ void TestReadInteraction::TestReadHandler_MultipleSubscriptionsWithDataVersionFi
         NL_TEST_ASSERT(apSuite, false);
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient) {
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+                                                                          chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
     };
 

--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -139,6 +139,7 @@ void JniReferences::CallVoidInt(JNIEnv * env, jobject object, const char * metho
 
     env->ExceptionClear();
     env->CallVoidMethod(object, method, argument);
+    VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
 }
 
 void JniReferences::ReportError(JNIEnv * env, CHIP_ERROR cbErr, const char * functName)
@@ -279,17 +280,17 @@ jdouble JniReferences::DoubleToPrimitive(jobject boxedDouble)
     return env->CallDoubleMethod(boxedDouble, valueMethod);
 }
 
-CHIP_ERROR JniReferences::CallSubscriptionEstablished(jobject javaCallback)
+CHIP_ERROR JniReferences::CallSubscriptionEstablished(jobject javaCallback, long subscriptionId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     JNIEnv * env   = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
 
     jmethodID subscriptionEstablishedMethod;
-    err = chip::JniReferences::GetInstance().FindMethod(env, javaCallback, "onSubscriptionEstablished", "()V",
+    err = chip::JniReferences::GetInstance().FindMethod(env, javaCallback, "onSubscriptionEstablished", "(J)V",
                                                         &subscriptionEstablishedMethod);
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_JNI_ERROR_METHOD_NOT_FOUND);
 
-    env->CallVoidMethod(javaCallback, subscriptionEstablishedMethod);
+    env->CallVoidMethod(javaCallback, subscriptionEstablishedMethod, subscriptionId);
     VerifyOrReturnError(!env->ExceptionCheck(), CHIP_JNI_ERROR_EXCEPTION_THROWN);
 
     return err;

--- a/src/lib/support/JniReferences.h
+++ b/src/lib/support/JniReferences.h
@@ -127,9 +127,9 @@ public:
     CHIP_ERROR GetObjectField(jobject objectToRead, const char * name, const char * signature, jobject & outObject);
 
     /**
-     * Call a void method with no arguments named "OnSubscriptionEstablished" on the provided jobject.
+     * Call a void method with subscriptionId named "OnSubscriptionEstablished" on the provided jobject.
      */
-    CHIP_ERROR CallSubscriptionEstablished(jobject javaCallback);
+    CHIP_ERROR CallSubscriptionEstablished(jobject javaCallback, long subscriptionId);
 
     /**
      * Creates a boxed type (e.g. java.lang.Integer) based on the the class name ("java/lang/Integer"), constructor JNI signature


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/issues/24056
https://github.com/project-chip/connectedhomeip/issues/25044

For active subscription, when we wanna tear down subscription, we need do two things, 
1. ShutDownSubscription from InteractionModelEngine which further call close in readClient, 
2. Remove client pointer in active read client pool in InteractionModelEngine.

When reviewing the Android/Java API,
1. ShutdownSubscription does nothing via DeviceProxy, it is empty operation there ==> which would noop or crash..
2. ReportCallback destructor in AndroidCallback.cpp only remove readClient pointer from pool, and does not call shutdown subscription.

When reviewing the darwin code, it seems we also only delete the pointer, it would shutdown subscription when shutdown commissioning.

In order to fix this issue, we need expose the right ShutdownInteraction API from interactionModelEngine to Java/JNI, 
1, user needs explicitly call ShutdownSubscription, which further call ReadClient::Close, then destroy client in onDone
2. when fabric is removed, it trigger ReadClient::Close, then destroy client in onDone.
3. when Response timeout or liveness timeout happens, it trigger ReadClient::Close, then destroy client in onDone.

In addition, when onDone is triggered from ShutdownSubscription API in android ui
thread(it acquire lock immediately in ShutdownSubscription ), it further call onDone, but there is another RAII unlock in OnDone which could cause context switch, then eventloop in matter would
acquire the lock in matter thread(https://github.com/project-chip/connectedhomeip/blob/master/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp#L177), complete the work, switch back with
the lock acquired from matter thread, then it delete readClient, and
session, where crash happens when it find the lock's thread id is different
from ui thread since this new lock is from matter thread
