### PR TITLE
[Tizen] Fix deadlock caused by mutex lock inversion

### DIFF
--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -108,9 +108,16 @@ struct ResolveContext : public GenericContext
     dnssd_service_h mServiceHandle = 0;
     bool mIsResolving              = false;
 
+    // Resolved service
+    DnssdService mResult               = {};
+    uint8_t * mResultTxtRecord         = nullptr;
+    unsigned short mResultTxtRecordLen = 0;
+
     ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId, DnssdResolveCallback callback,
                    void * context);
     ~ResolveContext() override;
+
+    void Finalize(CHIP_ERROR error);
 };
 
 class DnssdTizen


### PR DESCRIPTION
### Problem

Tizen mDNS API uses callbacks for notifying caller about particular events, like resolving service. Unfortunately, Tizen API internally uses global recursive mutex for every API call, which is not unlocked before calling callbacks...

The problem arises when the caller uses its own mutex which needs to be locked inside a callback function passed to mDNS API. We might have a case when:

- in thread 1, we are running callback function, which holds mDNS API internal lock, and in that callback we need to lock our lock
- in thread 2, mDNS API is called under callers lock, which internally tries to lock its internal lock

### Changes

As a workaround, mDNS callback function will not lock matter stack mutex, but instead it will only gather all data and schedule further data processing to a glib idle source callback. Fixes #25466

### Testing

Tested using test case provided in https://github.com/project-chip/connectedhomeip/issues/25466

