### PR TITLE
[silabs] Fix to SiWx917 SoC Auto MCU Reset issue

### DIFF
--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -34,6 +34,9 @@
 #include "nvm3_default.h"
 #include "nvm3_hal_flash.h"
 #include <nvm3_lock.h>
+#ifdef BRD4325A
+#include "rsi_ccp_common.h"
+#endif
 
 // Substitute the GSDK weak nvm3_lockBegin and nvm3_lockEnd
 // for an application controlled re-entrance protection
@@ -43,6 +46,9 @@ static StaticSemaphore_t nvm3_SemStruct;
 void nvm3_lockBegin(void)
 {
     VerifyOrDie(nvm3_Sem != NULL);
+#ifdef BRD4325A
+    __disable_irq();
+#endif
     xSemaphoreTake(nvm3_Sem, portMAX_DELAY);
 }
 
@@ -50,6 +56,9 @@ void nvm3_lockEnd(void)
 {
     VerifyOrDie(nvm3_Sem != NULL);
     xSemaphoreGive(nvm3_Sem);
+#ifdef BRD4325A
+    __enable_irq();
+#endif
 }
 
 namespace chip {

--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -38,7 +38,7 @@
 #include "rsi_ccp_common.h"
 #endif
 
-#ifndef BRD4325A   // TODO: fix semaphore usage in nvm3_lock for siwx917. use weak implementation for that board instead
+#ifndef BRD4325A // TODO: fix semaphore usage in nvm3_lock for siwx917. use weak implementation for that board instead
 // Substitute the GSDK weak nvm3_lockBegin and nvm3_lockEnd
 // for an application controlled re-entrance protection
 static SemaphoreHandle_t nvm3_Sem;
@@ -68,7 +68,7 @@ namespace Internal {
 
 CHIP_ERROR SilabsConfig::Init()
 {
-#ifndef BRD4325A   // TODO: fix semaphore usage in nvm3_lock for siwx917. use weak implementation for that board instead
+#ifndef BRD4325A // TODO: fix semaphore usage in nvm3_lock for siwx917. use weak implementation for that board instead
     nvm3_Sem = xSemaphoreCreateBinaryStatic(&nvm3_SemStruct);
 
     if (nvm3_Sem == NULL)
@@ -82,7 +82,7 @@ CHIP_ERROR SilabsConfig::Init()
 
 void SilabsConfig::DeInit()
 {
-#ifndef BRD4325A   // TODO: fix semaphore usage in nvm3_lock for siwx917. use weak implementation for that board instead
+#ifndef BRD4325A // TODO: fix semaphore usage in nvm3_lock for siwx917. use weak implementation for that board instead
     vSemaphoreDelete(nvm3_Sem);
 #endif // not BRD4325A
     nvm3_close(nvm3_defaultHandle);

--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -34,9 +34,6 @@
 #include "nvm3_default.h"
 #include "nvm3_hal_flash.h"
 #include <nvm3_lock.h>
-#ifdef BRD4325A
-#include "rsi_ccp_common.h"
-#endif
 
 #ifndef BRD4325A // TODO: fix semaphore usage in nvm3_lock for siwx917. use weak implementation for that board instead
 // Substitute the GSDK weak nvm3_lockBegin and nvm3_lockEnd

--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -38,6 +38,7 @@
 #include "rsi_ccp_common.h"
 #endif
 
+#ifndef BRD4325A   // TODO: fix semaphore usage in nvm3_lock for siwx917. use weak implementation for that board instead
 // Substitute the GSDK weak nvm3_lockBegin and nvm3_lockEnd
 // for an application controlled re-entrance protection
 static SemaphoreHandle_t nvm3_Sem;
@@ -46,9 +47,6 @@ static StaticSemaphore_t nvm3_SemStruct;
 void nvm3_lockBegin(void)
 {
     VerifyOrDie(nvm3_Sem != NULL);
-#ifdef BRD4325A
-    __disable_irq();
-#endif
     xSemaphoreTake(nvm3_Sem, portMAX_DELAY);
 }
 
@@ -56,10 +54,8 @@ void nvm3_lockEnd(void)
 {
     VerifyOrDie(nvm3_Sem != NULL);
     xSemaphoreGive(nvm3_Sem);
-#ifdef BRD4325A
-    __enable_irq();
-#endif
 }
+#endif // not BRD4325A
 
 namespace chip {
 namespace DeviceLayer {
@@ -72,6 +68,7 @@ namespace Internal {
 
 CHIP_ERROR SilabsConfig::Init()
 {
+#ifndef BRD4325A   // TODO: fix semaphore usage in nvm3_lock for siwx917. use weak implementation for that board instead
     nvm3_Sem = xSemaphoreCreateBinaryStatic(&nvm3_SemStruct);
 
     if (nvm3_Sem == NULL)
@@ -79,12 +76,15 @@ CHIP_ERROR SilabsConfig::Init()
         return CHIP_ERROR_NO_MEMORY;
     }
     xSemaphoreGive(nvm3_Sem);
+#endif // not BRD4325A
     return MapNvm3Error(nvm3_open(nvm3_defaultHandle, nvm3_defaultInit));
 }
 
 void SilabsConfig::DeInit()
 {
+#ifndef BRD4325A   // TODO: fix semaphore usage in nvm3_lock for siwx917. use weak implementation for that board instead
     vSemaphoreDelete(nvm3_Sem);
+#endif // not BRD4325A
     nvm3_close(nvm3_defaultHandle);
 }
 


### PR DESCRIPTION
#### problem:
917 SoC auto MCU reset issue is observed with this PR https://github.com/project-chip/connectedhomeip/pull/25503
__disable_irq() and __enable_irq() where added in the nvm3 lock for SoC but this is overriding now and it is causing the reset issue.

#### Fix:
We added __disable_irq() and __enable_irq() code in the nvm3_lockBegin() and nvm3_lockEnd() respectively for SoC to avoid the reset issue.

