### PR TITLE
Fix the EFR32 version stamping

### DIFF
--- a/third_party/silabs/BUILD.gn
+++ b/third_party/silabs/BUILD.gn
@@ -45,6 +45,7 @@ config("silabs_config") {
 
 group("efr32_sdk") {
   public_deps = [ efr32_sdk_target ]
+  public_configs = [ ":silabs_config" ]
 }
 
 # Openthread GSDK libraries configurations


### PR DESCRIPTION
There are build rules to set CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING to a custom string, but the #define is not actually set in the context where it is used (GenericConfigurationManagerImpl).

Fix this by exporting it from //third_party/silabs:efr32_sdk