### PR TITLE
Add m5stack light example to smoke test prebuilts

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -30,8 +30,9 @@ steps:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle --target
               esp32-m5stack-all-clusters-ipv6only --target
-              esp32-m5stack-all-clusters-minimal-rpc-ipv6only --target
               esp32-m5stack-all-clusters-rpc --target
+              esp32-m5stack-light --target
+              esp32-m5stack-light-ipv6only --target
               esp32-m5stack-ota-requestor build --create-archives
               /workspace/artifacts/
       waitFor:


### PR DESCRIPTION
Add m5stack builds for light app to cloudbuild smoke tests.

