### PR TITLE
Reducing delay between UDC requests from 1000ms to 100ms

### DIFF
--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
@@ -50,7 +50,7 @@ CHIP_ERROR UserDirectedCommissioningClient::SendUDCMessage(TransportMgrBase * tr
             ChipLogError(AppServer, "UDC SendMessage failed: %" CHIP_ERROR_FORMAT, err.Format());
             return err;
         }
-        sleep(1);
+        usleep(100 * 1000); // 100ms
     }
 
     ChipLogProgress(Inet, "UDC msg sent");


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/25634

### Change summary
The Matter spec says it may send up to 4 retries (5 total) for UDC at least 100ms apart. However, so far the delay in the SDK for each request was 1 second - this delays the subsequent on-network commissioning process by 5+ seconds. This PR reduces that delay (per UDC request) to the minimum delay prescribed by the spec. This should help reduce the cumulative delay from 5 sec to 500ms.

### Testing
Tested using the Android tv-casting-app sending UDC requests to the Linux tv-app. Observed that the requests are now sent just 100ms apart.