### PR TITLE
Revert "Use assertChipStackLockedByCurrentThread when accessing statics in src/system/SystemStats.cpp"

### DIFF
--- a/src/lib/core/tests/BUILD.gn
+++ b/src/lib/core/tests/BUILD.gn
@@ -37,7 +37,6 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support:testing",
-    "${chip_root}/src/platform",
     "${nlunit_test_root}:nlunit-test",
   ]
 }

--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -401,19 +401,24 @@ namespace DeviceLayer {
         chip::Ble::ChipBleUUID charId;
         [BleConnection fillServiceWithCharacteristicUuids:characteristic svcId:&svcId charId:&charId];
 
-        dispatch_async(_chipWorkQueue, ^{
-            // build a inet buffer from the rxEv and send to blelayer.
-            auto msgBuf = chip::System::PacketBufferHandle::NewWithData(characteristic.value.bytes, characteristic.value.length);
+        // build a inet buffer from the rxEv and send to blelayer.
+        __block chip::System::PacketBufferHandle msgBuf
+            = chip::System::PacketBufferHandle::NewWithData(characteristic.value.bytes, characteristic.value.length);
 
-            if (msgBuf.IsNull()) {
-                ChipLogError(Ble, "Failed at allocating buffer for incoming BLE data");
+        if (!msgBuf.IsNull()) {
+            dispatch_async(_chipWorkQueue, ^{
+                if (!_mBleLayer->HandleIndicationReceived((__bridge void *) peripheral, &svcId, &charId, std::move(msgBuf))) {
+                    // since this error comes from device manager core
+                    // we assume it would do the right thing, like closing the connection
+                    ChipLogError(Ble, "Failed at handling incoming BLE data");
+                }
+            });
+        } else {
+            ChipLogError(Ble, "Failed at allocating buffer for incoming BLE data");
+            dispatch_async(_chipWorkQueue, ^{
                 _mBleLayer->HandleConnectionError((__bridge void *) peripheral, CHIP_ERROR_NO_MEMORY);
-            } else if (!_mBleLayer->HandleIndicationReceived((__bridge void *) peripheral, &svcId, &charId, std::move(msgBuf))) {
-                // since this error comes from device manager core
-                // we assume it would do the right thing, like closing the connection
-                ChipLogError(Ble, "Failed at handling incoming BLE data");
-            }
-        });
+            });
+        }
     } else {
         ChipLogError(
             Ble, "BLE:Error receiving indication of Characteristics on the device: [%s]", [error.localizedDescription UTF8String]);

--- a/src/setup_payload/tests/BUILD.gn
+++ b/src/setup_payload/tests/BUILD.gn
@@ -34,7 +34,6 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/lib/support:testing",
-    "${chip_root}/src/platform",
     "${chip_root}/src/setup_payload",
     "${nlunit_test_root}:nlunit-test",
   ]

--- a/src/system/SystemStats.cpp
+++ b/src/system/SystemStats.cpp
@@ -29,7 +29,6 @@
 #include <system/SystemStats.h>
 
 #include <lib/support/SafeInt.h>
-#include <platform/LockTracker.h>
 
 #include <string.h>
 
@@ -60,29 +59,21 @@ count_t sHighWatermarks[kNumEntries];
 
 const Label * GetStrings()
 {
-    assertChipStackLockedByCurrentThread();
-
     return sStatsStrings;
 }
 
 count_t * GetResourcesInUse()
 {
-    assertChipStackLockedByCurrentThread();
-
     return sResourcesInUse;
 }
 
 count_t * GetHighWatermarks()
 {
-    assertChipStackLockedByCurrentThread();
-
     return sHighWatermarks;
 }
 
 void UpdateSnapshot(Snapshot & aSnapshot)
 {
-    assertChipStackLockedByCurrentThread();
-
     memcpy(&aSnapshot.mResourcesInUse, &sResourcesInUse, sizeof(aSnapshot.mResourcesInUse));
     memcpy(&aSnapshot.mHighWatermarks, &sHighWatermarks, sizeof(aSnapshot.mHighWatermarks));
 


### PR DESCRIPTION
Causes many crashes

Reverts project-chip/connectedhomeip#25485

fixes #25604