### PR TITLE
[ICD] Subscription resumption logic should skip subscriptions created during startup wait time

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1639,17 +1639,15 @@ void InteractionModelEngine::ResumeSubscriptionsTimerCallback(System::Layer * ap
     while (iterator->Next(subscriptionInfo))
     {
         // If subscription happens between reboot and this timer callback, it's already live and should skip resumption
-        bool subscriptionAlreadyLive = false;
-        imEngine->mReadHandlers.ForEachActiveObject([&](ReadHandler * handler) {
-            SubscriptionId subscriptionId;
-            handler->GetSubscriptionId(subscriptionId);
-            if (subscriptionId == subscriptionInfo.mSubscriptionId)
-            {
-                subscriptionAlreadyLive = true;
-            }
-            return Loop::Continue;
-        });
-        if (subscriptionAlreadyLive)
+        if (Loop::Break == imEngine->mReadHandlers.ForEachActiveObject([&](ReadHandler * handler) {
+                SubscriptionId subscriptionId;
+                handler->GetSubscriptionId(subscriptionId);
+                if (subscriptionId == subscriptionInfo.mSubscriptionId)
+                {
+                    return Loop::Break;
+                }
+                return Loop::Continue;
+            }))
         {
             ChipLogProgress(InteractionModel, "Skip resuming live subscriptionId %" PRIu32, subscriptionInfo.mSubscriptionId);
             continue;


### PR DESCRIPTION
For https://github.com/project-chip/connectedhomeip/pull/25416 @bzbarsky-apple  pointed out that if a subscription request comes in during the startup min interval wait time, the new subscription would also be persisted and the logic would create a ReadHandler object for the same subscription.

This fixes the issue by skipping resuming subscription if the SubscriptionId matches on in the ReadHandler list.