### PR TITLE
Update cloudbuild docker image versions to 0.6.48

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -6,7 +6,7 @@ steps:
           - "--init"
           - "--recursive"
       id: Submodules
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.48"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -21,7 +21,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.48"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -76,7 +76,7 @@ steps:
               --target k32w-shell
               build
               --create-archives /workspace/artifacts/
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.48"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.48"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 2700s
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.48"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -26,7 +26,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.48"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.48"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               git submodule update --init --recursive
       id: Submodules
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.48"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -22,7 +22,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.48"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -41,7 +41,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.48"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -62,7 +62,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.48"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -84,7 +84,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.48"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -144,7 +144,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.6.47"
+    - name: "connectedhomeip/chip-build-vscode:0.6.48"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
VSCode required a kotlinc path update in #25462, without that android projects cannot be compiled.