### PR TITLE
[Ameba] setdeviceinstanceinfoprovider use factorydataprovider by default

### DIFF
--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -172,9 +172,7 @@ extern "C" void ChipTest(void)
 
     // Set DeviceInstanceInfoProvider after CHIPDeviceManager init
     // CHIPDeviceManager init will set GenericDeviceInsanceInfoProvider first
-#if CONFIG_ENABLE_AMEBA_FACTORY_DATA
     SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
-#endif
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, 0);
 

--- a/examples/chef/ameba/main/chipinterface.cpp
+++ b/examples/chef/ameba/main/chipinterface.cpp
@@ -127,11 +127,10 @@ extern "C" void ChipTest(void)
 
     initPref();
 
-    // Initialize device attestation, commissionable data and device instance info
-    // TODO: Use our own DeviceInstanceInfoProvider
-    // SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
+    mFactoryDataProvider.Init();
     SetCommissionableDataProvider(&mFactoryDataProvider);
     SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
+
     CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
 
     err = deviceMgr.Init(&EchoCallbacks);
@@ -143,6 +142,10 @@ extern "C" void ChipTest(void)
     {
         ChipLogProgress(DeviceLayer, "DeviceManagerInit() - OK\r\n");
     }
+
+    // Set DeviceInstanceInfoProvider after CHIPDeviceManager init
+    // CHIPDeviceManager init will set GenericDeviceInsanceInfoProvider first
+    SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, 0);
 

--- a/examples/light-switch-app/ameba/main/chipinterface.cpp
+++ b/examples/light-switch-app/ameba/main/chipinterface.cpp
@@ -132,11 +132,10 @@ extern "C" void ChipTest(void)
 
     initPref();
 
-    // Initialize device attestation, commissionable data and device instance info
-    // TODO: Use our own DeviceInstanceInfoProvider
-    // SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
+    mFactoryDataProvider.Init();
     SetCommissionableDataProvider(&mFactoryDataProvider);
     SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
+
     CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
 
     err = deviceMgr.Init(&EchoCallbacks);
@@ -148,6 +147,10 @@ extern "C" void ChipTest(void)
     {
         ChipLogProgress(DeviceLayer, "DeviceManagerInit() - OK\r\n");
     }
+
+    // Set DeviceInstanceInfoProvider after CHIPDeviceManager init
+    // CHIPDeviceManager init will set GenericDeviceInsanceInfoProvider first
+    SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, 0);
 

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -148,11 +148,10 @@ extern "C" void ChipTest(void)
 
     initPref();
 
-    // Initialize device attestation, commissionable data and device instance info
-    // TODO: Use our own DeviceInstanceInfoProvider
-    // SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
+    mFactoryDataProvider.Init();
     SetCommissionableDataProvider(&mFactoryDataProvider);
     SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
+
     CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
 
     err = deviceMgr.Init(&EchoCallbacks);
@@ -164,6 +163,10 @@ extern "C" void ChipTest(void)
     {
         ChipLogProgress(DeviceLayer, "DeviceManagerInit() - OK\r\n");
     }
+
+    // Set DeviceInstanceInfoProvider after CHIPDeviceManager init
+    // CHIPDeviceManager init will set GenericDeviceInsanceInfoProvider first
+    SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, 0);
 

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -95,9 +95,7 @@ extern "C" void ChipTest(void)
 
     initPref();
 
-    // Initialize device attestation, commissionable data and device instance info
-    // TODO: Use our own DeviceInstanceInfoProvider
-    // SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
+    mFactoryDataProvider.Init();
     SetCommissionableDataProvider(&mFactoryDataProvider);
     SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
 
@@ -111,6 +109,10 @@ extern "C" void ChipTest(void)
     {
         ChipLogProgress(DeviceLayer, "DeviceManagerInit() - OK\r\n");
     }
+
+    // Set DeviceInstanceInfoProvider after CHIPDeviceManager init
+    // CHIPDeviceManager init will set GenericDeviceInsanceInfoProvider first
+    SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, 0);
 }


### PR DESCRIPTION
- Let FactoryDataProvider be deviceinstanceinfoprovider by default