### PR TITLE
Remove asserts for Chip Task lock in SystemStats.cpp

### DIFF
--- a/src/system/SystemStats.cpp
+++ b/src/system/SystemStats.cpp
@@ -60,29 +60,21 @@ count_t sHighWatermarks[kNumEntries];
 
 const Label * GetStrings()
 {
-    assertChipStackLockedByCurrentThread();
-
     return sStatsStrings;
 }
 
 count_t * GetResourcesInUse()
 {
-    assertChipStackLockedByCurrentThread();
-
     return sResourcesInUse;
 }
 
 count_t * GetHighWatermarks()
 {
-    assertChipStackLockedByCurrentThread();
-
     return sHighWatermarks;
 }
 
 void UpdateSnapshot(Snapshot & aSnapshot)
 {
-    assertChipStackLockedByCurrentThread();
-
     memcpy(&aSnapshot.mResourcesInUse, &sResourcesInUse, sizeof(aSnapshot.mResourcesInUse));
     memcpy(&aSnapshot.mHighWatermarks, &sHighWatermarks, sizeof(aSnapshot.mHighWatermarks));
 


### PR DESCRIPTION
Remove asserts added in #25485 as they cause crashes for many platforms. We don't revert the PR to keep the Darwin changes that fixes a data race.

fixes #25604