### PR TITLE
[Telink] Move SetRouterPromotion(false) at the end of OpenCommissioningWindow

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -234,6 +234,15 @@ CHIP_ERROR CommissioningWindowManager::OpenCommissioningWindow(Seconds16 commiss
 
     mCommissioningTimeoutTimerArmed = true;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_THREAD_FTD
+    // Block device role changing into Router if commissioning window opened and device not yet Router.
+    if (ConnectivityManagerImpl().GetThreadDeviceType() == ConnectivityManager::kThreadDeviceType_Router)
+    {
+        ThreadStackMgr().SetRouterPromotion(false);
+        mRecoverRouterDeviceRole = true;
+    }
+#endif
+
     return AdvertiseAndListenForPASE();
 }
 
@@ -469,15 +478,6 @@ CHIP_ERROR CommissioningWindowManager::StartAdvertisement()
 
     // reset all advertising, switching to our new commissioning mode.
     app::DnssdServer::Instance().StartServer();
-
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_THREAD_FTD
-    // Block device role changing into Router if commissioning window opened and device not yet Router.
-    if (ConnectivityManagerImpl().GetThreadDeviceType() == ConnectivityManager::kThreadDeviceType_Router)
-    {
-        ThreadStackMgr().SetRouterPromotion(false);
-        mRecoverRouterDeviceRole = true;
-    }
-#endif
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -236,6 +236,8 @@ CHIP_ERROR CommissioningWindowManager::OpenCommissioningWindow(Seconds16 commiss
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_THREAD_FTD
     // Block device role changing into Router if commissioning window opened and device not yet Router.
+    // AdvertiseAndListenForPASE fails doesn't matter, because if it does the callers of OpenCommissioningWindow
+    // will end up calling ResetState, which will reset the boolean.
     if (ConnectivityManagerImpl().GetThreadDeviceType() == ConnectivityManager::kThreadDeviceType_Router)
     {
         ThreadStackMgr().SetRouterPromotion(false);


### PR DESCRIPTION
**Problem**

We're still doing the SetRouterPromotion(false); multiple times on commissioning failures, but doing the SetRouterPromotion(true) only once when we reset.

**Change overview**

Move SetRouterPromotion(false) at the end of OpenCommissioningWindow.

**Testing**

Tested manually.

Steps:

- Pair FTD device with Apple Home (Apple HomePod Mini)
- Open commissioning window before FTD device becomes Router
- Pair device with Google Home (Google Nest Hub)
- Device paired successfully and controllable
- Device becomes Router after commissioning window closed (second device paired)