### PR TITLE
[Tizen] Bluetooth add advertising flags setup

### DIFF
--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -678,9 +678,9 @@ int BLEManagerImpl::StartBLEAdvertising()
                                                      service_data, sizeof(service_data));
     VerifyOrExit(ret == BT_ERROR_NONE,
                  ChipLogError(DeviceLayer, "bt_adapter_le_add_advertising_service_data() failed. ret: %d", ret));
+
     ret = bt_adapter_le_set_advertising_flags(
         mAdvertiser, BT_ADAPTER_LE_ADVERTISING_FLAGS_GEN_DISC | BT_ADAPTER_LE_ADVERTISING_FLAGS_BREDR_UNSUP);
-
     VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_adapter_le_set_advertising_flags() failed. ret: %d", ret));
 
     ret = bt_adapter_le_set_advertising_device_name(mAdvertiser, BT_ADAPTER_LE_PACKET_ADVERTISING, true);

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -676,6 +676,10 @@ int BLEManagerImpl::StartBLEAdvertising()
                                                      service_data, sizeof(service_data));
     VerifyOrExit(ret == BT_ERROR_NONE,
                  ChipLogError(DeviceLayer, "bt_adapter_le_add_advertising_service_data() failed. ret: %d", ret));
+    ret = bt_adapter_le_set_advertising_flags(
+        mAdvertiser, BT_ADAPTER_LE_ADVERTISING_FLAGS_GEN_DISC | BT_ADAPTER_LE_ADVERTISING_FLAGS_BREDR_UNSUP);
+
+    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_adapter_le_set_advertising_flags() failed. ret: %d", ret));
 
     ret = bt_adapter_le_set_advertising_device_name(mAdvertiser, BT_ADAPTER_LE_PACKET_ADVERTISING, true);
     VerifyOrExit(ret == BT_ERROR_NONE,

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -42,6 +42,8 @@
 #include <utility>
 
 #include <bluetooth.h>
+#include <bluetooth_internal.h>
+#include <bluetooth_type_internal.h>
 #include <glib.h>
 
 #include <ble/Ble.h>


### PR DESCRIPTION
## Problem
During pairing ble-wifi with the Tizen device running the `lighting-app` and the Linux running `chip-tool`, the Tizen device is not recognized as a proper BLE device.  

## Solution
Set proper advertising flags during advertising setup. 

## Testing

On  the Linux device, run chip-tool:

``` sh
./chip-tool pairing ble-wifi 0x01 <wifi> <pass> 20202021 3840
```
On the Tizen device run lighting-app:

``` sh
app_launcher -s org.tizen.matter.example.lighting wifi true
```


