### PR TITLE
Default to use an IPV4 address

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -430,6 +430,19 @@ private:
     static void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     void ReadServerClusters(chip::EndpointId endpointId);
 
+    /**
+     * @brief Retrieve the IP Address to use for the UDC request.
+     * This function will look for an IPv4 address in the list of IPAddresses passed in if available and return
+     * that address if found. If there are no available IPv4 addresses, it will default to the first available address.
+     * This logic is similar to the one used by the UDC server that prefers IPv4 addresses.
+     *
+     * @param ipAddresses - The list of ip addresses available to use
+     * @param numIPs - The number of ip addresses available in the array
+     *
+     * @returns The IPv4 address in the array if available, otherwise will return the first address in the list.
+     */
+    static chip::Inet::IPAddress * getIpAddressForUDCRequest(chip::Inet::IPAddress ipAddresses[], const size_t numIPs);
+
     PersistenceManager mPersistenceManager;
     bool mInited        = false;
     bool mUdcInProgress = false;

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -145,13 +145,35 @@ CHIP_ERROR CastingServer::SendUserDirectedCommissioningRequest(chip::Transport::
     return Server::GetInstance().SendUserDirectedCommissioningRequest(commissioner);
 }
 
+chip::Inet::IPAddress * CastingServer::getIpAddressForUDCRequest(chip::Inet::IPAddress ipAddresses[], const size_t numIPs)
+{
+    size_t ipIndexToUse = 0;
+    for (size_t i = 0; i < numIPs; i++)
+    {
+        if (ipAddresses[i].IsIPv4())
+        {
+            ipIndexToUse = i;
+            ChipLogProgress(AppServer, "Found iPv4 address at index: %lu", ipIndexToUse);
+            break;
+        }
+
+        if (i == (numIPs - 1))
+        {
+            ChipLogProgress(AppServer, "Could not find an iPv4 address, defaulting to the first address in IP list");
+        }
+    }
+
+    return &ipAddresses[ipIndexToUse];
+}
+
 CHIP_ERROR CastingServer::SendUserDirectedCommissioningRequest(Dnssd::DiscoveredNodeData * selectedCommissioner)
 {
     mUdcInProgress = true;
     // Send User Directed commissioning request
+    chip::Inet::IPAddress * ipAddressToUse =
+        getIpAddressForUDCRequest(selectedCommissioner->resolutionData.ipAddress, selectedCommissioner->resolutionData.numIPs);
     ReturnErrorOnFailure(SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress::UDP(
-        selectedCommissioner->resolutionData.ipAddress[0], selectedCommissioner->resolutionData.port,
-        selectedCommissioner->resolutionData.interfaceId)));
+        *ipAddressToUse, selectedCommissioner->resolutionData.port, selectedCommissioner->resolutionData.interfaceId)));
     mTargetVideoPlayerVendorId   = selectedCommissioner->commissionData.vendorId;
     mTargetVideoPlayerProductId  = selectedCommissioner->commissionData.productId;
     mTargetVideoPlayerDeviceType = selectedCommissioner->commissionData.deviceType;

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -153,13 +153,13 @@ chip::Inet::IPAddress * CastingServer::getIpAddressForUDCRequest(chip::Inet::IPA
         if (ipAddresses[i].IsIPv4())
         {
             ipIndexToUse = i;
-            ChipLogProgress(AppServer, "Found iPv4 address at index: %lu", ipIndexToUse);
+            ChipLogProgress(AppServer, "Found IPv4 address at index: %lu - prioritizing use of IPv4", ipIndexToUse);
             break;
         }
 
         if (i == (numIPs - 1))
         {
-            ChipLogProgress(AppServer, "Could not find an iPv4 address, defaulting to the first address in IP list");
+            ChipLogProgress(AppServer, "Could not find an IPv4 address, defaulting to the first address in IP list");
         }
     }
 


### PR DESCRIPTION
On some devices it appears that the commissioner may not have an appropriate IPV6 address and attempts to send a user directed commissioning request to a device using its IPV6 address.

Its a bit unclear how this situation happens but in theory it could occur. In most cases this should be safe to default to an ipv4 address if it is available.

The implementation of the user directed commissioning server does something similar.

In the test setup we had, an iOS device was acting as the commissionee (sending the UDC packet). One interface (the loop back) has both an IPv6 and IPv4 address, the WiFi interface however only had an IPv4 address.
We observed the iOS device attempting to send the UDC packet back over the IPv6 address to the commissioner but tracing over wireshark showed no packets being sent.

This setup could only be reproduced with one particular travel router and the same scenario could not be reproduced on other setups.
