### PR TITLE
 Deprecating chip_server_cluster_attributes

### DIFF
--- a/examples/darwin-framework-tool/templates/commands.zapt
+++ b/examples/darwin-framework-tool/templates/commands.zapt
@@ -92,7 +92,7 @@ private:
 {{/unless}}
 {{/chip_cluster_commands}}
 
-{{#chip_server_cluster_attributes}}
+{{#zcl_attributes_server removeKeys='isOptional'}}
 {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#*inline "cluster"}}Cluster{{asUpperCamelCase parent.name preserveAcronyms=true}}{{/inline}}
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
@@ -201,7 +201,7 @@ private:
     {{else if (isCharString type)}}
     chip::ByteSpan mValue;
     {{else}}
-    {{chipType}} mValue;
+    {{as_underlying_zcl_type type}} mValue;
     {{/if_chip_complex}}
 };
 
@@ -246,7 +246,7 @@ public:
 
 {{/if}}
 {{/unless}}
-{{/chip_server_cluster_attributes}}
+{{/zcl_attributes_server}}
 {{/unless}}
 {{/chip_client_clusters}}
 
@@ -268,7 +268,7 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands)
         make_unique<{{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}>(), //
         {{/unless}}
         {{/chip_cluster_commands}}
-        {{#chip_server_cluster_attributes}}
+        {{#zcl_attributes_server removeKeys='isOptional'}}
         {{#first}}
          make_unique<ReadAttribute>(Id), //
         {{/first}}
@@ -291,7 +291,7 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands)
         make_unique<SubscribeAttribute{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(), //
         {{/if}}
         {{/unless}}
-        {{/chip_server_cluster_attributes}}
+        {{/zcl_attributes_server}}
         {{#zcl_events}}
         {{#first}}
         make_unique<ReadEvent>(Id), //

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -7,7 +7,7 @@ ARG COMMITHASH=7b99e6399c6069037c613782d78132c69b9dcabb
 # ZAP Development install, so that it runs on both x64 and arm64
 # Generally this should match with the ZAP version that is used for codegen within the
 # specified SHA
-ARG ZAP_VERSION=v2023.03.06-nightly
+ARG ZAP_VERSION=v2023.03.17-nightly
 
 # Ensure TARGETPLATFORM is set
 RUN case ${TARGETPLATFORM} in \

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -8,7 +8,7 @@
                 "mac-arm64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2023.03.06-nightly.1"]
+            "tags": ["version:2@v2023.03.17-nightly.1"]
         }
     ]
 }

--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/CHIPClientCallbacks.h
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/CHIPClientCallbacks.h
@@ -29,3 +29,11 @@
 #include <lib/support/Span.h>
 
 // List specific responses
+typedef void (*OtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallback)(
+    void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & data);
+typedef void (*OtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallback)(
+    void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & data);
+typedef void (*OtaSoftwareUpdateProviderEventListListAttributeCallback)(
+    void * context, const chip::app::DataModel::DecodableList<chip::EventId> & data);
+typedef void (*OtaSoftwareUpdateProviderAttributeListListAttributeCallback)(
+    void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & data);

--- a/scripts/tools/zap/tests/outputs/lighting-app/app-templates/CHIPClientCallbacks.h
+++ b/scripts/tools/zap/tests/outputs/lighting-app/app-templates/CHIPClientCallbacks.h
@@ -29,3 +29,11 @@
 #include <lib/support/Span.h>
 
 // List specific responses
+typedef void (*OtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallback)(
+    void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & data);
+typedef void (*OtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallback)(
+    void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & data);
+typedef void (*OtaSoftwareUpdateProviderEventListListAttributeCallback)(
+    void * context, const chip::app::DataModel::DecodableList<chip::EventId> & data);
+typedef void (*OtaSoftwareUpdateProviderAttributeListListAttributeCallback)(
+    void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & data);

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2023.3.17'
+MIN_ZAP_VERSION = '2023.3.16'
 
 
 class ZapTool:

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2023.3.6'
+MIN_ZAP_VERSION = '2023.3.17'
 
 
 class ZapTool:

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
@@ -14,11 +14,11 @@
 
 // List specific responses
 {{#chip_client_clusters}}
-{{#chip_server_cluster_attributes}}
+{{#zcl_attributes_server removeKeys='isOptional'}}
 {{#if isArray}}
 typedef void (*{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback)(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} data);
 {{/if}}
-{{/chip_server_cluster_attributes}}
+{{/zcl_attributes_server}}
 {{/chip_client_clusters}}
 
 {{/if}}

--- a/src/app/zap-templates/templates/app/access.zapt
+++ b/src/app/zap-templates/templates/app/access.zapt
@@ -15,7 +15,7 @@
 // Parallel array data (*cluster*, attribute, privilege) for read attribute
 #define GENERATED_ACCESS_READ_ATTRIBUTE__CLUSTER { \
     {{/first}}
-    {{#chip_server_cluster_attributes}}
+    {{#enabled_attributes_for_cluster_and_side name 'server'}}
         {{#access entity="attribute"}}
             {{#if hasOperation}}
                 {{#if (isStrEqual operation "read")}}
@@ -37,7 +37,7 @@
                 {{/if}}
             {{/if}}
         {{/access}}
-    {{/chip_server_cluster_attributes}}
+    {{/enabled_attributes_for_cluster_and_side}}
     {{#last}}
 }
     {{/last}}
@@ -48,7 +48,7 @@
 // Parallel array data (cluster, *attribute*, privilege) for read attribute
 #define GENERATED_ACCESS_READ_ATTRIBUTE__ATTRIBUTE { \
     {{/first}}
-    {{#chip_server_cluster_attributes}}
+    {{#enabled_attributes_for_cluster_and_side name 'server'}}
         {{#access entity="attribute"}}
             {{#if hasOperation}}
                 {{#if (isStrEqual operation "read")}}
@@ -70,7 +70,7 @@
                 {{/if}}
             {{/if}}
         {{/access}}
-    {{/chip_server_cluster_attributes}}
+    {{/enabled_attributes_for_cluster_and_side}}
     {{#last}}
 }
     {{/last}}
@@ -81,7 +81,7 @@
 // Parallel array data (cluster, attribute, *privilege*) for read attribute
 #define GENERATED_ACCESS_READ_ATTRIBUTE__PRIVILEGE { \
     {{/first}}
-    {{#chip_server_cluster_attributes}}
+    {{#enabled_attributes_for_cluster_and_side name 'server'}}
         {{#access entity="attribute"}}
             {{#if hasOperation}}
                 {{#if (isStrEqual operation "read")}}
@@ -103,7 +103,7 @@
                 {{/if}}
             {{/if}}
         {{/access}}
-    {{/chip_server_cluster_attributes}}
+    {{/enabled_attributes_for_cluster_and_side}}
     {{#last}}
 }
     {{/last}}
@@ -116,7 +116,7 @@
 // Parallel array data (*cluster*, attribute, privilege) for write attribute
 #define GENERATED_ACCESS_WRITE_ATTRIBUTE__CLUSTER { \
     {{/first}}
-    {{#chip_server_cluster_attributes}}
+    {{#enabled_attributes_for_cluster_and_side name 'server'}}
         {{#access entity="attribute"}}
             {{#if hasOperation}}
                 {{#if (isStrEqual operation "write")}}
@@ -138,7 +138,7 @@
                 {{/if}}
             {{/if}}
         {{/access}}
-    {{/chip_server_cluster_attributes}}
+    {{/enabled_attributes_for_cluster_and_side}}
     {{#last}}
 }
     {{/last}}
@@ -149,7 +149,7 @@
 // Parallel array data (cluster, *attribute*, privilege) for write attribute
 #define GENERATED_ACCESS_WRITE_ATTRIBUTE__ATTRIBUTE { \
     {{/first}}
-    {{#chip_server_cluster_attributes}}
+    {{#enabled_attributes_for_cluster_and_side name 'server'}}
         {{#access entity="attribute"}}
             {{#if hasOperation}}
                 {{#if (isStrEqual operation "write")}}
@@ -171,7 +171,7 @@
                 {{/if}}
             {{/if}}
         {{/access}}
-    {{/chip_server_cluster_attributes}}
+    {{/enabled_attributes_for_cluster_and_side}}
     {{#last}}
 }
     {{/last}}
@@ -182,7 +182,7 @@
 // Parallel array data (cluster, attribute, *privilege*) for write attribute
 #define GENERATED_ACCESS_WRITE_ATTRIBUTE__PRIVILEGE { \
     {{/first}}
-    {{#chip_server_cluster_attributes}}
+    {{#enabled_attributes_for_cluster_and_side name 'server'}}
         {{#access entity="attribute"}}
             {{#if hasOperation}}
                 {{#if (isStrEqual operation "write")}}
@@ -204,7 +204,7 @@
                 {{/if}}
             {{/if}}
         {{/access}}
-    {{/chip_server_cluster_attributes}}
+    {{/enabled_attributes_for_cluster_and_side}}
     {{#last}}
 }
     {{/last}}

--- a/src/app/zap-templates/templates/app/attributes/Accessors.zapt
+++ b/src/app/zap-templates/templates/app/attributes/Accessors.zapt
@@ -26,7 +26,7 @@ namespace Attributes {
 {{#if_is_struct type}}
 {{else if (canHaveSimpleAccessors this)}}
 namespace {{asUpperCamelCase label}} {
-EmberAfStatus Get(chip::EndpointId endpoint, {{accessorGetterType this}} value); // {{type}} {{isArray}}
+EmberAfStatus Get(chip::EndpointId endpoint, {{accessorGetterType this}} value); // {{type}}
 EmberAfStatus Set(chip::EndpointId endpoint, {{zapTypeToEncodableClusterObjectType type ns=parent.name forceNotNullable=true forceNotOptional=true}} value);
 {{#if isNullable}}
 EmberAfStatus SetNull(chip::EndpointId endpoint);

--- a/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
@@ -24,7 +24,7 @@ id MTRDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader &
         using namespace Clusters::{{asUpperCamelCase name}};
         switch (aPath.mAttributeId)
         {
-        {{#chip_server_cluster_attributes}}
+        {{#zcl_attributes_server removeKeys='isOptional'}}
         {{#unless (wasRemoved (asUpperCamelCase ../name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
         case Attributes::{{asUpperCamelCase name}}::Id: {
             using TypeInfo = Attributes::{{asUpperCamelCase name}}::TypeInfo;
@@ -39,7 +39,7 @@ id MTRDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader &
             return value;
         }
         {{/unless}}
-        {{/chip_server_cluster_attributes}}
+        {{/zcl_attributes_server}}
         default:
           *aError = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB;
           break;

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
@@ -129,7 +129,7 @@ MTR{{cluster}}Cluster{{command}}Params
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/chip_cluster_commands}}
 
-{{#chip_server_cluster_attributes}}
+{{#zcl_attributes_server removeKeys='isOptional'}}
 {{! This is used as the implementation for both the new-name and old-name bits, so check for both here. }}
 {{#unless (and (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))
                (or (wasRemoved (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))
@@ -232,7 +232,7 @@ reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value
 
 {{/if}}
 {{/unless}}
-{{/chip_server_cluster_attributes}}
+{{/zcl_attributes_server}}
 
 @end
 {{/unless}}
@@ -277,7 +277,7 @@ reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value
                 command=(compatCommandNameRemapping parent.name name)}}
 {{/chip_cluster_commands}}
 
-{{#chip_server_cluster_attributes}}
+{{#zcl_attributes_server removeKeys='isOptional'}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))
            (not (wasRemoved (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))))}}
 {{#*inline "attribute"}}Attribute{{compatAttributeNameRemapping parent.name name}}{{/inline}}
@@ -333,7 +333,7 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 }
 {{/if}}
 {{/if}}
-{{/chip_server_cluster_attributes}}
+{{/zcl_attributes_server}}
 
 - (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
                                endpoint:(uint16_t)endpoint

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/chip_cluster_commands}}
 
-{{#chip_server_cluster_attributes}}
+{{#zcl_attributes_server removeKeys='isOptional'}}
 {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 - (void)read{{>attribute}}With
@@ -62,7 +62,7 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 + (void) read{{>attribute}}WithClusterStateCache:(MTRClusterStateCacheContainer *)clusterStateCacheContainer endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue completion:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))completion {{availability (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true) minimalRelease="First major API revamp"}};
 {{/if}}
 {{/unless}}
-{{/chip_server_cluster_attributes}}
+{{/zcl_attributes_server}}
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
@@ -203,7 +203,7 @@ typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName bitm
                 command=(compatCommandNameRemapping parent.name name)}}
 {{/chip_cluster_commands}}
 
-{{#chip_server_cluster_attributes}}
+{{#zcl_attributes_server removeKeys='isOptional'}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))
            (not (wasRemoved (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))))}}
 {{#*inline "attribute"}}Attribute{{compatAttributeNameRemapping parent.name name}}{{/inline}}
@@ -225,7 +225,7 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 + (void) read{{>attribute}}WithAttributeCache:(MTRAttributeCacheContainer *)attributeCacheContainer endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue completionHandler:(void (^)({{asObjectiveCClass type parent.name compatRemapClusterName=true}} * _Nullable value, NSError * _Nullable error))completionHandler {{availability (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name) deprecatedRelease="First major API revamp" deprecationMessage=(concat "Please use readAttribute" (asUpperCamelCase name preserveAcronyms=true) "WithAttributeCache:endpoint:queue:completion:")}};
 {{/if}}
 {{/if}}
-{{/chip_server_cluster_attributes}}
+{{/zcl_attributes_server}}
 
 @end
 

--- a/src/darwin/Framework/CHIP/templates/MTRCallbackBridge-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCallbackBridge-src.zapt
@@ -38,7 +38,7 @@
 {{#>MTRCallbackBridge type="vendor_id"    isNullable=true  ns="chip"}}NullableVendorIdAttributeCallback{{/MTRCallbackBridge}}
 
 {{#chip_client_clusters includeAll=true}}
-{{#chip_server_cluster_attributes}}
+{{#zcl_attributes_server removeKeys='isOptional'}}
 {{#unless (wasRemoved (asUpperCamelCase ../name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#if isArray}}
 {{#>MTRCallbackBridge ns=parent.name                                }}{{asUpperCamelCase ../../name preserveAcronyms=true}}{{asUpperCamelCase ../name preserveAcronyms=true}}ListAttributeCallback{{/MTRCallbackBridge}}
@@ -51,7 +51,7 @@
   {{/if_is_strongly_typed_bitmap}}
 {{/if}}
 {{/unless}}
-{{/chip_server_cluster_attributes}}
+{{/zcl_attributes_server}}
 {{/chip_client_clusters}}
 
 {{#chip_client_clusters includeAll=true}}

--- a/src/darwin/Framework/CHIP/templates/MTRCallbackBridge.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCallbackBridge.zapt
@@ -32,7 +32,7 @@ typedef void (*Nullable{{asUpperCamelCase parent.name preserveAcronyms=true}}Clu
 {{/zcl_clusters}}
 
 {{#chip_client_clusters includeAll=true}}
-{{#chip_server_cluster_attributes}}
+{{#zcl_attributes_server removeKeys='isOptional'}}
 {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#if isArray}}
 typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCamelCase name preserveAcronyms=true}}ListAttributeCallback)(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} data);
@@ -45,7 +45,7 @@ typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCa
 {{/if_is_strongly_typed_bitmap}}
 {{/if}}
 {{/unless}}
-{{/chip_server_cluster_attributes}}
+{{/zcl_attributes_server}}
 {{/chip_client_clusters}}
 
 {{#>MTRCallbackBridge header="1" partial-type="Status"                         }}DefaultSuccessCallback{{/MTRCallbackBridge}}
@@ -80,7 +80,7 @@ typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCa
 {{#>MTRCallbackBridge header="1" type="vendor_id"    isNullable=true  ns="chip"}}NullableVendorIdAttributeCallback{{/MTRCallbackBridge}}
 
 {{#chip_client_clusters includeAll=true}}
-{{#chip_server_cluster_attributes}}
+{{#zcl_attributes_server removeKeys='isOptional'}}
 {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#if isArray}}
 {{#>MTRCallbackBridge header="1" ns=parent.name                                }}{{asUpperCamelCase ../../name preserveAcronyms=true}}{{asUpperCamelCase ../name preserveAcronyms=true}}ListAttributeCallback{{/MTRCallbackBridge}}
@@ -93,7 +93,7 @@ typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCa
   {{/if_is_strongly_typed_bitmap}}
 {{/if}}
 {{/unless}}
-{{/chip_server_cluster_attributes}}
+{{/zcl_attributes_server}}
 {{/chip_client_clusters}}
 
 {{#chip_client_clusters includeAll=true}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
@@ -182,7 +182,7 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/chip_cluster_commands}}
 
-{{#chip_server_cluster_attributes}}
+{{#zcl_attributes_server}}
 {{! This is used as the implementation for both the new-name and old-name bits, so check for both here. }}
 {{#unless (and (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))
                (or (wasRemoved (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))
@@ -214,7 +214,7 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
 {{/if}}
 
 {{/unless}}
-{{/chip_server_cluster_attributes}}
+{{/zcl_attributes_server}}
 
 @end
 {{/unless}}
@@ -262,7 +262,7 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
 {{> commandImpl cluster=(compatClusterNameRemapping parent.name)
                 command=(compatCommandNameRemapping parent.name name)}}
 {{/chip_cluster_commands}}
-{{~#chip_server_cluster_attributes}}
+{{~#zcl_attributes_server}}
 {{~#*inline "attributeImpls"}}
 {{#unless (or (isStrEqual attribute (asUpperCamelCase name preserveAcronyms=true))
               (wasRemoved (compatClusterNameRemapping parent.name) attribute=attribute))}}
@@ -283,7 +283,7 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
 {{/unless}}
 {{/inline~}}
 {{> attributeImpls attribute=(compatAttributeNameRemapping parent.name name)}}
-{{/chip_server_cluster_attributes}}
+{{/zcl_attributes_server}}
 @end
 {{/if}}
 

--- a/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/chip_cluster_commands}}
 
-{{#chip_server_cluster_attributes}}
+{{#zcl_attributes_server}}
 {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 {{#*inline "availability"}}
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs params:(MTRWriteParams * _Nullable)params {{> availability}};
 {{/if}}
 {{/unless}}
-{{/chip_server_cluster_attributes}}
+{{/zcl_attributes_server}}
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{> commandDecl cluster=(compatClusterNameRemapping parent.name)
                 command=(compatCommandNameRemapping parent.name name)}}
 {{/chip_cluster_commands}}
-{{~#chip_server_cluster_attributes}}
+{{~#zcl_attributes_server}}
 {{~#*inline "attributeDecls"}}
 {{#unless (isStrEqual attribute (asUpperCamelCase name preserveAcronyms=true))}}
 - (NSDictionary<NSString *, id> *)readAttribute{{attribute}}WithParams:(MTRReadParams * _Nullable)params {{availability cluster attribute=attribute deprecatedRelease="First major API revamp" deprecationMessage=(concat "Please use readAttribute" (asUpperCamelCase name preserveAcronyms=true) "WithParams on MTRCluster" (asUpperCamelCase parent.name preserveAcronyms=true))}};
@@ -105,7 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{/inline~}}
 {{> attributeDecls cluster=(compatClusterNameRemapping parent.name)
                    attribute=(compatAttributeNameRemapping parent.name name)}}
-{{/chip_server_cluster_attributes}}
+{{/zcl_attributes_server}}
 @end
 
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/partials/attribute_data_callback_name.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/attribute_data_callback_name.zapt
@@ -13,9 +13,20 @@
     {{~#if (isStrEqual (asUpperCamelCase type) (asUpperCamelCase "vendor_id"))~}}
       VendorId
     {{~else if_is_strongly_typed_chip_enum type~}}
-        {{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase type preserveAcronyms=true}}
+      {{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase type preserveAcronyms=true}}
+    {{~else if (isOctetString type)~}}
+      OctetString
+    {{~else if (isCharString type)~}}
+      CharString
+    {{~else if (or (is_str_equal type "float")
+                   (is_str_equal type "single"))~}}
+      Float
+    {{~else if (is_str_equal type "double")~}}
+      Double
+    {{~else if (is_str_equal type "boolean")~}}
+      Boolean
     {{~else~}}
-      {{chipCallback.name}}
+      Int{{as_zcl_data_type_size type parent.id sizeIn='bits' roundUpToPowerOfTwo=1}}{{~#if_is_data_type_signed type parent.id~}}s{{else}}u{{/if_is_data_type_signed}}
     {{~/if~}}
   {{~/if_is_struct~}}
 {{~/if~}}


### PR DESCRIPTION
Replacing a state helper such as chip_server_cluster_attributes with a stateless helper zcl_attributes_server such that we can get deprecate the stateful helpers one by one.

Github: ZAP#898


