### PR TITLE
[Silabs]Added file path in build gn for mqtt transport interface

### DIFF
--- a/examples/platform/silabs/SiWx917/BUILD.gn
+++ b/examples/platform/silabs/SiWx917/BUILD.gn
@@ -76,7 +76,7 @@ if (enable_dic) {
   config("efr32_dic_config") {
     include_dirs = [
       "${chip_root}/third_party/silabs/mqtt/stack",
-      "${chip_root}/examples/platform/silabs/DIC/mqtt_transport_interface/include",
+      "${chip_root}/third_party/silabs/mqtt/mqtt_transport_interface/include",
       "${chip_root}/examples/platform/silabs/DIC/matter_abs_interface/include",
     ]
   }
@@ -84,12 +84,12 @@ if (enable_dic) {
   source_set("efr32-dic") {
     sources = [
       "${chip_root}/examples/platform/silabs/DIC/matter_abs_interface/src/dic.c",
-      "${chip_root}/examples/platform/silabs/DIC/mqtt_transport_interface/src/MQTT_transport.c",
-      "${chip_root}/examples/platform/silabs/DIC/mqtt_transport_interface/src/altcp.c",
-      "${chip_root}/examples/platform/silabs/DIC/mqtt_transport_interface/src/altcp_alloc.c",
-      "${chip_root}/examples/platform/silabs/DIC/mqtt_transport_interface/src/altcp_tcp.c",
-      "${chip_root}/examples/platform/silabs/DIC/mqtt_transport_interface/src/altcp_tls_mbedtls.c",
-      "${chip_root}/examples/platform/silabs/DIC/mqtt_transport_interface/src/altcp_tls_mbedtls_mem.c",
+      "${chip_root}/third_party/silabs/mqtt/mqtt_transport_interface/src/MQTT_transport.c",
+      "${chip_root}/third_party/silabs/mqtt/mqtt_transport_interface/src/altcp.c",
+      "${chip_root}/third_party/silabs/mqtt/mqtt_transport_interface/src/altcp_alloc.c",
+      "${chip_root}/third_party/silabs/mqtt/mqtt_transport_interface/src/altcp_tcp.c",
+      "${chip_root}/third_party/silabs/mqtt/mqtt_transport_interface/src/altcp_tls_mbedtls.c",
+      "${chip_root}/third_party/silabs/mqtt/mqtt_transport_interface/src/altcp_tls_mbedtls_mem.c",
     ]
     public_deps = [
       "${chip_root}/src/inet",

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -100,7 +100,7 @@ if (enable_dic) {
   config("efr32_dic_config") {
     include_dirs = [
       "${chip_root}/third_party/silabs/mqtt/stack",
-      "${chip_root}/examples/platform/silabs/DIC/mqtt_transport_interface/include",
+      "${chip_root}/third_party/silabs/mqtt/mqtt_transport_interface/include",
       "${chip_root}/examples/platform/silabs/DIC/matter_abs_interface/include",
     ]
   }
@@ -108,12 +108,12 @@ if (enable_dic) {
   source_set("efr32-dic") {
     sources = [
       "${chip_root}/examples/platform/silabs/DIC/matter_abs_interface/src/dic.c",
-      "${chip_root}/examples/platform/silabs/DIC/mqtt_transport_interface/src/MQTT_transport.c",
-      "${chip_root}/examples/platform/silabs/DIC/mqtt_transport_interface/src/altcp.c",
-      "${chip_root}/examples/platform/silabs/DIC/mqtt_transport_interface/src/altcp_alloc.c",
-      "${chip_root}/examples/platform/silabs/DIC/mqtt_transport_interface/src/altcp_tcp.c",
-      "${chip_root}/examples/platform/silabs/DIC/mqtt_transport_interface/src/altcp_tls_mbedtls.c",
-      "${chip_root}/examples/platform/silabs/DIC/mqtt_transport_interface/src/altcp_tls_mbedtls_mem.c",
+      "${chip_root}/third_party/silabs/mqtt/mqtt_transport_interface/src/MQTT_transport.c",
+      "${chip_root}/third_party/silabs/mqtt/mqtt_transport_interface/src/altcp.c",
+      "${chip_root}/third_party/silabs/mqtt/mqtt_transport_interface/src/altcp_alloc.c",
+      "${chip_root}/third_party/silabs/mqtt/mqtt_transport_interface/src/altcp_tcp.c",
+      "${chip_root}/third_party/silabs/mqtt/mqtt_transport_interface/src/altcp_tls_mbedtls.c",
+      "${chip_root}/third_party/silabs/mqtt/mqtt_transport_interface/src/altcp_tls_mbedtls_mem.c",
     ]
     public_deps = [
       "${chip_root}/src/inet",


### PR DESCRIPTION
Added:

Mqtt transport interface files move to third party/silabs/mqtt,  for that added file path in build gn for mqtt transport interface files, 

