### PR TITLE
Show command help text in chip-tool cluster listings.

### DIFF
--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -399,6 +399,23 @@ void Commands::ShowCluster(std::string executable, std::string clusterName, Comm
         if (shouldPrint)
         {
             fprintf(stderr, "  | * %-82s|\n", command->GetName());
+            const char * helpText = command->GetHelpText();
+            if (command->GetHelpText())
+            {
+                // We leave 82 chars for command names.  The help text starts
+                // two chars further to the right, so there are 80 chars left
+                // for it.
+                if (strlen(helpText) > 80)
+                {
+                    // Add "..." at the end to indicate truncation, and only
+                    // show the first 77 chars, since that's what will fit.
+                    fprintf(stderr, "  |   - %.77s...|\n", helpText);
+                }
+                else
+                {
+                    fprintf(stderr, "  |   - %-80s|\n", helpText);
+                }
+            }
         }
     }
     fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");

--- a/examples/chip-tool/commands/pairing/CloseSessionCommand.h
+++ b/examples/chip-tool/commands/pairing/CloseSessionCommand.h
@@ -27,8 +27,8 @@ class CloseSessionCommand : public CHIPCommand
 {
 public:
     CloseSessionCommand(CredentialIssuerCommands * credIssuerCommands) :
-        CHIPCommand("close-session", credIssuerCommands), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
-        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
+        CHIPCommand("close-session", credIssuerCommands, "Sends a CloseSession message to the given destination node id."),
+        mOnDeviceConnectedCallback(OnDeviceConnectedFn, this), mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {
         AddArgument("destination-id", 0, UINT64_MAX, &mDestinationId);
         AddArgument("timeout", 0, UINT64_MAX, &mTimeoutSecs,


### PR DESCRIPTION
Also adds help text for the close-session command.

