### PR TITLE
Update simulated README and fix gn_build_test_example template path.

### DIFF
--- a/docs/guides/simulated_device_linux.md
+++ b/docs/guides/simulated_device_linux.md
@@ -24,20 +24,21 @@ is defined by a ZAP config file and tests can be added with a
 
 -   [Building Prerequisites](./BUILDING.md#prerequisites)
 -   [Prepare For Building](./BUILDING.md#prepare-for-building)
+-   [Code Generate](../code_generation.md)
+-   [ZAP Installed](../code_generation.md#installing-zap-and-environment-variables)
 
-## Generating and building the default Simulated App with Script
+## Building the default Simulated App with Script
 
 In order to utilize the app against a commissioner or controller, the app will
 need to be specifically built.
 
-1. To generate the ZAP files, and build the `chip-app1` binary completing the
-   following steps:
+1. To build the `chip-app1` binary completing the following steps:
 
     ```
-     ./scripts/examples/gn_build_test_example.sh app1
+    ./scripts/examples/gn_build_example.sh examples/placeholder/linux out/debug/simulated/ chip_tests_zap_config=\"app1\"
     ```
 
-## Build the App only
+## Build the App with gn and ninja
 
 In order to utilize the app against a commissioner or controller, the app will
 need to be specifically built.
@@ -46,13 +47,7 @@ need to be specifically built.
 
     ```
     source scripts/activate.sh
-    CHIP_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-    GN_ARGS="chip_tests_zap_config=\"app1\""
-    GN_ARGS+="chip_project_config_include_dirs=[\"$CHIP_ROOT/examples/placeholder/linux/apps/app1/include\", \"$CHIP_ROOT/config/standalone\"]"
-    GN_ARGS+="chip_config_network_layer_ble=false"
-
-    gn gen --check --fail-on-unused-args --root=examples/placeholder/linux out/simulated --args="$GN_ARGS"
-
+    gn gen --check --root=examples/placeholder/linux out/simulated --args="chip_tests_zap_config=\"app1\""
     ninja -C out/simulated
     ```
 
@@ -61,24 +56,18 @@ need to be specifically built.
 Now that the building is completed there is a `chip-app1` binary created. This
 binary can be executed on a linux os.
 
-1. To generate the ZAP files, and build the `chip-app1` binary completing the
-   following steps:
-
-    ```
-    ./out/simulated/chip-app1
-    ```
+```
+./out/simulated/chip-app1
+```
 
 ## Running the app with test parameter
 
 Now that the building is completed there is a `chip-app1` binary created. This
 binary can be executed on a linux os with test commands.
 
-1. To generate the ZAP files, and build the `chip-app1` binary completing the
-   following steps:
-
-    ```
-    ./out/simulated/chip-app1 --command [TEST NAME]
-    ```
+```
+./out/simulated/chip-app1 --command [TEST NAME]
+```
 
 ## Interacting with the simulated app
 
@@ -88,11 +77,13 @@ interact with it using chip-tool
 1. Follow the instruction to build chip-tool in the
    [chip-tool readme](../../examples/chip-tool/README.md).
 
-2. Run this command to commission.
+2. Run this command to commission with whatever is listed on the "SetupQRCode:"
+   line in the log output:
+
     ```
-    ./out/debug/standalone/chip-tool pairing code 0x654321 MT:-24J0AFN00KA0648G00
+      ./out/debug/standalone/chip-tool pairing code 0x654321 MT:-24J0AFN00KA0648G00
     ```
-    or whatever is listed on the "SetupQRCode:" line in the log output.
+
 3. Most tests will start at this point and now an send cluster commands with
    chip-tool as follow.
 
@@ -113,14 +104,18 @@ new code is generated.
 
 1. YAML test file are located in
    [YAML folder](../../src/app/tests/suites/certification/)
+
 2. Test names must follow a strict format dues to CI of test recognition. The
    format is as follows:
+
     - Test_TC\_[`CATEGORY ABBREVIATION`]\_[`SECTION NUMBER`]\_[`SUBSECTION
       NUMBER`]\_Simulated.yaml
     - <strong>`IMPORTANT`: The test name must end in Simulated with the
       capital.</strong>
+
 3. Available properties can be found in
    [YAML Test Name](../../src/app/tests/suites/README.md)
+
 4. An Additional property is as follows:
 
     | Name | Description                                                                 |
@@ -129,14 +124,26 @@ new code is generated.
 
 5. [Test_TC_DM_1_3_Simulated](../../src/app/tests/suites/certification/Test_TC_DM_1_3_Simulated.yaml)
    is an example of a written test that runs on the simulated device.
+
 6. Next, it will need to be added to
-   [examples/placeholder/linux/apps/app1/tests.js](../../examples/placeholder/linux/apps/app1/tests.js).
-   in the following array
+   [examples/placeholder/linux/apps/app1/tests.js](../../examples/placeholder/linux/apps/app1/tests.js)
+   in the following array:
+
     ```javascript
     const tests = ["Test_TC_DM_1_3_Simulated"];
     ```
-7. Then, the code will be generated using ZAP. Follow
-   [Gen Script](#generating-and-building-the-default-simulated-app-with-script)
-   to do so.
-8. When submitting code for review, create 2 commits. One for YAML changes and
+
+7. Then, the code will be generated using ZAP.
+
+    ```
+    ./scripts/tools/zap/generate.py examples/placeholder/linux/apps/app1/config.zap -t examples/placeholder/templates/templates.json -o zzz_generated/placeholder/app1/zap-generated
+    ```
+
+    The following command can be used to generate and compile:
+
+    ```
+    ./scripts/examples/gn_build_test_example.sh app1
+    ```
+
+8) When submitting code for review, create 2 commits. One for YAML changes and
    second for generated code.

--- a/scripts/examples/gn_build_test_example.sh
+++ b/scripts/examples/gn_build_test_example.sh
@@ -40,7 +40,7 @@ function runZAP() {
     "$CHIP_ROOT"/scripts/tools/zap/generate.py "$ZAP_INPUT_FILE" -o "$ZAP_OUTPUT_DIR"
 
     # Generates the specific files for the given zap configuration
-    TARGET_APP=$APP_DIR "$CHIP_ROOT"/scripts/tools/zap/generate.py "$ZAP_INPUT_FILE" -t "$INPUT_DIR"/../templates/templates.json -o "$ZAP_OUTPUT_DIR"
+    TARGET_APP=$APP_DIR "$CHIP_ROOT"/scripts/tools/zap/generate.py "$ZAP_INPUT_FILE" -t "$INPUT_DIR"/apps/"$APP_DIR"/templates/templates.json -o "$ZAP_OUTPUT_DIR"
 }
 
 function runGN() {


### PR DESCRIPTION
- Update simulated README on updated instructions to build
- Update simulated README on updated instruction in generating tests
- Update correct path in gn_build_test_example script