### PR TITLE
[ESP32] SecureCertDACProvider implementation to read attestation info from esp_secur…

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -985,6 +985,7 @@ otatesting
 otaURL
 OTBR
 otcli
+outform
 outgoingCommands
 OxygenConcentrationMeasurement
 OzoneConcentrationMeasurement
@@ -1024,6 +1025,7 @@ Pigweed
 PinCode
 pinrequest
 pkgconfig
+PKI
 plaintext
 PlatformManager
 PlatformManagerImpl
@@ -1180,6 +1182,7 @@ sdkconfig
 SDKs
 SDKTARGETSYSROOT
 sdl
+SecureCertDACProvider
 SED
 SEGGER
 semver

--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -207,6 +207,11 @@ if (CONFIG_ENABLE_ESP32_DEVICE_INFO_PROVIDER)
     chip_gn_arg_append("chip_use_device_info_provider"                     "true")
 endif()
 
+if (CONFIG_SEC_CERT_DAC_PROVIDER)
+    chip_gn_arg_append("chip_use_secure_cert_dac_provider"                 "true")
+endif()
+
+
 set(args_gn_input "${CMAKE_CURRENT_BINARY_DIR}/args.gn.in")
 file(GENERATE OUTPUT "${args_gn_input}" CONTENT "${chip_gn_args}")
 
@@ -345,6 +350,11 @@ endif()
 
 idf_component_get_property(main_lib main COMPONENT_LIB)
 list(APPEND chip_libraries $<TARGET_FILE:${main_lib}>)
+
+if (CONFIG_SEC_CERT_DAC_PROVIDER)
+    idf_component_get_property(esp32_secure_cert_mgr_lib espressif__esp_secure_cert_mgr COMPONENT_LIB)
+    list(APPEND chip_libraries $<TARGET_FILE:${esp32_secure_cert_mgr_lib}>)
+endif()
 
 target_link_libraries(${COMPONENT_LIB} INTERFACE -Wl,--start-group
                                                 ${chip_libraries}

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -678,6 +678,13 @@ menu "CHIP Device Layer"
             help
                 Enable ESP32 Device LocationCapability
 
+        config SEC_CERT_DAC_PROVIDER
+            bool "Use Secure Cert DAC Provider"
+            default n
+            help
+                Use ESP32 Secure Cert DAC Provider which is  ESP32 DeviceAttestationCredentialsProvider implementation which reads attestation
+                information from the esp_secure_cert partition
+
     endmenu
 
 

--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -5,3 +5,8 @@ dependencies:
         rules:
             - if: "idf_version >=5.0"
             - if: "target != esp32h2"
+
+    espressif/esp_secure_cert_mgr:
+        version: "^2.2.1"
+        rules:
+            - if: "idf_version >=4.3"

--- a/docs/guides/esp32/README.md
+++ b/docs/guides/esp32/README.md
@@ -16,3 +16,4 @@ example on ESP32 series of SoCs
 -   [Flash and NVS encryption for securing factory data](flash_nvs_encryption.md)
 -   [RPC Console and Device Tracing](rpc_console.md)
 -   [Matter OTA](ota.md)
+-   [Generating and Using ESP Secure Cert Parttiton](secure_cert_partition.md)

--- a/docs/guides/esp32/secure_cert_partition.md
+++ b/docs/guides/esp32/secure_cert_partition.md
@@ -1,0 +1,183 @@
+# Using esp_secure_cert partition
+
+## 1.1 ESP Secure Cert Partition
+
+-   When a device is pre-provisioned, the PKI credentials are generated for the
+    device and stored in a partition named esp_secure_cert.
+-   In the Matter Pre-Provisioning service, the Matter DAC certificate is
+    pre-flashed in esp_secure_cert partition.
+-   The ESP32SecureCertDACProvider reads the PKI credentials from
+    esp_secure_cert_partition.
+-   The DAC,PAI and private key are read from the esp_secure_cert_partition, but
+    the certificate declaration is read from the factory data partition.
+    Therefore, we need to also generate a factory partition besides
+    esp_secure_cert_partition.
+-   The esp_secure_cert partition can be generated on host with help of
+    configure_esp_secure_cert.py utility.
+-   The use of esp_secure_cert_partition is demonstrated in lighting-app.
+
+## 1.2 Prerequisites:
+
+To generate the esp_secure_cert_partition and the factory_data_partition, we
+need the DAC and PAI certificate as well as the private key(DAC key) in .der
+format. The factory_data_provider in addition requires the certificate
+declaration in .der format. The generation of the required certificates and keys
+is mentioned in the steps given below.
+
+### 1.2.1 Build certification generation tool:
+
+Run the commands below:
+
+```
+cd path/to/connectedhomeip
+source scripts/activate.sh
+gn gen out/host
+ninja -C out/host chip-cert
+cd out/host
+```
+
+At /path/to/connectedhomeip/out/host run the below commands.
+
+### 1.2.2 Generating Certification Declaration
+
+```
+./chip-cert gen-cd -K ../../credentials/test/certification-declaration/Chip-Test-CD-Signing-Key.pem -C ../../credentials/test/certification-declaration/Chip-Test-CD-Signing-Cert.pem -O esp_dac_fff1_8000.der -f 1 -V 0xfff1 -p 0x8000 -d 0x0016 -c "CSA00000SWC00000-01" -l 0 -i 0 -n 1 -t 0
+```
+
+### 1.2.3 Generating PAI
+
+```
+./chip-cert gen-att-cert -t i -c "ESP TEST PAI" -V 0xfff1 -P 0x8000 -C ../../credentials/development/attestation/Chip-Development-PAA-Cert.pem -K ../../credentials/development/attestation/Chip-Development-PAA-Key.pem -o Esp-Development-PAI-Cert.pem -O Esp-Development-PAI-Key.pem -l 4294967295
+```
+
+### 1.2.4 Generating DAC
+
+```
+./chip-cert gen-att-cert -t d -c "ESP TEST DAC 01" -V 0xfff1 -P 0x8000 -C Esp-Development-PAI-Cert.pem -K Esp-Development-PAI-Key.pem -o Esp-Development-DAC-01.pem -O Esp-Development-DAC-Key-01.pem -l 4294967295
+```
+
+### 1.2.5 Change format for the certificates and key (.pem to .der format)
+
+-   Convert DAC key from .pem to .der format.
+
+```
+openssl ec -in Esp-Development-DAC-Key-01.pem -out Esp-Development-DAC-Key-01.der -inform pem -outform der
+```
+
+-   Convert DAC and PAI cert from .pem to .der format
+
+```
+openssl x509 -in Esp-Development-DAC-01.pem -out Esp-Development-DAC-01.der-inform pem -outform der
+openssl x509 -in Esp-Development-PAI-Cert.pem -out Esp-Development-PAI-Cert.der -inform pem -outform der
+```
+
+The certificates in the steps 1.2 will be generated at
+/path/to/connectedhomeip/out/host.For steps 1.3 and 1.4 go to
+connectedhomeip/scripts/tools , set IDF_PATH.
+
+## 1.3 Generating esp_secure_cert_partition
+
+To generate the esp_secure_cert_partition install esp-secure-cert-tool using
+
+```
+pip install esp-secure-cert-tool
+```
+
+Example command to generate a esp_secure_cert_partition
+
+```
+configure_esp_secure_cert.py --private-key path/to/dac-key \
+--device-cert path/to/dac-cert \
+--ca-cert path/to/pai-cert \
+--target_chip esp32c3 \
+--port /dev/ttyUSB0 -- skip_flash
+```
+
+Refer
+https://github.com/espressif/esp_secure_cert_mgr/tree/main/tools#generate-esp_secure_cert-partition
+for more help.
+
+## 1.4 Generating the factory_data_partition
+
+Example command to generate a factory_data_partition
+
+```
+./generate_esp32_chip_factory_bin.py -d 3434 -p 99663300 \
+                                    --product-name ESP-lighting-app --product-id 0x8000 \
+                                    --vendor-name Test-vendor --vendor-id 0xFFF1 \
+                                    --hw-ver 1 --hw-ver-str DevKit \
+                                    --dac-cert path/to/dac-cert \
+                                    --dac-key path/to/dac-key \
+                                    --pai-cert path/to/pai-cert \
+                                    --cd path/to/certificate-declaration
+```
+
+Refer
+https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/esp32/factory_data.md#generate-nvs-binary-image
+to generate a factory_data_partition.
+
+## 1.5 Build the firmware with below configuration options
+
+```
+# Disable the DS Peripheral support
+CONFIG_ESP_SECURE_CERT_DS_PERIPHERAL=n
+# Use DAC Provider implementation which reads attestation data from secure cert partition
+CONFIG_SEC_CERT_DAC_PROVIDER=y
+# Enable some options which reads CD and other basic info from the factory partition
+CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER=y
+CONFIG_ENABLE_ESP32_DEVICE_INSTANCE_INFO_PROVIDER=y
+CONFIG_CHIP_FACTORY_NAMESPACE_PARTITION_LABEL="fctry"
+```
+
+In order to use the esp_secure_cert_partition, in addition to enabling the above
+config options, you should also have the esp_secure_cert_partition and factory
+partition in your app. For reference, refer to partitions.csv file of
+lighting-app.
+
+## 1.6 Flashing firmware, secure cert and factory partition
+
+### Build and flash
+
+```
+idf.py -p (PORT) build flash
+```
+
+### Flash `esp_secure_cert` and factory partition binaries
+
+The `esp_secure_cert` partition binary contains device attestation information
+and the factory partition binary contains Matter manufacturing specific data.
+
+-   Flash `esp_secure_cert` partition binary
+
+```
+esptool.py -p (PORT) write_flash 0xd000 path/to/secure_cert_partition.bin
+```
+
+-   Flash factory partition binary
+
+```
+esptool.py -p (PORT) write_flash 0x3E0000 path/to/factory_partition.bin
+```
+
+### Monitor
+
+```
+idf.py monitor
+```
+
+Please flash the above mentioned partitions by looking into the addresses in
+partitions.csv.The above commands are for example purpose.
+
+## 1.6 Test commissioning using chip-tool
+
+Run the following command from host to commission the device.
+
+```
+./chip-tool pairing ble-wifi 1234 my_SSID my_PASSPHRASE my_PASSCODE my_DISCRIMINATOR --paa-trust-store-path /path/to/PAA-Certificates/
+```
+
+For example:
+
+```
+./chip-tool pairing ble-wifi 0x7283 my_SSID my_PASSPHRASE 99663300 3434 --paa-trust-store-path /path/to/connectedhomeip/credentials/development/attestation/
+```

--- a/examples/lighting-app/esp32/partitions.csv
+++ b/examples/lighting-app/esp32/partitions.csv
@@ -1,7 +1,10 @@
 # Name,   Type, SubType, Offset,  Size, Flags
-# Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs,     ,        0x6000,
-otadata,  data, ota,     ,        0x2000,
-phy_init, data, phy,     ,        0x1000,
-ota_0,    app,  ota_0,   ,        1500K,
-ota_1,    app,  ota_1,   ,        1500K,
+# Note: Firmware partition offset needs to be 64K aligned, initial 36K (9 sectors) are reserved for bootloader and partition table
+esp_secure_cert,  0x3F,        ,    0xD000,     0x2000,    encrypted
+nvs,      data, nvs,     0x10000,   0x6000,
+nvs_keys, data, nvs_keys,,          0x1000,
+otadata,  data, ota,     ,          0x2000
+phy_init, data, phy,     ,          0x1000,
+ota_0,    app,  ota_0,   0x20000,   0x1E0000,
+ota_1,    app,  ota_1,   0x200000,  0x1E0000,
+fctry,    data, nvs,     0x3E0000,  0x6000

--- a/examples/lighting-app/esp32/sdkconfig.defaults
+++ b/examples/lighting-app/esp32/sdkconfig.defaults
@@ -53,5 +53,5 @@ CONFIG_ESPTOOLPY_FLASHSIZE="4MB"
 # Disable softap support by default
 CONFIG_ESP_WIFI_SOFTAP_SUPPORT=n
 # This example uses the older version of RMT driver to work with both
-# idf-v4.4.3 and idf-v5.0, so supressing the warnings by setting below option
+# idf-v4.4.3 and idf-v5.0, so suppressing the warnings by setting below option
 CONFIG_RMT_SUPPRESS_DEPRECATE_WARN=y

--- a/src/platform/ESP32/BUILD.gn
+++ b/src/platform/ESP32/BUILD.gn
@@ -27,6 +27,7 @@ declare_args() {
   chip_enable_chipoble = true
   chip_bt_nimble_enabled = false
   chip_bt_bluedroid_enabled = false
+  chip_use_secure_cert_dac_provider = false
 }
 
 defines = [
@@ -64,7 +65,10 @@ static_library("ESP32") {
     "${chip_root}/src/setup_payload",
   ]
 
-  public = [ "${chip_root}/src/credentials/DeviceAttestationCredsProvider.h" ]
+  public = [
+    "${chip_root}/src/credentials/CHIPCert.h",
+    "${chip_root}/src/credentials/DeviceAttestationCredsProvider.h",
+  ]
 
   public_deps = [
     "${chip_root}/src/crypto",
@@ -146,6 +150,13 @@ static_library("ESP32") {
     sources += [
       "ESP32DeviceInfoProvider.cpp",
       "ESP32DeviceInfoProvider.h",
+    ]
+  }
+
+  if (chip_use_secure_cert_dac_provider) {
+    sources += [
+      "ESP32SecureCertDACProvider.cpp",
+      "ESP32SecureCertDACProvider.h",
     ]
   }
 

--- a/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
@@ -1,0 +1,147 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <credentials/CHIPCert.h>
+#include <crypto/CHIPCryptoPAL.h>
+#include <esp_fault.h>
+#include <esp_log.h>
+#include <esp_secure_cert_read.h>
+#include <platform/ESP32/ESP32Config.h>
+#include <platform/ESP32/ESP32SecureCertDACProvider.h>
+
+#define TAG "dac_provider"
+
+#if CONFIG_SEC_CERT_DAC_PROVIDER
+
+namespace chip {
+namespace DeviceLayer {
+
+using namespace chip::Credentials;
+using namespace chip::DeviceLayer::Internal;
+
+namespace {
+static constexpr uint32_t kDACPrivateKeySize = 32;
+static constexpr uint32_t kDACPublicKeySize  = 65;
+static constexpr uint8_t kPrivKeyOffset      = 7;
+static constexpr uint8_t kPubKeyOffset       = 56;
+
+CHIP_ERROR LoadKeypairFromRaw(ByteSpan privateKey, ByteSpan publicKey, Crypto::P256Keypair & keypair)
+{
+    Crypto::P256SerializedKeypair serializedKeypair;
+    ReturnErrorOnFailure(serializedKeypair.SetLength(privateKey.size() + publicKey.size()));
+    memcpy(serializedKeypair.Bytes(), publicKey.data(), publicKey.size());
+    memcpy(serializedKeypair.Bytes() + publicKey.size(), privateKey.data(), privateKey.size());
+    return keypair.Deserialize(serializedKeypair);
+}
+} // namespace
+
+CHIP_ERROR ESP32SecureCertDACProvider ::GetCertificationDeclaration(MutableByteSpan & outBuffer)
+{
+    size_t certSize;
+    ReturnErrorOnFailure(
+        ESP32Config::ReadConfigValueBin(ESP32Config::kConfigKey_CertDeclaration, outBuffer.data(), outBuffer.size(), certSize));
+    outBuffer.reduce_size(certSize);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ESP32SecureCertDACProvider ::GetFirmwareInformation(MutableByteSpan & out_firmware_info_buffer)
+{
+    // We do not provide any FirmwareInformation.
+    out_firmware_info_buffer.reduce_size(0);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ESP32SecureCertDACProvider ::GetDeviceAttestationCert(MutableByteSpan & outBuffer)
+{
+    char * dac_cert  = NULL;
+    uint32_t dac_len = 0;
+
+    esp_err_t err = esp_secure_cert_get_device_cert(&dac_cert, &dac_len);
+    if (err == ESP_OK && dac_cert != NULL && dac_len != 0)
+    {
+        ESP_FAULT_ASSERT(err == ESP_OK && dac_cert != NULL && dac_len != 0);
+        VerifyOrReturnError(dac_len <= kMaxDERCertLength, CHIP_ERROR_UNSUPPORTED_CERT_FORMAT,
+                            esp_secure_cert_free_ca_cert(dac_cert));
+        VerifyOrReturnError(dac_len <= outBuffer.size(), CHIP_ERROR_BUFFER_TOO_SMALL, esp_secure_cert_free_ca_cert(dac_cert));
+        memcpy(outBuffer.data(), dac_cert, outBuffer.size());
+        outBuffer.reduce_size(dac_len);
+        esp_secure_cert_free_device_cert(dac_cert);
+        return CHIP_NO_ERROR;
+    }
+
+    ESP_LOGE(TAG, "esp_secure_cert_get_device_cert failed err:%d", err);
+    return CHIP_ERROR_INCORRECT_STATE;
+}
+
+CHIP_ERROR ESP32SecureCertDACProvider ::GetProductAttestationIntermediateCert(MutableByteSpan & outBuffer)
+{
+    char * pai_cert  = NULL;
+    uint32_t pai_len = 0;
+    esp_err_t err    = esp_secure_cert_get_ca_cert(&pai_cert, &pai_len);
+    if (err == ESP_OK && pai_cert != NULL && pai_len != 0)
+    {
+        ESP_FAULT_ASSERT(err == ESP_OK && pai_cert != NULL && pai_len != 0);
+        VerifyOrReturnError(pai_len <= kMaxDERCertLength, CHIP_ERROR_UNSUPPORTED_CERT_FORMAT,
+                            esp_secure_cert_free_ca_cert(pai_cert));
+        VerifyOrReturnError(pai_len <= outBuffer.size(), CHIP_ERROR_BUFFER_TOO_SMALL, esp_secure_cert_free_ca_cert(pai_cert));
+        memcpy(outBuffer.data(), pai_cert, outBuffer.size());
+        outBuffer.reduce_size(pai_len);
+        esp_secure_cert_free_ca_cert(pai_cert);
+        return CHIP_NO_ERROR;
+    }
+
+    ESP_LOGE(TAG, "esp_secure_cert_get_ca_cert failed err:%d", err);
+    return CHIP_ERROR_INCORRECT_STATE;
+}
+
+CHIP_ERROR ESP32SecureCertDACProvider ::SignWithDeviceAttestationKey(const ByteSpan & messageToSign,
+                                                                     MutableByteSpan & outSignBuffer)
+{
+    Crypto::P256ECDSASignature signature;
+    Crypto::P256Keypair keypair;
+    char * sc_keypair       = NULL;
+    uint32_t sc_keypair_len = 0;
+
+    VerifyOrReturnError(IsSpanUsable(outSignBuffer), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(IsSpanUsable(messageToSign), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(outSignBuffer.size() >= signature.Capacity(), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    esp_err_t err = esp_secure_cert_get_priv_key(&sc_keypair, &sc_keypair_len);
+    if (err == ESP_OK && sc_keypair != NULL && sc_keypair_len != 0)
+    {
+        ESP_FAULT_ASSERT(err == ESP_OK && sc_keypair != NULL && sc_keypair_len != 0);
+        CHIP_ERROR chipError =
+            LoadKeypairFromRaw(ByteSpan(reinterpret_cast<const uint8_t *>(sc_keypair + kPrivKeyOffset), kDACPrivateKeySize),
+                               ByteSpan(reinterpret_cast<const uint8_t *>(sc_keypair + kPubKeyOffset), kDACPublicKeySize), keypair);
+        VerifyOrReturnError(chipError == CHIP_NO_ERROR, chipError, esp_secure_cert_free_priv_key(sc_keypair));
+
+        chipError = keypair.ECDSA_sign_msg(messageToSign.data(), messageToSign.size(), signature);
+        VerifyOrReturnError(chipError == CHIP_NO_ERROR, chipError, esp_secure_cert_free_priv_key(sc_keypair));
+
+        esp_secure_cert_free_priv_key(sc_keypair);
+        chipError = CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, outSignBuffer);
+        return chipError;
+    }
+
+    ESP_LOGE(TAG, "esp_secure_cert_get_priv_key failed err:%d", err);
+    return CHIP_ERROR_INCORRECT_STATE;
+}
+
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif // CONFIG_SEC_CERT_DAC_PROVIDER

--- a/src/platform/ESP32/ESP32SecureCertDACProvider.h
+++ b/src/platform/ESP32/ESP32SecureCertDACProvider.h
@@ -1,0 +1,36 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <credentials/DeviceAttestationCredsProvider.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+class ESP32SecureCertDACProvider : public Credentials::DeviceAttestationCredentialsProvider
+{
+public:
+    ESP32SecureCertDACProvider() : Credentials::DeviceAttestationCredentialsProvider() {}
+    ~ESP32SecureCertDACProvider() {}
+    CHIP_ERROR GetCertificationDeclaration(MutableByteSpan & outBuffer) override;
+    CHIP_ERROR GetFirmwareInformation(MutableByteSpan & out_firmware_info_buffer) override;
+    CHIP_ERROR GetDeviceAttestationCert(MutableByteSpan & outBuffer) override;
+    CHIP_ERROR GetProductAttestationIntermediateCert(MutableByteSpan & outBuffer) override;
+    CHIP_ERROR SignWithDeviceAttestationKey(const ByteSpan & messageToSign, MutableByteSpan & outSignBuffer) override;
+};
+} // namespace DeviceLayer
+} // namespace chip


### PR DESCRIPTION
**Change Overview**
 Added the code related to SecureCertDACProvider to read attestation info from esp_secure_cert_partition.
 Added the configuration of SEC_CERT_DAC_PROVIDER and code which helps to decide which implementation of
 DAC Provider to use.
 Added esp_secure_cert_mgr component.



