### PR TITLE
use environment variables for EFR SDK root

### DIFF
--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -221,7 +221,7 @@ class Efr32Builder(GnBuilder):
         if "GSDK_ROOT" in os.environ:
             # EFR32 SDK is very large. If the SDK path is already known (the
             # case for pre-installed images), use it directly.
-            self.extra_gn_options['efr32_sdk_root'] = os.environ['GSDK_ROOT']
+            self.extra_gn_options.append(f"efr32_sdk_root=\"{os.environ['GSDK_ROOT']}\"")
 
     def GnBuildArgs(self):
         return self.extra_gn_options

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -218,7 +218,7 @@ class Efr32Builder(GnBuilder):
             self.extra_gn_options.append(
                 'sl_matter_version_str="v1.0-%s-%s"' % (branchName, shortCommitSha))
 
-        if "GSDK_ROOT" not in os.environ:
+        if "GSDK_ROOT" in os.environ:
             # EFR32 SDK is very large. If the SDK path is already known (the
             # case for pre-installed images), use it directly.
             self.extra_gn_options['efr32_sdk_root'] = os.environ['GSDK_ROOT']

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -221,7 +221,8 @@ class Efr32Builder(GnBuilder):
         if "GSDK_ROOT" in os.environ:
             # EFR32 SDK is very large. If the SDK path is already known (the
             # case for pre-installed images), use it directly.
-            self.extra_gn_options.append(f"efr32_sdk_root=\"{os.environ['GSDK_ROOT']}\"")
+            sdk_path=shlex.quote(os.environ['GSDK_ROOT'])
+            self.extra_gn_options.append(f"efr32_sdk_root=\"{sdk_path}\"")
 
     def GnBuildArgs(self):
         return self.extra_gn_options

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -221,7 +221,7 @@ class Efr32Builder(GnBuilder):
         if "GSDK_ROOT" in os.environ:
             # EFR32 SDK is very large. If the SDK path is already known (the
             # case for pre-installed images), use it directly.
-            sdk_path=shlex.quote(os.environ['GSDK_ROOT'])
+            sdk_path = shlex.quote(os.environ['GSDK_ROOT'])
             self.extra_gn_options.append(f"efr32_sdk_root=\"{sdk_path}\"")
 
     def GnBuildArgs(self):

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -219,6 +219,8 @@ class Efr32Builder(GnBuilder):
                 'sl_matter_version_str="v1.0-%s-%s"' % (branchName, shortCommitSha))
 
         if "GSDK_ROOT" not in os.environ:
+            # EFR32 SDK is very large. If the SDK path is already known (the
+            # case for pre-installed images), use it directly.
             self.extra_gn_options['efr32_sdk_root'] = os.environ['GSDK_ROOT']
 
     def GnBuildArgs(self):

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -218,6 +218,9 @@ class Efr32Builder(GnBuilder):
             self.extra_gn_options.append(
                 'sl_matter_version_str="v1.0-%s-%s"' % (branchName, shortCommitSha))
 
+        if "GSDK_ROOT" not in os.environ:
+            self.extra_gn_options['efr32_sdk_root'] = os.environ['GSDK_ROOT']
+
     def GnBuildArgs(self):
         return self.extra_gn_options
 


### PR DESCRIPTION
Update build_examples to use the gecko sdk root if available - this can save some large sdk download times.