### PR TITLE
Fix integer/long detection for codegen

### DIFF
--- a/scripts/py_matter_idl/matter_idl/generators/java/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/java/__init__.py
@@ -20,7 +20,7 @@ from typing import List, Set, Union
 from matter_idl.generators import CodeGenerator, GeneratorStorage
 from matter_idl.generators.types import (BasicInteger, BasicString, FundamentalType, IdlBitmapType, IdlEnumType, IdlType,
                                          ParseDataType, TypeLookupContext)
-from matter_idl.matter_idl_types import Attribute, Cluster, ClusterSide, Command, DataType, Field, FieldQuality, Idl, ClusterSide
+from matter_idl.matter_idl_types import Attribute, Cluster, ClusterSide, Command, DataType, Field, FieldQuality, Idl
 from stringcase import capitalcase
 
 


### PR DESCRIPTION
ZAP `asJavaType` considers every 32-bit integer to be Long and smaller to be Integer (unclear why since java integers are supposed to be 32 bit, however this is what the code does).

Found two bugs in our codegen:
  - 24-bit integers were not considered (check for >= 4 only matched 32-bit but not 24-bit, where as zap matches 24-bit too)
  - matching was not done for bitmaps and enums (zap code did match these)
