### PR TITLE
IDL codegen type lookup: mark bitmaps to be bitmaps

### DIFF
--- a/scripts/py_matter_idl/matter_idl/generators/types.py
+++ b/scripts/py_matter_idl/matter_idl/generators/types.py
@@ -379,7 +379,7 @@ def ParseDataType(data_type: DataType, lookup: TypeLookupContext) -> Union[Basic
     elif lowercase_name in ['enum8', 'enum16', 'enum32']:
         return IdlEnumType(idl_name=lowercase_name, base_type=__CHIP_SIZED_TYPES__[lowercase_name])
     elif lowercase_name in ['bitmap8', 'bitmap16', 'bitmap24', 'bitmap32']:
-        return IdlEnumType(idl_name=lowercase_name, base_type=__CHIP_SIZED_TYPES__[lowercase_name])
+        return IdlBitmapType(idl_name=lowercase_name, base_type=__CHIP_SIZED_TYPES__[lowercase_name])
 
     int_type = __CHIP_SIZED_TYPES__.get(lowercase_name, None)
     if int_type is not None:


### PR DESCRIPTION
I belive a copy&paste resulted in bitmaps showing up as enums.

Fix this.