### PR TITLE
[ColorControl] Step mode Stop doesn't exist. return error on a stepmode = 0

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -1180,7 +1180,7 @@ bool ColorControlServer::stepHueCommand(app::CommandHandler * commandObj, const 
     VerifyOrExit(colorHueTransitionState != nullptr, status = Status::UnsupportedEndpoint);
 
     // Confirm validity of the step mode received
-    if (stepMode != STEP_MODE_STOP && stepMode != STEP_MODE_UP && stepMode != STEP_MODE_DOWN)
+    if (stepMode != STEP_MODE_UP && stepMode != STEP_MODE_DOWN)
     {
         commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return true;
@@ -1199,12 +1199,6 @@ bool ColorControlServer::stepHueCommand(app::CommandHandler * commandObj, const 
 
     // New command.  Need to stop any active transitions.
     stopAllColorTransitions(endpoint);
-
-    if (stepMode == STEP_MODE_STOP)
-    {
-        commandObj->AddStatus(commandPath, Status::Success);
-        return true;
-    }
 
     // Handle color mode transition, if necessary.
     if (isEnhanced)
@@ -1420,7 +1414,7 @@ bool ColorControlServer::stepSaturationCommand(app::CommandHandler * commandObj,
     VerifyOrExit(colorSaturationTransitionState != nullptr, status = Status::UnsupportedEndpoint);
 
     // Confirm validity of the step mode received
-    if (stepMode != STEP_MODE_STOP && stepMode != STEP_MODE_UP && stepMode != STEP_MODE_DOWN)
+    if (stepMode != STEP_MODE_UP && stepMode != STEP_MODE_DOWN)
     {
         commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return true;
@@ -1439,12 +1433,6 @@ bool ColorControlServer::stepSaturationCommand(app::CommandHandler * commandObj,
 
     // New command.  Need to stop any active transitions.
     stopAllColorTransitions(endpoint);
-
-    if (stepMode == MOVE_MODE_STOP)
-    {
-        commandObj->AddStatus(commandPath, Status::Success);
-        return true;
-    }
 
     // Handle color mode transition, if necessary.
     handleModeSwitch(endpoint, COLOR_MODE_HSV);
@@ -2354,7 +2342,7 @@ bool ColorControlServer::stepColorTempCommand(app::CommandHandler * commandObj, 
     VerifyOrExit(colorTempTransitionState != nullptr, status = Status::UnsupportedEndpoint);
 
     // Confirm validity of the step mode received
-    if (stepMode != STEP_MODE_STOP && stepMode != STEP_MODE_UP && stepMode != STEP_MODE_DOWN)
+    if (stepMode != STEP_MODE_UP && stepMode != STEP_MODE_DOWN)
     {
         commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return true;
@@ -2368,12 +2356,6 @@ bool ColorControlServer::stepColorTempCommand(app::CommandHandler * commandObj, 
 
     // New command.  Need to stop any active transitions.
     stopAllColorTransitions(endpoint);
-
-    if (stepMode == MOVE_MODE_STOP)
-    {
-        commandObj->AddStatus(commandPath, Status::Success);
-        return true;
-    }
 
     Attributes::ColorTempPhysicalMinMireds::Get(endpoint, &tempPhysicalMin);
     Attributes::ColorTempPhysicalMaxMireds::Get(endpoint, &tempPhysicalMax);

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -76,7 +76,6 @@ public:
 
     enum StepMode
     {
-        STEP_MODE_STOP = 0x00,
         STEP_MODE_UP   = 0x01,
         STEP_MODE_DOWN = 0x03
     };


### PR DESCRIPTION
Fixes #25589
There is a StepMode STOP behaviour implemented in color control step commands but this isn't defined by the spec.

remove that code and return INVALID_COMMAND if a stepmode value != to 1 or 3 is received