### PR TITLE
[shell/MainLoopDefault.cpp] Add a missing null check

### DIFF
--- a/src/lib/shell/MainLoopDefault.cpp
+++ b/src/lib/shell/MainLoopDefault.cpp
@@ -196,6 +196,18 @@ void Engine::RunMainLoop()
     while (true)
     {
         char * line = static_cast<char *>(Platform::MemoryAlloc(CHIP_SHELL_MAX_LINE_SIZE));
+        if (line == nullptr)
+        {
+            CHIP_ERROR error = CHIP_ERROR_NO_MEMORY;
+            char errorStr[160];
+            bool errorStrFound = FormatCHIPError(errorStr, sizeof(errorStr), error);
+            if (!errorStrFound)
+            {
+                errorStr[0] = 0;
+            }
+            streamer_printf(streamer_get(), "Error: %s\r\n", errorStr);
+        }
+
         if (ReadLine(line, CHIP_SHELL_MAX_LINE_SIZE) == 0u)
         {
             // Stop loop in case of empty read (Ctrl-D).


### PR DESCRIPTION
#### Problem


This PR add a check for nullptr in case the memory allocation fails in the main loop of the shell at [src/lib/shell/MainLoopDefault.cpp](https://github.com/project-chip/connectedhomeip/compare/master...vivien-apple:connectedhomeip-1:Shell_MainLoopDefault?expand=1#diff-6f688df104e97aef88b9aaf726973590b33c94d03c20a12950b8a6688e74bb80)