### PR TITLE
[ESP32] fix build error import from PR #25289

### DIFF
--- a/src/platform/ESP32/ESP32DeviceInfoProvider.cpp
+++ b/src/platform/ESP32/ESP32DeviceInfoProvider.cpp
@@ -241,7 +241,7 @@ ESP32DeviceInfoProvider::SupportedCalendarTypesIteratorImpl::SupportedCalendarTy
 size_t ESP32DeviceInfoProvider::SupportedCalendarTypesIteratorImpl::Count()
 {
     size_t count = 0;
-    for (uint8_t i = 0; i < to_underlying(CalendarTypeEnum::kUnknownEnumValue); i++)
+    for (uint8_t i = 0; i < to_underlying(app::Clusters::TimeFormatLocalization::CalendarTypeEnum::kUnknownEnumValue); i++)
     {
         if (mSupportedCalendarTypes & (1 << i))
         {
@@ -254,7 +254,7 @@ size_t ESP32DeviceInfoProvider::SupportedCalendarTypesIteratorImpl::Count()
 
 bool ESP32DeviceInfoProvider::SupportedCalendarTypesIteratorImpl::Next(CalendarType & output)
 {
-    while (mIndex < to_underlying(CalendarTypeEnum::kUnknownEnumValue))
+    while (mIndex < to_underlying(app::Clusters::TimeFormatLocalization::CalendarTypeEnum::kUnknownEnumValue))
     {
         if (mSupportedCalendarTypes & (1 << mIndex))
         {


### PR DESCRIPTION
A build error for ESP32 platform was imorted from PR [#25289 ](https://github.com/project-chip/connectedhomeip/pull/25289/files#diff-b8e52eb6755c4ea8fedd025f27751dee2533e3d3a82f36f752534a2436720b66)
In the **src/platform/ESP32/ESP32DeviceInfoProvider.cpp** file, replace the **CalendarType** with **CalendarTypeEnum** directly is incorrect, we can find the declaration of CalendarTypeEnum. 

Test method: Enable the **ENABLE_ESP32_DEVICE_INFO_PROVIDER** in menuconfig, then build a example like lighting-app.
