### PR TITLE
Reduce CPU usage of chip-console

### DIFF
--- a/examples/common/pigweed/rpc_console/py/chip_rpc/console.py
+++ b/examples/common/pigweed/rpc_console/py/chip_rpc/console.py
@@ -328,7 +328,7 @@ def console(device: str, baudrate: int,
     serial_impl = SerialWithLogging
 
     if socket_addr is None:
-        serial_device = serial_impl(device, baudrate, timeout=0)
+        serial_device = serial_impl(device, baudrate, timeout=0.1)
         def read(): return serial_device.read(8192)
         write = serial_device.write
     else:


### PR DESCRIPTION
This is busy polling the serial port, and as a result uses 100% CPU. Use a non-zero timeout to avoid this.

Using asyncio would be better, but pyserial support for this is still experimental.