### PR TITLE
[Silabs] Bugfixes for wifi NCP and SoC

### DIFF
--- a/examples/platform/silabs/SiWx917/SiWx917/rsi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/rsi_if.c
@@ -109,10 +109,24 @@ int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap)
  *********************************************************************/
 int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info)
 {
-    /* TODO : Place holder until we have similar functionality
-     *        available for SiWx917
-     */
-    int32_t status = 0;
+    int32_t status;
+    uint8_t buff[RSI_RESPONSE_MAX_SIZE] = { 0 };
+    status                              = rsi_wlan_get(RSI_WLAN_EXT_STATS, buff, sizeof(buff));
+    if (status != RSI_SUCCESS)
+    {
+        WFX_RSI_LOG("\r\n Failed, Error Code : 0x%lX\r\n", status);
+    }
+    else
+    {
+        rsi_wlan_ext_stats_t * test   = (rsi_wlan_ext_stats_t *) buff;
+        extra_info->beacon_lost_count = test->beacon_lost_count - temp_reset->beacon_lost_count;
+        extra_info->beacon_rx_count   = test->beacon_rx_count - temp_reset->beacon_rx_count;
+        extra_info->mcast_rx_count    = test->mcast_rx_count - temp_reset->mcast_rx_count;
+        extra_info->mcast_tx_count    = test->mcast_tx_count - temp_reset->mcast_tx_count;
+        extra_info->ucast_rx_count    = test->ucast_rx_count - temp_reset->ucast_rx_count;
+        extra_info->ucast_tx_count    = test->ucast_tx_count - temp_reset->ucast_tx_count;
+        extra_info->overrun_count     = test->overrun_count - temp_reset->overrun_count;
+    }
     return status;
 }
 
@@ -126,10 +140,24 @@ int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info)
  *********************************************************************/
 int32_t wfx_rsi_reset_count()
 {
-    /* TODO : Place holder until we have similar functionality
-     *        available for SiWx917
-     */
-    int32_t status = 0;
+    int32_t status;
+    uint8_t buff[RSI_RESPONSE_MAX_SIZE] = { 0 };
+    status                              = rsi_wlan_get(RSI_WLAN_EXT_STATS, buff, sizeof(buff));
+    if (status != RSI_SUCCESS)
+    {
+        WFX_RSI_LOG("\r\n Failed, Error Code : 0x%lX\r\n", status);
+    }
+    else
+    {
+        rsi_wlan_ext_stats_t * test   = (rsi_wlan_ext_stats_t *) buff;
+        temp_reset->beacon_lost_count = test->beacon_lost_count;
+        temp_reset->beacon_rx_count   = test->beacon_rx_count;
+        temp_reset->mcast_rx_count    = test->mcast_rx_count;
+        temp_reset->mcast_tx_count    = test->mcast_tx_count;
+        temp_reset->ucast_rx_count    = test->ucast_rx_count;
+        temp_reset->ucast_tx_count    = test->ucast_tx_count;
+        temp_reset->overrun_count     = test->overrun_count;
+    }
     return status;
 }
 

--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -116,10 +116,6 @@ int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap)
  *********************************************************************/
 int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info)
 {
-#ifdef SiWx917_WIFI
-    // TODO: for wisemcu
-    return 0;
-#else
     int32_t status;
     uint8_t buff[RSI_RESPONSE_MAX_SIZE] = { 0 };
     status                              = rsi_wlan_get(RSI_WLAN_EXT_STATS, buff, sizeof(buff));
@@ -139,7 +135,6 @@ int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info)
         extra_info->overrun_count     = test->overrun_count - temp_reset->overrun_count;
     }
     return status;
-#endif
 }
 
 /******************************************************************
@@ -152,10 +147,6 @@ int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info)
  *********************************************************************/
 int32_t wfx_rsi_reset_count()
 {
-#ifdef SiWx917_WIFI
-    // TODO: for wisemcu
-    return 0;
-#else
     int32_t status;
     uint8_t buff[RSI_RESPONSE_MAX_SIZE] = { 0 };
     status                              = rsi_wlan_get(RSI_WLAN_EXT_STATS, buff, sizeof(buff));
@@ -175,7 +166,6 @@ int32_t wfx_rsi_reset_count()
         temp_reset->overrun_count     = test->overrun_count;
     }
     return status;
-#endif
 }
 
 /******************************************************************

--- a/examples/platform/silabs/efr32/wf200/host_if.cpp
+++ b/examples/platform/silabs/efr32/wf200/host_if.cpp
@@ -578,11 +578,6 @@ static void wfx_events_task(void * p_arg)
                 {
                     wfx_ipv6_notify(1);
                     hasNotifiedIPV6 = true;
-
-                    // send device to power save mode
-                    sl_wfx_set_power_mode(WFM_PM_MODE_DTIM, WFM_PM_POLL_FAST_PS, 0);
-                    sl_wfx_enable_device_power_save();
-
                     if (!hasNotifiedWifiConnectivity)
                     {
                         wfx_connected_notify(CONNECTION_STATUS_SUCCESS, &ap_mac);
@@ -611,7 +606,7 @@ static void wfx_events_task(void * p_arg)
             if (!(wfx_get_wifi_state() & SL_WFX_AP_INTERFACE_UP))
             {
                 // Enable the power save
-                sl_wfx_set_power_mode(WFM_PM_MODE_PS, WFM_PM_POLL_UAPSD, BEACON_1);
+                sl_wfx_set_power_mode(WFM_PM_MODE_DTIM, WFM_PM_POLL_FAST_PS, BEACON_1);
                 sl_wfx_enable_device_power_save();
             }
 #endif // SLEEP_ENABLED

--- a/src/lib/shell/MainLoopEFR32.cpp
+++ b/src/lib/shell/MainLoopEFR32.cpp
@@ -176,6 +176,10 @@ void ProcessShellLine(intptr_t args)
         }
     }
     MemoryFree(line);
+#ifdef BRD4325A
+    // small delay for uart print
+    vTaskDelay(1);
+#endif
     streamer_printf(streamer_get(), kShellPrompt);
 }
 

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -83,7 +83,6 @@ template("siwx917_sdk") {
       "SILABS_LOG_ENABLED=${silabs_log_enabled}",
       "SL_HEAP_SIZE=32768",
       "SL_WIFI=1",
-      "SiWx917_WIFI",
       "CCP_SI917_BRINGUP",
       "RS911X_WIFI",
       "RSI_WLAN_ENABLE",

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -229,10 +229,7 @@ template("efr32_sdk") {
         ]
       }
       if (use_SiWx917) {
-        #Added this flag only for SiwX917 NCP board
-        #TODO: Remove when rsi_wlan_ext_stats gets implemented using Wisemcu SDK
         defines += [
-          "SiWx917_WIFI",
           "EXP_BOARD=1",
           "CHIP_9117=1",
         ]
@@ -313,6 +310,8 @@ template("efr32_sdk") {
         "SL_CATALOG_POWER_MANAGER_PRESENT",
         "SL_CATALOG_SLEEPTIMER_PRESENT",
         "SL_SLEEP_TIME_MS=${sleep_time_ms}",
+        # Used for wifi devices to get packet details
+        "WIFI_DEBUG_ENABLED=1",
       ]
     }
 

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -310,6 +310,7 @@ template("efr32_sdk") {
         "SL_CATALOG_POWER_MANAGER_PRESENT",
         "SL_CATALOG_SLEEPTIMER_PRESENT",
         "SL_SLEEP_TIME_MS=${sleep_time_ms}",
+
         # Used for wifi devices to get packet details
         "WIFI_DEBUG_ENABLED=1",
       ]


### PR DESCRIPTION
Fixes for wifi for Silabs wifi
1. removing the duplicate wf200 power save
2. Adding `wfx_rsi_get_ap_ext` for NCP and SCP from the latest wisemcu
3. adding a small delay for UART for matter shell
4. Enabled wifi logs for sleepy