### PR TITLE
Use version from zap.json to download zap

### DIFF
--- a/scripts/tools/zap/zap_download.py
+++ b/scripts/tools/zap/zap_download.py
@@ -16,9 +16,9 @@
 
 import enum
 import io
+import json
 import logging
 import os
-import re
 import shlex
 import shutil
 import subprocess
@@ -141,19 +141,19 @@ def _GetZapVersionToUse(project_root):
     # This heuristic may be bad at times, however then you can also override the
     # version in command line parameters
 
-    match_re = re.compile(r'.*ENV\s+ZAP_VERSION=([^# ]*)')
+    zap_version = ""
+    zap_path = os.path.join(project_root, "scripts/setup/zap.json")
+    zap_json = json.load(open(zap_path))
+    for package in zap_json.get("packages", []):
+        for tag in package.get("tags", []):
+            if tag.startswith("version:2@"):
+                zap_version = tag.removeprefix("version:2@")
+                suffix_index = zap_version.rfind(".")
+                if suffix_index != -1:
+                    zap_version = zap_version[:suffix_index]
+                return zap_version
 
-    docker_path = os.path.join(project_root, "integrations/docker/images/chip-build/Dockerfile")
-
-    with open(docker_path, 'rt') as f:
-        for l in f.readlines():
-            l = l.strip()
-            m = match_re.match(l)
-            if not m:
-                continue
-            return m.group(1)
-
-    raise Exception(f"Failed to determine version from {docker_path}")
+    raise Exception(f"Failed to determine version from {zap_path}")
 
 
 @click.command()


### PR DESCRIPTION
Zap version was retrieved from a Dockerfile that doesn't exist any more.
Use zap.json instead to get it.

