### PR TITLE
[Tizen] Improve BLE scan logging

### DIFF
--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -104,16 +104,15 @@ static void __AdapterStateChangedCb(int result, bt_adapter_state_e adapterState,
 
 void BLEManagerImpl::GattConnectionStateChangedCb(int result, bool connected, const char * remoteAddress, void * userData)
 {
-    ChipLogProgress(DeviceLayer, "Gatt Connection State Changed [%u]: %s", result, connected ? "Connected" : "Disconnected");
     switch (result)
     {
     case BT_ERROR_NONE:
     case BT_ERROR_ALREADY_DONE:
+        ChipLogProgress(DeviceLayer, "GATT %s", connected ? "connected" : "disconnected");
         sInstance.HandleConnectionEvent(connected, remoteAddress);
         break;
     default:
-        ChipLogError(DeviceLayer, "%s: %s", connected ? "Connection req failed" : "Disconnection req failed",
-                     get_error_message(result));
+        ChipLogError(DeviceLayer, "GATT %s failed: %s", connected ? "connection" : "disconnection", get_error_message(result));
         if (connected)
             sInstance.NotifyHandleConnectFailed(CHIP_ERROR_INTERNAL);
     }
@@ -405,9 +404,9 @@ void BLEManagerImpl::NotifyBLEDisconnection(BLE_CONNECTION_OBJECT conId, CHIP_ER
 
 void BLEManagerImpl::NotifyHandleConnectFailed(CHIP_ERROR error)
 {
+    ChipLogProgress(DeviceLayer, "Connection failed: %" CHIP_ERROR_FORMAT, error.Format());
     if (sInstance.mIsCentral)
     {
-        ChipLogProgress(DeviceLayer, "Connection Failed: Post Platform event");
         ChipDeviceEvent event;
         event.Type                                    = DeviceEventType::kPlatformTizenBLECentralConnectFailed;
         event.Platform.BLECentralConnectFailed.mError = error;

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -28,6 +28,7 @@
 #include <utility>
 
 #include <bluetooth.h>
+#include <bluetooth_internal.h>
 
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Span.h>
@@ -170,9 +171,11 @@ exit:
 
 static bool __IsScanFilterSupported()
 {
-    // Tizen API: bt_adapter_le_is_scan_filter_supported() is currently internal
-    // Defaulting to true
-    return true;
+    bool is_supported;
+    int ret = bt_adapter_le_is_scan_filter_supported(&is_supported);
+    VerifyOrReturnValue(ret == BT_ERROR_NONE, false,
+                        ChipLogError(DeviceLayer, "bt_adapter_le_is_scan_filter_supported() failed: %s", get_error_message(ret)));
+    return is_supported;
 }
 
 void ChipDeviceScanner::CheckScanFilter(ScanFilterType filterType, ScanFilterData & filterData)

--- a/src/platform/Tizen/ChipDeviceScanner.h
+++ b/src/platform/Tizen/ChipDeviceScanner.h
@@ -30,6 +30,7 @@
 
 #include <ble/CHIPBleServiceData.h>
 #include <lib/core/CHIPError.h>
+#include <system/SystemClock.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -85,7 +86,7 @@ public:
     ~ChipDeviceScanner(void);
 
     /// Initiate a scan for devices, with the given timeout & scan filter data
-    CHIP_ERROR StartChipScan(unsigned timeoutMs, ScanFilterType filterType, ScanFilterData & filterData);
+    CHIP_ERROR StartChipScan(System::Clock::Timeout timeout, ScanFilterType filterType, ScanFilterData & filterData);
 
     /// Stop any currently running scan
     CHIP_ERROR StopChipScan(void);
@@ -107,6 +108,7 @@ private:
     bool mIsScanning                      = false;
     bool mIsStopping                      = false;
     GMainLoop * mAsyncLoop                = nullptr;
+    unsigned int mScanTimeoutMs           = 10000;
     bt_scan_filter_h mScanFilter          = nullptr;
 };
 


### PR DESCRIPTION
### Problem

BLE scan logs non-error level messages as error. Also, it does not show error reason, but bare numbers which are hard to decipher.

### Changes

- use System::Clock::Timeout for timeout
- do not report progress messages as error
- convert error code to message when printing logs
- check BLE scan filter support with proper Tizen API

### Testing

Tested locally with:
```
dlogutil CHIP &
/opt/usr/apps/chip-tool pairing ble-wifi 1 <SSID> <pass> 20202021 3840
```