### PR TITLE
Switch the color control move/step enums to enum class.

### DIFF
--- a/examples/all-clusters-app/ameba/main/include/ColorControlCommands.h
+++ b/examples/all-clusters-app/ameba/main/include/ColorControlCommands.h
@@ -324,6 +324,8 @@ void ProcessColorControlUnicastBindingRead(BindingCommandData * data, const Embe
 void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding,
                                               OperationalDeviceProxy * peer_device)
 {
+    using namespace Clusters::ColorControl;
+
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
         ChipLogProgress(NotSpecified, "ColorControl command succeeds");
     };
@@ -358,7 +360,7 @@ void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const E
     {
     case Clusters::ColorControl::Commands::MoveToHue::Id:
         moveToHueCommand.hue             = static_cast<uint8_t>(data->args[0]);
-        moveToHueCommand.direction       = static_cast<EmberAfHueDirection>(data->args[1]);
+        moveToHueCommand.direction       = static_cast<HueDirection>(data->args[1]);
         moveToHueCommand.transitionTime  = static_cast<uint16_t>(data->args[2]);
         moveToHueCommand.optionsMask     = static_cast<uint8_t>(data->args[3]);
         moveToHueCommand.optionsOverride = static_cast<uint8_t>(data->args[4]);
@@ -367,7 +369,7 @@ void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const E
         break;
 
     case Clusters::ColorControl::Commands::MoveHue::Id:
-        moveHueCommand.moveMode        = static_cast<EmberAfHueMoveMode>(data->args[0]);
+        moveHueCommand.moveMode        = static_cast<HueMoveMode>(data->args[0]);
         moveHueCommand.rate            = static_cast<uint8_t>(data->args[1]);
         moveHueCommand.optionsMask     = static_cast<uint8_t>(data->args[2]);
         moveHueCommand.optionsOverride = static_cast<uint8_t>(data->args[3]);
@@ -376,7 +378,7 @@ void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const E
         break;
 
     case Clusters::ColorControl::Commands::StepHue::Id:
-        stepHueCommand.stepMode        = static_cast<EmberAfHueStepMode>(data->args[0]);
+        stepHueCommand.stepMode        = static_cast<HueStepMode>(data->args[0]);
         stepHueCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
         stepHueCommand.transitionTime  = static_cast<uint8_t>(data->args[2]);
         stepHueCommand.optionsMask     = static_cast<uint8_t>(data->args[3]);
@@ -395,7 +397,7 @@ void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const E
         break;
 
     case Clusters::ColorControl::Commands::MoveSaturation::Id:
-        moveSaturationCommand.moveMode        = static_cast<EmberAfSaturationMoveMode>(data->args[0]);
+        moveSaturationCommand.moveMode        = static_cast<SaturationMoveMode>(data->args[0]);
         moveSaturationCommand.rate            = static_cast<uint8_t>(data->args[1]);
         moveSaturationCommand.optionsMask     = static_cast<uint8_t>(data->args[2]);
         moveSaturationCommand.optionsOverride = static_cast<uint8_t>(data->args[3]);
@@ -404,7 +406,7 @@ void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const E
         break;
 
     case Clusters::ColorControl::Commands::StepSaturation::Id:
-        stepSaturationCommand.stepMode        = static_cast<EmberAfSaturationStepMode>(data->args[0]);
+        stepSaturationCommand.stepMode        = static_cast<SaturationStepMode>(data->args[0]);
         stepSaturationCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
         stepSaturationCommand.transitionTime  = static_cast<uint8_t>(data->args[2]);
         stepSaturationCommand.optionsMask     = static_cast<uint8_t>(data->args[3]);
@@ -463,7 +465,7 @@ void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const E
 
     case Clusters::ColorControl::Commands::EnhancedMoveToHue::Id:
         enhancedMoveToHueCommand.enhancedHue     = static_cast<uint16_t>(data->args[0]);
-        enhancedMoveToHueCommand.direction       = static_cast<EmberAfHueDirection>(data->args[1]);
+        enhancedMoveToHueCommand.direction       = static_cast<HueDirection>(data->args[1]);
         enhancedMoveToHueCommand.transitionTime  = static_cast<uint16_t>(data->args[2]);
         enhancedMoveToHueCommand.optionsMask     = static_cast<uint8_t>(data->args[3]);
         enhancedMoveToHueCommand.optionsOverride = static_cast<uint8_t>(data->args[4]);
@@ -472,7 +474,7 @@ void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const E
         break;
 
     case Clusters::ColorControl::Commands::EnhancedMoveHue::Id:
-        enhancedMoveHueCommand.moveMode        = static_cast<EmberAfHueMoveMode>(data->args[0]);
+        enhancedMoveHueCommand.moveMode        = static_cast<HueMoveMode>(data->args[0]);
         enhancedMoveHueCommand.rate            = static_cast<uint16_t>(data->args[1]);
         enhancedMoveHueCommand.optionsMask     = static_cast<uint8_t>(data->args[2]);
         enhancedMoveHueCommand.optionsOverride = static_cast<uint8_t>(data->args[3]);
@@ -481,7 +483,7 @@ void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const E
         break;
 
     case Clusters::ColorControl::Commands::EnhancedStepHue::Id:
-        enhancedStepHueCommand.stepMode        = static_cast<EmberAfHueStepMode>(data->args[0]);
+        enhancedStepHueCommand.stepMode        = static_cast<HueStepMode>(data->args[0]);
         enhancedStepHueCommand.stepSize        = static_cast<uint16_t>(data->args[1]);
         enhancedStepHueCommand.transitionTime  = static_cast<uint16_t>(data->args[2]);
         enhancedStepHueCommand.optionsMask     = static_cast<uint8_t>(data->args[3]);
@@ -521,7 +523,7 @@ void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const E
         break;
 
     case Clusters::ColorControl::Commands::MoveColorTemperature::Id:
-        moveColorTemperatureCommand.moveMode                      = static_cast<EmberAfHueMoveMode>(data->args[0]);
+        moveColorTemperatureCommand.moveMode                      = static_cast<HueMoveMode>(data->args[0]);
         moveColorTemperatureCommand.rate                          = static_cast<uint16_t>(data->args[1]);
         moveColorTemperatureCommand.colorTemperatureMinimumMireds = static_cast<uint16_t>(data->args[2]);
         moveColorTemperatureCommand.colorTemperatureMaximumMireds = static_cast<uint16_t>(data->args[3]);
@@ -532,7 +534,7 @@ void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const E
         break;
 
     case Clusters::ColorControl::Commands::StepColorTemperature::Id:
-        stepColorTemperatureCommand.stepMode                      = static_cast<EmberAfHueStepMode>(data->args[0]);
+        stepColorTemperatureCommand.stepMode                      = static_cast<HueStepMode>(data->args[0]);
         stepColorTemperatureCommand.stepSize                      = static_cast<uint16_t>(data->args[1]);
         stepColorTemperatureCommand.transitionTime                = static_cast<uint16_t>(data->args[2]);
         stepColorTemperatureCommand.colorTemperatureMinimumMireds = static_cast<uint16_t>(data->args[3]);
@@ -547,6 +549,8 @@ void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const E
 
 void ProcessColorControlGroupBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding)
 {
+    using namespace Clusters::ColorControl;
+
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 
     Clusters::ColorControl::Commands::MoveToHue::Type moveToHueCommand;
@@ -573,7 +577,7 @@ void ProcessColorControlGroupBindingCommand(BindingCommandData * data, const Emb
     {
     case Clusters::ColorControl::Commands::MoveToHue::Id:
         moveToHueCommand.hue             = static_cast<uint8_t>(data->args[0]);
-        moveToHueCommand.direction       = static_cast<EmberAfHueDirection>(data->args[1]);
+        moveToHueCommand.direction       = static_cast<HueDirection>(data->args[1]);
         moveToHueCommand.transitionTime  = static_cast<uint16_t>(data->args[2]);
         moveToHueCommand.optionsMask     = static_cast<uint8_t>(data->args[3]);
         moveToHueCommand.optionsOverride = static_cast<uint8_t>(data->args[4]);
@@ -581,7 +585,7 @@ void ProcessColorControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
 
     case Clusters::ColorControl::Commands::MoveHue::Id:
-        moveHueCommand.moveMode        = static_cast<EmberAfHueMoveMode>(data->args[0]);
+        moveHueCommand.moveMode        = static_cast<HueMoveMode>(data->args[0]);
         moveHueCommand.rate            = static_cast<uint8_t>(data->args[1]);
         moveHueCommand.optionsMask     = static_cast<uint8_t>(data->args[2]);
         moveHueCommand.optionsOverride = static_cast<uint8_t>(data->args[3]);
@@ -589,7 +593,7 @@ void ProcessColorControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
 
     case Clusters::ColorControl::Commands::StepHue::Id:
-        stepHueCommand.stepMode        = static_cast<EmberAfHueStepMode>(data->args[0]);
+        stepHueCommand.stepMode        = static_cast<HueStepMode>(data->args[0]);
         stepHueCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
         stepHueCommand.transitionTime  = static_cast<uint8_t>(data->args[2]);
         stepHueCommand.optionsMask     = static_cast<uint8_t>(data->args[3]);
@@ -606,7 +610,7 @@ void ProcessColorControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
 
     case Clusters::ColorControl::Commands::MoveSaturation::Id:
-        moveSaturationCommand.moveMode        = static_cast<EmberAfSaturationMoveMode>(data->args[0]);
+        moveSaturationCommand.moveMode        = static_cast<SaturationMoveMode>(data->args[0]);
         moveSaturationCommand.rate            = static_cast<uint8_t>(data->args[1]);
         moveSaturationCommand.optionsMask     = static_cast<uint8_t>(data->args[2]);
         moveSaturationCommand.optionsOverride = static_cast<uint8_t>(data->args[3]);
@@ -614,7 +618,7 @@ void ProcessColorControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
 
     case Clusters::ColorControl::Commands::StepSaturation::Id:
-        stepSaturationCommand.stepMode        = static_cast<EmberAfSaturationStepMode>(data->args[0]);
+        stepSaturationCommand.stepMode        = static_cast<SaturationStepMode>(data->args[0]);
         stepSaturationCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
         stepSaturationCommand.transitionTime  = static_cast<uint8_t>(data->args[2]);
         stepSaturationCommand.optionsMask     = static_cast<uint8_t>(data->args[3]);
@@ -667,7 +671,7 @@ void ProcessColorControlGroupBindingCommand(BindingCommandData * data, const Emb
 
     case Clusters::ColorControl::Commands::EnhancedMoveToHue::Id:
         enhancedMoveToHueCommand.enhancedHue     = static_cast<uint16_t>(data->args[0]);
-        enhancedMoveToHueCommand.direction       = static_cast<EmberAfHueDirection>(data->args[1]);
+        enhancedMoveToHueCommand.direction       = static_cast<HueDirection>(data->args[1]);
         enhancedMoveToHueCommand.transitionTime  = static_cast<uint16_t>(data->args[2]);
         enhancedMoveToHueCommand.optionsMask     = static_cast<uint8_t>(data->args[3]);
         enhancedMoveToHueCommand.optionsOverride = static_cast<uint8_t>(data->args[4]);
@@ -675,7 +679,7 @@ void ProcessColorControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
 
     case Clusters::ColorControl::Commands::EnhancedMoveHue::Id:
-        enhancedMoveHueCommand.moveMode        = static_cast<EmberAfHueMoveMode>(data->args[0]);
+        enhancedMoveHueCommand.moveMode        = static_cast<HueMoveMode>(data->args[0]);
         enhancedMoveHueCommand.rate            = static_cast<uint16_t>(data->args[1]);
         enhancedMoveHueCommand.optionsMask     = static_cast<uint8_t>(data->args[2]);
         enhancedMoveHueCommand.optionsOverride = static_cast<uint8_t>(data->args[3]);
@@ -683,7 +687,7 @@ void ProcessColorControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
 
     case Clusters::ColorControl::Commands::EnhancedStepHue::Id:
-        enhancedStepHueCommand.stepMode        = static_cast<EmberAfHueStepMode>(data->args[0]);
+        enhancedStepHueCommand.stepMode        = static_cast<HueStepMode>(data->args[0]);
         enhancedStepHueCommand.stepSize        = static_cast<uint16_t>(data->args[1]);
         enhancedStepHueCommand.transitionTime  = static_cast<uint16_t>(data->args[2]);
         enhancedStepHueCommand.optionsMask     = static_cast<uint8_t>(data->args[3]);
@@ -720,7 +724,7 @@ void ProcessColorControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
 
     case Clusters::ColorControl::Commands::MoveColorTemperature::Id:
-        moveColorTemperatureCommand.moveMode                      = static_cast<EmberAfHueMoveMode>(data->args[0]);
+        moveColorTemperatureCommand.moveMode                      = static_cast<HueMoveMode>(data->args[0]);
         moveColorTemperatureCommand.rate                          = static_cast<uint16_t>(data->args[1]);
         moveColorTemperatureCommand.colorTemperatureMinimumMireds = static_cast<uint16_t>(data->args[2]);
         moveColorTemperatureCommand.colorTemperatureMaximumMireds = static_cast<uint16_t>(data->args[3]);
@@ -730,7 +734,7 @@ void ProcessColorControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
 
     case Clusters::ColorControl::Commands::StepColorTemperature::Id:
-        stepColorTemperatureCommand.stepMode                      = static_cast<EmberAfHueStepMode>(data->args[0]);
+        stepColorTemperatureCommand.stepMode                      = static_cast<HueStepMode>(data->args[0]);
         stepColorTemperatureCommand.stepSize                      = static_cast<uint16_t>(data->args[1]);
         stepColorTemperatureCommand.transitionTime                = static_cast<uint16_t>(data->args[2]);
         stepColorTemperatureCommand.colorTemperatureMinimumMireds = static_cast<uint16_t>(data->args[3]);

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -813,7 +813,7 @@ EmberEventControl * ColorControlServer::configureHSVEventControl(EndpointId endp
  * @return false Failed
  */
 bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                        uint8_t moveMode, uint16_t rate, uint8_t optionsMask, uint8_t optionsOverride,
+                                        HueMoveMode moveMode, uint16_t rate, uint8_t optionsMask, uint8_t optionsOverride,
                                         bool isEnhanced)
 {
     EndpointId endpoint                               = commandPath.mEndpointId;
@@ -823,9 +823,7 @@ bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const 
     VerifyOrExit(colorHueTransitionState != nullptr, status = Status::UnsupportedEndpoint);
 
     // check moveMode before any operation is done on the transition states
-    if ((rate == 0 && moveMode != EMBER_ZCL_HUE_MOVE_MODE_STOP) ||
-        (moveMode != EMBER_ZCL_HUE_MOVE_MODE_STOP && moveMode != EMBER_ZCL_HUE_MOVE_MODE_UP &&
-         moveMode != EMBER_ZCL_HUE_MOVE_MODE_DOWN))
+    if (moveMode == HueMoveMode::kUnknownEnumValue || (rate == 0 && moveMode != HueMoveMode::kStop))
     {
         commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return true;
@@ -842,7 +840,7 @@ bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const 
     // now, kick off the state machine.
     initHueTransitionState(endpoint, colorHueTransitionState, isEnhanced);
 
-    if (moveMode == EMBER_ZCL_HUE_MOVE_MODE_STOP)
+    if (moveMode == HueMoveMode::kStop)
     {
         // Per spec any saturation transition must also be cancelled.
         Color16uTransitionState * saturationState = getSaturationTransitionState(endpoint);
@@ -861,7 +859,7 @@ bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const 
         handleModeSwitch(endpoint, ColorControlServer::ColorMode::COLOR_MODE_HSV);
     }
 
-    if (moveMode == EMBER_ZCL_HUE_MOVE_MODE_UP)
+    if (moveMode == HueMoveMode::kUp)
     {
         if (isEnhanced)
         {
@@ -874,7 +872,7 @@ bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const 
 
         colorHueTransitionState->up = true;
     }
-    else if (moveMode == EMBER_ZCL_HUE_MOVE_MODE_DOWN)
+    else if (moveMode == HueMoveMode::kDown)
     {
         if (isEnhanced)
         {
@@ -919,14 +917,14 @@ exit:
  * @return false Failed
  */
 bool ColorControlServer::moveToHueCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                          uint16_t hue, uint8_t hueMoveMode, uint16_t transitionTime, uint8_t optionsMask,
+                                          uint16_t hue, HueDirection moveDirection, uint16_t transitionTime, uint8_t optionsMask,
                                           uint8_t optionsOverride, bool isEnhanced)
 {
     EndpointId endpoint = commandPath.mEndpointId;
 
     Status status       = Status::Success;
     uint16_t currentHue = 0;
-    uint8_t direction;
+    HueDirection direction;
 
     ColorHueTransitionState * colorHueTransitionState = getColorHueTransitionState(endpoint);
 
@@ -957,42 +955,40 @@ bool ColorControlServer::moveToHueCommand(app::CommandHandler * commandObj, cons
         transitionTime++;
     }
 
-    // For move to hue, the move modes are different from the other move commands.
-    // Need to translate from the move to hue transitions to the internal
-    // representation.
-    switch (hueMoveMode)
+    // Convert the ShortestDistance/LongestDistance moveDirection values into Up/Down.
+    switch (moveDirection)
     {
-    case EMBER_ZCL_HUE_DIRECTION_SHORTEST_DISTANCE:
+    case HueDirection::kShortestDistance:
         if ((isEnhanced && (static_cast<uint16_t>(currentHue - hue) > HALF_MAX_UINT16T)) ||
             (!isEnhanced && (static_cast<uint8_t>(currentHue - hue) > HALF_MAX_UINT8T)))
         {
-            direction = MOVE_MODE_UP;
+            direction = HueDirection::kUp;
         }
         else
         {
-            direction = MOVE_MODE_DOWN;
+            direction = HueDirection::kDown;
         }
         break;
-    case EMBER_ZCL_HUE_DIRECTION_LONGEST_DISTANCE:
+    case HueDirection::kLongestDistance:
         if ((isEnhanced && (static_cast<uint16_t>(currentHue - hue) > HALF_MAX_UINT16T)) ||
             (!isEnhanced && (static_cast<uint8_t>(currentHue - hue) > HALF_MAX_UINT8T)))
         {
-            direction = MOVE_MODE_DOWN;
+            direction = HueDirection::kDown;
         }
         else
         {
-            direction = MOVE_MODE_UP;
+            direction = HueDirection::kUp;
         }
         break;
-    case EMBER_ZCL_HUE_DIRECTION_UP:
-        direction = MOVE_MODE_UP;
+    case HueDirection::kUp:
+    case HueDirection::kDown:
+        direction = moveDirection;
         break;
-    case EMBER_ZCL_HUE_DIRECTION_DOWN:
-        direction = MOVE_MODE_DOWN;
-        break;
-    default:
+    case HueDirection::kUnknownEnumValue:
         commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return true;
+        /* No default case, so if a new direction value gets added we will just fail
+           to compile until we handle it correctly.  */
     }
 
     if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
@@ -1029,7 +1025,7 @@ bool ColorControlServer::moveToHueCommand(app::CommandHandler * commandObj, cons
     colorHueTransitionState->stepsRemaining = transitionTime;
     colorHueTransitionState->stepsTotal     = transitionTime;
     colorHueTransitionState->endpoint       = endpoint;
-    colorHueTransitionState->up             = (direction == MOVE_MODE_UP);
+    colorHueTransitionState->up             = (direction == HueDirection::kUp);
     colorHueTransitionState->repeat         = false;
 
     SetHSVRemainingTime(endpoint);
@@ -1169,7 +1165,7 @@ exit:
  * @return false Failed
  */
 bool ColorControlServer::stepHueCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                        uint8_t stepMode, uint16_t stepSize, uint16_t transitionTime, uint8_t optionsMask,
+                                        HueStepMode stepMode, uint16_t stepSize, uint16_t transitionTime, uint8_t optionsMask,
                                         uint8_t optionsOverride, bool isEnhanced)
 {
     EndpointId endpoint = commandPath.mEndpointId;
@@ -1180,7 +1176,7 @@ bool ColorControlServer::stepHueCommand(app::CommandHandler * commandObj, const 
     VerifyOrExit(colorHueTransitionState != nullptr, status = Status::UnsupportedEndpoint);
 
     // Confirm validity of the step mode received
-    if (stepMode != STEP_MODE_UP && stepMode != STEP_MODE_DOWN)
+    if (stepMode == HueStepMode::kUnknownEnumValue)
     {
         commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return true;
@@ -1216,12 +1212,12 @@ bool ColorControlServer::stepHueCommand(app::CommandHandler * commandObj, const 
     if (isEnhanced)
     {
 
-        if (stepMode == STEP_MODE_UP)
+        if (stepMode == HueStepMode::kUp)
         {
             colorHueTransitionState->finalEnhancedHue = addEnhancedHue(colorHueTransitionState->currentEnhancedHue, stepSize);
             colorHueTransitionState->up               = true;
         }
-        else if (stepMode == STEP_MODE_DOWN)
+        else if (stepMode == HueStepMode::kDown)
         {
             colorHueTransitionState->finalEnhancedHue = subtractEnhancedHue(colorHueTransitionState->currentEnhancedHue, stepSize);
             colorHueTransitionState->up               = false;
@@ -1229,12 +1225,12 @@ bool ColorControlServer::stepHueCommand(app::CommandHandler * commandObj, const 
     }
     else
     {
-        if (stepMode == MOVE_MODE_UP)
+        if (stepMode == HueStepMode::kUp)
         {
             colorHueTransitionState->finalHue = addHue(colorHueTransitionState->currentHue, static_cast<uint8_t>(stepSize));
             colorHueTransitionState->up       = true;
         }
-        else if (stepMode == STEP_MODE_DOWN)
+        else if (stepMode == HueStepMode::kDown)
         {
             colorHueTransitionState->finalHue = subtractHue(colorHueTransitionState->currentHue, static_cast<uint8_t>(stepSize));
             colorHueTransitionState->up       = false;
@@ -1270,9 +1266,7 @@ bool ColorControlServer::moveSaturationCommand(app::CommandHandler * commandObj,
     VerifyOrExit(colorSaturationTransitionState != nullptr, status = Status::UnsupportedEndpoint);
 
     // check moveMode before any operation is done on the transition states
-    if ((rate == 0 && moveMode != EMBER_ZCL_SATURATION_MOVE_MODE_STOP) ||
-        (moveMode != EMBER_ZCL_SATURATION_MOVE_MODE_STOP && moveMode != EMBER_ZCL_SATURATION_MOVE_MODE_UP &&
-         moveMode != EMBER_ZCL_SATURATION_MOVE_MODE_DOWN))
+    if (moveMode == SaturationMoveMode::kUnknownEnumValue || (rate == 0 && moveMode != SaturationMoveMode::kStop))
     {
         commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return true;
@@ -1292,7 +1286,7 @@ bool ColorControlServer::moveSaturationCommand(app::CommandHandler * commandObj,
     // now, kick off the state machine.
     initSaturationTransitionState(endpoint, colorSaturationTransitionState);
 
-    if (moveMode == EMBER_ZCL_SATURATION_MOVE_MODE_STOP)
+    if (moveMode == SaturationMoveMode::kStop)
     {
         // Per spec any hue transition must also be cancelled.
         ColorHueTransitionState * hueState = getColorHueTransitionState(endpoint);
@@ -1304,11 +1298,11 @@ bool ColorControlServer::moveSaturationCommand(app::CommandHandler * commandObj,
     // Handle color mode transition, if necessary.
     handleModeSwitch(endpoint, COLOR_MODE_HSV);
 
-    if (moveMode == EMBER_ZCL_SATURATION_MOVE_MODE_UP)
+    if (moveMode == SaturationMoveMode::kUp)
     {
         colorSaturationTransitionState->finalValue = MAX_SATURATION_VALUE;
     }
-    else if (moveMode == EMBER_ZCL_SATURATION_MOVE_MODE_DOWN)
+    else if (moveMode == SaturationMoveMode::kDown)
     {
         colorSaturationTransitionState->finalValue = MIN_SATURATION_VALUE;
     }
@@ -1401,7 +1395,7 @@ exit:
 bool ColorControlServer::stepSaturationCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                const Commands::StepSaturation::DecodableType & commandData)
 {
-    uint8_t stepMode          = commandData.stepMode;
+    auto stepMode             = commandData.stepMode;
     uint8_t stepSize          = commandData.stepSize;
     uint8_t transitionTime    = commandData.transitionTime;
     uint8_t optionsMask       = commandData.optionsMask;
@@ -1414,7 +1408,7 @@ bool ColorControlServer::stepSaturationCommand(app::CommandHandler * commandObj,
     VerifyOrExit(colorSaturationTransitionState != nullptr, status = Status::UnsupportedEndpoint);
 
     // Confirm validity of the step mode received
-    if (stepMode != STEP_MODE_UP && stepMode != STEP_MODE_DOWN)
+    if (stepMode == SaturationStepMode::kUnknownEnumValue)
     {
         commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return true;
@@ -1441,11 +1435,11 @@ bool ColorControlServer::stepSaturationCommand(app::CommandHandler * commandObj,
     initSaturationTransitionState(endpoint, colorSaturationTransitionState);
     currentSaturation = static_cast<uint8_t>(colorSaturationTransitionState->currentValue);
 
-    if (stepMode == MOVE_MODE_UP)
+    if (stepMode == SaturationStepMode::kUp)
     {
         colorSaturationTransitionState->finalValue = addSaturation(currentSaturation, stepSize);
     }
-    else if (stepMode == MOVE_MODE_DOWN)
+    else if (stepMode == SaturationStepMode::kDown)
     {
         colorSaturationTransitionState->finalValue = subtractSaturation(currentSaturation, stepSize);
     }
@@ -2205,7 +2199,7 @@ void ColorControlServer::updateTempCommand(EndpointId endpoint)
 bool ColorControlServer::moveColorTempCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                               const Commands::MoveColorTemperature::DecodableType & commandData)
 {
-    uint8_t moveMode                 = commandData.moveMode;
+    auto moveMode                    = commandData.moveMode;
     uint16_t rate                    = commandData.rate;
     uint16_t colorTemperatureMinimum = commandData.colorTemperatureMinimumMireds;
     uint16_t colorTemperatureMaximum = commandData.colorTemperatureMaximumMireds;
@@ -2221,8 +2215,7 @@ bool ColorControlServer::moveColorTempCommand(app::CommandHandler * commandObj, 
     VerifyOrExit(colorTempTransitionState != nullptr, status = Status::UnsupportedEndpoint);
 
     // check moveMode before any operation is done on the transition states
-    if ((rate == 0 && moveMode != MOVE_MODE_STOP) ||
-        (moveMode != MOVE_MODE_STOP && moveMode != MOVE_MODE_UP && moveMode != MOVE_MODE_DOWN))
+    if (moveMode == HueMoveMode::kUnknownEnumValue || (rate == 0 && moveMode != HueMoveMode::kStop))
     {
         commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return true;
@@ -2240,7 +2233,7 @@ bool ColorControlServer::moveColorTempCommand(app::CommandHandler * commandObj, 
     // New command.  Need to stop any active transitions.
     stopAllColorTransitions(endpoint);
 
-    if (moveMode == MOVE_MODE_STOP)
+    if (moveMode == HueMoveMode::kStop)
     {
         commandObj->AddStatus(commandPath, Status::Success);
         return true;
@@ -2263,7 +2256,7 @@ bool ColorControlServer::moveColorTempCommand(app::CommandHandler * commandObj, 
     Attributes::ColorTemperatureMireds::Get(endpoint, &colorTempTransitionState->initialValue);
     colorTempTransitionState->currentValue = colorTempTransitionState->initialValue;
 
-    if (moveMode == MOVE_MODE_UP)
+    if (moveMode == HueMoveMode::kUp)
     {
         if (tempPhysicalMax > colorTemperatureMaximum)
         {
@@ -2326,7 +2319,7 @@ bool ColorControlServer::moveToColorTempCommand(app::CommandHandler * commandObj
 bool ColorControlServer::stepColorTempCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                               const Commands::StepColorTemperature::DecodableType & commandData)
 {
-    uint8_t stepMode                 = commandData.stepMode;
+    auto stepMode                    = commandData.stepMode;
     uint16_t stepSize                = commandData.stepSize;
     uint16_t transitionTime          = commandData.transitionTime;
     uint16_t colorTemperatureMinimum = commandData.colorTemperatureMinimumMireds;
@@ -2342,7 +2335,7 @@ bool ColorControlServer::stepColorTempCommand(app::CommandHandler * commandObj, 
     VerifyOrExit(colorTempTransitionState != nullptr, status = Status::UnsupportedEndpoint);
 
     // Confirm validity of the step mode received
-    if (stepMode != STEP_MODE_UP && stepMode != STEP_MODE_DOWN)
+    if (stepMode == HueStepMode::kUnknownEnumValue)
     {
         commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return true;
@@ -2382,7 +2375,7 @@ bool ColorControlServer::stepColorTempCommand(app::CommandHandler * commandObj, 
     Attributes::ColorTemperatureMireds::Get(endpoint, &colorTempTransitionState->initialValue);
     colorTempTransitionState->currentValue = colorTempTransitionState->initialValue;
 
-    if (stepMode == STEP_MODE_UP)
+    if (stepMode == HueStepMode::kUp)
     {
         uint32_t finalValue32u = static_cast<uint32_t>(colorTempTransitionState->initialValue) + static_cast<uint32_t>(stepSize);
         if (finalValue32u > UINT16_MAX)
@@ -2394,7 +2387,7 @@ bool ColorControlServer::stepColorTempCommand(app::CommandHandler * commandObj, 
             colorTempTransitionState->finalValue = static_cast<uint16_t>(finalValue32u);
         }
     }
-    else if (stepMode == STEP_MODE_DOWN)
+    else if (stepMode == HueStepMode::kDown)
     {
         uint32_t finalValue32u = static_cast<uint32_t>(colorTempTransitionState->initialValue) - static_cast<uint32_t>(stepSize);
         if (finalValue32u > UINT16_MAX)

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -66,19 +66,9 @@ public:
     /**********************************************************
      * Enums
      *********************************************************/
-
-    enum MoveMode
-    {
-        MOVE_MODE_STOP = 0x00,
-        MOVE_MODE_UP   = 0x01,
-        MOVE_MODE_DOWN = 0x03
-    };
-
-    enum StepMode
-    {
-        STEP_MODE_UP   = 0x01,
-        STEP_MODE_DOWN = 0x03
-    };
+    using HueStepMode  = chip::app::Clusters::ColorControl::HueStepMode;
+    using HueMoveMode  = chip::app::Clusters::ColorControl::HueMoveMode;
+    using HueDirection = chip::app::Clusters::ColorControl::HueDirection;
 
     enum ColorLoopDirection
     {
@@ -151,16 +141,16 @@ public:
 
 #ifdef EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_HSV
     bool moveHueCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                        uint8_t moveMode, uint16_t rate, uint8_t optionsMask, uint8_t optionsOverride, bool isEnhanced);
+                        HueMoveMode moveMode, uint16_t rate, uint8_t optionsMask, uint8_t optionsOverride, bool isEnhanced);
     bool moveToHueCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath, uint16_t hue,
-                          uint8_t hueMoveMode, uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride,
+                          HueDirection moveDirection, uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride,
                           bool isEnhanced);
     bool moveToHueAndSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                                        uint16_t hue, uint8_t saturation, uint16_t transitionTime, uint8_t optionsMask,
                                        uint8_t optionsOverride, bool isEnhanced);
     bool stepHueCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                        uint8_t stepMode, uint16_t stepSize, uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride,
-                        bool isEnhanced);
+                        HueStepMode stepMode, uint16_t stepSize, uint16_t transitionTime, uint8_t optionsMask,
+                        uint8_t optionsOverride, bool isEnhanced);
     bool moveSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                                const chip::app::Clusters::ColorControl::Commands::MoveSaturation::DecodableType & commandData);
     bool moveToSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -9,9 +9,6 @@ WeakEnums:
     - ColorMode
     - EnhancedColorMode
     - HardwareFaultEnum
-    - HueDirection
-    - HueMoveMode
-    - HueStepMode
     - IdentifyEffectIdentifier
     - IdentifyEffectVariant
     - IdentifyIdentifyType
@@ -21,8 +18,6 @@ WeakEnums:
     - PHYRateEnum
     - RadioFaultEnum
     - RoutingRole
-    - SaturationMoveMode
-    - SaturationStepMode
     - StepMode
 
 DefineBitmaps:

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
@@ -1762,19 +1762,10 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::HueDirect
     using EnumType = ColorControl::HueDirection;
     switch (val)
     {
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
     case EnumType::kShortestDistance:
     case EnumType::kLongestDistance:
     case EnumType::kUp:
     case EnumType::kDown:
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-    case EMBER_ZCL_HUE_DIRECTION_SHORTEST_DISTANCE:
-    case EMBER_ZCL_HUE_DIRECTION_LONGEST_DISTANCE:
-    case EMBER_ZCL_HUE_DIRECTION_UP:
-    case EMBER_ZCL_HUE_DIRECTION_DOWN:
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         return val;
     default:
         return static_cast<EnumType>(4);
@@ -1785,17 +1776,9 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::HueMoveMo
     using EnumType = ColorControl::HueMoveMode;
     switch (val)
     {
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
     case EnumType::kStop:
     case EnumType::kUp:
     case EnumType::kDown:
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-    case EMBER_ZCL_HUE_MOVE_MODE_STOP:
-    case EMBER_ZCL_HUE_MOVE_MODE_UP:
-    case EMBER_ZCL_HUE_MOVE_MODE_DOWN:
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         return val;
     default:
         return static_cast<EnumType>(2);
@@ -1806,15 +1789,8 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::HueStepMo
     using EnumType = ColorControl::HueStepMode;
     switch (val)
     {
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
     case EnumType::kUp:
     case EnumType::kDown:
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-    case EMBER_ZCL_HUE_STEP_MODE_UP:
-    case EMBER_ZCL_HUE_STEP_MODE_DOWN:
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         return val;
     default:
         return static_cast<EnumType>(0);
@@ -1825,17 +1801,9 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::Saturatio
     using EnumType = ColorControl::SaturationMoveMode;
     switch (val)
     {
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
     case EnumType::kStop:
     case EnumType::kUp:
     case EnumType::kDown:
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-    case EMBER_ZCL_SATURATION_MOVE_MODE_STOP:
-    case EMBER_ZCL_SATURATION_MOVE_MODE_UP:
-    case EMBER_ZCL_SATURATION_MOVE_MODE_DOWN:
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         return val;
     default:
         return static_cast<EnumType>(2);
@@ -1846,15 +1814,8 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::Saturatio
     using EnumType = ColorControl::SaturationStepMode;
     switch (val)
     {
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
     case EnumType::kUp:
     case EnumType::kDown:
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-    case EMBER_ZCL_SATURATION_STEP_MODE_UP:
-    case EMBER_ZCL_SATURATION_STEP_MODE_DOWN:
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         return val;
     default:
         return static_cast<EnumType>(0);

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -2278,9 +2278,6 @@ using ColorMode                                                                 
 static ColorMode __attribute__((unused)) kColorModekUnknownEnumValue                       = static_cast<ColorMode>(3);
 #endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 // Enum for HueDirection
 enum class HueDirection : uint8_t
 {
@@ -2294,14 +2291,7 @@ enum class HueDirection : uint8_t
     // enum value. This specific should never be transmitted.
     kUnknownEnumValue = 4,
 };
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-using HueDirection                                                                         = EmberAfHueDirection;
-static HueDirection __attribute__((unused)) kHueDirectionkUnknownEnumValue                 = static_cast<HueDirection>(4);
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 // Enum for HueMoveMode
 enum class HueMoveMode : uint8_t
 {
@@ -2314,14 +2304,7 @@ enum class HueMoveMode : uint8_t
     // enum value. This specific should never be transmitted.
     kUnknownEnumValue = 2,
 };
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-using HueMoveMode                                                                          = EmberAfHueMoveMode;
-static HueMoveMode __attribute__((unused)) kHueMoveModekUnknownEnumValue                   = static_cast<HueMoveMode>(2);
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 // Enum for HueStepMode
 enum class HueStepMode : uint8_t
 {
@@ -2333,14 +2316,7 @@ enum class HueStepMode : uint8_t
     // enum value. This specific should never be transmitted.
     kUnknownEnumValue = 0,
 };
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-using HueStepMode                                                                          = EmberAfHueStepMode;
-static HueStepMode __attribute__((unused)) kHueStepModekUnknownEnumValue                   = static_cast<HueStepMode>(0);
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 // Enum for SaturationMoveMode
 enum class SaturationMoveMode : uint8_t
 {
@@ -2353,14 +2329,7 @@ enum class SaturationMoveMode : uint8_t
     // enum value. This specific should never be transmitted.
     kUnknownEnumValue = 2,
 };
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-using SaturationMoveMode                                                                   = EmberAfSaturationMoveMode;
-static SaturationMoveMode __attribute__((unused)) kSaturationMoveModekUnknownEnumValue     = static_cast<SaturationMoveMode>(2);
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 // Enum for SaturationStepMode
 enum class SaturationStepMode : uint8_t
 {
@@ -2372,10 +2341,6 @@ enum class SaturationStepMode : uint8_t
     // enum value. This specific should never be transmitted.
     kUnknownEnumValue = 0,
 };
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-using SaturationStepMode                                                                   = EmberAfSaturationStepMode;
-static SaturationStepMode __attribute__((unused)) kSaturationStepModekUnknownEnumValue     = static_cast<SaturationStepMode>(0);
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 
 // Bitmap for ColorCapabilities
 enum class ColorCapabilities : uint16_t

--- a/zzz_generated/app-common/app-common/zap-generated/enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/enums.h
@@ -94,30 +94,6 @@ enum EmberAfHardwareFaultEnum : uint8_t
     EMBER_ZCL_HARDWARE_FAULT_ENUM_TAMPER_DETECTED           = 10,
 };
 
-// Enum for HueDirection
-enum EmberAfHueDirection : uint8_t
-{
-    EMBER_ZCL_HUE_DIRECTION_SHORTEST_DISTANCE = 0,
-    EMBER_ZCL_HUE_DIRECTION_LONGEST_DISTANCE  = 1,
-    EMBER_ZCL_HUE_DIRECTION_UP                = 2,
-    EMBER_ZCL_HUE_DIRECTION_DOWN              = 3,
-};
-
-// Enum for HueMoveMode
-enum EmberAfHueMoveMode : uint8_t
-{
-    EMBER_ZCL_HUE_MOVE_MODE_STOP = 0,
-    EMBER_ZCL_HUE_MOVE_MODE_UP   = 1,
-    EMBER_ZCL_HUE_MOVE_MODE_DOWN = 3,
-};
-
-// Enum for HueStepMode
-enum EmberAfHueStepMode : uint8_t
-{
-    EMBER_ZCL_HUE_STEP_MODE_UP   = 1,
-    EMBER_ZCL_HUE_STEP_MODE_DOWN = 3,
-};
-
 // Enum for IdentifyEffectIdentifier
 enum EmberAfIdentifyEffectIdentifier : uint8_t
 {
@@ -209,21 +185,6 @@ enum EmberAfRoutingRole : uint8_t
     EMBER_ZCL_ROUTING_ROLE_REED              = 4,
     EMBER_ZCL_ROUTING_ROLE_ROUTER            = 5,
     EMBER_ZCL_ROUTING_ROLE_LEADER            = 6,
-};
-
-// Enum for SaturationMoveMode
-enum EmberAfSaturationMoveMode : uint8_t
-{
-    EMBER_ZCL_SATURATION_MOVE_MODE_STOP = 0,
-    EMBER_ZCL_SATURATION_MOVE_MODE_UP   = 1,
-    EMBER_ZCL_SATURATION_MOVE_MODE_DOWN = 3,
-};
-
-// Enum for SaturationStepMode
-enum EmberAfSaturationStepMode : uint8_t
-{
-    EMBER_ZCL_SATURATION_STEP_MODE_UP   = 1,
-    EMBER_ZCL_SATURATION_STEP_MODE_DOWN = 3,
 };
 
 // Enum for StepMode


### PR DESCRIPTION
Gets us some type safety and removes some of the confusion where we were switching on a thing called moveMode but comparing it to move direction values.


