### PR TITLE
[ESP32] Added support of mode select for esp32 to read/write SupportedModes attribute from factory partition

### DIFF
--- a/docs/guides/esp32/factory_data.md
+++ b/docs/guides/esp32/factory_data.md
@@ -35,8 +35,7 @@ Following data can be added to the manufacturing partition using
     -   Supported locales
     -   Supported calendar types
     -   Supported modes
-        -   Note: Size of label should be less than 64 and `\0` is being added
-            at last.
+        -   Note: As per spec at max size of label should be 64 and `\0` will be added at the end.
 
 ### Configuration Options
 

--- a/docs/guides/esp32/factory_data.md
+++ b/docs/guides/esp32/factory_data.md
@@ -35,7 +35,8 @@ Following data can be added to the manufacturing partition using
     -   Supported locales
     -   Supported calendar types
     -   Supported modes
-        -   Note: As per spec at max size of label should be 64 and `\0` will be added at the end.
+        -   Note: As per spec at max size of label should be 64 and `\0` will be
+            added at the end.
 
 ### Configuration Options
 

--- a/docs/guides/esp32/factory_data.md
+++ b/docs/guides/esp32/factory_data.md
@@ -34,6 +34,8 @@ Following data can be added to the manufacturing partition using
     -   Fixed Labels
     -   Supported locales
     -   Supported calendar types
+    -   Supported modes
+		- Note: Size of label should be less than 64 and `\0` is being added at last.
 
 ### Configuration Options
 

--- a/docs/guides/esp32/factory_data.md
+++ b/docs/guides/esp32/factory_data.md
@@ -35,7 +35,8 @@ Following data can be added to the manufacturing partition using
     -   Supported locales
     -   Supported calendar types
     -   Supported modes
-		- Note: Size of label should be less than 64 and `\0` is being added at last.
+        -   Note: Size of label should be less than 64 and `\0` is being added
+            at last.
 
 ### Configuration Options
 

--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/common"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/shell_extension"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/lock"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/mode-support"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/util"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/reporting"
@@ -91,6 +92,9 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/src"
 )
 
+
+set(EXCLUDE_SRCS "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp")
+
 if (CONFIG_ENABLE_PW_RPC)
 # Append additional directories for RPC build
 set(PRIV_INCLUDE_DIRS_LIST  "${PRIV_INCLUDE_DIRS_LIST}"
@@ -119,7 +123,7 @@ endif()
 
 idf_component_register(PRIV_INCLUDE_DIRS ${PRIV_INCLUDE_DIRS_LIST}
                        SRC_DIRS ${SRC_DIRS_LIST}
-                       EXCLUDE_SRCS ${EXCLUDE_SRCS_LIST}
+                       EXCLUDE_SRCS ${EXCLUDE_SRCS}
                        PRIV_REQUIRES ${PRIV_REQUIRES_LIST})
 
 get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
@@ -1,0 +1,115 @@
+#include "static-supported-modes-manager.h"
+#include <app/util/debug-printing.h>
+#include <app/util/ember-print.h>
+#include "ESP32Config.h"
+
+using namespace chip;
+using namespace chip::app::Clusters;
+using namespace chip::DeviceLayer::Internal;
+using namespace chip::app::Clusters::ModeSelect;
+using chip::Protocols::InteractionModel::Status;
+
+using ModeOptionStructType = Structs::ModeOptionStruct::Type;
+using SemanticTag          = Structs::SemanticTagStruct::Type;
+template <typename T>
+using List               = app::DataModel::List<T>;
+char chip::app::Clusters::ModeSelect::StaticSupportedModesManager::supportedModeLabel[64] = "";
+
+const StaticSupportedModesManager StaticSupportedModesManager::instance = StaticSupportedModesManager();
+
+SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeOptionsProvider(EndpointId endpointId) const
+{
+	char keyBuf[ESP32Config::kMaxConfigKeyNameLength];
+    uint32_t supportedModeCount = 0;
+
+    VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesCount(keyBuf, sizeof(keyBuf), endpointId) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+    ESP32Config::Key countKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+    VerifyOrReturnValue(ESP32Config::ReadConfigValue(countKey, supportedModeCount) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+
+	ModeOptionStructType *modeOptionStruct = new ModeOptionStructType[supportedModeCount + 1];
+	
+	for (int index = 0; index < supportedModeCount; index++) {
+		Structs::ModeOptionStruct::Type option;
+   	 	uint32_t supportedModeMode = 0;
+    	uint32_t semanticTagCount = 0;
+		size_t outLen   = 0;
+		
+		memset(supportedModeLabel, 0, sizeof(supportedModeLabel));
+		memset(keyBuf, 0, sizeof(char)*ESP32Config::kMaxConfigKeyNameLength);
+    	VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesLabel(keyBuf, sizeof(keyBuf), endpointId, index) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+    	ESP32Config::Key labelKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+    	VerifyOrReturnValue(ESP32Config::ReadConfigValueStr(labelKey, supportedModeLabel, sizeof(supportedModeLabel), outLen) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+
+		
+		memset(keyBuf, 0, sizeof(char)*ESP32Config::kMaxConfigKeyNameLength);
+    	VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesValue(keyBuf, sizeof(keyBuf), endpointId, index) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+    	ESP32Config::Key modeKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+    	VerifyOrReturnValue(ESP32Config::ReadConfigValue(labelKey, supportedModeMode) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+		
+		memset(keyBuf, 0, sizeof(char)*ESP32Config::kMaxConfigKeyNameLength);
+    	VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagsCount(keyBuf, sizeof(keyBuf), endpointId, index) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+    	ESP32Config::Key stCountKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+    	VerifyOrReturnValue(ESP32Config::ReadConfigValue(stCountKey, semanticTagCount) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+
+		SemanticTag *semanticTags = new SemanticTag[semanticTagCount];
+		for (auto stIndex = 0; stIndex < semanticTagCount; stIndex++) {
+
+			uint32_t semanticTagValue = 0;
+			uint32_t semanticTagMfgCode = 0;
+			SemanticTag tag;
+
+			memset(keyBuf, 0, sizeof(char)*ESP32Config::kMaxConfigKeyNameLength);
+    		VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagValue(keyBuf, sizeof(keyBuf), endpointId, index, stIndex) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+    		ESP32Config::Key stValueKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+    		VerifyOrReturnValue(ESP32Config::ReadConfigValue(stValueKey, semanticTagValue) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+
+			memset(keyBuf, 0, sizeof(char)*ESP32Config::kMaxConfigKeyNameLength);
+    		VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagMfgCode(keyBuf, sizeof(keyBuf), endpointId, index, stIndex) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+    		ESP32Config::Key stMfgCodeKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+    		VerifyOrReturnValue(ESP32Config::ReadConfigValue(stMfgCodeKey, semanticTagMfgCode) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+
+			tag.value = static_cast<uint16_t>(semanticTagValue);
+			tag.mfgCode = static_cast<chip::VendorId>(semanticTagMfgCode);
+			semanticTags[stIndex] = static_cast<const SemanticTag>(tag);
+			
+		}
+			
+    	option.label =  chip::CharSpan::fromCharString(supportedModeLabel);
+    	option.mode = static_cast<uint8_t>(supportedModeMode);
+    	option.semanticTags = DataModel::List<const SemanticTag>(semanticTags, semanticTagCount);
+
+		modeOptionStruct[index] = option;
+
+	}
+
+    return ModeOptionsProvider(modeOptionStruct, modeOptionStruct + supportedModeCount);
+}
+
+Status StaticSupportedModesManager::getModeOptionByMode(unsigned short endpointId, unsigned char mode,
+                                                        const ModeOptionStructType ** dataPtr) const
+{
+    auto modeOptionsProvider = this->getModeOptionsProvider(endpointId);
+    if (modeOptionsProvider.begin() == nullptr)
+    {
+        return Status::UnsupportedCluster;
+    }
+    auto * begin = this->getModeOptionsProvider(endpointId).begin();
+    auto * end   = this->getModeOptionsProvider(endpointId).end();
+
+    for (auto * it = begin; it != end; ++it)
+    {
+        auto & modeOption = *it;
+        if (modeOption.mode == mode)
+        {
+            *dataPtr = &modeOption;
+            return Status::Success;
+        }
+    }
+    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "Cannot find the mode %u", mode);
+    return Status::InvalidCommand;
+}
+
+const ModeSelect::SupportedModesManager * ModeSelect::getSupportedModesManager()
+{
+    return &StaticSupportedModesManager::instance;
+}

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
@@ -1,7 +1,25 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #include "static-supported-modes-manager.h"
-#include "ESP32Config.h"
 #include <app/util/debug-printing.h>
 #include <app/util/ember-print.h>
+#include <platform/ESP32/ESP32Config.h>
 
 using namespace chip;
 using namespace chip::app::Clusters;
@@ -13,9 +31,6 @@ using ModeOptionStructType = Structs::ModeOptionStruct::Type;
 using SemanticTag          = Structs::SemanticTagStruct::Type;
 template <typename T>
 using List = app::DataModel::List<T>;
-
-StaticSupportedModesManager::ModeOptionStructType * StaticSupportedModesManager::modeOptionStructList = nullptr;
-StaticSupportedModesManager::SemanticTag * StaticSupportedModesManager::semanticTags                  = nullptr;
 
 const StaticSupportedModesManager StaticSupportedModesManager::instance = StaticSupportedModesManager();
 
@@ -36,6 +51,9 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
         return ModeOptionsProvider(epModeOptionsProviderList[endpointId].begin(), epModeOptionsProviderList[endpointId].end());
     }
 
+    ModeOptionStructType * modeOptionStructList = nullptr;
+    SemanticTag * semanticTags                  = nullptr;
+
     char keyBuf[ESP32Config::kMaxConfigKeyNameLength];
     uint32_t supportedModeCount = 0;
 
@@ -51,6 +69,8 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
         return ModeOptionsProvider(nullptr, nullptr);
     }
 
+    epModeOptionsProviderList[endpointId] = ModeOptionsProvider(modeOptionStructList, modeOptionStructList + supportedModeCount);
+
     for (int index = 0; index < supportedModeCount; index++)
     {
         Structs::ModeOptionStruct::Type option;
@@ -61,35 +81,41 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
         memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
         VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesLabel(keyBuf, sizeof(keyBuf), endpointId, index) ==
                                 CHIP_NO_ERROR,
-                            ModeOptionsProvider(nullptr, nullptr), CleanUp());
+                            ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
         ESP32Config::Key labelKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
         VerifyOrReturnValue(ESP32Config::ReadConfigValueStr(labelKey, nullptr, 0, outLen) == CHIP_NO_ERROR,
-                            ModeOptionsProvider(nullptr, nullptr), CleanUp());
+                            ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
 
         char * modeLabel = new char[outLen + 1];
+        if (modeLabel == nullptr)
+        {
+            CleanUp(endpointId);
+            return ModeOptionsProvider(nullptr, nullptr);
+        }
+
         VerifyOrReturnValue(ESP32Config::ReadConfigValueStr(labelKey, modeLabel, outLen + 1, outLen) == CHIP_NO_ERROR,
-                            ModeOptionsProvider(nullptr, nullptr), CleanUp());
+                            ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
 
         memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
         VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesValue(keyBuf, sizeof(keyBuf), endpointId, index) ==
                                 CHIP_NO_ERROR,
-                            ModeOptionsProvider(nullptr, nullptr), CleanUp());
+                            ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
         ESP32Config::Key modeKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
         VerifyOrReturnValue(ESP32Config::ReadConfigValue(labelKey, supportedModeMode) == CHIP_NO_ERROR,
-                            ModeOptionsProvider(nullptr, nullptr), CleanUp());
+                            ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
 
         memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
         VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagsCount(keyBuf, sizeof(keyBuf), endpointId, index) ==
                                 CHIP_NO_ERROR,
-                            ModeOptionsProvider(nullptr, nullptr), CleanUp());
+                            ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
         ESP32Config::Key stCountKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
         VerifyOrReturnValue(ESP32Config::ReadConfigValue(stCountKey, semanticTagCount) == CHIP_NO_ERROR,
-                            ModeOptionsProvider(nullptr, nullptr), CleanUp());
+                            ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
 
         semanticTags = new SemanticTag[semanticTagCount];
         if (semanticTags == nullptr)
         {
-            CleanUp();
+            CleanUp(endpointId);
             return ModeOptionsProvider(nullptr, nullptr);
         }
         for (auto stIndex = 0; stIndex < semanticTagCount; stIndex++)
@@ -102,18 +128,18 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
             memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
             VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagValue(keyBuf, sizeof(keyBuf), endpointId, index, stIndex) ==
                                     CHIP_NO_ERROR,
-                                ModeOptionsProvider(nullptr, nullptr), CleanUp());
+                                ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
             ESP32Config::Key stValueKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
             VerifyOrReturnValue(ESP32Config::ReadConfigValue(stValueKey, semanticTagValue) == CHIP_NO_ERROR,
-                                ModeOptionsProvider(nullptr, nullptr), CleanUp());
+                                ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
 
             memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
             VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagMfgCode(keyBuf, sizeof(keyBuf), endpointId, index, stIndex) ==
                                     CHIP_NO_ERROR,
-                                ModeOptionsProvider(nullptr, nullptr), CleanUp());
+                                ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
             ESP32Config::Key stMfgCodeKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
             VerifyOrReturnValue(ESP32Config::ReadConfigValue(stMfgCodeKey, semanticTagMfgCode) == CHIP_NO_ERROR,
-                                ModeOptionsProvider(nullptr, nullptr), CleanUp());
+                                ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
 
             tag.value             = static_cast<uint16_t>(semanticTagValue);
             tag.mfgCode           = static_cast<chip::VendorId>(semanticTagMfgCode);
@@ -126,7 +152,6 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
 
         modeOptionStructList[index] = option;
     }
-    epModeOptionsProviderList[endpointId] = ModeOptionsProvider(modeOptionStructList, modeOptionStructList + supportedModeCount);
 
     return ModeOptionsProvider(modeOptionStructList, modeOptionStructList + supportedModeCount);
 }
@@ -160,28 +185,25 @@ const ModeSelect::SupportedModesManager * ModeSelect::getSupportedModesManager()
     return &StaticSupportedModesManager::instance;
 }
 
-void StaticSupportedModesManager::FreeSupportedModes() const
+void StaticSupportedModesManager::FreeSupportedModes(EndpointId endpointId) const
 {
-    for (int i = 0; i < FIXED_ENDPOINT_COUNT; i++)
+    if (epModeOptionsProviderList[endpointId].begin() != nullptr)
     {
-        if (epModeOptionsProviderList[i].begin() != nullptr)
+        auto * begin = epModeOptionsProviderList[endpointId].begin();
+        auto * end   = epModeOptionsProviderList[endpointId].end();
+        for (auto * it = begin; it != end; ++it)
         {
-            auto * begin = epModeOptionsProviderList[i].begin();
-            auto * end   = epModeOptionsProviderList[i].end();
-            for (auto * it = begin; it != end; ++it)
-            {
-                auto & modeOption = *it;
-                delete modeOption.label.data();
-                delete[] modeOption.semanticTags.data();
-            }
-            delete[] begin;
+            auto & modeOption = *it;
+            delete[] modeOption.label.data();
+            delete[] modeOption.semanticTags.data();
         }
-        epModeOptionsProviderList[i] = ModeOptionsProvider();
+        delete[] begin;
     }
+    epModeOptionsProviderList[endpointId] = ModeOptionsProvider();
 }
 
-void StaticSupportedModesManager::CleanUp() const
+void StaticSupportedModesManager::CleanUp(EndpointId endpointId) const
 {
     ChipLogError(Zcl, "Supported mode data is in incorrect format");
-    FreeSupportedModes();
+    FreeSupportedModes(endpointId);
 }

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
@@ -27,25 +27,25 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
     VerifyOrReturnValue(ESP32Config::ReadConfigValue(countKey, supportedModeCount) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
 
 	ModeOptionStructType *modeOptionStruct = new ModeOptionStructType[supportedModeCount + 1];
-	
+
 	for (int index = 0; index < supportedModeCount; index++) {
 		Structs::ModeOptionStruct::Type option;
    	 	uint32_t supportedModeMode = 0;
     	uint32_t semanticTagCount = 0;
 		size_t outLen   = 0;
-		
+
 		memset(supportedModeLabel, 0, sizeof(supportedModeLabel));
 		memset(keyBuf, 0, sizeof(char)*ESP32Config::kMaxConfigKeyNameLength);
     	VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesLabel(keyBuf, sizeof(keyBuf), endpointId, index) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
     	ESP32Config::Key labelKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
     	VerifyOrReturnValue(ESP32Config::ReadConfigValueStr(labelKey, supportedModeLabel, sizeof(supportedModeLabel), outLen) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
 
-		
+
 		memset(keyBuf, 0, sizeof(char)*ESP32Config::kMaxConfigKeyNameLength);
     	VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesValue(keyBuf, sizeof(keyBuf), endpointId, index) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
     	ESP32Config::Key modeKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
     	VerifyOrReturnValue(ESP32Config::ReadConfigValue(labelKey, supportedModeMode) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
-		
+
 		memset(keyBuf, 0, sizeof(char)*ESP32Config::kMaxConfigKeyNameLength);
     	VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagsCount(keyBuf, sizeof(keyBuf), endpointId, index) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
     	ESP32Config::Key stCountKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
@@ -71,9 +71,9 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
 			tag.value = static_cast<uint16_t>(semanticTagValue);
 			tag.mfgCode = static_cast<chip::VendorId>(semanticTagMfgCode);
 			semanticTags[stIndex] = static_cast<const SemanticTag>(tag);
-			
+
 		}
-			
+
     	option.label =  chip::CharSpan::fromCharString(supportedModeLabel);
     	option.mode = static_cast<uint8_t>(supportedModeMode);
     	option.semanticTags = DataModel::List<const SemanticTag>(semanticTags, semanticTagCount);

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
@@ -15,7 +15,7 @@ template <typename T>
 using List = app::DataModel::List<T>;
 
 StaticSupportedModesManager::ModeOptionStructType * StaticSupportedModesManager::modeOptionStructList = nullptr;
-StaticSupportedModesManager::SemanticTag * StaticSupportedModesManager::semanticTags              = nullptr;
+StaticSupportedModesManager::SemanticTag * StaticSupportedModesManager::semanticTags                  = nullptr;
 
 const StaticSupportedModesManager StaticSupportedModesManager::instance = StaticSupportedModesManager();
 
@@ -46,7 +46,8 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
                         ModeOptionsProvider(nullptr, nullptr));
 
     modeOptionStructList = new ModeOptionStructType[supportedModeCount];
-    if (modeOptionStructList == nullptr) {
+    if (modeOptionStructList == nullptr)
+    {
         return ModeOptionsProvider(nullptr, nullptr);
     }
 
@@ -65,7 +66,7 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
         VerifyOrReturnValue(ESP32Config::ReadConfigValueStr(labelKey, nullptr, 0, outLen) == CHIP_NO_ERROR,
                             ModeOptionsProvider(nullptr, nullptr), CleanUp());
 
-        char *modeLabel = new char[outLen + 1];
+        char * modeLabel = new char[outLen + 1];
         VerifyOrReturnValue(ESP32Config::ReadConfigValueStr(labelKey, modeLabel, outLen + 1, outLen) == CHIP_NO_ERROR,
                             ModeOptionsProvider(nullptr, nullptr), CleanUp());
 
@@ -86,7 +87,8 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
                             ModeOptionsProvider(nullptr, nullptr), CleanUp());
 
         semanticTags = new SemanticTag[semanticTagCount];
-        if (semanticTags == nullptr) {
+        if (semanticTags == nullptr)
+        {
             CleanUp();
             return ModeOptionsProvider(nullptr, nullptr);
         }
@@ -176,7 +178,6 @@ void StaticSupportedModesManager::FreeSupportedModes() const
         }
         epModeOptionsProviderList[i] = ModeOptionsProvider();
     }
-
 }
 
 void StaticSupportedModesManager::CleanUp() const

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
@@ -1,7 +1,7 @@
 #include "static-supported-modes-manager.h"
+#include "ESP32Config.h"
 #include <app/util/debug-printing.h>
 #include <app/util/ember-print.h>
-#include "ESP32Config.h"
 
 using namespace chip;
 using namespace chip::app::Clusters;
@@ -12,75 +12,92 @@ using chip::Protocols::InteractionModel::Status;
 using ModeOptionStructType = Structs::ModeOptionStruct::Type;
 using SemanticTag          = Structs::SemanticTagStruct::Type;
 template <typename T>
-using List               = app::DataModel::List<T>;
+using List                                                                                = app::DataModel::List<T>;
 char chip::app::Clusters::ModeSelect::StaticSupportedModesManager::supportedModeLabel[64] = "";
 
 const StaticSupportedModesManager StaticSupportedModesManager::instance = StaticSupportedModesManager();
 
 SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeOptionsProvider(EndpointId endpointId) const
 {
-	char keyBuf[ESP32Config::kMaxConfigKeyNameLength];
+    char keyBuf[ESP32Config::kMaxConfigKeyNameLength];
     uint32_t supportedModeCount = 0;
 
-    VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesCount(keyBuf, sizeof(keyBuf), endpointId) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+    VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesCount(keyBuf, sizeof(keyBuf), endpointId) == CHIP_NO_ERROR,
+                        ModeOptionsProvider(nullptr, nullptr));
     ESP32Config::Key countKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
-    VerifyOrReturnValue(ESP32Config::ReadConfigValue(countKey, supportedModeCount) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+    VerifyOrReturnValue(ESP32Config::ReadConfigValue(countKey, supportedModeCount) == CHIP_NO_ERROR,
+                        ModeOptionsProvider(nullptr, nullptr));
 
-	ModeOptionStructType *modeOptionStruct = new ModeOptionStructType[supportedModeCount + 1];
+    ModeOptionStructType * modeOptionStruct = new ModeOptionStructType[supportedModeCount + 1];
 
-	for (int index = 0; index < supportedModeCount; index++) {
-		Structs::ModeOptionStruct::Type option;
-   	 	uint32_t supportedModeMode = 0;
-    	uint32_t semanticTagCount = 0;
-		size_t outLen   = 0;
+    for (int index = 0; index < supportedModeCount; index++)
+    {
+        Structs::ModeOptionStruct::Type option;
+        uint32_t supportedModeMode = 0;
+        uint32_t semanticTagCount  = 0;
+        size_t outLen              = 0;
 
-		memset(supportedModeLabel, 0, sizeof(supportedModeLabel));
-		memset(keyBuf, 0, sizeof(char)*ESP32Config::kMaxConfigKeyNameLength);
-    	VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesLabel(keyBuf, sizeof(keyBuf), endpointId, index) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
-    	ESP32Config::Key labelKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
-    	VerifyOrReturnValue(ESP32Config::ReadConfigValueStr(labelKey, supportedModeLabel, sizeof(supportedModeLabel), outLen) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+        memset(supportedModeLabel, 0, sizeof(supportedModeLabel));
+        memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
+        VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesLabel(keyBuf, sizeof(keyBuf), endpointId, index) ==
+                                CHIP_NO_ERROR,
+                            ModeOptionsProvider(nullptr, nullptr));
+        ESP32Config::Key labelKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+        VerifyOrReturnValue(ESP32Config::ReadConfigValueStr(labelKey, supportedModeLabel, sizeof(supportedModeLabel), outLen) ==
+                                CHIP_NO_ERROR,
+                            ModeOptionsProvider(nullptr, nullptr));
 
+        memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
+        VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesValue(keyBuf, sizeof(keyBuf), endpointId, index) ==
+                                CHIP_NO_ERROR,
+                            ModeOptionsProvider(nullptr, nullptr));
+        ESP32Config::Key modeKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+        VerifyOrReturnValue(ESP32Config::ReadConfigValue(labelKey, supportedModeMode) == CHIP_NO_ERROR,
+                            ModeOptionsProvider(nullptr, nullptr));
 
-		memset(keyBuf, 0, sizeof(char)*ESP32Config::kMaxConfigKeyNameLength);
-    	VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesValue(keyBuf, sizeof(keyBuf), endpointId, index) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
-    	ESP32Config::Key modeKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
-    	VerifyOrReturnValue(ESP32Config::ReadConfigValue(labelKey, supportedModeMode) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+        memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
+        VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagsCount(keyBuf, sizeof(keyBuf), endpointId, index) ==
+                                CHIP_NO_ERROR,
+                            ModeOptionsProvider(nullptr, nullptr));
+        ESP32Config::Key stCountKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+        VerifyOrReturnValue(ESP32Config::ReadConfigValue(stCountKey, semanticTagCount) == CHIP_NO_ERROR,
+                            ModeOptionsProvider(nullptr, nullptr));
 
-		memset(keyBuf, 0, sizeof(char)*ESP32Config::kMaxConfigKeyNameLength);
-    	VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagsCount(keyBuf, sizeof(keyBuf), endpointId, index) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
-    	ESP32Config::Key stCountKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
-    	VerifyOrReturnValue(ESP32Config::ReadConfigValue(stCountKey, semanticTagCount) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+        SemanticTag * semanticTags = new SemanticTag[semanticTagCount];
+        for (auto stIndex = 0; stIndex < semanticTagCount; stIndex++)
+        {
 
-		SemanticTag *semanticTags = new SemanticTag[semanticTagCount];
-		for (auto stIndex = 0; stIndex < semanticTagCount; stIndex++) {
+            uint32_t semanticTagValue   = 0;
+            uint32_t semanticTagMfgCode = 0;
+            SemanticTag tag;
 
-			uint32_t semanticTagValue = 0;
-			uint32_t semanticTagMfgCode = 0;
-			SemanticTag tag;
+            memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
+            VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagValue(keyBuf, sizeof(keyBuf), endpointId, index, stIndex) ==
+                                    CHIP_NO_ERROR,
+                                ModeOptionsProvider(nullptr, nullptr));
+            ESP32Config::Key stValueKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+            VerifyOrReturnValue(ESP32Config::ReadConfigValue(stValueKey, semanticTagValue) == CHIP_NO_ERROR,
+                                ModeOptionsProvider(nullptr, nullptr));
 
-			memset(keyBuf, 0, sizeof(char)*ESP32Config::kMaxConfigKeyNameLength);
-    		VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagValue(keyBuf, sizeof(keyBuf), endpointId, index, stIndex) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
-    		ESP32Config::Key stValueKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
-    		VerifyOrReturnValue(ESP32Config::ReadConfigValue(stValueKey, semanticTagValue) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+            memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
+            VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagMfgCode(keyBuf, sizeof(keyBuf), endpointId, index, stIndex) ==
+                                    CHIP_NO_ERROR,
+                                ModeOptionsProvider(nullptr, nullptr));
+            ESP32Config::Key stMfgCodeKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+            VerifyOrReturnValue(ESP32Config::ReadConfigValue(stMfgCodeKey, semanticTagMfgCode) == CHIP_NO_ERROR,
+                                ModeOptionsProvider(nullptr, nullptr));
 
-			memset(keyBuf, 0, sizeof(char)*ESP32Config::kMaxConfigKeyNameLength);
-    		VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagMfgCode(keyBuf, sizeof(keyBuf), endpointId, index, stIndex) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
-    		ESP32Config::Key stMfgCodeKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
-    		VerifyOrReturnValue(ESP32Config::ReadConfigValue(stMfgCodeKey, semanticTagMfgCode) == CHIP_NO_ERROR, ModeOptionsProvider(nullptr, nullptr));
+            tag.value             = static_cast<uint16_t>(semanticTagValue);
+            tag.mfgCode           = static_cast<chip::VendorId>(semanticTagMfgCode);
+            semanticTags[stIndex] = static_cast<const SemanticTag>(tag);
+        }
 
-			tag.value = static_cast<uint16_t>(semanticTagValue);
-			tag.mfgCode = static_cast<chip::VendorId>(semanticTagMfgCode);
-			semanticTags[stIndex] = static_cast<const SemanticTag>(tag);
+        option.label        = chip::CharSpan::fromCharString(supportedModeLabel);
+        option.mode         = static_cast<uint8_t>(supportedModeMode);
+        option.semanticTags = DataModel::List<const SemanticTag>(semanticTags, semanticTagCount);
 
-		}
-
-    	option.label =  chip::CharSpan::fromCharString(supportedModeLabel);
-    	option.mode = static_cast<uint8_t>(supportedModeMode);
-    	option.semanticTags = DataModel::List<const SemanticTag>(semanticTags, semanticTagCount);
-
-		modeOptionStruct[index] = option;
-
-	}
+        modeOptionStruct[index] = option;
+    }
 
     return ModeOptionsProvider(modeOptionStruct, modeOptionStruct + supportedModeCount);
 }

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
@@ -27,7 +27,7 @@ void StaticSupportedModesManager::InitEndpointArray()
 	for(int i=0; i<FIXED_ENDPOINT_COUNT; i++) {
 		endpointArray[i][0] = nullptr;
 		endpointArray[i][1] = nullptr;
-	} 
+	}
 }
 
 SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeOptionsProvider(EndpointId endpointId) const
@@ -166,9 +166,8 @@ void StaticSupportedModesManager::FreeSupportedModes()
 		}
 		endpointArray[i][0] = nullptr;
 		endpointArray[i][1] = nullptr;
-	} 
+	}
 	delete[] modeLabelList;
 	delete[] modeOptionStruct;
-	delete[] semanticTags; 
+	delete[] semanticTags;
 }
-

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
@@ -12,29 +12,31 @@ using chip::Protocols::InteractionModel::Status;
 using ModeOptionStructType = Structs::ModeOptionStruct::Type;
 using SemanticTag          = Structs::SemanticTagStruct::Type;
 template <typename T>
-using List                                                                                = app::DataModel::List<T>;
+using List = app::DataModel::List<T>;
 
-StaticSupportedModesManager::ModeLabel* StaticSupportedModesManager::modeLabelList = nullptr;
-StaticSupportedModesManager::ModeOptionStructType* StaticSupportedModesManager::modeOptionStruct = nullptr;
-StaticSupportedModesManager::SemanticTag* StaticSupportedModesManager::semanticTags = nullptr;
+StaticSupportedModesManager::ModeLabel * StaticSupportedModesManager::modeLabelList               = nullptr;
+StaticSupportedModesManager::ModeOptionStructType * StaticSupportedModesManager::modeOptionStruct = nullptr;
+StaticSupportedModesManager::SemanticTag * StaticSupportedModesManager::semanticTags              = nullptr;
 
 const StaticSupportedModesManager StaticSupportedModesManager::instance = StaticSupportedModesManager();
 
-ModeOptionStructType *StaticSupportedModesManager::endpointArray[FIXED_ENDPOINT_COUNT][2];
+ModeOptionStructType * StaticSupportedModesManager::endpointArray[FIXED_ENDPOINT_COUNT][2];
 
 void StaticSupportedModesManager::InitEndpointArray()
 {
-	for(int i=0; i<FIXED_ENDPOINT_COUNT; i++) {
-		endpointArray[i][0] = nullptr;
-		endpointArray[i][1] = nullptr;
-	}
+    for (int i = 0; i < FIXED_ENDPOINT_COUNT; i++)
+    {
+        endpointArray[i][0] = nullptr;
+        endpointArray[i][1] = nullptr;
+    }
 }
 
 SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeOptionsProvider(EndpointId endpointId) const
 {
-	if(endpointArray[endpointId][0] != nullptr && endpointArray[endpointId][1] != nullptr) {
-		return ModeOptionsProvider(endpointArray[endpointId][0], endpointArray[endpointId][1]);
-	}
+    if (endpointArray[endpointId][0] != nullptr && endpointArray[endpointId][1] != nullptr)
+    {
+        return ModeOptionsProvider(endpointArray[endpointId][0], endpointArray[endpointId][1]);
+    }
 
     char keyBuf[ESP32Config::kMaxConfigKeyNameLength];
     uint32_t supportedModeCount = 0;
@@ -45,7 +47,7 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
     VerifyOrReturnValue(ESP32Config::ReadConfigValue(countKey, supportedModeCount) == CHIP_NO_ERROR,
                         ModeOptionsProvider(nullptr, nullptr));
 
-	modeLabelList = new ModeLabel[supportedModeCount];
+    modeLabelList    = new ModeLabel[supportedModeCount];
     modeOptionStruct = new ModeOptionStructType[supportedModeCount];
 
     for (int index = 0; index < supportedModeCount; index++)
@@ -61,8 +63,9 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
                                 CHIP_NO_ERROR,
                             ModeOptionsProvider(nullptr, nullptr));
         ESP32Config::Key labelKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
-        VerifyOrReturnValue(ESP32Config::ReadConfigValueStr(labelKey, modeLabelList[index].supportedModeLabel, sizeof(modeLabelList[index].supportedModeLabel), outLen) ==
-                                CHIP_NO_ERROR,
+        VerifyOrReturnValue(ESP32Config::ReadConfigValueStr(labelKey, modeLabelList[index].supportedModeLabel,
+                                                            sizeof(modeLabelList[index].supportedModeLabel),
+                                                            outLen) == CHIP_NO_ERROR,
                             ModeOptionsProvider(nullptr, nullptr));
 
         memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
@@ -116,8 +119,8 @@ SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeO
 
         modeOptionStruct[index] = option;
     }
-	endpointArray[endpointId][0] = modeOptionStruct;
-	endpointArray[endpointId][1] = (modeOptionStruct + supportedModeCount);
+    endpointArray[endpointId][0] = modeOptionStruct;
+    endpointArray[endpointId][1] = (modeOptionStruct + supportedModeCount);
 
     return ModeOptionsProvider(modeOptionStruct, modeOptionStruct + supportedModeCount);
 }
@@ -153,21 +156,24 @@ const ModeSelect::SupportedModesManager * ModeSelect::getSupportedModesManager()
 
 void StaticSupportedModesManager::FreeSupportedModes()
 {
-	for(int i=0; i<FIXED_ENDPOINT_COUNT; i++) {
-		if(endpointArray[i][0] != nullptr) {
-    		auto * begin = static_cast<ModeOptionStructType *>(endpointArray[i][0]);
-    		auto * end   = static_cast<ModeOptionStructType *>(endpointArray[i][1]);
-			for(auto *it = begin; it != end; ++it) {
-        		auto & modeOption = *it;
-				delete[] modeOption.label.data();
-				delete[] modeOption.semanticTags.data();
-			}
-			delete[] begin;
-		}
-		endpointArray[i][0] = nullptr;
-		endpointArray[i][1] = nullptr;
-	}
-	delete[] modeLabelList;
-	delete[] modeOptionStruct;
-	delete[] semanticTags;
+    for (int i = 0; i < FIXED_ENDPOINT_COUNT; i++)
+    {
+        if (endpointArray[i][0] != nullptr)
+        {
+            auto * begin = static_cast<ModeOptionStructType *>(endpointArray[i][0]);
+            auto * end   = static_cast<ModeOptionStructType *>(endpointArray[i][1]);
+            for (auto * it = begin; it != end; ++it)
+            {
+                auto & modeOption = *it;
+                delete[] modeOption.label.data();
+                delete[] modeOption.semanticTags.data();
+            }
+            delete[] begin;
+        }
+        endpointArray[i][0] = nullptr;
+        endpointArray[i][1] = nullptr;
+    }
+    delete[] modeLabelList;
+    delete[] modeOptionStruct;
+    delete[] semanticTags;
 }

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -32,20 +32,14 @@ private:
     using ModeOptionStructType = Structs::ModeOptionStruct::Type;
     using SemanticTag          = Structs::SemanticTagStruct::Type;
 
-    struct ModeLabel
-    {
-        char supportedModeLabel[64];
-    };
-
-    static ModeLabel * modeLabelList;
-    static ModeOptionStructType * modeOptionStruct;
+    static ModeOptionStructType * modeOptionStructList;
     static SemanticTag * semanticTags;
-    // TODO : We need to decide wheather the endpointArray shoule be static or dynamic.
-    static ModeOptionStructType * endpointArray[FIXED_ENDPOINT_COUNT][2];
+
+    static ModeOptionsProvider epModeOptionsProviderList[FIXED_ENDPOINT_COUNT];
 
     void InitEndpointArray();
 
-    void FreeSupportedModes();
+    void FreeSupportedModes() const;
 
 public:
     static const StaticSupportedModesManager instance;
@@ -55,9 +49,15 @@ public:
     Protocols::InteractionModel::Status getModeOptionByMode(EndpointId endpointId, uint8_t mode,
                                                             const ModeOptionStructType ** dataPtr) const override;
 
+    void CleanUp() const;
+
     StaticSupportedModesManager() { InitEndpointArray(); }
 
-    ~StaticSupportedModesManager() { FreeSupportedModes(); }
+    ~StaticSupportedModesManager() {
+        if(modeOptionStructList != nullptr) {
+            FreeSupportedModes();
+        }
+    }
 
     static inline const StaticSupportedModesManager & getStaticSupportedModesManagerInstance() { return instance; }
 };

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -1,0 +1,54 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/clusters/mode-select-server/supported-modes-manager.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace ModeSelect {
+
+
+class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::SupportedModesManager
+{
+    using ModeOptionStructType = Structs::ModeOptionStruct::Type;
+
+public:
+    static const StaticSupportedModesManager instance;
+	
+	static char supportedModeLabel[64];
+
+    SupportedModesManager::ModeOptionsProvider getModeOptionsProvider(EndpointId endpointId) const override;
+
+    Protocols::InteractionModel::Status getModeOptionByMode(EndpointId endpointId, uint8_t mode, const ModeOptionStructType ** dataPtr) const override;
+
+    ~StaticSupportedModesManager(){};
+
+    StaticSupportedModesManager() {}
+
+    static inline const StaticSupportedModesManager & getStaticSupportedModesManagerInstance() { return instance; }
+};
+
+const SupportedModesManager * getSupportedModesManager();
+
+} // namespace ModeSelect
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -53,8 +53,10 @@ public:
 
     StaticSupportedModesManager() { InitEndpointArray(); }
 
-    ~StaticSupportedModesManager() {
-        if(modeOptionStructList != nullptr) {
+    ~StaticSupportedModesManager()
+    {
+        if (modeOptionStructList != nullptr)
+        {
             FreeSupportedModes();
         }
     }

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <app/clusters/mode-select-server/supported-modes-manager.h>
+#include <src/app/util/af.h>
 
 namespace chip {
 namespace app {
@@ -27,13 +28,9 @@ namespace ModeSelect {
 
 class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::SupportedModesManager
 {
+private:
     using ModeOptionStructType = Structs::ModeOptionStruct::Type;
 	using SemanticTag          = Structs::SemanticTagStruct::Type;
-
-public:
-    static const StaticSupportedModesManager instance;
-
-    //static char supportedModeLabel[255][64];
 
 	struct ModeLabel {
 		char supportedModeLabel[64];
@@ -42,18 +39,28 @@ public:
 	static ModeLabel *modeLabelList;
     static ModeOptionStructType * modeOptionStruct;
     static SemanticTag * semanticTags;
+	// TODO : We need to decide wheather the endpointArray shoule be static or dynamic.
+	static ModeOptionStructType *endpointArray[FIXED_ENDPOINT_COUNT][2];
+
+	void InitEndpointArray();
+
+	void FreeSupportedModes();
+
+
+public:
+    static const StaticSupportedModesManager instance;
 
     SupportedModesManager::ModeOptionsProvider getModeOptionsProvider(EndpointId endpointId) const override;
 
     Protocols::InteractionModel::Status getModeOptionByMode(EndpointId endpointId, uint8_t mode,
                                                             const ModeOptionStructType ** dataPtr) const override;
 
-    StaticSupportedModesManager() {}
+    StaticSupportedModesManager() {
+		InitEndpointArray();
+	}
 
     ~StaticSupportedModesManager(){
-		delete[] modeLabelList;
-		delete[] modeOptionStruct;
-		delete[] semanticTags; 
+		FreeSupportedModes();
 	}
 
     static inline const StaticSupportedModesManager & getStaticSupportedModesManagerInstance() { return instance; }

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -30,22 +30,22 @@ class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::Supp
 {
 private:
     using ModeOptionStructType = Structs::ModeOptionStruct::Type;
-	using SemanticTag          = Structs::SemanticTagStruct::Type;
+    using SemanticTag          = Structs::SemanticTagStruct::Type;
 
-	struct ModeLabel {
-		char supportedModeLabel[64];
-	};
+    struct ModeLabel
+    {
+        char supportedModeLabel[64];
+    };
 
-	static ModeLabel *modeLabelList;
+    static ModeLabel * modeLabelList;
     static ModeOptionStructType * modeOptionStruct;
     static SemanticTag * semanticTags;
-	// TODO : We need to decide wheather the endpointArray shoule be static or dynamic.
-	static ModeOptionStructType *endpointArray[FIXED_ENDPOINT_COUNT][2];
+    // TODO : We need to decide wheather the endpointArray shoule be static or dynamic.
+    static ModeOptionStructType * endpointArray[FIXED_ENDPOINT_COUNT][2];
 
-	void InitEndpointArray();
+    void InitEndpointArray();
 
-	void FreeSupportedModes();
-
+    void FreeSupportedModes();
 
 public:
     static const StaticSupportedModesManager instance;
@@ -55,13 +55,9 @@ public:
     Protocols::InteractionModel::Status getModeOptionByMode(EndpointId endpointId, uint8_t mode,
                                                             const ModeOptionStructType ** dataPtr) const override;
 
-    StaticSupportedModesManager() {
-		InitEndpointArray();
-	}
+    StaticSupportedModesManager() { InitEndpointArray(); }
 
-    ~StaticSupportedModesManager(){
-		FreeSupportedModes();
-	}
+    ~StaticSupportedModesManager() { FreeSupportedModes(); }
 
     static inline const StaticSupportedModesManager & getStaticSupportedModesManagerInstance() { return instance; }
 };

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2023 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,14 +32,11 @@ private:
     using ModeOptionStructType = Structs::ModeOptionStruct::Type;
     using SemanticTag          = Structs::SemanticTagStruct::Type;
 
-    static ModeOptionStructType * modeOptionStructList;
-    static SemanticTag * semanticTags;
-
     static ModeOptionsProvider epModeOptionsProviderList[FIXED_ENDPOINT_COUNT];
 
     void InitEndpointArray();
 
-    void FreeSupportedModes() const;
+    void FreeSupportedModes(EndpointId endpointId) const;
 
 public:
     static const StaticSupportedModesManager instance;
@@ -49,15 +46,15 @@ public:
     Protocols::InteractionModel::Status getModeOptionByMode(EndpointId endpointId, uint8_t mode,
                                                             const ModeOptionStructType ** dataPtr) const override;
 
-    void CleanUp() const;
+    void CleanUp(EndpointId endpointId) const;
 
     StaticSupportedModesManager() { InitEndpointArray(); }
 
     ~StaticSupportedModesManager()
     {
-        if (modeOptionStructList != nullptr)
+        for (int i = 0; i < FIXED_ENDPOINT_COUNT; i++)
         {
-            FreeSupportedModes();
+            FreeSupportedModes(i);
         }
     }
 

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -32,7 +32,7 @@ class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::Supp
 
 public:
     static const StaticSupportedModesManager instance;
-	
+
 	static char supportedModeLabel[64];
 
     SupportedModesManager::ModeOptionsProvider getModeOptionsProvider(EndpointId endpointId) const override;

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -28,20 +28,33 @@ namespace ModeSelect {
 class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::SupportedModesManager
 {
     using ModeOptionStructType = Structs::ModeOptionStruct::Type;
+	using SemanticTag          = Structs::SemanticTagStruct::Type;
 
 public:
     static const StaticSupportedModesManager instance;
 
-    static char supportedModeLabel[64];
+    //static char supportedModeLabel[255][64];
+
+	struct ModeLabel {
+		char supportedModeLabel[64];
+	};
+
+	static ModeLabel *modeLabelList;
+    static ModeOptionStructType * modeOptionStruct;
+    static SemanticTag * semanticTags;
 
     SupportedModesManager::ModeOptionsProvider getModeOptionsProvider(EndpointId endpointId) const override;
 
     Protocols::InteractionModel::Status getModeOptionByMode(EndpointId endpointId, uint8_t mode,
                                                             const ModeOptionStructType ** dataPtr) const override;
 
-    ~StaticSupportedModesManager(){};
-
     StaticSupportedModesManager() {}
+
+    ~StaticSupportedModesManager(){
+		delete[] modeLabelList;
+		delete[] modeOptionStruct;
+		delete[] semanticTags; 
+	}
 
     static inline const StaticSupportedModesManager & getStaticSupportedModesManagerInstance() { return instance; }
 };

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -25,7 +25,6 @@ namespace app {
 namespace Clusters {
 namespace ModeSelect {
 
-
 class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::SupportedModesManager
 {
     using ModeOptionStructType = Structs::ModeOptionStruct::Type;
@@ -33,11 +32,12 @@ class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::Supp
 public:
     static const StaticSupportedModesManager instance;
 
-	static char supportedModeLabel[64];
+    static char supportedModeLabel[64];
 
     SupportedModesManager::ModeOptionsProvider getModeOptionsProvider(EndpointId endpointId) const override;
 
-    Protocols::InteractionModel::Status getModeOptionByMode(EndpointId endpointId, uint8_t mode, const ModeOptionStructType ** dataPtr) const override;
+    Protocols::InteractionModel::Status getModeOptionByMode(EndpointId endpointId, uint8_t mode,
+                                                            const ModeOptionStructType ** dataPtr) const override;
 
     ~StaticSupportedModesManager(){};
 

--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -22,6 +22,7 @@ import enum
 import logging
 import os
 import sys
+import re
 from types import SimpleNamespace
 
 import cryptography.x509
@@ -226,6 +227,31 @@ def get_fixed_label_dict(fixed_labels):
 
     return fl_dict
 
+# get_supported_modes_dict() converts the list of strings to per endpoint dictionaries.
+# example input  : ['0/label1/1"1\0x8000, 2\0x8000",  1/label2/1/"1\0x8000, 2\0x8000"']
+# example outout : {'1': [{'Label': 'label1', 'Mode': 0, 'Semantic_Tag': [{'value': 1, 'mfgCode': 32768}, {'value': 2, 'mfgCode': 32768}]}, {'Label': 'label2', 'Mode': 1, 'Semantic_Tag': [{'value': 1, 'mfgCode': 32768}, {'value': 2, 'mfgCode': 32768}]}]}
+
+
+def get_supported_modes_dict(supported_modes):
+    output_dict = {}
+    
+    for mode_str in supported_modes:
+        mode_label_strs = mode_str.split('/')
+        mode = mode_label_strs[0]
+        label = mode_label_strs[1]
+        ep = mode_label_strs[2]
+        
+        semantic_tag_strs = mode_label_strs[3].split(', ')
+        semantic_tags = [{"value": int(v.split('\\')[0]), "mfgCode": int(v.split('\\')[1], 16)} for v in semantic_tag_strs]
+        
+        mode_dict = {"Label": label, "Mode": int(mode), "Semantic_Tag": semantic_tags}
+        
+        if ep in output_dict:
+            output_dict[ep].append(mode_dict)
+        else:
+            output_dict[ep] = [mode_dict]
+    
+    return output_dict
 
 def check_str_range(s, min_len, max_len, name):
     if s and ((len(s) < min_len) or (len(s) > max_len)):
@@ -358,6 +384,61 @@ def populate_factory_data(args, spake2p_params):
                 FACTORY_DATA.update({'fl-k/{:x}/{:x}'.format(int(key), i): _label_key})
                 FACTORY_DATA.update({'fl-v/{:x}/{:x}'.format(int(key), i): _label_value})
 
+    # SupportedModes are stored as multiple entries
+    #  - sm-sz/<ep>                 : number of supported modes for the endpoint
+    #  - sm-label/<ep>/<index>      : supported modes label key for the endpoint and index
+    #  - sm-mode/<ep>/<index>       : supported modes mode key for the endpoint and index
+    #  - sm-st-sz/<ep>/<index>      : supported modes SemanticTag key for the endpoint and index
+    #  - st-v/<ep>/<index>/<ind>    : semantic tag value key for the endpoint and index and ind
+    #  - st-mfg/<ep>/<index>/<ind>  : semantic tag mfg code key for the endpoint and index and ind
+    if (args.supported_modes is not None):
+        dictionary = get_supported_modes_dict(args.supported_modes)
+        for ep in dictionary.keys():
+            _sz = {
+                'type': 'data',
+                'encoding': 'u32',
+                'value': len(dictionary[ep])
+            }
+            FACTORY_DATA.update({'sm-sz/{:x}'.format(int(ep)): _sz})
+            for i in range(len(dictionary[ep])):
+                item = dictionary[ep][i]
+                _label = {
+                    'type': 'data',
+                    'encoding': 'string',
+                    'value': item["Label"]
+                }
+                _mode = {
+                    'type': 'data',
+                    'encoding': 'u32',
+                    'value': item["Mode"]
+                }
+                _st_sz = {
+                    'type': 'data',
+                    'encoding': 'u32',
+                    'value': len(item["Semantic_Tag"])
+                }
+                FACTORY_DATA.update({'sm-label/{:x}/{:x}'.format(int(ep), i): _label})
+                FACTORY_DATA.update({'sm-mode/{:x}/{:x}'.format(int(ep), i): _mode})
+                FACTORY_DATA.update({'sm-st-sz/{:x}/{:x}'.format(int(ep), i): _st_sz})
+
+                for j in range(len(item["Semantic_Tag"])):
+                    entry = item["Semantic_Tag"][j]
+
+                    _value = {
+                        'type': 'data',
+                        'encoding': 'u32',
+                        'value': entry["value"]
+                    }
+                    _mfg_code = {
+                        'type': 'data',
+                        'encoding': 'u32',
+                        'value': entry["mfgCode"]
+                    }
+
+                    FACTORY_DATA.update({'st-v/{:x}/{:x}/{:x}'.format(int(ep), i, j): _value})
+                    FACTORY_DATA.update({'st-mfg/{:x}/{:x}/{:x}'.format(int(ep), i, j): _mfg_code})
+ 
+
 
 def gen_raw_ec_keypair_from_der(key_file, pubkey_raw_file, privkey_raw_file):
     with open(key_file, 'rb') as f:
@@ -467,6 +548,8 @@ def main():
     parser.add_argument('--locales', nargs='+', help='List of supported locales, Language Tag as defined by BCP47, eg. en-US en-GB')
     parser.add_argument('--fixed-labels', nargs='+',
                         help='List of fixed labels, eg: "0/orientation/up" "1/orientation/down" "2/orientation/down"')
+    parser.add_argument('--supported-modes', type=str, nargs='+', required=False,
+                        help='List of supported modes, eg: mode1/label1/ep/"tagValue1\mfgCode, tagValue2\mfgCode"  mode2/label2/ep/"tagValue1\mfgCode, tagValue2\mfgCode"  mode3/label3/ep/"tagValue1\mfgCode, tagValue2\mfgCode"')
 
     parser.add_argument('-s', '--size', type=any_base_int, default=0x6000,
                         help='The size of the partition.bin, default: 0x6000')

--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -234,24 +234,25 @@ def get_fixed_label_dict(fixed_labels):
 
 def get_supported_modes_dict(supported_modes):
     output_dict = {}
-    
+
     for mode_str in supported_modes:
         mode_label_strs = mode_str.split('/')
         mode = mode_label_strs[0]
         label = mode_label_strs[1]
         ep = mode_label_strs[2]
-        
+
         semantic_tag_strs = mode_label_strs[3].split(', ')
         semantic_tags = [{"value": int(v.split('\\')[0]), "mfgCode": int(v.split('\\')[1], 16)} for v in semantic_tag_strs]
-        
+
         mode_dict = {"Label": label, "Mode": int(mode), "Semantic_Tag": semantic_tags}
-        
+
         if ep in output_dict:
             output_dict[ep].append(mode_dict)
         else:
             output_dict[ep] = [mode_dict]
-    
+
     return output_dict
+
 
 def check_str_range(s, min_len, max_len, name):
     if s and ((len(s) < min_len) or (len(s) > max_len)):
@@ -437,7 +438,6 @@ def populate_factory_data(args, spake2p_params):
 
                     FACTORY_DATA.update({'st-v/{:x}/{:x}/{:x}'.format(int(ep), i, j): _value})
                     FACTORY_DATA.update({'st-mfg/{:x}/{:x}/{:x}'.format(int(ep), i, j): _mfg_code})
- 
 
 
 def gen_raw_ec_keypair_from_der(key_file, pubkey_raw_file, privkey_raw_file):

--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -21,7 +21,6 @@ import base64
 import enum
 import logging
 import os
-import re
 import sys
 from types import SimpleNamespace
 
@@ -228,7 +227,7 @@ def get_fixed_label_dict(fixed_labels):
     return fl_dict
 
 # get_supported_modes_dict() converts the list of strings to per endpoint dictionaries.
-# example input  : ['0/label1/1"1\0x8000, 2\0x8000",  1/label2/1/"1\0x8000, 2\0x8000"']
+# example input  : ['0/label1/1/"1\0x8000, 2\0x8000",  1/label2/1/"1\0x8000, 2\0x8000"']
 # example outout : {'1': [{'Label': 'label1', 'Mode': 0, 'Semantic_Tag': [{'value': 1, 'mfgCode': 32768}, {'value': 2, 'mfgCode': 32768}]}, {'Label': 'label2', 'Mode': 1, 'Semantic_Tag': [{'value': 1, 'mfgCode': 32768}, {'value': 2, 'mfgCode': 32768}]}]}
 
 
@@ -549,7 +548,7 @@ def main():
     parser.add_argument('--fixed-labels', nargs='+',
                         help='List of fixed labels, eg: "0/orientation/up" "1/orientation/down" "2/orientation/down"')
     parser.add_argument('--supported-modes', type=str, nargs='+', required=False,
-                        help='List of supported modes, eg: mode1/label1/ep/"tagValue1\mfgCode, tagValue2\mfgCode"  mode2/label2/ep/"tagValue1\mfgCode, tagValue2\mfgCode"  mode3/label3/ep/"tagValue1\mfgCode, tagValue2\mfgCode"')
+                        help='List of supported modes, eg: mode1/label1/ep/"tagValue1\\mfgCode, tagValue2\\mfgCode"  mode2/label2/ep/"tagValue1\\mfgCode, tagValue2\\mfgCode"  mode3/label3/ep/"tagValue1\\mfgCode, tagValue2\\mfgCode"')
 
     parser.add_argument('-s', '--size', type=any_base_int, default=0x6000,
                         help='The size of the partition.bin, default: 0x6000')

--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -21,8 +21,8 @@ import base64
 import enum
 import logging
 import os
-import sys
 import re
+import sys
 from types import SimpleNamespace
 
 import cryptography.x509

--- a/src/app/clusters/mode-select-server/supported-modes-manager.h
+++ b/src/app/clusters/mode-select-server/supported-modes-manager.h
@@ -20,9 +20,6 @@
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/util/af-enums.h>
-#include <app/util/af.h>
-#include <app/util/attribute-storage.h>
-#include <app/util/basic-types.h>
 #include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {

--- a/src/app/clusters/mode-select-server/supported-modes-manager.h
+++ b/src/app/clusters/mode-select-server/supported-modes-manager.h
@@ -53,6 +53,8 @@ public:
          */
         inline pointer end() const { return mEnd; }
 
+        ModeOptionsProvider() : mBegin(nullptr), mEnd(nullptr) {}
+
         ModeOptionsProvider(const pointer aBegin, const pointer aEnd) : mBegin(aBegin), mEnd(aEnd) {}
 
         pointer mBegin;

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -181,7 +181,6 @@ public:
         return snprintf(key, size, "fl-v/%x/%x", endpoint, index) > 0 ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
     }
 
-
     // Supported modes
 
     static CHIP_ERROR SupportedModesCount(char * key, size_t size, uint16_t endpoint)
@@ -214,7 +213,6 @@ public:
         VerifyOrReturnError(key, CHIP_ERROR_INVALID_ARGUMENT);
         return snprintf(key, size, "st-mfg/%x/%x/%x", endpoint, index, ind) > 0 ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
     }
-
 };
 
 } // namespace Internal

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -180,6 +180,41 @@ public:
         VerifyOrReturnError(key, CHIP_ERROR_INVALID_ARGUMENT);
         return snprintf(key, size, "fl-v/%x/%x", endpoint, index) > 0 ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
     }
+
+
+    // Supported modes
+
+    static CHIP_ERROR SupportedModesCount(char * key, size_t size, uint16_t endpoint)
+    {
+        VerifyOrReturnError(key, CHIP_ERROR_INVALID_ARGUMENT);
+        return snprintf(key, size, "sm-sz/%x", endpoint) > 0 ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
+    }
+    static CHIP_ERROR SupportedModesLabel(char * key, size_t size, uint16_t endpoint, uint16_t index)
+    {
+        VerifyOrReturnError(key, CHIP_ERROR_INVALID_ARGUMENT);
+        return snprintf(key, size, "sm-label/%x/%x", endpoint, index) > 0 ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
+    }
+    static CHIP_ERROR SupportedModesValue(char * key, size_t size, uint16_t endpoint, uint16_t index)
+    {
+        VerifyOrReturnError(key, CHIP_ERROR_INVALID_ARGUMENT);
+        return snprintf(key, size, "sm-mode/%x/%x", endpoint, index) > 0 ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
+    }
+    static CHIP_ERROR SemanticTagsCount(char * key, size_t size, uint16_t endpoint, uint16_t index)
+    {
+        VerifyOrReturnError(key, CHIP_ERROR_INVALID_ARGUMENT);
+        return snprintf(key, size, "sm-st-sz/%x/%x", endpoint, index) > 0 ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
+    }
+    static CHIP_ERROR SemanticTagValue(char * key, size_t size, uint16_t endpoint, uint16_t index, uint16_t ind)
+    {
+        VerifyOrReturnError(key, CHIP_ERROR_INVALID_ARGUMENT);
+        return snprintf(key, size, "st-v/%x/%x/%x", endpoint, index, ind) > 0 ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
+    }
+    static CHIP_ERROR SemanticTagMfgCode(char * key, size_t size, uint16_t endpoint, uint16_t index, uint16_t ind)
+    {
+        VerifyOrReturnError(key, CHIP_ERROR_INVALID_ARGUMENT);
+        return snprintf(key, size, "st-mfg/%x/%x/%x", endpoint, index, ind) > 0 ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
+    }
+
 };
 
 } // namespace Internal

--- a/src/platform/ESP32/ESP32DeviceInfoProvider.cpp
+++ b/src/platform/ESP32/ESP32DeviceInfoProvider.cpp
@@ -80,6 +80,7 @@ bool ESP32DeviceInfoProvider::FixedLabelIteratorImpl::Next(FixedLabelType & outp
 
     VerifyOrReturnValue(ESP32Config::KeyAllocator::FixedLabelValue(keyBuf, sizeof(keyBuf), mEndpoint,
                                                                    static_cast<uint16_t>(mIndex)) == CHIP_NO_ERROR,
+                        false);
     ESP32Config::Key valueKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
     VerifyOrReturnValue(ESP32Config::ReadConfigValueStr(valueKey, mFixedLabelValueBuf, sizeof(mFixedLabelValueBuf), valueOutLen) ==
                             CHIP_NO_ERROR,

--- a/src/platform/ESP32/ESP32DeviceInfoProvider.cpp
+++ b/src/platform/ESP32/ESP32DeviceInfoProvider.cpp
@@ -80,7 +80,6 @@ bool ESP32DeviceInfoProvider::FixedLabelIteratorImpl::Next(FixedLabelType & outp
 
     VerifyOrReturnValue(ESP32Config::KeyAllocator::FixedLabelValue(keyBuf, sizeof(keyBuf), mEndpoint,
                                                                    static_cast<uint16_t>(mIndex)) == CHIP_NO_ERROR,
-                        false);
     ESP32Config::Key valueKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
     VerifyOrReturnValue(ESP32Config::ReadConfigValueStr(valueKey, mFixedLabelValueBuf, sizeof(mFixedLabelValueBuf), valueOutLen) ==
                             CHIP_NO_ERROR,


### PR DESCRIPTION
- Problem :

> Fixes #25765

- Changed :

> Used esp32 factory data provider script to generated data for `SupportedMode` attribute of `ModeSelect` cluster.
> Read `SupportedMode` from `nvs`.
> Fixed compilation error for `FixedLabel`

- Testing :

> Tested commissiong and read `SupprotedMode` attribute using chip-tool.