### PR TITLE
Add external variables support for Python bindings

### DIFF
--- a/src/controller/python/chip/server/__init__.py
+++ b/src/controller/python/chip/server/__init__.py
@@ -3,7 +3,8 @@ import glob
 import os
 import platform
 
-from chip.server.types import PostAttributeChangeCallback
+from chip.server.types import (ExternalAttributeReadCallback, ExternalAttributeWriteCallback, PostAttributeChangeCallback,
+                               PreAttributeChangeCallback)
 
 NATIVE_LIBRARY_BASE_NAME = "_ChipServer.so"
 
@@ -73,7 +74,10 @@ class NativeLibraryHandleMethodArguments:
 _nativeLibraryHandle: ctypes.CDLL = None
 
 
-def GetLibraryHandle(cb: PostAttributeChangeCallback) -> ctypes.CDLL:
+def GetLibraryHandle(pre: PreAttributeChangeCallback = None,
+                     post: PostAttributeChangeCallback = None,
+                     read: ExternalAttributeReadCallback = None,
+                     write: ExternalAttributeWriteCallback = None) -> ctypes.CDLL:
     """Get a memoized handle to the chip native code dll."""
 
     global _nativeLibraryHandle
@@ -83,9 +87,9 @@ def GetLibraryHandle(cb: PostAttributeChangeCallback) -> ctypes.CDLL:
         setter = NativeLibraryHandleMethodArguments(_nativeLibraryHandle)
         setter.Set("pychip_server_native_init", None, [])
         setter.Set("pychip_server_set_callbacks",
-                   None, [PostAttributeChangeCallback])
+                   None, [PreAttributeChangeCallback, PostAttributeChangeCallback, ExternalAttributeReadCallback, ExternalAttributeWriteCallback])
 
         _nativeLibraryHandle.pychip_server_native_init()
-        _nativeLibraryHandle.pychip_server_set_callbacks(cb)
+        _nativeLibraryHandle.pychip_server_set_callbacks(pre, post, read, write)
 
     return _nativeLibraryHandle

--- a/src/controller/python/chip/server/types.py
+++ b/src/controller/python/chip/server/types.py
@@ -1,12 +1,72 @@
-from ctypes import CFUNCTYPE, c_char_p, c_uint8, c_uint16
+from ctypes import CFUNCTYPE, POINTER, Structure, Union, c_char_p, c_uint8, c_uint16, c_uint32, c_void_p
+
+
+class DefaultAttributeValue(Union):
+    _fields_ = [
+        ("ptrToDefaultValue", c_void_p),
+        ("defaultValue", c_uint16),
+    ]
+
+
+class AttributeMinMaxValue(Structure):
+    _fields_ = [
+        ("defaultValue", DefaultAttributeValue),
+        ("minValue", DefaultAttributeValue),
+        ("maxValue", DefaultAttributeValue),
+    ]
+
+
+class DefaultOrMinMaxAttributeValue(Union):
+    _fields_ = [
+        ("ptrToDefaultValue", c_void_p),
+        ("defaultValue", c_uint32),
+        ("ptrToMinMaxValue", POINTER(AttributeMinMaxValue)),
+    ]
+
+
+class AttributeMetadata(Structure):
+    _fields_ = [
+        ("defaultValue", DefaultOrMinMaxAttributeValue),
+        ("attributeId", c_uint32),
+        ("size", c_uint16),
+        ("attributeType", c_uint8),
+        ("mask", c_uint8),
+    ]
+
 
 PostAttributeChangeCallback = CFUNCTYPE(
     None,
-    # py_object,
     c_uint16,
     c_uint16,
     c_uint16,
     c_uint8,
     c_uint16,
     c_char_p,
+)
+
+PreAttributeChangeCallback = CFUNCTYPE(
+    c_uint8,
+    c_uint16,
+    c_uint16,
+    c_uint16,
+    c_uint8,
+    c_uint16,
+    c_char_p,
+)
+
+ExternalAttributeReadCallback = CFUNCTYPE(
+    c_uint8,
+    c_uint16,
+    c_uint16,
+    POINTER(AttributeMetadata),
+    c_void_p,
+    c_uint16,
+)
+
+ExternalAttributeWriteCallback = CFUNCTYPE(
+    c_uint8,
+    c_uint16,
+    c_uint16,
+    POINTER(AttributeMetadata),
+    c_void_p,
 )


### PR DESCRIPTION
This PR allows setting Python callbacks for attribute pre-update and external variables setting