### PR TITLE
Resolve race condition before UserPrompt in simulated tests.

### DIFF
--- a/examples/placeholder/linux/include/TestCommand.h
+++ b/examples/placeholder/linux/include/TestCommand.h
@@ -111,7 +111,6 @@ public:
         TestCommand * command = reinterpret_cast<TestCommand *>(context);
         command->isRunning    = true;
         command->NextTest();
-        chip::DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEvent, context);
     }
 
     static void OnPlatformEvent(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
@@ -121,6 +120,7 @@ public:
         case chip::DeviceLayer::DeviceEventType::kCommissioningComplete:
             ChipLogProgress(chipTool, "Commissioning complete");
             chip::DeviceLayer::PlatformMgr().ScheduleWork(ScheduleNextTest, arg);
+            chip::DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEvent, arg);
             break;
         }
     }
@@ -129,7 +129,7 @@ public:
     {
         if (commandPath == mCommandPath)
         {
-            NextTest();
+            chip::DeviceLayer::PlatformMgr().ScheduleWork(ScheduleNextTest, reinterpret_cast<intptr_t>(this));
             return;
         }
 
@@ -141,7 +141,7 @@ public:
     {
         if (attributePath == mAttributePath)
         {
-            NextTest();
+            chip::DeviceLayer::PlatformMgr().ScheduleWork(ScheduleNextTest, reinterpret_cast<intptr_t>(this));
             return;
         }
 


### PR DESCRIPTION
- Fixes #25382  
- Updated the next test to be executed as scheduled work so it does not block the read/write/command to complete when a user prompt is executed on the following step.

Tests:
- Validated that the issue filed no longer occurs.
- Validated that all steps are completed in the test.
- Validated that user prompt is still accepted and continue after typing it in.
