### PR TITLE
Enable builds for m5stack

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -154,7 +154,7 @@ def BuildEsp32Target():
 
     # boards
     target.AppendFixedTargets([
-        TargetPart('m5stack', board=Esp32Board.M5Stack).OnlyIfRe('-(all-clusters|ota-requestor)'),
+        TargetPart('m5stack', board=Esp32Board.M5Stack),
         TargetPart('c3devkit', board=Esp32Board.C3DevKit),
         TargetPart('devkitc', board=Esp32Board.DevKitC),
         TargetPart('qemu', board=Esp32Board.QEMU).OnlyIfRe('-tests'),


### PR DESCRIPTION
DevKitC and M5stack are the same MCU. Allow all apps to have a m5stack build, even if not having display enabled.

this allows for targets such as `/scripts/build/build_examples.py --enable-flashbundle --target esp32-m5stack-light build`.