### PR TITLE
[Silabs][SiWx917]Re-add enable_wifi_ipv4 arg in ligthing-app

### DIFF
--- a/examples/lighting-app/silabs/SiWx917/BUILD.gn
+++ b/examples/lighting-app/silabs/SiWx917/BUILD.gn
@@ -52,6 +52,9 @@ declare_args() {
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
 
+  # Argument to Disable IPv4 for wifi
+  chip_enable_wifi_ipv4 = false
+
   # Argument to force enable WPA3 security on rs91x
   rs91x_wpa3_only = false
 


### PR DESCRIPTION
PR #25591 moved the `chip_enable_wifi_ipv4` build argument to a common location for EFR32 platform. 
This change was not extended to the siwx917 platform except for a removal in 1 build.gn.

Siwx917 requires a build file clean up/refactor. 
For now, just re-add the argument to the siwx917 lighting-app like it was before so the app can build in the mean time.
