### PR TITLE
Fix various mis-alignments wrt spec in cluster XML.

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/boolean-state-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/boolean-state-cluster.xml
@@ -26,7 +26,7 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
-    <attribute side="server" code="0x0000" define="STATE_VALUE" type="boolean" writable="false"  default="0" reportable="true" optional="false">StateValue</attribute>
+    <attribute side="server" code="0x0000" define="STATE_VALUE" type="boolean" writable="false" reportable="true" optional="false">StateValue</attribute>
 
     <event code="0x0000" name="StateChange" priority="info" side="server">
       <description>This event SHALL be generated when the StateValue attribute changes.</description>

--- a/src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml
@@ -31,6 +31,6 @@ limitations under the License.
     <define>FIXED_LABEL_CLUSTER</define>
     <description>The Fixed Label Cluster provides a feature for the device to tag an endpoint with zero or more read only
 labels.</description>
-    <attribute side="server" code="0x0000" define="LABEL_LIST" type="ARRAY" entryType="LabelStruct" length="254" writable="false" optional="false">LabelList</attribute>
+    <attribute side="server" code="0x0000" define="LABEL_LIST" type="ARRAY" entryType="LabelStruct" writable="false" optional="false">LabelList</attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/network-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/network-commissioning-cluster.xml
@@ -87,7 +87,7 @@ limitations under the License.
             <description>MaxNetworks</description>
             <access op="read" privilege="administer"/>
         </attribute>
-        <attribute side="server" code="0x0001" define="NETWORKS" type="ARRAY" entryType="NetworkInfo" length="12" writable="false" optional="false">
+        <attribute side="server" code="0x0001" define="NETWORKS" type="ARRAY" entryType="NetworkInfo" writable="false" optional="false">
             <description>Networks</description>
             <access op="read" privilege="administer"/>
         </attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/occupancy-sensing-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/occupancy-sensing-cluster.xml
@@ -53,13 +53,13 @@ limitations under the License.
     <attribute side="server" code="0x0001" define="OCCUPANCY_SENSOR_TYPE" type="OccupancySensorTypeEnum" min="0x00" max="0xFE" writable="false" optional="false">OccupancySensorType</attribute>
     <attribute side="server" code="0x0002" define="OCCUPANCY_SENSOR_TYPE_BITMAP" type="OccupancySensorTypeBitmap" min="0x00" max="0x07" writable="false" optional="false">OccupancySensorTypeBitmap</attribute>
 
-    <attribute side="server" code="0x0010" define="PIR_OCCUPIED_TO_UNOCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">
+    <attribute side="server" code="0x0010" define="PIR_OCCUPIED_TO_UNOCCUPIED_DELAY" type="INT16U" writable="true" default="0x0000" optional="true">
       <description>PIROccupiedToUnoccupiedDelay</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
     </attribute>
 
-    <attribute side="server" code="0x0011" define="PIR_UNOCCUPIED_TO_OCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">
+    <attribute side="server" code="0x0011" define="PIR_UNOCCUPIED_TO_OCCUPIED_DELAY" type="INT16U" writable="true" default="0x0000" optional="true">
       <description>PIRUnoccupiedToOccupiedDelay</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
@@ -71,13 +71,13 @@ limitations under the License.
       <access op="write" role="manage"/>
     </attribute>
 
-    <attribute side="server" code="0x0020" define="ULTRASONIC_OCCUPIED_TO_UNOCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">
+    <attribute side="server" code="0x0020" define="ULTRASONIC_OCCUPIED_TO_UNOCCUPIED_DELAY" type="INT16U" writable="true" default="0x0000" optional="true">
       <description>UltrasonicOccupiedToUnoccupiedDelay</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
     </attribute>
 
-    <attribute side="server" code="0x0021" define="ULTRASONIC_UNOCCUPIED_TO_OCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">
+    <attribute side="server" code="0x0021" define="ULTRASONIC_UNOCCUPIED_TO_OCCUPIED_DELAY" type="INT16U" writable="true" default="0x0000" optional="true">
       <description>UltrasonicUnoccupiedToOccupiedDelay</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
@@ -89,13 +89,13 @@ limitations under the License.
       <access op="write" role="manage"/>
     </attribute>
 
-    <attribute side="server" code="0x0030" define="PHYSICAL_CONTACT_OCCUPIED_TO_UNOCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">
+    <attribute side="server" code="0x0030" define="PHYSICAL_CONTACT_OCCUPIED_TO_UNOCCUPIED_DELAY" type="INT16U" writable="true" default="0x0000" optional="true">
       <description>PhysicalContactOccupiedToUnoccupiedDelay</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
     </attribute>
 
-    <attribute side="server" code="0x0031" define="PHYSICAL_CONTACT_UNOCCUPIED_TO_OCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">
+    <attribute side="server" code="0x0031" define="PHYSICAL_CONTACT_UNOCCUPIED_TO_OCCUPIED_DELAY" type="INT16U" writable="true" default="0x0000" optional="true">
       <description>PhysicalContactUnoccupiedToOccupiedDelay</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>

--- a/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
@@ -64,7 +64,7 @@ limitations under the License.
       <access op="read" privilege="administer"/>
     </attribute>
     <attribute side="server" code="0x0001" define="FABRICS" type="ARRAY" entryType="FabricDescriptorStruct" writable="false" optional="false">Fabrics</attribute>
-    <attribute side="server" code="0x0002" define="SUPPORTED_FABRICS" type="INT8U" writable="false" optional="false">SupportedFabrics</attribute>
+    <attribute side="server" code="0x0002" define="SUPPORTED_FABRICS" type="INT8U" writable="false" min="5" max="254" optional="false">SupportedFabrics</attribute>
     <attribute side="server" code="0x0003" define="COMMISSIONED_FABRICS" type="INT8U" writable="false" optional="false">CommissionedFabrics</attribute>
     <attribute side="server" code="0x0004" define="TRUSTED_ROOT_CERTIFICATES" type="ARRAY" entryType="OCTET_STRING" writable="false" optional="false">TrustedRootCertificates</attribute>
     <attribute side="server" code="0x0005" define="CURRENT_FABRIC_INDEX" type="INT8U" writable="false" optional="false">CurrentFabricIndex</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/pressure-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/pressure-measurement-cluster.xml
@@ -25,11 +25,11 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" tickFrequency="half" init="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="3"/>
-    <attribute side="server" code="0x0000" define="PRESSURE_MEASURED_VALUE" type="INT16S" writable="false" reportable="true" default="0x0000" optional="false" isNullable="true">MeasuredValue</attribute>
+    <attribute side="server" code="0x0000" define="PRESSURE_MEASURED_VALUE" type="INT16S" writable="false" reportable="true" optional="false" isNullable="true">MeasuredValue</attribute>
     <attribute side="server" code="0x0001" define="PRESSURE_MIN_MEASURED_VALUE" type="INT16S" writable="false" optional="false" isNullable="true">MinMeasuredValue</attribute>
     <attribute side="server" code="0x0002" define="PRESSURE_MAX_MEASURED_VALUE" type="INT16S" writable="false" optional="false" isNullable="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PRESSURE_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" reportable="true" optional="true" default="0">Tolerance</attribute>
-    <attribute side="server" code="0x0010" define="PRESSURE_SCALED_VALUE" type="INT16S" writable="false" reportable="true" optional="true" default="0" isNullable="true">ScaledValue</attribute>
+    <attribute side="server" code="0x0003" define="PRESSURE_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" optional="true" default="0">Tolerance</attribute>
+    <attribute side="server" code="0x0010" define="PRESSURE_SCALED_VALUE" type="INT16S" writable="false" optional="true" default="0" isNullable="true">ScaledValue</attribute>
     <attribute side="server" code="0x0011" define="PRESSURE_MIN_SCALED_VALUE" type="INT16S" writable="false" optional="true" default="0" isNullable="true">MinScaledValue</attribute>
     <attribute side="server" code="0x0012" define="PRESSURE_MAX_SCALED_VALUE" type="INT16S" writable="false" optional="true" default="0" isNullable="true">MaxScaledValue</attribute>
     <attribute side="server" code="0x0013" define="PRESSURE_SCALED_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" reportable="true" optional="true" default="0">ScaledTolerance</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/relative-humidity-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/relative-humidity-measurement-cluster.xml
@@ -28,6 +28,6 @@ limitations under the License.
     <attribute side="server" code="0x0000" define="RELATIVE_HUMIDITY_MEASURED_VALUE" type="INT16U" writable="false" reportable="true" optional="false" isNullable="true">MeasuredValue</attribute>
     <attribute side="server" code="0x0001" define="RELATIVE_HUMIDITY_MIN_MEASURED_VALUE" type="INT16U" min="0x0000" max="0x270F" writable="false" optional="false" isNullable="true">MinMeasuredValue</attribute>
     <attribute side="server" code="0x0002" define="RELATIVE_HUMIDITY_MAX_MEASURED_VALUE" type="INT16U" min="0x0001" max="0x2710" writable="false" optional="false" isNullable="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="RELATIVE_HUMIDITY_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" reportable="true" optional="true">Tolerance</attribute>
+    <attribute side="server" code="0x0003" define="RELATIVE_HUMIDITY_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" optional="true">Tolerance</attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/temperature-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/temperature-measurement-cluster.xml
@@ -27,6 +27,6 @@ limitations under the License.
     <attribute side="server" code="0x0000" define="TEMP_MEASURED_VALUE" type="INT16S" min="0x954d" max="0x7fff" writable="false" isNullable="true" optional="false">MeasuredValue</attribute>
     <attribute side="server" code="0x0001" define="TEMP_MIN_MEASURED_VALUE" type="INT16S" min="0x954d" max="0x7ffe" writable="false" isNullable="true" default="0x8000" optional="false">MinMeasuredValue</attribute>
     <attribute side="server" code="0x0002" define="TEMP_MAX_MEASURED_VALUE" type="INT16S" min="0x954e" max="0x7fff" writable="false" isNullable="true" default="0x8000" optional="false">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="TEMP_TOLERANCE" type="INT16U" min="0" max="0x8000" writable="false" default="0" optional="true">Tolerance</attribute>
+    <attribute side="server" code="0x0003" define="TEMP_TOLERANCE" type="INT16U" min="0" max="0x0800" writable="false" default="0" optional="true">Tolerance</attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/user-label-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/user-label-cluster.xml
@@ -23,7 +23,7 @@ limitations under the License.
     <code>0x0041</code>
     <define>USER_LABEL_CLUSTER</define>
     <description>The User Label Cluster provides a feature to tag an endpoint with zero or more labels.</description>
-    <attribute side="server" code="0x0000" define="LABEL_LIST" type="ARRAY" entryType="LabelStruct" length="254" writable="true" optional="false">
+    <attribute side="server" code="0x0000" define="LABEL_LIST" type="ARRAY" entryType="LabelStruct" writable="true" optional="false">
       <description>LabelList</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>


### PR DESCRIPTION
1) Remove default that is not listed in spec table in Boolean State.
   * Fixes https://github.com/project-chip/connectedhomeip/issues/25605 2) Remove length constraint on list in Fixed Label and User Label.
   * Fixes https://github.com/project-chip/connectedhomeip/issues/25610 3) Remove length constraint on list in Network Commissioning.
   * Partially addresses https://github.com/project-chip/connectedhomeip/issues/25612 4) Remove incorrect max values in Occupancy Sensing.
   * Fixes https://github.com/project-chip/connectedhomeip/issues/25614 5) Add min/max for SupportedFabrics in Operational Credentials
   * Fixes https://github.com/project-chip/connectedhomeip/issues/25616 6) Remove defaults and "reportable" annotations that are not in the spec table
   in Pressure Measurement
   * Fixes https://github.com/project-chip/connectedhomeip/issues/25617 7) Fix max value of Tolerance attribute in Temperature Measurement
   * Fixes https://github.com/project-chip/connectedhomeip/issues/25618 8) Remove stray "reportable" on Tolerance in Relative Humidity Measurement
   * Fixes https://github.com/project-chip/connectedhomeip/issues/25620
