### PR TITLE
Reduce priority of factory reset task

### DIFF
--- a/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
@@ -292,6 +292,13 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
     // Restart the system.
     ChipLogProgress(DeviceLayer, "System restarting");
+
+    // When called from an RPC, the following reset occurs before the RPC can respond,
+    // which breaks tests (because it looks like the RPC hasn't successfully completed).
+    // One way to fix this is to reduce the priority of this task, to allow logging to
+    // complete before the reset occurs.
+    vTaskPrioritySet(NULL, 0);
+
     NVIC_SystemReset();
 }
 


### PR DESCRIPTION
Since the task priorities were adjusted for #24099 (and maybe even before?) the factory reset RPC would time out, breaking any test which relies on the RPC successfully completing.

This is because the reset is happening immediately, before whatever is handling the RPC can complete.

Reducing the FreeRTOS task priority just before the reset "fixes" it. (Maybe there's a better fix?)

Tested on Mighty Gecko SiLabs board.

