### PR TITLE
Fix write attribute for ARM64 Apple Platform devices

### DIFF
--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -939,9 +939,9 @@ def WriteAttributes(future: Future, eventLoop, device, attributes: List[Attribut
     res = builtins.chipStack.Call(
         lambda: handle.pychip_WriteClient_WriteAttributes(
             ctypes.py_object(transaction), device,
-            ctypes.c_uint16(0 if timedRequestTimeoutMs is None else timedRequestTimeoutMs),
-            ctypes.c_uint16(0 if interactionTimeoutMs is None else interactionTimeoutMs),
-            ctypes.c_uint16(0 if busyWaitMs is None else busyWaitMs),
+            ctypes.c_size_t(0 if timedRequestTimeoutMs is None else timedRequestTimeoutMs),
+            ctypes.c_size_t(0 if interactionTimeoutMs is None else interactionTimeoutMs),
+            ctypes.c_size_t(0 if busyWaitMs is None else busyWaitMs),
             ctypes.c_size_t(len(attributes)), *writeargs)
     )
     if not res.is_success:
@@ -969,8 +969,8 @@ def WriteGroupAttributes(groupId: int, devCtrl: c_void_p, attributes: List[Attri
 
     return builtins.chipStack.Call(
         lambda: handle.pychip_WriteClient_WriteGroupAttributes(
-            ctypes.c_uint16(groupId), devCtrl,
-            ctypes.c_uint16(0 if busyWaitMs is None else busyWaitMs),
+            ctypes.c_size_t(groupId), devCtrl,
+            ctypes.c_size_t(0 if busyWaitMs is None else busyWaitMs),
             ctypes.c_size_t(len(attributes)), *writeargs)
     )
 
@@ -1108,6 +1108,18 @@ def Init():
 
         handle.pychip_WriteClient_WriteAttributes.restype = PyChipError
         handle.pychip_WriteClient_WriteGroupAttributes.restype = PyChipError
+
+        # Both WriteAttributes and WriteGroupAttributes are variadic functions. As per ctype documentation
+        # https://docs.python.org/3/library/ctypes.html#calling-varadic-functions, it is critical that we
+        # specify the argtypes attribute for the regular, non-variadic, function arguments for this to work
+        # on ARM64 for Apple Platforms.
+        # TODO We could move away from a variadic function to one where we provide a vector of the
+        # attribute information we want written using a vector. This possibility was not implemented at the
+        # time where simply specified the argtypes, because of time constraints. This solution was quicker
+        # to fix the crash on ARM64 Apple platforms without a refactor.
+        handle.pychip_WriteClient_WriteAttributes.argtypes = [py_object, c_void_p, c_size_t, c_size_t, c_size_t, c_size_t]
+        handle.pychip_WriteClient_WriteGroupAttributes.argtypes = [c_size_t, c_void_p, c_size_t, c_size_t]
+
         setter.Set('pychip_WriteClient_InitCallbacks', None, [
                    _OnWriteResponseCallbackFunct, _OnWriteErrorCallbackFunct, _OnWriteDoneCallbackFunct])
         handle.pychip_ReadClient_Read.restype = PyChipError


### PR DESCRIPTION
Problem: On M1 Macbooks, calling `WriteAttributes` or `WriteGroupAttributes` results in a segfault. The issue was because we did not specify the `argtyes` attribute for the regular, non-variadic, function arguments. Additionally it was found that we had issue passing in `uint16_t` non-variadic types, to overcome this we simply pass the values as `size_t` and cast it to the expected `uint16_t` type.

