### PR TITLE
[Silabs] Adds refactored chip_enable_wifi_ipv4 flag

### DIFF
--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -33,7 +33,6 @@ source "$CHIP_ROOT/scripts/activate.sh"
 set -x
 env
 USE_WIFI=false
-SL_WIFI_ENABLE_IPV4=false
 USE_GIT_SHA_FOR_VERSION=true
 
 SILABS_THREAD_TARGET=\""../silabs:ot-efr32-cert"\"
@@ -168,7 +167,7 @@ else
                 shift
                 ;;
             --chip_enable_wifi_ipv4)
-                SL_WIFI_ENABLE_IPV4=true
+                ipArgs="chip_enable_wifi_ipv4=true chip_inet_config_enable_ipv4=true "
                 shift
                 ;;
             --additional_data_advertising)
@@ -227,8 +226,7 @@ else
     BUILD_DIR=$OUTDIR/$SILABS_BOARD
     echo BUILD_DIR="$BUILD_DIR"
     if [ "$USE_WIFI" == true ]; then
-        optArgs+="chip_enable_wifi_ipv4=$SL_WIFI_ENABLE_IPV4 "
-        optArgs+="chip_inet_config_enable_ipv4=$SL_WIFI_ENABLE_IPV4 "
+        optArgs+="$ipArgs"
         gn gen --check --fail-on-unused-args --export-compile-commands --root="$ROOT" --dotfile="$ROOT"/build_for_wifi_gnfile.gn --args="silabs_board=\"$SILABS_BOARD\" $optArgs" "$BUILD_DIR"
     else
         # thread build

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -33,6 +33,7 @@ source "$CHIP_ROOT/scripts/activate.sh"
 set -x
 env
 USE_WIFI=false
+SL_WIFI_ENABLE_IPV4=false
 USE_GIT_SHA_FOR_VERSION=true
 
 SILABS_THREAD_TARGET=\""../silabs:ot-efr32-cert"\"
@@ -167,7 +168,7 @@ else
                 shift
                 ;;
             --chip_enable_wifi_ipv4)
-                optArgs+="chip_enable_wifi_ipv4=true "
+                SL_WIFI_ENABLE_IPV4=true
                 shift
                 ;;
             --additional_data_advertising)
@@ -226,6 +227,8 @@ else
     BUILD_DIR=$OUTDIR/$SILABS_BOARD
     echo BUILD_DIR="$BUILD_DIR"
     if [ "$USE_WIFI" == true ]; then
+        optArgs+="chip_enable_wifi_ipv4=$SL_WIFI_ENABLE_IPV4 "
+        optArgs+="chip_inet_config_enable_ipv4=$SL_WIFI_ENABLE_IPV4 "
         gn gen --check --fail-on-unused-args --export-compile-commands --root="$ROOT" --dotfile="$ROOT"/build_for_wifi_gnfile.gn --args="silabs_board=\"$SILABS_BOARD\" $optArgs" "$BUILD_DIR"
     else
         # thread build

--- a/src/platform/silabs/SiWx917/wifi_args.gni
+++ b/src/platform/silabs/SiWx917/wifi_args.gni
@@ -43,7 +43,7 @@ lwip_ethernet = true
 
 chip_device_platform = "SiWx917"
 chip_enable_openthread = false
-chip_inet_config_enable_ipv4 = true
+
 chip_inet_config_enable_dns_resolver = false
 chip_inet_config_enable_tcp_endpoint = true
 

--- a/src/platform/silabs/SiWx917/wifi_args.gni
+++ b/src/platform/silabs/SiWx917/wifi_args.gni
@@ -44,6 +44,7 @@ lwip_ethernet = true
 chip_device_platform = "SiWx917"
 chip_enable_openthread = false
 
+chip_inet_config_enable_ipv4 = false
 chip_inet_config_enable_dns_resolver = false
 chip_inet_config_enable_tcp_endpoint = true
 

--- a/src/platform/silabs/efr32/wifi_args.gni
+++ b/src/platform/silabs/efr32/wifi_args.gni
@@ -47,6 +47,7 @@ lwip_ethernet = true
 chip_device_platform = "efr32"
 chip_enable_openthread = false
 
+chip_inet_config_enable_ipv4 = false
 chip_inet_config_enable_dns_resolver = false
 chip_inet_config_enable_tcp_endpoint = true
 

--- a/src/platform/silabs/efr32/wifi_args.gni
+++ b/src/platform/silabs/efr32/wifi_args.gni
@@ -46,7 +46,7 @@ lwip_ethernet = true
 
 chip_device_platform = "efr32"
 chip_enable_openthread = false
-chip_inet_config_enable_ipv4 = true
+
 chip_inet_config_enable_dns_resolver = false
 chip_inet_config_enable_tcp_endpoint = true
 

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -43,8 +43,9 @@ declare_args() {
 
   silabs_log_enabled = true
 
-  # Argument to Disable IPv4 for wifi(rs911)
-  chip_enable_wifi_ipv4 = false
+  # Argument to enable IPv4 for wifi
+  # aligning to match chip_inet_config_enable_ipv4 default configuration
+  chip_enable_wifi_ipv4 = true
 }
 
 assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -45,7 +45,7 @@ declare_args() {
 
   # Argument to enable IPv4 for wifi
   # aligning to match chip_inet_config_enable_ipv4 default configuration
-  chip_enable_wifi_ipv4 = true
+  chip_enable_wifi_ipv4 = false
 }
 
 assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -47,8 +47,9 @@ declare_args() {
   # Enable Sleepy end device
   enable_sleepy_device = false
 
-  # Argument to Disable IPv4 for wifi(rs911)
-  chip_enable_wifi_ipv4 = false
+  # Argument to enable IPv4 for wifi
+  # aligning to match chip_inet_config_enable_ipv4 default configuration
+  chip_enable_wifi_ipv4 = true
 }
 
 assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")
@@ -233,7 +234,7 @@ template("efr32_sdk") {
         import("${chip_root}/src/platform/silabs/efr32/wifi_args.gni")
 
         defines += [ "LWIP_NETIF_API=1" ]
-        if (lwip_ipv4) {
+        if (chip_enable_wifi_ipv4) {
           defines += [
             "LWIP_IPV4=1",
 

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -49,7 +49,7 @@ declare_args() {
 
   # Argument to enable IPv4 for wifi
   # aligning to match chip_inet_config_enable_ipv4 default configuration
-  chip_enable_wifi_ipv4 = true
+  chip_enable_wifi_ipv4 = false
 }
 
 assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")


### PR DESCRIPTION
Previous this flag was only disabling the DHCP client on the device, which meant IPv4 based sources were still compiled. This meant that the size of the resulting image was unnecessarily bigger without providing the functionality.

This PR aims at fixing and aligning the expectations of toggling IPv4 support at source code level.