### PR TITLE
Update the template path in gn_build_test_example

### DIFF
--- a/scripts/examples/gn_build_test_example.sh
+++ b/scripts/examples/gn_build_test_example.sh
@@ -40,7 +40,7 @@ function runZAP() {
     "$CHIP_ROOT"/scripts/tools/zap/generate.py "$ZAP_INPUT_FILE" -o "$ZAP_OUTPUT_DIR"
 
     # Generates the specific files for the given zap configuration
-    TARGET_APP=$APP_DIR "$CHIP_ROOT"/scripts/tools/zap/generate.py "$ZAP_INPUT_FILE" -t "$INPUT_DIR"/../templates/templates.json -o "$ZAP_OUTPUT_DIR"
+    TARGET_APP=$APP_DIR "$CHIP_ROOT"/scripts/tools/zap/generate.py "$ZAP_INPUT_FILE" -t "$INPUT_DIR"/apps/$APP_DIR/templates/templates.json -o "$ZAP_OUTPUT_DIR"
 }
 
 function runGN() {


### PR DESCRIPTION
- Update gn_build_test_example script to specify the correct templates path.
- Generated and build with gn_build_test_example to validate issue is resolved.