### PR TITLE
[Android/Java]Fix nullable and nonnull  annotation for onError in reportCallback interface

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
@@ -442,7 +442,7 @@ class WildcardFragment : Fragment() {
     val devicePointer = ChipClient.getConnectedDevicePointer(context, deviceId)
     return suspendCoroutine { cont ->
       deviceController.readAttributePath(object : ReportCallback {
-        override fun onError(attributePath: ChipAttributePath?, eventPath: ChipEventPath?, e: java.lang.Exception?) {
+        override fun onError(attributePath: ChipAttributePath?, eventPath: ChipEventPath?, e: java.lang.Exception) {
           cont.resume(0u)
         }
 

--- a/src/controller/java/src/chip/devicecontroller/ReportCallback.java
+++ b/src/controller/java/src/chip/devicecontroller/ReportCallback.java
@@ -20,12 +20,15 @@ package chip.devicecontroller;
 import chip.devicecontroller.model.ChipAttributePath;
 import chip.devicecontroller.model.ChipEventPath;
 import chip.devicecontroller.model.NodeState;
-import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /** An interface for receiving read/subscribe CHIP reports. */
 public interface ReportCallback {
-  void onError(@Nullable ChipAttributePath attributePath, @Nullable ChipEventPath eventPath, @Nonnull Exception e);
+  void onError(
+      @Nullable ChipAttributePath attributePath,
+      @Nullable ChipEventPath eventPath,
+      @Nonnull Exception e);
 
   void onReport(NodeState nodeState);
 

--- a/src/controller/java/src/chip/devicecontroller/ReportCallback.java
+++ b/src/controller/java/src/chip/devicecontroller/ReportCallback.java
@@ -20,10 +20,12 @@ package chip.devicecontroller;
 import chip.devicecontroller.model.ChipAttributePath;
 import chip.devicecontroller.model.ChipEventPath;
 import chip.devicecontroller.model.NodeState;
+import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 /** An interface for receiving read/subscribe CHIP reports. */
 public interface ReportCallback {
-  void onError(ChipAttributePath attributePath, ChipEventPath eventPath, Exception e);
+  void onError(@Nullable ChipAttributePath attributePath, @Nullable ChipEventPath eventPath, @Nonnull Exception e);
 
   void onReport(NodeState nodeState);
 


### PR DESCRIPTION
Fix nullable and nonnull annotation for onEroor in reportCallback interface
