### PR TITLE
Adding in build step to strip debug symbols

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -1205,6 +1205,7 @@ SHA
 ShadeConfiguration
 SHAs
 showDocumentation
+showsdks
 shubhamdp
 SIGINT
 SiLabs
@@ -1480,6 +1481,7 @@ xbef
 xc
 xcd
 Xcode
+xcodebuild
 xcodeproj
 xcworkspace
 xd

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge.xcodeproj/project.pbxproj
@@ -161,8 +161,8 @@
 				3CCB872E286A502100771BAD /* ShellScript */,
 				3CCB87182869085400771BAD /* Headers */,
 				3CCB87192869085400771BAD /* Sources */,
+				02DECDA929B2BD3400D27C39 /* ShellScript */,
 				3CCB871A2869085400771BAD /* Frameworks */,
-				3CCB871B2869085400771BAD /* Resources */,
 			);
 			buildRules = (
 			);
@@ -205,17 +205,24 @@
 		};
 /* End PBXProject section */
 
-/* Begin PBXResourcesBuildPhase section */
-		3CCB871B2869085400771BAD /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
+/* Begin PBXShellScriptBuildPhase section */
+		02DECDA929B2BD3400D27C39 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
 			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "./strip_debug_symbols.sh\n";
 		};
-/* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
 		3CCB872E286A502100771BAD /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -292,7 +299,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
+				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -356,13 +363,14 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
+				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = z;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -386,6 +394,7 @@
 			buildSettings = {
 				CHIP_ROOT = "$(PROJECT_DIR)/../../../..";
 				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -462,6 +471,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.matter.MatterTvCastingBridge;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -473,6 +483,7 @@
 			buildSettings = {
 				CHIP_ROOT = "$(PROJECT_DIR)/../../../..";
 				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -524,6 +535,26 @@
 					"-Wformat",
 					"-Wformat-nonliteral",
 					"-Wformat-security",
+				);
+				"OTHER_LDFLAGS[arch=*]" = (
+					"-framework",
+					CoreData,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreBluetooth,
+					"-lnetwork",
+					"-Wl,-unexported_symbol,\"__Z*\"",
+				);
+				"OTHER_LDFLAGS[sdk=macosx*]" = (
+					"-framework",
+					IOKit,
+					"-lnetwork",
+					"-framework",
+					CoreBluetooth,
+					"-framework",
+					CoreData,
+					"-Wl,-unexported_symbol,\"__Z*\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.matter.MatterTvCastingBridge;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/strip_debug_symbols.sh
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/strip_debug_symbols.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+#
+#    Copyright (c) 2023 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This script runs as a part of the Post-Actions of the MatterTvCastingBridge build scheme
+#
+
+set -ex
+
+if [ "$CONFIGURATION" == "Debug" ]; then
+    echo "Skipping stripping debug symbols since we are using the '$CONFIGURATION' configuration"
+    exit 0
+fi
+
+files_to_strip=("libTvCastingCommon.a")
+
+for lib_path in "${LIBRARY_SEARCH_PATHS[@]}"; do
+    for lib_name in "$(ls "$lib_path")"; do
+        if [[ ${files_to_strip[*]} =~ ${lib_name} ]]; then
+            echo "Stripping file $lib_path/$lib_name"
+            strip -S -x -r "$lib_path/$lib_name"
+        fi
+    done
+done

--- a/examples/tv-casting-app/darwin/TvCasting/README.md
+++ b/examples/tv-casting-app/darwin/TvCasting/README.md
@@ -11,6 +11,7 @@ the TV.
 
 -   [Matter TV Casting iOS App Example](#matter-tv-casting-ios-app-example)
     -   [Building the Application](#building-the-application)
+        -   [Building through command line](#building-through-command-line)
         -   [Compilation Fixes](#compilation-fixes)
     -   [Installing the Application](#installing-the-application)
 
@@ -34,6 +35,20 @@ fail with missing signing configuration errors.
 
 You need to update the Project configuration for TvCasting app to use your
 Personal Developer account and a unique Bundle ID.
+
+### Building through command line
+
+To build the app through the command line, use the xcodebuild app.
+
+```shell
+xcodebuild -workspace TvCastingDarwin.xcworkspace -scheme TvCasting -sdk <SDK_TARGET>
+```
+
+The list of available SDKs can be found by using the showsdks flag.
+
+```shell
+xcodebuild -showsdks
+```
 
 ### Compilation Fixes
 
@@ -78,3 +93,8 @@ to run.
 
 Now you can launch the application from the Home screen or from Xcode by hitting
 the run button once more.
+
+## Debugging
+
+Use the "TvCasting" scheme when building to enable debugging. If you wish to
+build the app without any debugging symbols, use the "TvCasting Release" scheme.

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/xcshareddata/xcschemes/TvCasting Release.xcscheme
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/xcshareddata/xcschemes/TvCasting Release.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1320"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3CC0E8F52841DD3400EC6A18"
+               BuildableName = "TvCasting.app"
+               BlueprintName = "TvCasting"
+               ReferencedContainer = "container:TvCasting.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3CC0E8F52841DD3400EC6A18"
+            BuildableName = "TvCasting.app"
+            BlueprintName = "TvCasting"
+            ReferencedContainer = "container:TvCasting.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3CC0E8F52841DD3400EC6A18"
+            BuildableName = "TvCasting.app"
+            BlueprintName = "TvCasting"
+            ReferencedContainer = "container:TvCasting.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
The libTvCastingApp.a file was ~110mb prior to this strip operation, afterwards it dropped to ~21mb.

I also added a new TvCasting Release scheme

The release scheme strips out debug targets, the standard one doesn't.

Tested this by seeing the drop on an XCode build and also verifying the TVapp still functions as before
