### PR TITLE
[Tizen] Do not log BLE binary data using "%s"

### DIFF
--- a/src/platform/Tizen/AppPreference.cpp
+++ b/src/platform/Tizen/AppPreference.cpp
@@ -86,7 +86,7 @@ CHIP_ERROR GetData(const char * key, void * data, size_t dataSize, size_t * getD
     }
     ::memcpy(data, decodedData.Get() + offset, copySize);
 
-    ChipLogDetail(DeviceLayer, "Get data [%s]: %u", key, static_cast<unsigned int>(copySize));
+    ChipLogDetail(DeviceLayer, "Get preference data: key=%s len=%u", key, static_cast<unsigned int>(copySize));
     ChipLogByteSpan(DeviceLayer, ByteSpan(reinterpret_cast<uint8_t *>(data), copySize));
 
     return CHIP_NO_ERROR;
@@ -114,7 +114,7 @@ CHIP_ERROR SaveData(const char * key, const void * data, size_t dataSize)
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    ChipLogDetail(DeviceLayer, "Save data [%s]: %u", key, static_cast<unsigned int>(dataSize));
+    ChipLogDetail(DeviceLayer, "Save preference data: key=%s len=%u", key, static_cast<unsigned int>(dataSize));
     ChipLogByteSpan(DeviceLayer, ByteSpan(reinterpret_cast<const uint8_t *>(data), dataSize));
 
     return CHIP_NO_ERROR;
@@ -133,7 +133,7 @@ CHIP_ERROR RemoveData(const char * key)
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    ChipLogProgress(DeviceLayer, "Remove data [%s]", key);
+    ChipLogProgress(DeviceLayer, "Remove preference data: key=%s", key);
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -182,7 +182,7 @@ void BLEManagerImpl::ReadValueRequestedCb(const char * remoteAddress, int reques
 
     VerifyOrReturn(__GetAttInfo(gattHandle, &uuid, &type) == BT_ERROR_NONE,
                    ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from GATT handle"));
-    ChipLogProgress(DeviceLayer, "Gatt read requested on %s: %s", __ConvertAttTypeToStr(type), StringOrNullMarker(uuid));
+    ChipLogProgress(DeviceLayer, "Gatt read requested on %s: uuid=%s", __ConvertAttTypeToStr(type), StringOrNullMarker(uuid));
     g_free(uuid);
 
     ret = bt_gatt_get_value(gattHandle, &value, &len);
@@ -208,8 +208,8 @@ void BLEManagerImpl::WriteValueRequestedCb(const char * remoteAddress, int reque
 
     VerifyOrReturn(__GetAttInfo(gattHandle, &uuid, &type) == BT_ERROR_NONE,
                    ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from GATT handle"));
-    ChipLogProgress(DeviceLayer, "Gatt write requested on %s [len=%d]: %s", __ConvertAttTypeToStr(type), len,
-                    StringOrNullMarker(uuid));
+    ChipLogProgress(DeviceLayer, "Gatt write requested on %s: uuid=%s len=%d", __ConvertAttTypeToStr(type),
+                    StringOrNullMarker(uuid), len);
     ChipLogByteSpan(DeviceLayer, ByteSpan(reinterpret_cast<const uint8_t *>(value), len));
     g_free(uuid);
 

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -174,6 +174,8 @@ private:
     static void AdvertisingStateChangedCb(int result, bt_advertiser_h advertiser, bt_adapter_le_advertising_state_e advState,
                                           void * userData);
     static void NotificationStateChangedCb(bool notify, bt_gatt_server_h server, bt_gatt_h gattHandle, void * userData);
+    static void ReadValueRequestedCb(const char * remoteAddress, int requestId, bt_gatt_server_h server, bt_gatt_h gattHandle,
+                                     int offset, void * userData);
     static void WriteValueRequestedCb(const char * remoteAddress, int requestId, bt_gatt_server_h server, bt_gatt_h gattHandle,
                                       bool responseNeeded, int offset, const char * value, int len, void * userData);
     static void IndicationConfirmationCb(int result, const char * remoteAddress, bt_gatt_server_h server, bt_gatt_h characteristic,


### PR DESCRIPTION
### Problem

Logging binary data with "%.*s" might lead to terminal (or Tizen logging service) corruption.

### Changes

- log binary data using dedicated `ChipLogByteSpan` function
- improve readability of app preference logging

### Testing

Tested locally:
```
I/CHIP    (  852): DL: Gatt write requested on Characteristic: uuid=18EE2EF5-263D-4559-959F-4F9C429F9D11 len=23
D/CHIP    (  852): DL: 0x09, 0x00, 0x00, 0x4f, 0x00, 0x04, 0x00, 0x00,
...
```