### PR TITLE
tv-casting-app: Allow for a way for Matter TV casting cache to be purged

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.ListView;
+import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import com.chip.casting.DiscoveredNodeData;
@@ -76,6 +77,22 @@ public class CommissionerDiscoveryFragment extends Fragment {
     View.OnClickListener manualCommissioningButtonOnClickListener =
         v -> callback.handleCommissioningButtonClicked(null);
     manualCommissioningButton.setOnClickListener(manualCommissioningButtonOnClickListener);
+
+    Button purgeCacheButton = getView().findViewById(R.id.purgeCacheButton);
+    Context context = getContext().getApplicationContext();
+    View.OnClickListener purgeCacheOnClickListener =
+        new View.OnClickListener() {
+          @Override
+          public void onClick(View v) {
+            boolean status = tvCastingApp.purgeCache();
+            Toast.makeText(
+                    context,
+                    "Cache purge " + (status ? "successful!" : "failed!"),
+                    Toast.LENGTH_SHORT)
+                .show();
+          }
+        };
+    purgeCacheButton.setOnClickListener(purgeCacheOnClickListener);
 
     ArrayAdapter<DiscoveredNodeData> arrayAdapter =
         new VideoPlayerCommissionerAdapter(getActivity(), commissionerVideoPlayerList);

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -181,6 +181,8 @@ public class TvCastingApp {
 
   public native List<VideoPlayer> getActiveTargetVideoPlayers();
 
+  public native boolean purgeCache();
+
   /*
    * CONTENT LAUNCHER CLUSTER
    *

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -303,6 +303,20 @@ exit:
     return true;
 }
 
+JNI_METHOD(jboolean, purgeCache)(JNIEnv * env, jobject)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "JNI_METHOD purgeCache called");
+
+    CHIP_ERROR err = CastingServer::GetInstance()->PurgeCache();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "TVCastingApp-JNI::purgeCache failed: %" CHIP_ERROR_FORMAT, err.Format());
+        return false;
+    }
+    return true;
+}
+
 JNI_METHOD(jboolean, contentLauncherLaunchURL)
 (JNIEnv * env, jobject, jobject contentApp, jstring contentUrl, jstring contentDisplayStr, jobject jResponseHandler)
 {

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_commissioner_discovery.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_commissioner_discovery.xml
@@ -15,6 +15,12 @@
         android:padding="10sp">
 
         <Button
+            android:id="@+id/purgeCacheButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Purge Cache" />
+
+        <Button
             android:id="@+id/manualCommissioningButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
@@ -185,7 +185,16 @@
  */
 - (void)disconnect:(dispatch_queue_t _Nonnull)clientQueue requestSentHandler:(nullable void (^)())requestSentHandler;
 
-/**
+/*!
+ @brief Purge data cached by the Matter casting library
+
+ @param clientQueue Queue to invoke callbacks on
+
+ @param responseHandler Called when purgeCache completes
+ */
+- (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(void (^)(MatterError * _Nonnull))responseHandler;
+
+/*!
  @brief Start the Matter server and reconnect to a previously connected Video Player (if any). This API is async
 
  @param clientQueue Queue to invoke callbacks on

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -667,15 +667,13 @@
 
 - (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(void (^)(MatterError * _Nonnull))responseHandler
 {
-    [self dispatchOnMatterSDKQueue:@"purgeCache(...)"
-                             block:^{
-                                 CHIP_ERROR err = CastingServer::GetInstance()->PurgeCache();
-                                 dispatch_async(clientQueue, ^{
-                                     responseHandler(
-                                         [[MatterError alloc] initWithCode:err.AsInteger()
-                                                                   message:[NSString stringWithUTF8String:err.AsString()]]);
-                                 });
-                             }];
+    dispatch_sync(_chipWorkQueue, ^{
+        CHIP_ERROR err = CastingServer::GetInstance()->PurgeCache();
+        dispatch_async(clientQueue, ^{
+            responseHandler([[MatterError alloc] initWithCode:err.AsInteger()
+                                                      message:[NSString stringWithUTF8String:err.AsString()]]);
+        });
+    });
 }
 
 - (void)contentLauncher_launchUrl:(ContentApp * _Nonnull)contentApp

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -665,6 +665,19 @@
     });
 }
 
+- (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(void (^)(MatterError * _Nonnull))responseHandler
+{
+    [self dispatchOnMatterSDKQueue:@"purgeCache(...)"
+                             block:^{
+                                 CHIP_ERROR err = CastingServer::GetInstance()->PurgeCache();
+                                 dispatch_async(clientQueue, ^{
+                                     responseHandler(
+                                         [[MatterError alloc] initWithCode:err.AsInteger()
+                                                                   message:[NSString stringWithUTF8String:err.AsString()]]);
+                                 });
+                             }];
+}
+
 - (void)contentLauncher_launchUrl:(ContentApp * _Nonnull)contentApp
                        contentUrl:(NSString * _Nonnull)contentUrl
                 contentDisplayStr:(NSString * _Nonnull)contentDisplayStr

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/StartFromCacheView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/StartFromCacheView.swift
@@ -28,6 +28,15 @@ struct StartFromCacheView: View {
     
     var body: some View {
         VStack(alignment: .leading) {
+            Button("Purge cache", action: {
+                viewModel.purgeAndReReadCache()
+            })
+            .frame(width: 200, height: 30, alignment: .center)
+            .border(Color.black, width: 1)
+            .background(Color.blue)
+            .foregroundColor(Color.white)
+            .padding()
+            
             NavigationLink(
                 destination: CommissionerDiscoveryView(),
                 label: {

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/StartFromCacheViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/StartFromCacheViewModel.swift
@@ -35,4 +35,16 @@ class StartFromCacheViewModel: ObservableObject {
             })
         }
     }
+    
+    func purgeAndReReadCache() {
+        if let castingServerBridge = CastingServerBridge.getSharedInstance()
+        {
+            castingServerBridge.purgeCache(DispatchQueue.main, responseHandler: { (error: MatterError) -> () in
+                DispatchQueue.main.async {
+                    self.Log.info("purgeCache returned \(error)")
+                    self.readFromCache()
+                }
+            })
+        }
+    }
 }

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -98,7 +98,7 @@ public:
                                            std::function<void(TargetEndpointInfo *)> onNewOrUpdatedEndpoint);
 
     void LogCachedVideoPlayers();
-    CHIP_ERROR PurgeVideoPlayerCache();
+    CHIP_ERROR PurgeCache();
 
     /**
      * Tears down all active subscriptions.

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -337,7 +337,7 @@ CHIP_ERROR CastingServer::VerifyOrEstablishConnection(TargetVideoPlayerInfo & ta
         onConnectionFailure);
 }
 
-CHIP_ERROR CastingServer::PurgeVideoPlayerCache()
+CHIP_ERROR CastingServer::PurgeCache()
 {
     return mPersistenceManager.PurgeVideoPlayerCache();
 }

--- a/examples/tv-casting-app/tv-casting-common/src/PersistenceManager.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/PersistenceManager.cpp
@@ -405,5 +405,11 @@ CHIP_ERROR PersistenceManager::ReadAllVideoPlayers(TargetVideoPlayerInfo outVide
 CHIP_ERROR PersistenceManager::PurgeVideoPlayerCache()
 {
     ChipLogProgress(AppServer, "PersistenceManager::PurgeVideoPlayerCache called");
-    return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(kCastingDataKey);
+    CHIP_ERROR err = chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(kCastingDataKey);
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND) // no error, if the key-value pair was not stored
+    {
+        ChipLogProgress(AppServer, "PersistenceManager::PurgeVideoPlayerCache ignoring error %" CHIP_ERROR_FORMAT, err.Format());
+        return CHIP_NO_ERROR;
+    }
+    return err;
 }


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/25664

### Problem
The Android/iOS/Linux tv-casting-apps currently do not have a way to delete the list of cached video players. Allowing this can be useful, in cases where, say a user may want their video players list deleted (for privacy) before signing out of the casting apps. If there is no way to do this, we run the risk of allowing a user-b to establish CASE with a video player user-a commissioned with, if both users are using the same tv-casting-app instance.

### Change summary
1. Added APIs for Android/iOS/Linux to purgeCache
2. Added GUI buttons on Android/iOS to call this API

### Testing
Tested with the Android/iOS tv-casting-apps and checked that the list of video players is deleted.