### PR TITLE
When retrying CASE during commissioning, extend the fail-safe.

### DIFF
--- a/src/app/CASEClient.cpp
+++ b/src/app/CASEClient.cpp
@@ -24,6 +24,11 @@ void CASEClient::SetRemoteMRPIntervals(const ReliableMessageProtocolConfig & rem
     mCASESession.SetRemoteMRPConfig(remoteMRPConfig);
 }
 
+const ReliableMessageProtocolConfig & CASEClient::GetRemoteMRPIntervals()
+{
+    return mCASESession.GetRemoteMRPConfig();
+}
+
 CHIP_ERROR CASEClient::EstablishSession(const CASEClientInitParams & params, const ScopedNodeId & peer,
                                         const Transport::PeerAddress & peerAddress,
                                         const ReliableMessageProtocolConfig & remoteMRPConfig,

--- a/src/app/CASEClient.h
+++ b/src/app/CASEClient.h
@@ -54,6 +54,8 @@ class DLL_EXPORT CASEClient
 public:
     void SetRemoteMRPIntervals(const ReliableMessageProtocolConfig & remoteMRPConfig);
 
+    const ReliableMessageProtocolConfig & GetRemoteMRPIntervals();
+
     CHIP_ERROR EstablishSession(const CASEClientInitParams & params, const ScopedNodeId & peer,
                                 const Transport::PeerAddress & peerAddress, const ReliableMessageProtocolConfig & remoteMRPConfig,
                                 SessionEstablishmentDelegate * delegate);

--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -33,7 +33,7 @@ void CASESessionManager::FindOrEstablishSession(const ScopedNodeId & peerId, Cal
                                                 Callback::Callback<OnDeviceConnectionFailure> * onFailure
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
                                                 ,
-                                                uint8_t attemptCount
+                                                uint8_t attemptCount, Callback::Callback<OnDeviceConnectionRetry> * onRetry
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
 )
 {
@@ -60,6 +60,10 @@ void CASESessionManager::FindOrEstablishSession(const ScopedNodeId & peerId, Cal
 
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
     session->UpdateAttemptCount(attemptCount);
+    if (onRetry)
+    {
+        session->AddRetryHandler(onRetry);
+    }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
 
     session->Connect(onConnection, onFailure);

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -85,7 +85,7 @@ public:
                                 Callback::Callback<OnDeviceConnectionFailure> * onFailure
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
                                 ,
-                                uint8_t attemptCount = 1
+                                uint8_t attemptCount = 1, Callback::Callback<OnDeviceConnectionRetry> * onRetry = nullptr
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
     );
 

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -36,8 +36,10 @@
 #include <messaging/ExchangeDelegate.h>
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
+#include <messaging/ReliableMessageProtocolConfig.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <protocols/secure_channel/CASESession.h>
+#include <system/SystemClock.h>
 #include <system/SystemLayer.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
@@ -117,7 +119,19 @@ private:
  * implementations as an example.
  */
 typedef void (*OnDeviceConnected)(void * context, Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
+
+/**
+ * Callback prototype when secure session establishment fails.
+ */
 typedef void (*OnDeviceConnectionFailure)(void * context, const ScopedNodeId & peerId, CHIP_ERROR error);
+
+/**
+ * Callback prototype when secure session establishement has failed and will be
+ * retried.  retryTimeout indicates how much time will pass before we know
+ * whether the retry has timed out waiting for a response to our Sigma1 message.
+ */
+typedef void (*OnDeviceConnectionRetry)(void * context, const ScopedNodeId & peerId, CHIP_ERROR error,
+                                        System::Clock::Seconds16 retryTimeout);
 
 /**
  * Object used to either establish a connection to peer or performing address lookup to a peer.
@@ -227,6 +241,9 @@ public:
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
     // Update our remaining attempt count to be at least the given value.
     void UpdateAttemptCount(uint8_t attemptCount);
+
+    // Add a retry handler for this session setup.
+    void AddRetryHandler(Callback::Callback<OnDeviceConnectionRetry> * onRetry);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
 
 private:
@@ -268,6 +285,8 @@ private:
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
     uint8_t mRemainingAttempts = 0;
     uint8_t mAttemptsDone      = 0;
+
+    Callback::CallbackDeque mConnectionRetry;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
 
     void MoveToState(State aTargetState);
@@ -313,14 +332,22 @@ private:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
     /**
-     * Schedule a setup reattempt, if possible.
+     * Schedule a setup reattempt, if possible.  The outparam indicates how long
+     * it will be before the reattempt happens.
      */
-    CHIP_ERROR ScheduleSessionSetupReattempt();
+    CHIP_ERROR ScheduleSessionSetupReattempt(System::Clock::Seconds16 & timerDelay);
 
     /**
      * Helper for our backoff retry timer.
      */
     static void TrySetupAgain(System::Layer * systemLayer, void * state);
+
+    /**
+     * Helper to notify our retry callbacks that a setup error occurred and we
+     * will retry.
+     */
+    void NotifyRetryHandlers(CHIP_ERROR error, const ReliableMessageProtocolConfig & remoteMrpConfig,
+                             System::Clock::Seconds16 retryDelay);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
 };
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -61,6 +61,7 @@
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <protocols/secure_channel/RendezvousParameters.h>
 #include <protocols/user_directed_commissioning/UserDirectedCommissioning.h>
+#include <system/SystemClock.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/UDP.h>
@@ -787,6 +788,10 @@ private:
 
     static void OnDeviceConnectedFn(void * context, Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR error);
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+    static void OnDeviceConnectionRetryFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR error,
+                                          System::Clock::Seconds16 retryTimeout);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
 
     static void OnDeviceAttestationInformationVerification(void * context,
                                                            const Credentials::DeviceAttestationVerifier::AttestationInfo & info,
@@ -897,6 +902,9 @@ private:
 
     chip::Callback::Callback<OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+    chip::Callback::Callback<OnDeviceConnectionRetry> mOnDeviceConnectionRetryCallback;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
 
     chip::Callback::Callback<Credentials::DeviceAttestationVerifier::OnAttestationInformationVerification>
         mDeviceAttestationInformationVerificationCallback;

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -35,11 +35,13 @@
 #include <lib/support/Base64.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeDelegate.h>
+#include <messaging/ReliableMessageProtocolConfig.h>
 #include <protocols/secure_channel/CASEDestinationId.h>
 #include <protocols/secure_channel/Constants.h>
 #include <protocols/secure_channel/PairingSession.h>
 #include <protocols/secure_channel/SessionEstablishmentExchangeDispatch.h>
 #include <protocols/secure_channel/SessionResumptionStorage.h>
+#include <system/SystemClock.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/CryptoContext.h>
 #include <transport/raw/MessageHeader.h>
@@ -174,6 +176,10 @@ public:
     }
 
     FabricIndex GetFabricIndex() const { return mFabricIndex; }
+
+    // Compute our Sigma1 response timeout.  This can give consumers an idea of
+    // how long it will take to detect that our Sigma1 did not get through.
+    static System::Clock::Timeout ComputeSigma1ResponseTimeout(const ReliableMessageProtocolConfig & remoteMrpConfig);
 
     // TODO: remove Clear, we should create a new instance instead reset the old instance.
     /** @brief This function zeroes out and resets the memory used by the object.


### PR DESCRIPTION
If we don't do this, we can get into a situation where our retries take longer than the fail-safe timer, so we are still retrying by the other side is not even listening anymore.

The changes here are as follows:

1) Expose various bits on CASEClient and CASESession to allow us to compute how
   long it will take before we know whether the next CASE retry has succeeded or
   failed.
2) Add a way for OperationalSessionSetup to notify its consumers that it's going
   to retry, and how long it expects it to take before it knows whether the
   retry has succeeded.
3) Change DeviceCommissioner to extend the fail-safe when it's told that
   OperationalSessionSetup will retry.

Fixes https://github.com/project-chip/connectedhomeip/issues/25581

