### PR TITLE
Use a longer backoff for CASE retries.

### DIFF
--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1984,4 +1984,12 @@ System::Clock::Timeout CASESession::ComputeSigma1ResponseTimeout(const ReliableM
         kExpectedSigma1ProcessingTime;
 }
 
+System::Clock::Timeout CASESession::ComputeSigma2ResponseTimeout(const ReliableMessageProtocolConfig & remoteMrpConfig)
+{
+    return GetRetransmissionTimeout(remoteMrpConfig.mActiveRetransTimeout, remoteMrpConfig.mIdleRetransTimeout,
+                                    // Assume peer is idle, as a worst-case assumption.
+                                    System::Clock::kZero, Transport::kMinActiveTime) +
+        kExpectedHighProcessingTime;
+}
+
 } // namespace chip

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -181,6 +181,10 @@ public:
     // how long it will take to detect that our Sigma1 did not get through.
     static System::Clock::Timeout ComputeSigma1ResponseTimeout(const ReliableMessageProtocolConfig & remoteMrpConfig);
 
+    // Compute our Sigma2 response timeout.  This can give consumers an idea of
+    // how long it will take to detect that our Sigma1 did not get through.
+    static System::Clock::Timeout ComputeSigma2ResponseTimeout(const ReliableMessageProtocolConfig & remoteMrpConfig);
+
     // TODO: remove Clear, we should create a new instance instead reset the old instance.
     /** @brief This function zeroes out and resets the memory used by the object.
      **/


### PR DESCRIPTION
We have a common failure mode for Thread devices where the commissioner sends Sigma1 prior to sending CommissioningComplete, the commissionee responds, but the Sigma2 (and all its retries) never reach the commissioner.

When this happens, our existing CASE retries do not help because they happen too quickly: the commissionee is waiting for Sigma3, and will ignore Sigma1 messages until it gets the Sigma3 or times out.

To address this, include the time it would take the commissionee to time out in our CASE retry delay for every other retry.  This allows us to retry quickly once, then give the commissionee time to start listening again, then retry quickly one or two times (depending on how many retries were requested), etc.
