### PR TITLE
[Silabs][SiWx917] Fix log disabling and the lock-app build

### DIFF
--- a/examples/lock-app/silabs/SiWx917/include/LockManager.h
+++ b/examples/lock-app/silabs/SiWx917/include/LockManager.h
@@ -58,6 +58,8 @@ static constexpr uint8_t kMaxHolidaySchedules        = 10;
 static constexpr uint8_t kMaxCredentialSize          = 20;
 static constexpr uint8_t kNumCredentialTypes         = 6;
 
+static constexpr uint8_t kMaxCredentials = kMaxUsers * kMaxCredentialsPerUser;
+
 } // namespace ResourceRanges
 
 namespace LockInitParams {
@@ -201,14 +203,14 @@ private:
     static void ActuatorMovementTimerEventHandler(AppEvent * aEvent);
 
     EmberAfPluginDoorLockUserInfo mLockUsers[kMaxUsers];
-    EmberAfPluginDoorLockCredentialInfo mLockCredentials[kNumCredentialTypes][kMaxCredentialsPerUser];
+    EmberAfPluginDoorLockCredentialInfo mLockCredentials[kNumCredentialTypes][kMaxCredentials];
     WeekDaysScheduleInfo mWeekdaySchedule[kMaxUsers][kMaxWeekdaySchedulesPerUser];
     YearDayScheduleInfo mYeardaySchedule[kMaxUsers][kMaxYeardaySchedulesPerUser];
     HolidayScheduleInfo mHolidaySchedule[kMaxHolidaySchedules];
 
     char mUserNames[ArraySize(mLockUsers)][DOOR_LOCK_MAX_USER_NAME_SIZE];
-    uint8_t mCredentialData[kNumCredentialTypes][kMaxCredentialsPerUser][kMaxCredentialSize];
-    CredentialStruct mCredentials[kMaxUsers][kMaxCredentialsPerUser];
+    uint8_t mCredentialData[kNumCredentialTypes][kMaxCredentials][kMaxCredentialSize];
+    CredentialStruct mCredentials[kMaxUsers][kMaxCredentials];
 
     static LockManager sLock;
     SI917DoorLock::LockInitParams::LockParam LockParams;

--- a/src/platform/silabs/Logging.cpp
+++ b/src/platform/silabs/Logging.cpp
@@ -432,6 +432,9 @@ extern "C" __attribute__((naked)) void HardFault_Handler(void)
                    "debugHardfault_address: .word debugHardfault  \n");
 }
 
+#endif // HARD_FAULT_LOG_ENABLE && SILABS_LOG_ENABLED
+
+#if HARD_FAULT_LOG_ENABLE
 extern "C" void vApplicationMallocFailedHook(void)
 {
     /* Called if a call to pvPortMalloc() fails because there is insufficient
@@ -440,8 +443,9 @@ extern "C" void vApplicationMallocFailedHook(void)
     timers, and semaphores.  The size of the FreeRTOS heap is set by the
     configTOTAL_HEAP_SIZE configuration constant in FreeRTOSConfig.h. */
 
+#if SILABS_LOG_ENABLED
     SILABS_LOG("Failed do a malloc on HEAP. Is it too small ?");
-
+#endif
     /* Force an assert. */
     configASSERT((volatile void *) NULL);
 }
@@ -455,8 +459,11 @@ extern "C" void vApplicationStackOverflowHook(TaskHandle_t pxTask, char * pcTask
     /* Run time stack overflow checking is performed if
     configCHECK_FOR_STACK_OVERFLOW is defined to 1 or 2.  This hook
     function is called if a stack overflow is detected. */
+
+#if SILABS_LOG_ENABLED
     SILABS_LOG("TASK OVERFLOW");
     SILABS_LOG(pcTaskName);
+#endif
     /* Force an assert. */
     configASSERT((volatile void *) NULL);
 }
@@ -519,6 +526,7 @@ extern "C" void vApplicationGetTimerTaskMemory(StaticTask_t ** ppxTimerTaskTCBBu
 #ifndef BRD4325A
 extern "C" void RAILCb_AssertFailed(RAIL_Handle_t railHandle, uint32_t errorCode)
 {
+#if SILABS_LOG_ENABLED
 #ifdef RAIL_ASSERT_DEBUG_STRING
     static const char * railErrorMessages[] = RAIL_ASSERT_ERROR_MESSAGES;
     const char * errorMessage               = "Unknown";
@@ -531,11 +539,11 @@ extern "C" void RAILCb_AssertFailed(RAIL_Handle_t railHandle, uint32_t errorCode
     SILABS_LOG("RAIL Assert : %s", errorMessage);
 #else
     SILABS_LOG("RAIL Assert : %ld", errorCode);
-#endif
-
+#endif // RAIL_ASSERT_DEBUG_STRING
+#endif // SILABS_LOG_ENABLED
     while (1)
         ;
 }
 #endif // BRD4325A
 
-#endif // HARD_FAULT_LOG_ENABLE && SILABS_LOG_ENABLED
+#endif // HARD_FAULT_LOG_ENABLE

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -32,7 +32,7 @@ declare_args() {
   use_silabs_thread_lib = false
   enable_openthread_cli = true
 
-  kvs_max_entries = 75
+  kvs_max_entries = 255
 
   # Use Silabs factory data provider example.
   # Users can implement their own.
@@ -41,8 +41,7 @@ declare_args() {
   # Enable Segger System View
   use_system_view = false
 
-  # Argument to Disable IPv4 for wifi(rs911)
-  chip_enable_wifi_ipv4 = false
+  silabs_log_enabled = true
 }
 
 assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")
@@ -107,7 +106,7 @@ template("efr32_sdk") {
       "__STARTUP_CLEAR_BSS",
       "HARD_FAULT_LOG_ENABLE",
       "CORTEXM3_EFM32_MICRO",
-      "SILABS_LOG_ENABLED=1",
+      "SILABS_LOG_ENABLED=${silabs_log_enabled}",
       "NVM3_DEFAULT_NVM_SIZE=40960",
       "NVM3_DEFAULT_MAX_OBJECT_SIZE=4092",
       "KVS_MAX_ENTRIES=${kvs_max_entries}",
@@ -143,10 +142,6 @@ template("efr32_sdk") {
     }
 
     defines += board_defines
-
-    if (chip_enable_wifi_ipv4) {
-      defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4=1" ]
-    }
 
     # Enabling led interface
     if (use_wstk_leds) {


### PR DESCRIPTION
A few fixes for the silabs SiWx917 wifi platform

- Logs could not be disabled by the common silabs build an argument for the 917: Add the arg and define in the platform gni
- Disabling said log caused some undefined functions for that platform: Fix some ifdefs
- Some of the latest lock-app changes were not fully applied to the siwx917 platform: Update the header