### PR TITLE
[Tizen] Do not fail if BLE is already connected

### DIFF
--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -109,7 +109,8 @@ void BLEManagerImpl::GattConnectionStateChangedCb(int result, bool connected, co
         sInstance.HandleConnectionEvent(connected, remoteAddress);
         break;
     default:
-        ChipLogError(DeviceLayer, "%s", connected ? "Connection req failed" : "Disconnection req failed");
+        ChipLogError(DeviceLayer, "%s: %s", connected ? "Connection req failed" : "Disconnection req failed",
+                     get_error_message(result));
         if (connected)
             sInstance.NotifyHandleConnectFailed(CHIP_ERROR_INTERNAL);
     }

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -101,17 +101,17 @@ static void __AdapterStateChangedCb(int result, bt_adapter_state_e adapterState,
 
 void BLEManagerImpl::GattConnectionStateChangedCb(int result, bool connected, const char * remoteAddress, void * userData)
 {
-    ChipLogProgress(DeviceLayer, "Gatt Connection State Changed: %s result [%d]", connected ? "Connected" : "Disconnected", result);
-
-    if (result != BT_ERROR_NONE)
+    ChipLogProgress(DeviceLayer, "Gatt Connection State Changed [%u]: %s", result, connected ? "Connected" : "Disconnected");
+    switch (result)
     {
+    case BT_ERROR_NONE:
+    case BT_ERROR_ALREADY_DONE:
+        sInstance.HandleConnectionEvent(connected, remoteAddress);
+        break;
+    default:
         ChipLogError(DeviceLayer, "%s", connected ? "Connection req failed" : "Disconnection req failed");
         if (connected)
             sInstance.NotifyHandleConnectFailed(CHIP_ERROR_INTERNAL);
-    }
-    else
-    {
-        sInstance.HandleConnectionEvent(connected, remoteAddress);
     }
 }
 


### PR DESCRIPTION
### Problem

If commissionee device is already connected (e.g. previous commissioning has failed after BLE connection, and it was restarted), Tizen will report BLE connection as failed...

### Changes

- handle `BT_ERROR_ALREADY_DONE` result code as not an error

### Testing

Tested manually with `chip-tool pairing ble-wifi 1 <SSID> <pass> 20202021 3840` on Tizen:
```
I/CHIP    (  914): DL: Gatt Connection State Changed [4265607427]: Connected         <--- 4265607427 == BT_ERROR_ALREADY_DONE
I/CHIP    (  914): DL: Device Connected [B8:27:EB:5E:BA:83]
I/CHIP    (  914): DL: AddConnectionData for [B8:27:EB:5E:BA:83]
```