### PR TITLE
Enable EndpointIterator to target search single group ID

### DIFF
--- a/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
+++ b/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
@@ -84,7 +84,7 @@ struct GroupTableCodec
         TLV::TLVType inner;
         ReturnErrorOnFailure(writer.StartContainer(TagEndpoints(), TLV::kTLVType_Array, inner));
         GroupDataProvider::GroupEndpoint mapping;
-        auto iter = mProvider->IterateEndpoints(mFabric, Optional<GroupId>(mInfo.group_id));
+        auto iter = mProvider->IterateEndpoints(mFabric, MakeOptional(mInfo.group_id));
         if (nullptr != iter)
         {
             while (iter->Next(mapping))

--- a/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
+++ b/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
@@ -84,15 +84,12 @@ struct GroupTableCodec
         TLV::TLVType inner;
         ReturnErrorOnFailure(writer.StartContainer(TagEndpoints(), TLV::kTLVType_Array, inner));
         GroupDataProvider::GroupEndpoint mapping;
-        auto iter = mProvider->IterateEndpoints(mFabric);
+        auto iter = mProvider->IterateEndpoints(mFabric, Optional<GroupId>(mInfo.group_id));
         if (nullptr != iter)
         {
             while (iter->Next(mapping))
             {
-                if (mapping.group_id == mInfo.group_id)
-                {
-                    ReturnErrorOnFailure(writer.Put(TLV::AnonymousTag(), static_cast<uint16_t>(mapping.endpoint_id)));
-                }
+                ReturnErrorOnFailure(writer.Put(TLV::AnonymousTag(), static_cast<uint16_t>(mapping.endpoint_id)));
             }
             iter->Release();
         }

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -253,8 +253,7 @@ public:
      *  @retval An instance of EndpointIterator on success
      *  @retval nullptr if no iterator instances are available.
      */
-    virtual EndpointIterator * IterateEndpoints(FabricIndex fabric_index,
-                                                Optional<GroupId> group_id = NullOptional) = 0;
+    virtual EndpointIterator * IterateEndpoints(FabricIndex fabric_index, Optional<GroupId> group_id = NullOptional) = 0;
 
     //
     // Group-Key map

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -249,12 +249,12 @@ public:
      *  Creates an iterator that may be used to obtain the list of (group, endpoint) pairs associated with the given fabric.
      *  In order to release the allocated memory, the Release() method must be called after the iteration is finished.
      *  Modifying the group table during the iteration is currently not supported, and may yield unexpected behaviour.
-     *  If you wish to iterator only the endpoints of a particular group id you can provide the optional `group_id` to do so.
+     *  If you wish to iterate only the endpoints of a particular group id you can provide the optional `group_id` to do so.
      *  @retval An instance of EndpointIterator on success
      *  @retval nullptr if no iterator instances are available.
      */
     virtual EndpointIterator * IterateEndpoints(FabricIndex fabric_index,
-                                                Optional<GroupId> group_id = Optional<GroupId>::Missing()) = 0;
+                                                Optional<GroupId> group_id = NullOptional) = 0;
 
     //
     // Group-Key map

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -252,7 +252,8 @@ public:
      *  @retval An instance of EndpointIterator on success
      *  @retval nullptr if no iterator instances are available.
      */
-    virtual EndpointIterator * IterateEndpoints(FabricIndex fabric_index) = 0;
+    virtual EndpointIterator * IterateEndpoints(FabricIndex fabric_index,
+                                                Optional<GroupId> group_id = Optional<GroupId>::Missing()) = 0;
 
     //
     // Group-Key map

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -249,6 +249,7 @@ public:
      *  Creates an iterator that may be used to obtain the list of (group, endpoint) pairs associated with the given fabric.
      *  In order to release the allocated memory, the Release() method must be called after the iteration is finished.
      *  Modifying the group table during the iteration is currently not supported, and may yield unexpected behaviour.
+     *  If you wish to iterator only the endpoints of a particular group id you can provide the optional `group_id` to do so.
      *  @retval An instance of EndpointIterator on success
      *  @retval nullptr if no iterator instances are available.
      */

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -68,7 +68,8 @@ public:
     CHIP_ERROR RemoveEndpoint(FabricIndex fabric_index, EndpointId endpoint_id) override;
     // Iterators
     GroupInfoIterator * IterateGroupInfo(FabricIndex fabric_index) override;
-    EndpointIterator * IterateEndpoints(FabricIndex fabric_index) override;
+    EndpointIterator * IterateEndpoints(FabricIndex fabric_index,
+                                        Optional<GroupId> group_id = Optional<GroupId>::Missing()) override;
 
     //
     // Group-Key map
@@ -133,7 +134,7 @@ protected:
     class EndpointIteratorImpl : public EndpointIterator
     {
     public:
-        EndpointIteratorImpl(GroupDataProviderImpl & provider, FabricIndex fabric_index);
+        EndpointIteratorImpl(GroupDataProviderImpl & provider, FabricIndex fabric_index, Optional<GroupId> group_id);
         size_t Count() override;
         bool Next(GroupEndpoint & output) override;
         void Release() override;

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -68,8 +68,7 @@ public:
     CHIP_ERROR RemoveEndpoint(FabricIndex fabric_index, EndpointId endpoint_id) override;
     // Iterators
     GroupInfoIterator * IterateGroupInfo(FabricIndex fabric_index) override;
-    EndpointIterator * IterateEndpoints(FabricIndex fabric_index,
-                                        Optional<GroupId> group_id = NullOptional) override;
+    EndpointIterator * IterateEndpoints(FabricIndex fabric_index, Optional<GroupId> group_id = NullOptional) override;
 
     //
     // Group-Key map

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -69,7 +69,7 @@ public:
     // Iterators
     GroupInfoIterator * IterateGroupInfo(FabricIndex fabric_index) override;
     EndpointIterator * IterateEndpoints(FabricIndex fabric_index,
-                                        Optional<GroupId> group_id = Optional<GroupId>::Missing()) override;
+                                        Optional<GroupId> group_id = NullOptional) override;
 
     //
     // Group-Key map


### PR DESCRIPTION
Running RR_1_1 test where we stress test by using max of everything on every fabric, it was found that each iterator step could take up to 21ms. For a large enough group table ReadGroupTable was taking more then 5 second. By targeting the group id for which we want to iterator over endpoints we can reduce time `ReadGroupTable` for large tables by an order of magnitude.

This is one of the 4 PR that will be required to address https://github.com/project-chip/connectedhomeip/issues/25532

