### PR TITLE
[Python][cleanup] Simplier function signature exposed to Python

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -205,6 +205,7 @@ chip_python_wheel_action("chip-core") {
         "chip/ChipStack.py",
         "chip/FabricAdmin.py",
         "chip/__init__.py",
+        "chip/api/opcreds.py",
         "chip/ble/__init__.py",
         "chip/ble/commissioning/__init__.py",
         "chip/ble/get_adapters.py",
@@ -275,6 +276,7 @@ chip_python_wheel_action("chip-core") {
 
   py_packages = [
     "chip",
+    "chip.api",
     "chip.ble",
     "chip.ble.commissioning",
     "chip.configuration",

--- a/src/controller/python/OpCredsBinding.hpp
+++ b/src/controller/python/OpCredsBinding.hpp
@@ -1,0 +1,71 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <controller/python/chip/crypto/p256keypair.h>
+#include <lib/core/CASEAuthTag.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/support/CHIPMem.h>
+
+struct pychip_OpCredsContext;
+
+/**
+ * Parameters for allocating a CHIP Commissioner.
+ *
+ * Note: The difference between a controller and a commissioner is the commissioner contains a CA which allows it to sign NOC by
+ * itself. A controller can be used to commission other devices with the help of externally implemented CA.
+ */
+struct pychip_OpCreds_AllocateCommissionerParams
+{
+    pychip_OpCredsContext * context;
+    chip::FabricId fabricId;
+    chip::NodeId nodeId;
+    chip::VendorId adminVendorId;
+    const char * paaTrustStorePath;
+    bool useTestCommissioner;
+    bool enableServerInteractions;
+    chip::CASEAuthTag * caseAuthTags;
+    uint32_t caseAuthTagLen;
+    chip::python::pychip_P256Keypair * operationalKey;
+};
+
+/**
+ * Parameters for allocating a CHIP Controller.
+ *
+ * Note: The difference between a controller and a commissioner is the commissioner contains a CA which allows it to sign NOC by
+ * itself. A controller can be used to commission other devices with the help of externally implemented CA.
+ *
+ * To initialize a controller, an NOC and a RCAC must be provided, and an optional ICAC may be provided. The NodeId and the FabricId
+ * will be extracted from the provided NOC.
+ */
+struct pychip_OpCreds_AllocateControllerParams
+{
+    chip::VendorId adminVendorId;
+    bool enableServerInteractions;
+    chip::python::pychip_P256Keypair * operationalKey;
+
+    const uint8_t * noc;
+    uint32_t nocLen;
+    const uint8_t * icac;
+    uint32_t icacLen;
+    const uint8_t * rcac;
+    uint32_t rcacLen;
+    const uint8_t * ipk;
+    uint32_t ipkLen;
+};

--- a/src/controller/python/chip/api/opcreds.py
+++ b/src/controller/python/chip/api/opcreds.py
@@ -1,0 +1,111 @@
+#
+#    Copyright (c) 2023 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+from ctypes import POINTER, Structure, byref, c_bool, c_char_p, c_uint8, c_uint32, c_void_p
+from typing import List
+
+from chip import native
+
+
+class chip_Controller_DeviceCommissioner(c_void_p):
+    pass
+
+
+class pychip_OpCreds_AllocateControllerParams(Structure):
+    _fields_ = [
+        ('adminVendorId', native.VendorId),
+        ('enableServerInteractions', c_bool),
+        ('operationalKey', native.pychip_P256Keypair),
+        ('noc', POINTER(c_uint8)),
+        ('nocLen', c_uint32),
+        ('icac', POINTER(c_uint8)),
+        ('icacLen', c_uint32),
+        ('rcac', POINTER(c_uint8)),
+        ('rcacLen', c_uint32),
+        ('ipk', POINTER(c_uint8)),
+        ('ipkLen', c_uint32),
+    ]
+
+
+class pychip_OpCreds_AllocateCommissionerParams(Structure):
+    _fields_ = [
+        ('opCredsContext', c_void_p),
+        ('fabricId', native.FabricId),
+        ('nodeId', native.NodeId),
+        ('adminVendorId', native.VendorId),
+        ('paaTrustStorePath', c_char_p),
+        ('useTestCommissioner', c_bool),
+        ('enableServerInteractions', c_bool),
+        ('caseAuthTags', POINTER(native.CASEAuthTag)),
+        ('caseAuthTagsLen', c_uint32),
+        ('operationalKey', native.pychip_P256Keypair),
+    ]
+
+
+@native.native_function
+def pychip_OpCreds_AllocateCommissioner(param: POINTER(pychip_OpCreds_AllocateControllerParams), ret_commissioner: POINTER(
+    chip_Controller_DeviceCommissioner)) -> native.PyChipError: ...
+
+
+@native.native_function
+def pychip_OpCreds_AllocateController(param: POINTER(pychip_OpCreds_AllocateControllerParams), ret_commissioner: POINTER(
+    chip_Controller_DeviceCommissioner)) -> native.PyChipError: ...
+
+
+def allocate_commissioner(fabricId: int, nodeId: int, adminVendorId: int,
+                          opCredsContext: c_void_p,
+                          caseAuthTags: List[int] = [],
+                          paaTrustStorePath: str = "", useTestCommissioner: bool = True,
+                          operationalKey: native.pychip_P256Keypair = None) -> chip_Controller_DeviceCommissioner:
+    params = pychip_OpCreds_AllocateCommissionerParams()
+    params.opCredsContext = opCredsContext
+    params.fabricId = fabricId
+    params.nodeId = nodeId
+    params.adminVendorId = adminVendorId
+    params.caseAuthTags = (c_uint32 * len(caseAuthTags))(*caseAuthTags)
+    params.caseAuthTagsLen = len(caseAuthTags)
+    params.paaTrustStorePath = paaTrustStorePath.encode()
+    params.useTestCommissioner = useTestCommissioner
+    params.operationalKey = operationalKey
+
+    ret = chip_Controller_DeviceCommissioner()
+
+    err = pychip_OpCreds_AllocateCommissioner(byref(params), byref(ret))
+    err.raise_on_error()
+
+    return ret
+
+
+def allocate_controller(noc: bytes, icac: bytes, rcac: bytes, ipk: bytes, operationalKey: native.pychip_P256Keypair, adminVendorId: native.VendorId) -> chip_Controller_DeviceCommissioner:
+    params = pychip_OpCreds_AllocateControllerParams()
+    params.adminVendorId = adminVendorId
+    params.noc = noc
+    params.nocLen = len(noc)
+    params.icac = icac
+    params.icacLen = len(icac) if icac else 0
+    params.rcac = rcac
+    params.rcacLen = len(rcac)
+    params.ipk = ipk
+    params.ipkLen = len(ipk)
+    params.operationalKey = operationalKey
+
+    ret = chip_Controller_DeviceCommissioner()
+
+    err = pychip_OpCreds_AllocateController(byref(params), byref(ret))
+    err.raise_on_error()
+
+    return ret


### PR DESCRIPTION
Fixes #25214 

This PR makes a cleanup on arguemtns of `pychip_OpCreds_AllocateController` (renamed from `pychip_OpCreds_AllocateControllerForPythonCommissioningFLow`) and `pychip_OpCreds_AllocateCommissioner` for better readability.

