### PR TITLE
Improve Java/Jni IM read/subscribe

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
@@ -180,7 +180,7 @@ class WildcardFragment : Fragment() {
                                        maxInterval,
                                        keepSubscriptions,
                                        isFabricFiltered,
-                                       0)
+                                       /* imTimeoutMs= */ 0)
     } else if (type == EVENT) {
       val eventPath = ChipEventPath.newInstance(endpointId, clusterId, eventId, isUrgent)
       deviceController.subscribeToPath(subscriptionEstablishedCallback,
@@ -194,7 +194,7 @@ class WildcardFragment : Fragment() {
                                       maxInterval,
                                       keepSubscriptions,
                                       isFabricFiltered,
-                                      0)
+                                      /* imTimeoutMs= */ 0)
     }
   }
 
@@ -212,7 +212,7 @@ class WildcardFragment : Fragment() {
                           listOf(attributePath),
                           null,
                           isFabricFiltered,
-                          0)
+                          /* imTimeoutMs= */ 0)
     } else if (type == EVENT) {
       val eventPath = ChipEventPath.newInstance(endpointId, clusterId, eventId)
       deviceController.readPath(reportCallback,
@@ -221,7 +221,7 @@ class WildcardFragment : Fragment() {
                           null,
                           listOf(eventPath),
                           isFabricFiltered,
-                          0)
+                          /* imTimeoutMs= */ 0)
     }
   }
 

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
@@ -179,7 +179,8 @@ class WildcardFragment : Fragment() {
                                        minInterval,
                                        maxInterval,
                                        keepSubscriptions,
-                                       isFabricFiltered)
+                                       isFabricFiltered,
+                                       0)
     } else if (type == EVENT) {
       val eventPath = ChipEventPath.newInstance(endpointId, clusterId, eventId, isUrgent)
       deviceController.subscribeToPath(subscriptionEstablishedCallback,
@@ -192,7 +193,8 @@ class WildcardFragment : Fragment() {
                                       minInterval,
                                       maxInterval,
                                       keepSubscriptions,
-                                      isFabricFiltered)
+                                      isFabricFiltered,
+                                      0)
     }
   }
 
@@ -209,7 +211,8 @@ class WildcardFragment : Fragment() {
                           addressUpdateFragment.deviceId),
                           listOf(attributePath),
                           null,
-                          isFabricFiltered)
+                          isFabricFiltered,
+                          0)
     } else if (type == EVENT) {
       val eventPath = ChipEventPath.newInstance(endpointId, clusterId, eventId)
       deviceController.readPath(reportCallback,
@@ -217,7 +220,8 @@ class WildcardFragment : Fragment() {
                           addressUpdateFragment.deviceId),
                           null,
                           listOf(eventPath),
-                          isFabricFiltered)
+                          isFabricFiltered,
+                          0)
     }
   }
 

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImReadCommand.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImReadCommand.kt
@@ -66,7 +66,7 @@ class PairOnNetworkLongImReadCommand(
       .getConnectedDevicePointer(getNodeId(), InternalGetConnectedDeviceCallback())
     clear()
     currentCommissioner()
-      .readPath(InternalReportCallback(), devicePointer, attributePathList, Collections.emptyList(), false)
+      .readPath(InternalReportCallback(), devicePointer, attributePathList, Collections.emptyList(), false, 0)
     waitCompleteMs(getTimeoutMillis())
   }
 

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImSubscribeCommand.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImSubscribeCommand.kt
@@ -81,7 +81,7 @@ class PairOnNetworkLongImSubscribeCommand(
       .getConnectedDevicePointer(getNodeId(), InternalGetConnectedDeviceCallback())
     clear()
     currentCommissioner()
-      .subscribeToPath(InternalSubscriptionEstablishedCallback(), InternalResubscriptionAttemptCallback(), InternalReportCallback(), devicePointer, attributePathList, Collections.emptyList(), 0, 5, false, false)
+      .subscribeToPath(InternalSubscriptionEstablishedCallback(), InternalResubscriptionAttemptCallback(), InternalReportCallback(), devicePointer, attributePathList, Collections.emptyList(), 0, 5, false, false, 0)
     waitCompleteMs(getTimeoutMillis())
     currentCommissioner().shutdownSubscriptions(currentCommissioner().getFabricIndex(), getNodeId(), subscriptionId);
   }

--- a/src/controller/java/AndroidCallbacks-JNI.cpp
+++ b/src/controller/java/AndroidCallbacks-JNI.cpp
@@ -38,7 +38,7 @@ JNI_METHOD(void, GetConnectedDeviceCallbackJni, deleteCallback)(JNIEnv * env, jo
     chip::DeviceLayer::StackLock lock;
     GetConnectedDeviceCallback * connectedDeviceCallback = reinterpret_cast<GetConnectedDeviceCallback *>(callbackHandle);
     VerifyOrReturn(connectedDeviceCallback != nullptr, ChipLogError(Controller, "GetConnectedDeviceCallback handle is nullptr"));
-    delete connectedDeviceCallback;
+    chip::Platform::Delete(connectedDeviceCallback);
 }
 
 JNI_METHOD(jlong, ReportCallbackJni, newCallback)
@@ -56,7 +56,7 @@ JNI_METHOD(void, ReportCallbackJni, deleteCallback)(JNIEnv * env, jobject self, 
     chip::DeviceLayer::StackLock lock;
     ReportCallback * reportCallback = reinterpret_cast<ReportCallback *>(callbackHandle);
     VerifyOrReturn(reportCallback != nullptr, ChipLogError(Controller, "ReportCallback handle is nullptr"));
-    delete reportCallback;
+    chip::Platform::Delete(reportCallback);
 }
 
 JNI_METHOD(jlong, ReportEventCallbackJni, newCallback)
@@ -91,7 +91,7 @@ JNI_METHOD(void, WriteAttributesCallbackJni, deleteCallback)(JNIEnv * env, jobje
     chip::DeviceLayer::StackLock lock;
     WriteAttributesCallback * writeAttributesCallback = reinterpret_cast<WriteAttributesCallback *>(callbackHandle);
     VerifyOrReturn(writeAttributesCallback != nullptr, ChipLogError(Controller, "WriteAttributesCallback handle is nullptr"));
-    delete writeAttributesCallback;
+    chip::Platform::Delete(writeAttributesCallback);
 }
 
 JNI_METHOD(jlong, InvokeCallbackJni, newCallback)
@@ -107,5 +107,5 @@ JNI_METHOD(void, InvokeCallbackJni, deleteCallback)(JNIEnv * env, jobject self, 
     chip::DeviceLayer::StackLock lock;
     InvokeCallback * invokeCallback = reinterpret_cast<InvokeCallback *>(callbackHandle);
     VerifyOrReturn(invokeCallback != nullptr, ChipLogError(Controller, "InvokeCallback handle is nullptr"));
-    delete invokeCallback;
+    chip::Platform::Delete(invokeCallback);
 }

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -186,6 +186,19 @@ void ReportCallback::OnReportBegin()
     mNodeStateObj = env->NewObject(mNodeStateCls, nodeStateCtor, map);
 }
 
+void ReportCallback::OnDeallocatePaths(app::ReadPrepareParams && aReadPrepareParams)
+{
+    if (aReadPrepareParams.mpAttributePathParamsList != nullptr)
+    {
+        delete[] aReadPrepareParams.mpAttributePathParamsList;
+    }
+
+    if (aReadPrepareParams.mpEventPathParamsList != nullptr)
+    {
+        delete[] aReadPrepareParams.mpEventPathParamsList;
+    }
+}
+
 void ReportCallback::OnReportEnd()
 {
     UpdateClusterDataVersion();
@@ -239,8 +252,12 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
     readerForJson.Init(*apData);
 
     jobject value = DecodeAttributeValue(aPath, readerForJavaObject, &err);
-    // If we don't know this attribute, just skip it.
-    VerifyOrReturn(err != CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB);
+    // If we don't know this attribute, suppress it.
+    if (err == CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB)
+    {
+        err = CHIP_NO_ERROR;
+    }
+
     VerifyOrReturn(err == CHIP_NO_ERROR, ReportError(attributePathObj, nullptr, err));
     VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe(),
                    ReportError(attributePathObj, nullptr, CHIP_JNI_ERROR_EXCEPTION_THROWN));

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -123,7 +123,7 @@ void GetConnectedDeviceCallback::OnDeviceConnectionFailureFn(void * context, con
 
 ReportCallback::ReportCallback(jobject wrapperCallback, jobject subscriptionEstablishedCallback, jobject reportCallback,
                                jobject resubscriptionAttemptCallback) :
-    mClusterCacheAdapter(*this)
+    mClusterCacheAdapter(*this, Optional<EventNumber>::Missing(), false /*cacheData*/)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));

--- a/src/controller/java/AndroidCallbacks.h
+++ b/src/controller/java/AndroidCallbacks.h
@@ -69,6 +69,8 @@ struct ReportCallback : public app::ClusterStateCache::Callback
 
     CHIP_ERROR OnResubscriptionNeeded(app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override;
 
+    void OnDeallocatePaths(app::ReadPrepareParams && aReadPrepareParams) override;
+
     /** Report errors back to Java layer. attributePath may be nullptr for general errors. */
     void ReportError(jobject attributePath, jobject eventPath, CHIP_ERROR err);
     void ReportError(jobject attributePath, jobject eventPath, Protocols::InteractionModel::Status status);

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -629,7 +629,7 @@ public class ChipDeviceController {
    * @param eventPaths a list of event paths
    * @param minInterval the requested minimum interval boundary floor in seconds
    * @param maxInterval the requested maximum interval boundary ceiling in seconds
-   * @param keepSubscriptions If KeepSubscriptions is FALSE, all existing or pending subscriptions 
+   * @param keepSubscriptions If KeepSubscriptions is FALSE, all existing or pending subscriptions
    *      on the publisher for this subscriber SHALL be terminated.
    * @param isFabricFiltered limits the data read within fabric-scoped lists to the accessing fabric
    * @param imTimeoutMs im interaction time out value, it would override the default value in c++ im

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -539,14 +539,27 @@ public class ChipDeviceController {
     return getAttestationChallenge(deviceControllerPtr, devicePtr);
   }
 
-  /** Subscribe to the given attribute path. */
+  /**
+   * @brief Auto-Resubscribe to the given attribute path with keepSubscriptions and isFabricFiltered
+   * @param SubscriptionEstablishedCallback Callback when a subscribe response has been received and
+   *     processed
+   * @param ResubscriptionAttemptCallback Callback when a resubscirption haoppens, the termination
+   *     cause is provided to help inform subsequent re-subscription logic.
+   * @param ReportCallback Callback when a report data has been received and processed for the given
+   *     paths.
+   * @param devicePtr connected device pointer
+   * @param attributeList a list of attribute paths
+   * @param imTimeoutMs im interaction time out value, it would override the default value in c++ im
+   *     layer if this value is non-zero.
+   */
   public void subscribeToAttributePath(
       SubscriptionEstablishedCallback subscriptionEstablishedCallback,
       ReportCallback reportCallback,
       long devicePtr,
       List<ChipAttributePath> attributePaths,
       int minInterval,
-      int maxInterval) {
+      int maxInterval,
+      int imTimeoutMs) {
     ReportCallbackJni jniCallback =
         new ReportCallbackJni(subscriptionEstablishedCallback, reportCallback, null);
     subscribe(
@@ -558,17 +571,31 @@ public class ChipDeviceController {
         minInterval,
         maxInterval,
         false,
-        false);
+        false,
+        imTimeoutMs);
   }
 
-  /** Subscribe to the given event path */
+  /**
+   * @brief Auto-Resubscribe to the given event path with keepSubscriptions and isFabricFiltered
+   * @param SubscriptionEstablishedCallback Callback when a subscribe response has been received and
+   *     processed
+   * @param ResubscriptionAttemptCallback Callback when a resubscirption haoppens, the termination
+   *     cause is provided to help inform subsequent re-subscription logic.
+   * @param ReportCallback Callback when a report data has been received and processed for the given
+   *     paths.
+   * @param devicePtr connected device pointer
+   * @param eventList a list of event paths
+   * @param imTimeoutMs im interaction time out value, it would override the default value in c++ im
+   *     layer if this value is non-zero.
+   */
   public void subscribeToEventPath(
       SubscriptionEstablishedCallback subscriptionEstablishedCallback,
       ReportCallback reportCallback,
       long devicePtr,
       List<ChipEventPath> eventPaths,
       int minInterval,
-      int maxInterval) {
+      int maxInterval,
+      int imTimeoutMs) {
     ReportCallbackJni jniCallback =
         new ReportCallbackJni(subscriptionEstablishedCallback, reportCallback, null);
     subscribe(
@@ -580,10 +607,25 @@ public class ChipDeviceController {
         minInterval,
         maxInterval,
         false,
-        false);
+        false,
+        imTimeoutMs);
   }
 
-  /** Subscribe to the given attribute/event path with keepSubscriptions and isFabricFiltered. */
+  /**
+   * @brief Auto-Resubscribe to the given attribute/event path with keepSubscriptions and
+   *     isFabricFiltered
+   * @param SubscriptionEstablishedCallback Callback when a subscribe response has been received and
+   *     processed
+   * @param ResubscriptionAttemptCallback Callback when a resubscirption haoppens, the termination
+   *     cause is provided to help inform subsequent re-subscription logic.
+   * @param ReportCallback Callback when a report data has been received and processed for the given
+   *     paths.
+   * @param devicePtr connected device pointer
+   * @param attributeList a list of attribute paths
+   * @param eventList a list of event paths
+   * @param imTimeoutMs im interaction time out value, it would override the default value in c++ im
+   *     layer if this value is non-zero.
+   */
   public void subscribeToPath(
       SubscriptionEstablishedCallback subscriptionEstablishedCallback,
       ResubscriptionAttemptCallback resubscriptionAttemptCallback,
@@ -594,12 +636,11 @@ public class ChipDeviceController {
       int minInterval,
       int maxInterval,
       boolean keepSubscriptions,
-      boolean isFabricFiltered) {
-    // TODO: pass resubscriptionAttemptCallback to ReportCallbackJni since jni layer
-    // is not ready
-    // for auto-resubscribe
+      boolean isFabricFiltered,
+      int imTimeoutMs) {
     ReportCallbackJni jniCallback =
-        new ReportCallbackJni(subscriptionEstablishedCallback, reportCallback, null);
+        new ReportCallbackJni(
+            subscriptionEstablishedCallback, reportCallback, resubscriptionAttemptCallback);
     subscribe(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
@@ -609,12 +650,24 @@ public class ChipDeviceController {
         minInterval,
         maxInterval,
         keepSubscriptions,
-        isFabricFiltered);
+        isFabricFiltered,
+        imTimeoutMs);
   }
 
-  /** Read the given attribute path. */
+  /**
+   * @brief read the given attribute path with isFabricFiltered
+   * @param ReportCallback Callback when a report data has been received and processed for the given
+   *     paths.
+   * @param devicePtr connected device pointer
+   * @param attributeList a list of attribute paths
+   * @param imTimeoutMs im interaction time out value, it would override the default value in c++ im
+   *     layer if this value is non-zero.
+   */
   public void readAttributePath(
-      ReportCallback callback, long devicePtr, List<ChipAttributePath> attributePaths) {
+      ReportCallback callback,
+      long devicePtr,
+      List<ChipAttributePath> attributePaths,
+      int imTimeoutMs) {
     ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
     read(
         deviceControllerPtr,
@@ -622,23 +675,49 @@ public class ChipDeviceController {
         devicePtr,
         attributePaths,
         null,
-        true);
+        true,
+        imTimeoutMs);
   }
 
-  /** Read the given event path. */
+  /**
+   * @brief read the given event path with isFabricFiltered
+   * @param ReportCallback Callback when a report data has been received and processed for the given
+   *     paths.
+   * @param devicePtr connected device pointer
+   * @param eventList a list of event paths
+   * @param imTimeoutMs im interaction time out value, it would override the default value in c++ im
+   *     layer if this value is non-zero.
+   */
   public void readEventPath(
-      ReportCallback callback, long devicePtr, List<ChipEventPath> eventPaths) {
+      ReportCallback callback, long devicePtr, List<ChipEventPath> eventPaths, int imTimeoutMs) {
     ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
-    read(deviceControllerPtr, jniCallback.getCallbackHandle(), devicePtr, null, eventPaths, true);
+    read(
+        deviceControllerPtr,
+        jniCallback.getCallbackHandle(),
+        devicePtr,
+        null,
+        eventPaths,
+        true,
+        imTimeoutMs);
   }
 
-  /** Read the given attribute/event path with isFabricFiltered flag. */
+  /**
+   * @brief read the given attribute/event path with isFabricFiltered
+   * @param ReportCallback Callback when a report data has been received and processed for the given
+   *     paths.
+   * @param devicePtr connected device pointer
+   * @param attributeList a list of attribute paths
+   * @param eventList a list of event paths
+   * @param imTimeoutMs im interaction time out value, it would override the default value in c++ im
+   *     layer if this value is non-zero.
+   */
   public void readPath(
       ReportCallback callback,
       long devicePtr,
       List<ChipAttributePath> attributePaths,
       List<ChipEventPath> eventPaths,
-      boolean isFabricFiltered) {
+      boolean isFabricFiltered,
+      int imTimeoutMs) {
     ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
     read(
         deviceControllerPtr,
@@ -646,7 +725,8 @@ public class ChipDeviceController {
         devicePtr,
         attributePaths,
         eventPaths,
-        isFabricFiltered);
+        isFabricFiltered,
+        imTimeoutMs);
   }
 
   /**
@@ -746,7 +826,8 @@ public class ChipDeviceController {
       int minInterval,
       int maxInterval,
       boolean keepSubscriptions,
-      boolean isFabricFiltered);
+      boolean isFabricFiltered,
+      int imTimeoutMs);
 
   private native void read(
       long deviceControllerPtr,
@@ -754,7 +835,8 @@ public class ChipDeviceController {
       long devicePtr,
       List<ChipAttributePath> attributePaths,
       List<ChipEventPath> eventPaths,
-      boolean isFabricFiltered);
+      boolean isFabricFiltered,
+      int imTimeoutMs);
 
   private native void write(
       long deviceControllerPtr,

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -548,7 +548,9 @@ public class ChipDeviceController {
    * @param ReportCallback Callback when a report data has been received and processed for the given
    *     paths.
    * @param devicePtr connected device pointer
-   * @param attributeList a list of attribute paths
+   * @param attributePaths a list of attribute paths
+   * @param minInterval the requested minimum interval boundary floor in seconds
+   * @param maxInterval the requested maximum interval boundary ceiling in seconds
    * @param imTimeoutMs im interaction time out value, it would override the default value in c++ im
    *     layer if this value is non-zero.
    */
@@ -584,7 +586,9 @@ public class ChipDeviceController {
    * @param ReportCallback Callback when a report data has been received and processed for the given
    *     paths.
    * @param devicePtr connected device pointer
-   * @param eventList a list of event paths
+   * @param eventPaths a list of event paths
+   * @param minInterval the requested minimum interval boundary floor in seconds
+   * @param maxInterval the requested maximum interval boundary ceiling in seconds
    * @param imTimeoutMs im interaction time out value, it would override the default value in c++ im
    *     layer if this value is non-zero.
    */
@@ -621,8 +625,13 @@ public class ChipDeviceController {
    * @param ReportCallback Callback when a report data has been received and processed for the given
    *     paths.
    * @param devicePtr connected device pointer
-   * @param attributeList a list of attribute paths
-   * @param eventList a list of event paths
+   * @param attributePaths a list of attribute paths
+   * @param eventPaths a list of event paths
+   * @param minInterval the requested minimum interval boundary floor in seconds
+   * @param maxInterval the requested maximum interval boundary ceiling in seconds
+   * @param keepSubscriptions If KeepSubscriptions is FALSE, all existing or pending subscriptions 
+   *      on the publisher for this subscriber SHALL be terminated.
+   * @param isFabricFiltered limits the data read within fabric-scoped lists to the accessing fabric
    * @param imTimeoutMs im interaction time out value, it would override the default value in c++ im
    *     layer if this value is non-zero.
    */
@@ -659,7 +668,7 @@ public class ChipDeviceController {
    * @param ReportCallback Callback when a report data has been received and processed for the given
    *     paths.
    * @param devicePtr connected device pointer
-   * @param attributeList a list of attribute paths
+   * @param attributePaths a list of attribute paths
    * @param imTimeoutMs im interaction time out value, it would override the default value in c++ im
    *     layer if this value is non-zero.
    */
@@ -684,7 +693,7 @@ public class ChipDeviceController {
    * @param ReportCallback Callback when a report data has been received and processed for the given
    *     paths.
    * @param devicePtr connected device pointer
-   * @param eventList a list of event paths
+   * @param eventPaths a list of event paths
    * @param imTimeoutMs im interaction time out value, it would override the default value in c++ im
    *     layer if this value is non-zero.
    */
@@ -706,8 +715,8 @@ public class ChipDeviceController {
    * @param ReportCallback Callback when a report data has been received and processed for the given
    *     paths.
    * @param devicePtr connected device pointer
-   * @param attributeList a list of attribute paths
-   * @param eventList a list of event paths
+   * @param attributePaths a list of attribute paths
+   * @param eventPaths a list of event paths
    * @param imTimeoutMs im interaction time out value, it would override the default value in c++ im
    *     layer if this value is non-zero.
    */

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -630,7 +630,7 @@ public class ChipDeviceController {
    * @param minInterval the requested minimum interval boundary floor in seconds
    * @param maxInterval the requested maximum interval boundary ceiling in seconds
    * @param keepSubscriptions If KeepSubscriptions is FALSE, all existing or pending subscriptions
-   *      on the publisher for this subscriber SHALL be terminated.
+   *     on the publisher for this subscriber SHALL be terminated.
    * @param isFabricFiltered limits the data read within fabric-scoped lists to the accessing fabric
    * @param imTimeoutMs im interaction time out value, it would override the default value in c++ im
    *     layer if this value is non-zero.


### PR DESCRIPTION
-- Add auto-resubscribe capability for subscribe
-- Refactor read/subscribe with better exception check. 
-- manually validate the resubscription via bring up/down/up all-cluster-app
-- when receiving custom cluster, report would suppress the error generated from clusterObjects.
-- Fix platform::delete usage in jni
-- add imTimeout parameter for read/subscribe
-- disable cluster state data chace in java/jni and only use event
cache, version cache from cluster state cache, since java also have
cache to store the data