### PR TITLE
[ESP32] fix factory partition tool to only generate discriminator as well

### DIFF
--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -486,6 +486,8 @@ def main():
 
     if args.passcode is not None:
         spake2p_params = gen_spake2p_params(args.passcode)
+    else:
+        spake2p_params = None
 
     populate_factory_data(args, spake2p_params)
 


### PR DESCRIPTION
#### Problem
- `scripts/tools/generate_esp32_chip_factory_bin.py` throws exception when provided with only discriminator

#### Change overview
- Should be able to build an NVS binary image for quick tests with different discriminator

#### Tests
- Flashed the generated binary into nvs and commissioned different discriminator