### PR TITLE
Disable gdbgui for python >=3.11 as it´s incompatible

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -114,9 +114,9 @@ future==0.18.3
     #   idf-component-manager
     #   mbed-os-tools
     #   pylink-square
-gdbgui==0.13.2.0 ; platform_machine != "aarch64" and sys_platform == "linux"
+gdbgui==0.13.2.0 ; platform_machine != "aarch64" and sys_platform == "linux" and python_version < "3.11"
     # via -r requirements.esp32.txt
-gevent==1.5.0
+gevent==1.5.0; python_version < "3.11"
     # via gdbgui
 ghapi==1.0.3
     # via -r requirements.txt
@@ -263,7 +263,7 @@ pycryptodome==3.9.8
     # via
     #   bflb-crypto-plus
     #   bflb-iot-tool
-pygdbmi==0.9.0.2
+pygdbmi==0.9.0.2; python_version < "3.11"
     # via
     #   -r requirements.esp32.txt
     #   gdbgui
@@ -308,7 +308,7 @@ python-dotenv==1.0.0 ; platform_machine != "aarch64" and sys_platform == "linux"
     #   mbed-tools
 python-engineio==3.14.2
     # via python-socketio
-python-socketio==4.6.1
+python-socketio==4.6.1; python_version < "3.11"
     # via
     #   -r requirements.esp32.txt
     #   flask-socketio

--- a/scripts/setup/requirements.esp32.txt
+++ b/scripts/setup/requirements.esp32.txt
@@ -2,13 +2,13 @@ click>=7.0
 future>=0.15.2
 pyparsing>=2.0.3,<2.4.0
 idf-component-manager
-pygdbmi<=0.9.0.2
+pygdbmi<=0.9.0.2 ; python_version < "3.11"
 reedsolo>=1.5.3,<=1.5.4
 bitstring>=3.1.6
 ecdsa>=0.16.0
 kconfiglib==13.7.1
 construct==2.10.54
-python-socketio<5
-gdbgui==0.13.2.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-jinja2<3.1
-itsdangerous<2.1
+python-socketio<5 ; python_version < "3.11"
+gdbgui==0.13.2.0 ; platform_machine != 'aarch64' and sys_platform == 'linux' and python_version < "3.11"
+jinja2<3.1 ; python_version < "3.11"
+itsdangerous<2.1 ; python_version < "3.11"


### PR DESCRIPTION
GDBGUI is incompatible with Python >= 3.11 see https://github.com/cs01/gdbgui/issues/447

and the similar fix done in esp-idf here:
https://github.com/espressif/esp-idf/commit/f9e52727279180f5f5ec4acb7996f01e92b40e06