### PR TITLE
[Silabs] Do not call nvm3_repack() from the FreeRTOS idle hook

### DIFF
--- a/examples/light-switch-app/silabs/efr32/README.md
+++ b/examples/light-switch-app/silabs/efr32/README.md
@@ -166,6 +166,10 @@ arguments
 
 -   Or with the Ozone debugger, just load the .out file.
 
+All EFR32 boards require a bootloader, see Silicon Labs documentation for more info. 
+Pre-built bootloader binaries are available in the Assets section of the Releases page 
+on [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+
 ## Viewing Logging Output
 
 The example application is built to use the SEGGER Real Time Transfer (RTT)

--- a/examples/light-switch-app/silabs/efr32/README.md
+++ b/examples/light-switch-app/silabs/efr32/README.md
@@ -166,9 +166,10 @@ arguments
 
 -   Or with the Ozone debugger, just load the .out file.
 
-All EFR32 boards require a bootloader, see Silicon Labs documentation for more info. 
-Pre-built bootloader binaries are available in the Assets section of the Releases page 
-on [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+All EFR32 boards require a bootloader, see Silicon Labs documentation for more
+info. Pre-built bootloader binaries are available in the Assets section of the
+Releases page on
+[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
 
 ## Viewing Logging Output
 

--- a/examples/lighting-app/silabs/efr32/README.md
+++ b/examples/lighting-app/silabs/efr32/README.md
@@ -158,9 +158,10 @@ arguments
 
 -   Or with the Ozone debugger, just load the .out file.
 
-All EFR32 boards require a bootloader, see Silicon Labs documentation for more info. 
-Pre-built bootloader binaries are available in the Assets section of the Releases page 
-on [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+All EFR32 boards require a bootloader, see Silicon Labs documentation for more
+info. Pre-built bootloader binaries are available in the Assets section of the
+Releases page on
+[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
 
 ## Viewing Logging Output
 

--- a/examples/lighting-app/silabs/efr32/README.md
+++ b/examples/lighting-app/silabs/efr32/README.md
@@ -158,6 +158,10 @@ arguments
 
 -   Or with the Ozone debugger, just load the .out file.
 
+All EFR32 boards require a bootloader, see Silicon Labs documentation for more info. 
+Pre-built bootloader binaries are available in the Assets section of the Releases page 
+on [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+
 ## Viewing Logging Output
 
 The example application is built to use the SEGGER Real Time Transfer (RTT)

--- a/examples/lock-app/silabs/efr32/README.md
+++ b/examples/lock-app/silabs/efr32/README.md
@@ -177,9 +177,10 @@ arguments
 
 -   Or with the Ozone debugger, just load the .out file.
 
-All EFR32 boards require a bootloader, see Silicon Labs documentation for more info. 
-Pre-built bootloader binaries are available in the Assets section of the Releases page 
-on [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+All EFR32 boards require a bootloader, see Silicon Labs documentation for more
+info. Pre-built bootloader binaries are available in the Assets section of the
+Releases page on
+[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
 
 ## Viewing Logging Output
 

--- a/examples/lock-app/silabs/efr32/README.md
+++ b/examples/lock-app/silabs/efr32/README.md
@@ -177,6 +177,10 @@ arguments
 
 -   Or with the Ozone debugger, just load the .out file.
 
+All EFR32 boards require a bootloader, see Silicon Labs documentation for more info. 
+Pre-built bootloader binaries are available in the Assets section of the Releases page 
+on [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+
 ## Viewing Logging Output
 
 The example application is built to use the SEGGER Real Time Transfer (RTT)

--- a/examples/platform/silabs/SiWx917/OTAConfig.cpp
+++ b/examples/platform/silabs/SiWx917/OTAConfig.cpp
@@ -21,12 +21,6 @@
 #include "application_properties.h"
 #include <app/server/Server.h>
 
-#if defined(SL_COMPONENT_CATALOG_PRESENT)
-#include "sl_component_catalog.h"
-#endif
-
-// Only include app properties if the Gecko SDK component that does it automatically isn't present
-#if !defined(SL_CATALOG_GECKO_BOOTLOADER_INTERFACE_PRESENT)
 // Header used for building the image GBL file
 #define APP_PROPERTIES_VERSION 1
 #define APP_PROPERTIES_ID                                                                                                          \
@@ -71,7 +65,6 @@ __attribute__((used)) ApplicationProperties_t sl_app_properties = {
     /// Pointer to Long Token Data Section
     .longTokenSectionAddress = NULL,
 };
-#endif // SL_CATALOG_GECKO_BOOTLOADER_INTERFACE_PRESENT
 
 // Global OTA objects
 chip::DefaultOTARequestor gRequestorCore;

--- a/examples/platform/silabs/SiWx917/matter_config.cpp
+++ b/examples/platform/silabs/SiWx917/matter_config.cpp
@@ -177,7 +177,4 @@ void SI917MatterConfig::InitWiFi(void)
 extern "C" void vApplicationIdleHook(void)
 {
     // FreeRTOS Idle callback
-
-    // Check CHIP Config nvm3 and repack flash if necessary.
-    Internal::SilabsConfig::RepackNvm3Flash();
 }

--- a/examples/platform/silabs/efr32/OTAConfig.cpp
+++ b/examples/platform/silabs/efr32/OTAConfig.cpp
@@ -21,12 +21,6 @@
 #include "application_properties.h"
 #include <app/server/Server.h>
 
-#if defined(SL_COMPONENT_CATALOG_PRESENT)
-#include "sl_component_catalog.h"
-#endif
-
-// Only include app properties if the Gecko SDK component that does it automatically isn't present
-#if !defined(SL_CATALOG_GECKO_BOOTLOADER_INTERFACE_PRESENT)
 // Header used for building the image GBL file
 #define APP_PROPERTIES_VERSION 1
 #define APP_PROPERTIES_ID                                                                                                          \
@@ -71,7 +65,6 @@ __attribute__((used)) ApplicationProperties_t sl_app_properties = {
     /// Pointer to Long Token Data Section
     .longTokenSectionAddress = NULL,
 };
-#endif // SL_CATALOG_GECKO_BOOTLOADER_INTERFACE_PRESENT
 
 // Global OTA objects
 chip::DefaultOTARequestor gRequestorCore;

--- a/examples/platform/silabs/efr32/matter_config.cpp
+++ b/examples/platform/silabs/efr32/matter_config.cpp
@@ -249,7 +249,4 @@ void EFR32MatterConfig::InitWiFi(void)
 extern "C" void vApplicationIdleHook(void)
 {
     // FreeRTOS Idle callback
-
-    // Check CHIP Config nvm3 and repack flash if necessary.
-    Internal::SilabsConfig::RepackNvm3Flash();
 }

--- a/examples/thermostat/silabs/efr32/README.md
+++ b/examples/thermostat/silabs/efr32/README.md
@@ -166,6 +166,10 @@ arguments
 
 -   Or with the Ozone debugger, just load the .out file.
 
+All EFR32 boards require a bootloader, see Silicon Labs documentation for more info. 
+Pre-built bootloader binaries are available in the Assets section of the Releases page 
+on [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+
 ## Viewing Logging Output
 
 The example application is built to use the SEGGER Real Time Transfer (RTT)

--- a/examples/thermostat/silabs/efr32/README.md
+++ b/examples/thermostat/silabs/efr32/README.md
@@ -166,9 +166,10 @@ arguments
 
 -   Or with the Ozone debugger, just load the .out file.
 
-All EFR32 boards require a bootloader, see Silicon Labs documentation for more info. 
-Pre-built bootloader binaries are available in the Assets section of the Releases page 
-on [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+All EFR32 boards require a bootloader, see Silicon Labs documentation for more
+info. Pre-built bootloader binaries are available in the Assets section of the
+Releases page on
+[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
 
 ## Viewing Logging Output
 

--- a/examples/window-app/silabs/efr32/README.md
+++ b/examples/window-app/silabs/efr32/README.md
@@ -155,6 +155,10 @@ arguments
 
 -   Or with the Ozone debugger, just load the .out file.
 
+All EFR32 boards require a bootloader, see Silicon Labs documentation for more info. 
+Pre-built bootloader binaries are available in the Assets section of the Releases page 
+on [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+
 ## Viewing Logging Output
 
 The example application is built to use the SEGGER Real Time Transfer (RTT)

--- a/examples/window-app/silabs/efr32/README.md
+++ b/examples/window-app/silabs/efr32/README.md
@@ -155,9 +155,10 @@ arguments
 
 -   Or with the Ozone debugger, just load the .out file.
 
-All EFR32 boards require a bootloader, see Silicon Labs documentation for more info. 
-Pre-built bootloader binaries are available in the Assets section of the Releases page 
-on [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+All EFR32 boards require a bootloader, see Silicon Labs documentation for more
+info. Pre-built bootloader binaries are available in the Assets section of the
+Releases page on
+[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
 
 ## Viewing Logging Output
 


### PR DESCRIPTION
The NVM3 lock was changed in this [PR](https://github.com/project-chip/connectedhomeip/pull/25503) to use semaphores. Because of this we are removing the call nvm3_repack(), a potentially blocking function, from the FreeRTOS idle hook. 

Additional minor changes unrelated to the above:
- Remove conditional inclusion of the bootloader Application Properties structure in the application image, SL_CATALOG_GECKO_BOOTLOADER_INTERFACE_PRESENT is always set in Silabs' matter_support submodule.
- Update README files with bootloader info