### PR TITLE
Fix run_testsuite.py so it works if not all of the apps are specified.

### DIFF
--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -279,6 +279,13 @@ class TestDefinition:
                 if path == paths.chip_tool or path == paths.chip_repl_yaml_tester_cmd or path == paths.chip_tool_with_python_cmd:
                     continue
 
+                # Skip items where we don't actually have a path.  This can
+                # happen if the relevant application does not exist.  It's
+                # non-fatal as long as we are not trying to run any tests that
+                # need that application.
+                if len(path) == 1 and path[0] is None:
+                    continue
+
                 # For the app indicated by self.target, give it the 'default' key to add to the register
                 if path == target_app:
                     key = 'default'


### PR DESCRIPTION
When running only a subset of tests (e.g. only DL_* tests), not all apps are needed for the tests to run.

This used to work because we used a fake "NOT_FOUND_IN_OUTPUT_" path for the missing apps, which was a string so the string manipulation on it worked, and the output was never used.

But after https://github.com/project-chip/connectedhomeip/pull/25368 we end up with None where we expect a string, and the script dies.

The fix is just to skip string manipulation on the path of apps that have None as a path.
