### PR TITLE
Fix failsafe extension when we have a device attestation delegate.

### DIFF
--- a/examples/darwin-framework-tool/commands/pairing/PairingCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/pairing/PairingCommandBridge.h
@@ -68,6 +68,12 @@ public:
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
             break;
         }
+
+        AddArgument("use-device-attestation-delegate", 0, 1, &mUseDeviceAttestationDelegate,
+                    "If true, use a device attestation delegate that always wants to be notified about attestation results.  "
+                    "Defaults to false.");
+        AddArgument("device-attestation-failsafe-time", 0, UINT16_MAX, &mDeviceAttestationFailsafeTime,
+                    "If set, the time to extend the failsafe to before calling the device attestation delegate");
     }
 
     /////////// CHIPCommandBridge Interface /////////
@@ -89,4 +95,6 @@ private:
     uint16_t mDiscriminator;
     uint32_t mSetupPINCode;
     char * mOnboardingPayload;
+    chip::Optional<bool> mUseDeviceAttestationDelegate;
+    chip::Optional<uint16_t> mDeviceAttestationFailsafeTime;
 };

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1186,14 +1186,14 @@ void DeviceCommissioner::ExtendArmFailSafeForDeviceAttestation(const Credentials
 
     mAttestationDeviceInfo = Platform::MakeUnique<Credentials::DeviceAttestationVerifier::AttestationDeviceInfo>(info);
 
-    auto expiryLengthSeconds = deviceAttestationDelegate->FailSafeExpiryTimeoutSecs();
-    bool failSafeSkipped     = expiryLengthSeconds.HasValue();
-    if (failSafeSkipped)
+    auto expiryLengthSeconds      = deviceAttestationDelegate->FailSafeExpiryTimeoutSecs();
+    bool waitForFailsafeExtension = expiryLengthSeconds.HasValue();
+    if (waitForFailsafeExtension)
     {
         ChipLogProgress(Controller, "Changing fail-safe timer to %u seconds to handle DA failure", expiryLengthSeconds.Value());
         // Per spec, anything we do with the fail-safe armed must not time out
         // in less than kMinimumCommissioningStepTimeout.
-        failSafeSkipped =
+        waitForFailsafeExtension =
             ExtendArmFailSafe(mDeviceBeingCommissioned, mCommissioningStage, expiryLengthSeconds.Value(),
                               MakeOptional(kMinimumCommissioningStepTimeout), OnArmFailSafeExtendedForDeviceAttestation,
                               OnFailedToExtendedArmFailSafeDeviceAttestation);
@@ -1203,7 +1203,7 @@ void DeviceCommissioner::ExtendArmFailSafeForDeviceAttestation(const Credentials
         ChipLogProgress(Controller, "Proceeding without changing fail-safe timer value as delegate has not set it");
     }
 
-    if (failSafeSkipped)
+    if (!waitForFailsafeExtension)
     {
         // Callee does not use data argument.
         const GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType data;

--- a/src/darwin/Framework/CHIPTests/MTRBackwardsCompatTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRBackwardsCompatTests.m
@@ -20,6 +20,7 @@
 
 #import "MTRErrorTestUtils.h"
 #import "MTRTestKeys.h"
+#import "MTRTestResetCommissioneeHelper.h"
 #import "MTRTestStorage.h"
 
 #import <app/util/af-enums.h>
@@ -1179,59 +1180,7 @@ static MTRBaseDevice * GetConnectedDevice(void)
 #if !MANUAL_INDIVIDUAL_TEST
 - (void)test999_TearDown
 {
-    // Put the device back in the state we found it: open commissioning window, no fabrics commissioned.
-    MTRBaseDevice * device = GetConnectedDevice();
-    dispatch_queue_t queue = dispatch_get_main_queue();
-
-    // Get our current fabric index, for later deletion.
-    XCTestExpectation * readFabricIndexExpectation = [self expectationWithDescription:@"Fabric index read"];
-
-    __block NSNumber * fabricIndex;
-    __auto_type * opCredsCluster = [[MTRBaseClusterOperationalCredentials alloc] initWithDevice:device endpoint:0 queue:queue];
-    [opCredsCluster
-        readAttributeCurrentFabricIndexWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable readError) {
-            XCTAssertNil(readError);
-            XCTAssertNotNil(value);
-            fabricIndex = value;
-            [readFabricIndexExpectation fulfill];
-        }];
-
-    [self waitForExpectations:@[ readFabricIndexExpectation ] timeout:kTimeoutInSeconds];
-
-    // Open a commissioning window.
-    XCTestExpectation * openCommissioningWindowExpectation = [self expectationWithDescription:@"Commissioning window opened"];
-
-    __auto_type * adminCommissioningCluster = [[MTRBaseClusterAdministratorCommissioning alloc] initWithDevice:device
-                                                                                                      endpoint:0
-                                                                                                         queue:queue];
-    __auto_type * openWindowParams = [[MTRAdministratorCommissioningClusterOpenBasicCommissioningWindowParams alloc] init];
-    openWindowParams.commissioningTimeout = @(900);
-    openWindowParams.timedInvokeTimeoutMs = @(50000);
-    [adminCommissioningCluster openBasicCommissioningWindowWithParams:openWindowParams
-                                                    completionHandler:^(NSError * _Nullable error) {
-                                                        XCTAssertNil(error);
-                                                        [openCommissioningWindowExpectation fulfill];
-                                                    }];
-
-    [self waitForExpectations:@[ openCommissioningWindowExpectation ] timeout:kTimeoutInSeconds];
-
-    // Remove our fabric from the device.
-    XCTestExpectation * removeFabricExpectation = [self expectationWithDescription:@"Fabric removed"];
-
-    __auto_type * removeParams = [[MTROperationalCredentialsClusterRemoveFabricParams alloc] init];
-    removeParams.fabricIndex = fabricIndex;
-
-    [opCredsCluster removeFabricWithParams:removeParams
-                         completionHandler:^(
-                             MTROperationalCredentialsClusterNOCResponseParams * _Nullable data, NSError * _Nullable removeError) {
-                             XCTAssertNil(removeError);
-                             XCTAssertNotNil(data);
-                             XCTAssertEqualObjects(data.statusCode, @(0));
-                             [removeFabricExpectation fulfill];
-                         }];
-
-    [self waitForExpectations:@[ removeFabricExpectation ] timeout:kTimeoutInSeconds];
-
+    ResetCommissionee(GetConnectedDevice(), dispatch_get_main_queue(), self, kTimeoutInSeconds);
     [self shutdownStack];
 }
 #endif

--- a/src/darwin/Framework/CHIPTests/MTRPairingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPairingTests.m
@@ -1,0 +1,258 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// module headers
+#import <Matter/Matter.h>
+
+#import "MTRErrorTestUtils.h"
+#import "MTRTestKeys.h"
+#import "MTRTestResetCommissioneeHelper.h"
+#import "MTRTestStorage.h"
+
+// system dependencies
+#import <XCTest/XCTest.h>
+
+// Set the following to 1 in order to run individual test case manually.
+#define MANUAL_INDIVIDUAL_TEST 0
+
+static const uint16_t kPairingTimeoutInSeconds = 10;
+static const uint16_t kTimeoutInSeconds = 3;
+static uint64_t sDeviceId = 0x12344321;
+static NSString * kOnboardingPayload = @"MT:-24J0AFN00KA0648G00";
+static const uint16_t kLocalPort = 5541;
+static const uint16_t kTestVendorId = 0xFFF1u;
+
+// Singleton controller we use.
+static MTRDeviceController * sController = nil;
+
+// Keys we can use to restart the controller.
+static MTRTestKeys * sTestKeys = nil;
+
+// A no-op MTRDeviceAttestationDelegate which lets us test (by default, in CI)
+// commissioning flows that have such a delegate.
+@interface NoOpAttestationDelegate : NSObject <MTRDeviceAttestationDelegate>
+@property (nonatomic) XCTestExpectation * expectation;
+
+- (instancetype)initWithExpectation:(XCTestExpectation *)expectation;
+@end
+
+@implementation NoOpAttestationDelegate
+- (instancetype)initWithExpectation:(XCTestExpectation *)expectation
+{
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    _expectation = expectation;
+    return self;
+}
+
+- (void)deviceAttestationCompletedForController:(MTRDeviceController *)controller
+                             opaqueDeviceHandle:(void *)opaqueDeviceHandle
+                          attestationDeviceInfo:(MTRDeviceAttestationDeviceInfo *)attestationDeviceInfo
+                                          error:(NSError * _Nullable)error
+{
+    [self.expectation fulfill];
+    [controller continueCommissioningDevice:opaqueDeviceHandle ignoreAttestationFailure:NO error:nil];
+}
+
+@end
+
+@interface MTRPairingTestPairingDelegate : NSObject <MTRDevicePairingDelegate>
+@property (nonatomic, strong) XCTestExpectation * expectation;
+@property (nonatomic, nullable) id<MTRDeviceAttestationDelegate> attestationDelegate;
+@property (nonatomic, nullable) NSNumber * failSafeExtension;
+@end
+
+@implementation MTRPairingTestPairingDelegate
+- (id)initWithExpectation:(XCTestExpectation *)expectation
+      attestationDelegate:(id<MTRDeviceAttestationDelegate>)attestationDelegate
+        failSafeExtension:(NSNumber *)failSafeExtension
+{
+    self = [super init];
+    if (self) {
+        _expectation = expectation;
+        _attestationDelegate = attestationDelegate;
+        _failSafeExtension = failSafeExtension;
+    }
+    return self;
+}
+
+- (void)onPairingComplete:(NSError *)error
+{
+    XCTAssertEqual(error.code, 0);
+
+    __auto_type * params = [[MTRCommissioningParameters alloc] init];
+    params.deviceAttestationDelegate = self.attestationDelegate;
+    params.failSafeTimeout = self.failSafeExtension;
+
+    NSError * commissionError = nil;
+    [sController commissionDevice:sDeviceId commissioningParams:params error:&commissionError];
+    XCTAssertNil(commissionError);
+
+    // Keep waiting for onCommissioningComplete
+}
+
+- (void)onCommissioningComplete:(NSError *)error
+{
+    XCTAssertEqual(error.code, 0);
+    [_expectation fulfill];
+    _expectation = nil;
+}
+
+@end
+
+// attestationDelegate and failSafeExtension can both be nil
+static void DoPairingTest(XCTestCase * testcase, id<MTRDeviceAttestationDelegate> attestationDelegate, NSNumber * failSafeExtension)
+{
+    // Don't reuse node ids, because that will confuse us.
+    ++sDeviceId;
+    XCTestExpectation * expectation = [testcase expectationWithDescription:@"Pairing Complete"];
+    __auto_type * controller = sController;
+
+    __auto_type * pairing = [[MTRPairingTestPairingDelegate alloc] initWithExpectation:expectation
+                                                                   attestationDelegate:attestationDelegate
+                                                                     failSafeExtension:failSafeExtension];
+    dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.pairing", DISPATCH_QUEUE_SERIAL);
+
+    [controller setPairingDelegate:pairing queue:callbackQueue];
+
+    NSError * error;
+    __auto_type * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:kOnboardingPayload error:&error];
+    XCTAssertNotNil(payload);
+    XCTAssertNil(error);
+
+    [controller setupCommissioningSessionWithPayload:payload newNodeID:@(sDeviceId) error:&error];
+    XCTAssertNil(error);
+
+    [testcase waitForExpectations:@[ expectation ] timeout:kPairingTimeoutInSeconds];
+
+    ResetCommissionee([MTRBaseDevice deviceWithNodeID:@(sDeviceId) controller:controller], dispatch_get_main_queue(), testcase,
+        kTimeoutInSeconds);
+}
+
+@interface MTRPairingTests : XCTestCase
+@end
+
+@implementation MTRPairingTests
+
+- (void)setUp
+{
+    [super setUp];
+    [self setContinueAfterFailure:NO];
+}
+
+- (void)tearDown
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self shutdownStack];
+#endif
+    [super tearDown];
+}
+
+- (void)initStack
+{
+    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    XCTAssertNotNil(factory);
+
+    __auto_type * storage = [[MTRTestStorage alloc] init];
+    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
+    factoryParams.port = @(kLocalPort);
+
+    BOOL ok = [factory startup:factoryParams];
+    XCTAssertTrue(ok);
+
+    __auto_type * testKeys = [[MTRTestKeys alloc] init];
+    XCTAssertNotNil(testKeys);
+
+    sTestKeys = testKeys;
+
+    // Needs to match what startControllerOnExistingFabric calls elsewhere in
+    // this file do.
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys fabricId:1 ipk:testKeys.ipk];
+    params.vendorId = @(kTestVendorId);
+
+    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    XCTAssertNotNil(controller);
+
+    sController = controller;
+}
+
+- (void)shutdownStack
+{
+    MTRDeviceController * controller = sController;
+    XCTAssertNotNil(controller);
+
+    [controller shutdown];
+    XCTAssertFalse([controller isRunning]);
+
+    [[MTRControllerFactory sharedInstance] shutdown];
+}
+
+#if !MANUAL_INDIVIDUAL_TEST
+- (void)test000_SetUp
+{
+    [self initStack];
+}
+#endif
+
+- (void)test001_PairWithoutAttestationDelegate
+{
+    DoPairingTest(self, nil, nil);
+}
+
+- (void)test002_PairWithAttestationDelegateNoFailsafeExtension
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Attestation delegate called"];
+
+    DoPairingTest(self, [[NoOpAttestationDelegate alloc] initWithExpectation:expectation], nil);
+
+    [self waitForExpectations:@[ expectation ] timeout:kTimeoutInSeconds];
+}
+
+- (void)test003_PairWithAttestationDelegateFailsafeExtensionShort
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Attestation delegate called"];
+
+    // Extend by a time that is going to be smaller than the 60s default we
+    // already have set via CHIP_DEVICE_CONFIG_FAILSAFE_EXPIRY_LENGTH_SEC on the
+    // server side, minus whatever time that has likely passed.
+    DoPairingTest(self, [[NoOpAttestationDelegate alloc] initWithExpectation:expectation], @(30));
+
+    [self waitForExpectations:@[ expectation ] timeout:kTimeoutInSeconds];
+}
+
+- (void)test004_PairWithAttestationDelegateFailsafeExtensionLong
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Attestation delegate called"];
+
+    // Extend by a time that is going to be larger than the 60s default we
+    // already have set via CHIP_DEVICE_CONFIG_FAILSAFE_EXPIRY_LENGTH_SEC on the
+    // server side.
+    DoPairingTest(self, [[NoOpAttestationDelegate alloc] initWithExpectation:expectation], @(90));
+
+    [self waitForExpectations:@[ expectation ] timeout:kTimeoutInSeconds];
+}
+
+#if !MANUAL_INDIVIDUAL_TEST
+- (void)test999_TearDown
+{
+    [self shutdownStack];
+}
+#endif
+
+@end

--- a/src/darwin/Framework/CHIPTests/MTRTestResetCommissioneeHelper.h
+++ b/src/darwin/Framework/CHIPTests/MTRTestResetCommissioneeHelper.h
@@ -1,0 +1,23 @@
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/Matter.h>
+#import <XCTest/XCTest.h>
+
+#pragma once
+
+void ResetCommissionee(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCase * testcase, uint16_t commandTimeout);

--- a/src/darwin/Framework/CHIPTests/MTRTestResetCommissioneeHelper.m
+++ b/src/darwin/Framework/CHIPTests/MTRTestResetCommissioneeHelper.m
@@ -1,0 +1,70 @@
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRTestResetCommissioneeHelper.h"
+
+void ResetCommissionee(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCase * testcase, uint16_t commandTimeout)
+{
+    // Put the device back in the state we found it: open commissioning window, no fabrics commissioned.
+    // Get our current fabric index, for later deletion.
+    XCTestExpectation * readFabricIndexExpectation = [testcase expectationWithDescription:@"Fabric index read"];
+
+    __block NSNumber * fabricIndex;
+    __auto_type * opCredsCluster = [[MTRBaseClusterOperationalCredentials alloc] initWithDevice:device endpoint:0 queue:queue];
+    [opCredsCluster
+        readAttributeCurrentFabricIndexWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable readError) {
+            XCTAssertNil(readError);
+            XCTAssertNotNil(value);
+            fabricIndex = value;
+            [readFabricIndexExpectation fulfill];
+        }];
+
+    [testcase waitForExpectations:@[ readFabricIndexExpectation ] timeout:commandTimeout];
+
+    // Open a commissioning window.
+    XCTestExpectation * openCommissioningWindowExpectation = [testcase expectationWithDescription:@"Commissioning window opened"];
+
+    __auto_type * adminCommissioningCluster = [[MTRBaseClusterAdministratorCommissioning alloc] initWithDevice:device
+                                                                                                      endpoint:0
+                                                                                                         queue:queue];
+    __auto_type * openWindowParams = [[MTRAdministratorCommissioningClusterOpenBasicCommissioningWindowParams alloc] init];
+    openWindowParams.commissioningTimeout = @(900);
+    openWindowParams.timedInvokeTimeoutMs = @(50000);
+    [adminCommissioningCluster openBasicCommissioningWindowWithParams:openWindowParams
+                                                    completionHandler:^(NSError * _Nullable error) {
+                                                        XCTAssertNil(error);
+                                                        [openCommissioningWindowExpectation fulfill];
+                                                    }];
+
+    [testcase waitForExpectations:@[ openCommissioningWindowExpectation ] timeout:commandTimeout];
+
+    // Remove our fabric from the device.
+    XCTestExpectation * removeFabricExpectation = [testcase expectationWithDescription:@"Fabric removed"];
+
+    __auto_type * removeParams = [[MTROperationalCredentialsClusterRemoveFabricParams alloc] init];
+    removeParams.fabricIndex = fabricIndex;
+
+    [opCredsCluster removeFabricWithParams:removeParams
+                         completionHandler:^(
+                             MTROperationalCredentialsClusterNOCResponseParams * _Nullable data, NSError * _Nullable removeError) {
+                             XCTAssertNil(removeError);
+                             XCTAssertNotNil(data);
+                             XCTAssertEqualObjects(data.statusCode, @(0));
+                             [removeFabricExpectation fulfill];
+                         }];
+
+    [testcase waitForExpectations:@[ removeFabricExpectation ] timeout:commandTimeout];
+}

--- a/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
@@ -24,6 +24,7 @@
 
 #import "MTRErrorTestUtils.h"
 #import "MTRTestKeys.h"
+#import "MTRTestResetCommissioneeHelper.h"
 #import "MTRTestStorage.h"
 
 #import <app/util/af-enums.h>
@@ -1831,59 +1832,8 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 #if !MANUAL_INDIVIDUAL_TEST
 - (void)test999_TearDown
 {
-    // Put the device back in the state we found it: open commissioning window, no fabrics commissioned.
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    __auto_type device = [MTRBaseDevice deviceWithNodeID:@(kDeviceId) controller:sController];
-
-    // Get our current fabric index, for later deletion.
-    XCTestExpectation * readFabricIndexExpectation = [self expectationWithDescription:@"Fabric index read"];
-
-    __block NSNumber * fabricIndex;
-    __auto_type * opCredsCluster = [[MTRBaseClusterOperationalCredentials alloc] initWithDevice:device endpointID:@(0) queue:queue];
-    [opCredsCluster
-        readAttributeCurrentFabricIndexWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable readError) {
-            XCTAssertNil(readError);
-            XCTAssertNotNil(value);
-            fabricIndex = value;
-            [readFabricIndexExpectation fulfill];
-        }];
-
-    [self waitForExpectations:@[ readFabricIndexExpectation ] timeout:kTimeoutInSeconds];
-
-    // Open a commissioning window.
-    XCTestExpectation * openCommissioningWindowExpectation = [self expectationWithDescription:@"Commissioning window opened"];
-
-    __auto_type * adminCommissioningCluster = [[MTRBaseClusterAdministratorCommissioning alloc] initWithDevice:device
-                                                                                                    endpointID:@(0)
-                                                                                                         queue:queue];
-    __auto_type * openWindowParams = [[MTRAdministratorCommissioningClusterOpenBasicCommissioningWindowParams alloc] init];
-    openWindowParams.commissioningTimeout = @(900);
-    openWindowParams.timedInvokeTimeoutMs = @(50000);
-    [adminCommissioningCluster openBasicCommissioningWindowWithParams:openWindowParams
-                                                    completionHandler:^(NSError * _Nullable error) {
-                                                        XCTAssertNil(error);
-                                                        [openCommissioningWindowExpectation fulfill];
-                                                    }];
-
-    [self waitForExpectations:@[ openCommissioningWindowExpectation ] timeout:kTimeoutInSeconds];
-
-    // Remove our fabric from the device.
-    XCTestExpectation * removeFabricExpectation = [self expectationWithDescription:@"Fabric removed"];
-
-    __auto_type * removeParams = [[MTROperationalCredentialsClusterRemoveFabricParams alloc] init];
-    removeParams.fabricIndex = fabricIndex;
-
-    [opCredsCluster removeFabricWithParams:removeParams
-                         completionHandler:^(
-                             MTROperationalCredentialsClusterNOCResponseParams * _Nullable data, NSError * _Nullable removeError) {
-                             XCTAssertNil(removeError);
-                             XCTAssertNotNil(data);
-                             XCTAssertEqualObjects(data.statusCode, @(0));
-                             [removeFabricExpectation fulfill];
-                         }];
-
-    [self waitForExpectations:@[ removeFabricExpectation ] timeout:kTimeoutInSeconds];
-
+    ResetCommissionee(
+        [MTRBaseDevice deviceWithNodeID:@(kDeviceId) controller:sController], dispatch_get_main_queue(), self, kTimeoutInSeconds);
     [self shutdownStack];
 }
 #endif

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -147,6 +147,8 @@
 		5173A47629C0E2ED00F67F48 /* MTRFabricInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5173A47329C0E2ED00F67F48 /* MTRFabricInfo.mm */; };
 		5173A47729C0E2ED00F67F48 /* MTRFabricInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 5173A47429C0E2ED00F67F48 /* MTRFabricInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5173A47929C0E82300F67F48 /* MTRFabricInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5173A47829C0E82300F67F48 /* MTRFabricInfoTests.m */; };
+		51742B4A29CB5FC1009974FE /* MTRTestResetCommissioneeHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 51742B4929CB5FC0009974FE /* MTRTestResetCommissioneeHelper.m */; };
+		51742B4E29CB6B88009974FE /* MTRPairingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 51742B4D29CB6B88009974FE /* MTRPairingTests.m */; };
 		517BF3F0282B62B800A8B7DB /* MTRCertificates.h in Headers */ = {isa = PBXBuildFile; fileRef = 517BF3EE282B62B800A8B7DB /* MTRCertificates.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		517BF3F1282B62B800A8B7DB /* MTRCertificates.mm in Sources */ = {isa = PBXBuildFile; fileRef = 517BF3EF282B62B800A8B7DB /* MTRCertificates.mm */; };
 		517BF3F3282B62CB00A8B7DB /* MTRCertificateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 517BF3F2282B62CB00A8B7DB /* MTRCertificateTests.m */; };
@@ -428,6 +430,9 @@
 		5173A47329C0E2ED00F67F48 /* MTRFabricInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRFabricInfo.mm; sourceTree = "<group>"; };
 		5173A47429C0E2ED00F67F48 /* MTRFabricInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRFabricInfo.h; sourceTree = "<group>"; };
 		5173A47829C0E82300F67F48 /* MTRFabricInfoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRFabricInfoTests.m; sourceTree = "<group>"; };
+		51742B4829CB5F45009974FE /* MTRTestResetCommissioneeHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRTestResetCommissioneeHelper.h; sourceTree = "<group>"; };
+		51742B4929CB5FC0009974FE /* MTRTestResetCommissioneeHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRTestResetCommissioneeHelper.m; sourceTree = "<group>"; };
+		51742B4D29CB6B88009974FE /* MTRPairingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRPairingTests.m; sourceTree = "<group>"; };
 		517BF3EE282B62B800A8B7DB /* MTRCertificates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRCertificates.h; sourceTree = "<group>"; };
 		517BF3EF282B62B800A8B7DB /* MTRCertificates.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRCertificates.mm; sourceTree = "<group>"; };
 		517BF3F2282B62CB00A8B7DB /* MTRCertificateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRCertificateTests.m; sourceTree = "<group>"; };
@@ -1031,6 +1036,8 @@
 				51E24E72274E0DAC007CCF6E /* MTRErrorTestUtils.mm */,
 				51C8E3F72825CDB600D47D00 /* MTRTestKeys.m */,
 				51D10D2D2808E2CA00E8CA3D /* MTRTestStorage.m */,
+				51742B4829CB5F45009974FE /* MTRTestResetCommissioneeHelper.h */,
+				51742B4929CB5FC0009974FE /* MTRTestResetCommissioneeHelper.m */,
 				3DFCB3282966684500332B35 /* MTRCertificateInfoTests.m */,
 				99C65E0F267282F1003402F6 /* MTRControllerTests.m */,
 				5AE6D4E327A99041001F2493 /* MTRDeviceTests.m */,
@@ -1043,6 +1050,7 @@
 				51669AEF2913204400F4AA36 /* MTRBackwardsCompatTests.m */,
 				510CECA6297F72470064E0B3 /* MTROperationalCertificateIssuerTests.m */,
 				5173A47829C0E82300F67F48 /* MTRFabricInfoTests.m */,
+				51742B4D29CB6B88009974FE /* MTRPairingTests.m */,
 				B202529D2459E34F00F97062 /* Info.plist */,
 			);
 			path = CHIPTests;
@@ -1432,6 +1440,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				51742B4E29CB6B88009974FE /* MTRPairingTests.m in Sources */,
 				51669AF02913204400F4AA36 /* MTRBackwardsCompatTests.m in Sources */,
 				51D10D2E2808E2CA00E8CA3D /* MTRTestStorage.m in Sources */,
 				7596A8512878709F004DAE0E /* MTRAsyncCallbackQueueTests.m in Sources */,
@@ -1441,6 +1450,7 @@
 				1E5801C328941C050033A199 /* MTRTestOTAProvider.m in Sources */,
 				5A6FEC9D27B5E48900F25F42 /* MTRXPCProtocolTests.m in Sources */,
 				5173A47929C0E82300F67F48 /* MTRFabricInfoTests.m in Sources */,
+				51742B4A29CB5FC1009974FE /* MTRTestResetCommissioneeHelper.m in Sources */,
 				5AE6D4E427A99041001F2493 /* MTRDeviceTests.m in Sources */,
 				510CECA8297F72970064E0B3 /* MTROperationalCertificateIssuerTests.m in Sources */,
 				5A7947DE27BEC3F500434CF2 /* MTRXPCListenerSampleTests.m in Sources */,


### PR DESCRIPTION
The boolean test in ExtendArmFailSafeForDeviceAttestation was backwards, so there were two failure cases:

1. If we had a delegate but FailSafeExpiryTimeoutSecs() returned NullOptional, we would skip extending the fail-safe (expected), but set failSafeSkipped to _false_, and so not actually make our "continue commissioning" callback.

2. If we had a delegate and FailSafeExpiryTimeoutSecs() returned a too-small value, we would also skip resetting the fail-safe, but end up setting failSafeSkipped to false, and hence again failing to make our "continue commissioning" callback.

The fix is to reverse the sense of the "do we need to call back immediately" boolean, to make it a little clearer what the logic flow is here, and then check it appropriately.
