### PR TITLE
Fix matter_yamltests with Python 3.11

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/parser_builder.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser_builder.py
@@ -51,9 +51,10 @@ class TestParserBuilderConfig:
            current parsing state.
     """
     tests: list[str] = field(default_factory=list)
-    parser_config: TestParserConfig = TestParserConfig()
+    parser_config: TestParserConfig = field(default_factory=TestParserConfig)
     hooks: TestParserHooks = TestParserHooks()
-    options: TestParserBuilderOptions = TestParserBuilderOptions()
+    options: TestParserBuilderOptions = field(
+        default_factory=TestParserBuilderOptions)
 
 
 class TestParserBuilder:


### PR DESCRIPTION
Due to https://docs.python.org/3.11/whatsnew/3.11.html#dataclasses, the previous code fails: it's using mutable class instances as default values of dataclass fields.
