### PR TITLE
Expose public API on ReadClient to trigger a resubscribe attempt if needed.

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1095,7 +1095,8 @@ void ReadClient::HandleDeviceConnectionFailure(void * context, const ScopedNodeI
     _this->Close(err);
 }
 
-void ReadClient::OnResubscribeTimerCallback(System::Layer * apSystemLayer, void * apAppState)
+void ReadClient::OnResubscribeTimerCallback(System::Layer * /* If this starts being used, fix callers that pass nullptr */,
+                                            void * apAppState)
 {
     ReadClient * const _this = static_cast<ReadClient *>(apAppState);
     VerifyOrDie(_this != nullptr);
@@ -1174,5 +1175,18 @@ CHIP_ERROR ReadClient::GetMinEventNumber(const ReadPrepareParams & aReadPrepareP
     }
     return CHIP_NO_ERROR;
 }
+
+void ReadClient::TriggerResubscribeIfScheduled(const char * reason)
+{
+    if (!mIsResubscriptionScheduled)
+    {
+        return;
+    }
+
+    ChipLogDetail(DataManagement, "ReadClient[%p] triggering resubscribe, reason: %s", this, reason);
+    CancelResubscribeTimer();
+    OnResubscribeTimerCallback(nullptr, this);
+}
+
 } // namespace app
 } // namespace chip

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -305,13 +305,7 @@ public:
 
     void OnUnsolicitedMessageFromPublisher()
     {
-        // accelerate resubscription if scheduled
-        if (mIsResubscriptionScheduled)
-        {
-            ChipLogDetail(DataManagement, "%s ReadClient[%p] resubscribe on unsolicited message", __func__, this);
-            CancelResubscribeTimer();
-            OnResubscribeTimerCallback(nullptr, this);
-        }
+        TriggerResubscribeIfScheduled("unsolicited message");
 
         // Then notify callbacks
         mpCallback.OnUnsolicitedMessageFromPublisher(this);
@@ -420,6 +414,16 @@ public:
      *
      */
     void OverrideLivenessTimeout(System::Clock::Timeout aLivenessTimeout);
+
+    /**
+     * If the ReadClient currently has a resubscription attempt scheduled,
+     * trigger that attempt right now.  This is generally useful when a consumer
+     * has some sort of indication that the server side is currently up and
+     * communicating, so right now is a good time to try to resubscribe.
+     *
+     * The reason string is used for logging if a resubscribe is triggered.
+     */
+    void TriggerResubscribeIfScheduled(const char * reason);
 
 private:
     friend class TestReadInteraction;


### PR DESCRIPTION
We did this already in OnUnsolicitedMessageFromPublisher but we'll want to more explicitly do this for checkin messages and whatnot, so we should just factor out the relevant part of the work into a separate function.
