### PR TITLE
doc: doc structure edits

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -434,6 +434,7 @@ Dnsmasq
 dnsmasqd
 DNSSD
 DNSStubListener
+docbuild
 Dockerfile
 Dockerfiles
 Don'ts

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Builds](https://github.com/project-chip/connectedhomeip/workflows/Builds/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/build.yaml)
 
-**Examples:** [![Examples - EFR32](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20EFR32/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-efr32.yaml)
+**Examples:**
+[![Examples - EFR32](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20EFR32/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-efr32.yaml)
 [![Examples - ESP32](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20ESP32/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-esp32.yaml)
 [![Examples - i.MX Linux](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20i.MX%20Linux/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-linux-imx.yaml)
 [![Examples - K32W with SE051](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20K32W%20with%20SE051/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-k32w.yaml)
@@ -14,15 +15,19 @@
 [![Build example - Infineon](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-infineon.yaml/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-infineon.yaml)
 [![Build example - BouffaloLab](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20BouffaloLab/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-bouffalolab.yaml)
 
-**Platforms:** [![Android](https://github.com/project-chip/connectedhomeip/workflows/Android/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/android.yaml)
+**Platforms:**
+[![Android](https://github.com/project-chip/connectedhomeip/workflows/Android/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/android.yaml)
 
-**Tests:** [![Unit / Integration Tests](https://github.com/project-chip/connectedhomeip/workflows/Unit%20/%20Integration%20Tests/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/unit_integration_test.yaml)
+**Tests:**
+[![Unit / Integration Tests](https://github.com/project-chip/connectedhomeip/workflows/Unit%20/%20Integration%20Tests/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/unit_integration_test.yaml)
 [![Cirque](https://github.com/project-chip/connectedhomeip/workflows/Cirque/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/cirque.yaml)
 [![QEMU](https://github.com/project-chip/connectedhomeip/workflows/QEMU/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/qemu.yaml)
 
-**Tools:** [![ZAP Templates](https://github.com/project-chip/connectedhomeip/workflows/ZAP/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/zap_templates.yaml)
+**Tools:**
+[![ZAP Templates](https://github.com/project-chip/connectedhomeip/workflows/ZAP/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/zap_templates.yaml)
 
-**Documentation:** [![Documentation Build](https://github.com/project-chip/connectedhomeip/actions/workflows/docbuild.yaml/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/docbuild.yaml)
+**Documentation:**
+[![Documentation Build](https://github.com/project-chip/connectedhomeip/actions/workflows/docbuild.yaml/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/docbuild.yaml)
 
 -   [Matter SDK documentation page](https://project-chip.github.io/connectedhomeip-doc/index.html)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Builds](https://github.com/project-chip/connectedhomeip/workflows/Builds/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/build.yaml)
 
-[![Examples - EFR32](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20EFR32/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-efr32.yaml)
+**Examples:** [![Examples - EFR32](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20EFR32/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-efr32.yaml)
 [![Examples - ESP32](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20ESP32/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-esp32.yaml)
 [![Examples - i.MX Linux](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20i.MX%20Linux/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-linux-imx.yaml)
 [![Examples - K32W with SE051](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20K32W%20with%20SE051/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-k32w.yaml)
@@ -14,13 +14,17 @@
 [![Build example - Infineon](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-infineon.yaml/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-infineon.yaml)
 [![Build example - BouffaloLab](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20BouffaloLab/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/examples-bouffalolab.yaml)
 
-[![Android](https://github.com/project-chip/connectedhomeip/workflows/Android/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/android.yaml)
+**Platforms:** [![Android](https://github.com/project-chip/connectedhomeip/workflows/Android/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/android.yaml)
 
-[![Unit / Integration Tests](https://github.com/project-chip/connectedhomeip/workflows/Unit%20/%20Integration%20Tests/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/unit_integration_test.yaml)
+**Tests:** [![Unit / Integration Tests](https://github.com/project-chip/connectedhomeip/workflows/Unit%20/%20Integration%20Tests/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/unit_integration_test.yaml)
 [![Cirque](https://github.com/project-chip/connectedhomeip/workflows/Cirque/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/cirque.yaml)
 [![QEMU](https://github.com/project-chip/connectedhomeip/workflows/QEMU/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/qemu.yaml)
 
-[![ZAP Templates](https://github.com/project-chip/connectedhomeip/workflows/ZAP/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/zap_templates.yaml)
+**Tools:** [![ZAP Templates](https://github.com/project-chip/connectedhomeip/workflows/ZAP/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/zap_templates.yaml)
+
+**Documentation:** [![Documentation Build](https://github.com/project-chip/connectedhomeip/actions/workflows/docbuild.yaml/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/docbuild.yaml)
+
+-   [Matter SDK documentation page](https://project-chip.github.io/connectedhomeip-doc/index.html)
 
 # About
 
@@ -180,26 +184,26 @@ Instructions about how to build Matter can be found [here](./docs/README.md) .
 
 The Matter repository is structured as follows:
 
-| File/Folder        | Content                                                            |
-| ------------------ | ------------------------------------------------------------------ |
-| build              | Build system support content and built output directories          |
-| build_overrides    | Build system parameter customization for different platforms       |
-| config             | Project configurations                                             |
-| credentials        | Development and test credentials                                   |
-| docs               | Documentation, including guides                                    |
-| examples           | Example firmware applications that demonstrate use of Matter       |
-| integrations       | 3rd Party integrations                                             |
-| scripts            | Scripts needed to work with the Matter repository                  |
-| src                | Implementation of Matter                                           |
-| third_party        | 3rd party code used by Matter                                      |
-| zzz_generated      | zap generated template code - Revolving around cluster information |
-| BUILD.gn           | Build file for the gn build system                                 |
-| CODE_OF_CONDUCT.md | Code of conduct for Matter and contribution to it                  |
-| CONTRIBUTING.md    | Guidelines for contributing to Matter                              |
-| LICENSE            | Matter license file                                                |
-| REVIEWERS.md       | PR reviewers                                                       |
-| gn_build.sh        | Build script for specific projects such as Android, EFR32, etc.    |
-| README.md          | This File                                                          |
+| File/Folder        | Content                                                                                                                                               |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| build              | Build system support content and built output directories                                                                                             |
+| build_overrides    | Build system parameter customization for different platforms                                                                                          |
+| config             | Project configurations                                                                                                                                |
+| credentials        | Development and test credentials                                                                                                                      |
+| docs               | Documentation, including guides. Visit the [Matter SDK documentation page](https://project-chip.github.io/connectedhomeip-doc/index.html) to read it. |
+| examples           | Example firmware applications that demonstrate use of Matter                                                                                          |
+| integrations       | 3rd Party integrations                                                                                                                                |
+| scripts            | Scripts needed to work with the Matter repository                                                                                                     |
+| src                | Implementation of Matter                                                                                                                              |
+| third_party        | 3rd party code used by Matter                                                                                                                         |
+| zzz_generated      | zap generated template code - Revolving around cluster information                                                                                    |
+| BUILD.gn           | Build file for the gn build system                                                                                                                    |
+| CODE_OF_CONDUCT.md | Code of conduct for Matter and contribution to it                                                                                                     |
+| CONTRIBUTING.md    | Guidelines for contributing to Matter                                                                                                                 |
+| LICENSE            | Matter license file                                                                                                                                   |
+| REVIEWERS.md       | PR reviewers                                                                                                                                          |
+| gn_build.sh        | Build script for specific projects such as Android, EFR32, etc.                                                                                       |
+| README.md          | This File                                                                                                                                             |
 
 # License
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(MATTER_BASE / "docs" / "_extensions"))
 # -- Project information -----------------------------------------------------
 
 project = "Matter"
-copyright = "2022, Matter Contributors"
+copyright = "2020-2023, Matter Contributors"
 author = "Matter Contributors"
 version = "1.0.0"
 
@@ -31,6 +31,7 @@ exclude_patterns = [
     "examples/providers/README.md",
     "examples/thermostat/nxp/linux-se05x/README.md",
     "examples/common/m5stack-tft/repo",
+    "docs/guides/README.md",
 ]
 
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -6,7 +6,56 @@ and features.
 ```{toctree}
 :glob:
 :maxdepth: 1
+:hidden:
 
 *
 esp32/README
 ```
+
+## Build Guides
+
+-   [Building](./BUILDING.md)
+
+## Platform Guides
+
+-   [Android - Building](./android_building.md)
+-   [Apple - Testing with iPhone, iPad, macOS, Apple TV, HomePod, Watch, etc](./darwin.md)
+-   [Espressif (ESP32) - Getting Started Guide](./esp32/README.md)
+-   [Infineon PSoC6 - Software Update](./infineon_psoc6_software_update.md)
+-   [Linux - Simulated Devices](./simulated_device_linux.md)
+-   [mbedOS - Adding a new target](./mbedos_add_new_target.md)
+-   [mbedOS - Commissioning](./mbedos_commissioning.md)
+-   [mbedOS - Platform Overview](./mbedos_platform_overview.md)
+-   [nRF Connect - Android Commissioning](./nrfconnect_android_commissioning.md)
+-   [nRF Connect - CLI Guide](./nrfconnect_examples_cli.md)
+-   [nRF Connect - Configuration](./nrfconnect_examples_configuration.md)
+-   [nRF Connect - Factory Data Configuration](./nrfconnect_factory_data_configuration.md)
+-   [nRF Connect - Platform Overview](./nrfconnect_platform_overview.md)
+-   [nRF Connect - Software Update](./nrfconnect_examples_software_update.md)
+-   [NXP - Android Commissioning](./nxp_k32w_android_commissioning.md)
+-   [NXP - Linux Examples](./nxp_imx8m_linux_examples.md)
+-   [Silicon Labs - Documentation](https://github.com/SiliconLabs/matter#readme)
+-   [Silicon Labs - Building](./silabs_efr32_building.md)
+-   [Silicon Labs - Software Update](./silabs_efr32_software_update.md)
+-   [TI - Platform Overview](./ti_platform_overview.md)
+
+## Tool Guides
+
+-   [CHIP Tool](./chip_tool_guide.md)
+-   [Python Matter-Repl](./matter-repl.md)
+-   [python-chip-controller - Advanced](./python_chip_controller_advanced_usage.md)
+-   [python-chip-controller - Building](./python_chip_controller_building.md)
+
+## Development Guides
+
+-   [Access Control](./access-control-guide.md)
+-   [IP Commissioning](./ip_commissioning.md)
+
+## Setup Guides
+
+-   [Open Thread - Hardware suggestions](./openthread_rcp_nrf_dongle.md)
+-   [Open Thread - Setting up a Raspberry Pi as a Border Router](./openthread_border_router_pi.md)
+
+## Troubleshooting Guides
+
+-   [Avahi - Troubleshooting](./troubleshooting_avahi.md)


### PR DESCRIPTION
Updated landing page for Guides with structure from guides/README.md.
Excluded guides/README.md from doxygen build, so it only shows in the GitHub markdown preview.
Added links to docs on the main README.md, so that the doc page is possible to be found.

