### PR TITLE
Fix android build error

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -153,7 +153,8 @@ chip::Inet::IPAddress * CastingServer::getIpAddressForUDCRequest(chip::Inet::IPA
         if (ipAddresses[i].IsIPv4())
         {
             ipIndexToUse = i;
-            ChipLogProgress(AppServer, "Found IPv4 address at index: %lu - prioritizing use of IPv4", ipIndexToUse);
+            ChipLogProgress(AppServer, "Found IPv4 address at index: %lu - prioritizing use of IPv4",
+                            static_cast<long>(ipIndexToUse));
             break;
         }
 


### PR DESCRIPTION
Fixes:

```
 ../../examples/tv-casting-app/android/third_party/connectedhomeip/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp:156:103: error: format specifies type 'unsigned long' but the argument has type 'size_t' (aka 'unsigned int') [-Werror,-Wformat]
173
INFO                ChipLogProgress(AppServer, "Found IPv4 address at index: %lu - prioritizing use of IPv4", ipIndexToUse);
174
INFO                                                                         ~~~                              ^~~~~~~~~~~~
```

as seen in https://github.com/project-chip/connectedhomeip/actions/runs/4466404744/jobs/7844554634?pr=25744