### PR TITLE
[Silabs] Fix enable_openthread_cli/uart build configuration

### DIFF
--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -58,7 +58,6 @@ assert(!(use_wf200 && chip_enable_openthread))
 
 if (chip_enable_wifi) {
   assert(use_rs9116 || use_wf200 || use_SiWx917)
-  enable_openthread_cli = false
   import("${chip_root}/src/platform/silabs/efr32/wifi_args.gni")
 
   if (use_rs9116) {
@@ -293,8 +292,7 @@ source_set("efr32-common") {
     sources += [ "LEDWidget.cpp" ]
   }
 
-  if (chip_enable_pw_rpc || chip_build_libshell || enable_openthread_cli ||
-      use_wf200 || use_rs9116) {
+  if (chip_enable_pw_rpc || chip_build_libshell || enable_openthread_cli) {
     sources += [ "uart.cpp" ]
   }
 

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -73,12 +73,9 @@ silabs_executable("efr32_device_tests") {
     "${examples_common_plat_dir}/PigweedLogger.cpp",
     "${examples_common_plat_dir}/heap_4_silabs.c",
     "${examples_plat_dir}/init_efrPlatform.cpp",
+    "${examples_plat_dir}/uart.cpp",
     "src/main.cpp",
   ]
-
-  if (chip_enable_pw_rpc || chip_build_libshell || enable_openthread_cli) {
-    sources += [ "${examples_plat_dir}/uart.cpp" ]
-  }
 
   deps = [
     ":nl_test_service.nanopb_rpc",

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -34,10 +34,8 @@ declare_args() {
   # Build openthread with prebuilt silabs lib
   use_silabs_thread_lib = false
 
-  # This undefined value (-1) is used to set a conditional default
-  # when users don't set it in build args
-  enable_openthread_cli = -1
-
+  # enable by default for thread/non-wifi-ncp builds
+  enable_openthread_cli = !(use_rs9116 || use_wf200 || use_SiWx917)
   kvs_max_entries = 255
 
   # Use Silabs factory data provider example.
@@ -66,11 +64,6 @@ declare_args() {
   sl_ot_efr32_root =
       "${efr32_sdk_root}/protocol/openthread/platform-abstraction/efr32"
   sl_openthread_root = "${efr32_sdk_root}/util/third_party/openthread"
-}
-
-if (enable_openthread_cli == -1) {
-  # enable by default for thread/non-wifi-ncp builds
-  enable_openthread_cli = !(use_rs9116 || use_wf200 || use_SiWx917)
 }
 
 # Defines an efr32 SDK build target.

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -33,7 +33,10 @@ declare_args() {
 
   # Build openthread with prebuilt silabs lib
   use_silabs_thread_lib = false
-  enable_openthread_cli = true
+
+  # This undefined value (-1) is used to set a conditional default
+  # when users don't set it in build args
+  enable_openthread_cli = -1
 
   kvs_max_entries = 255
 
@@ -63,6 +66,11 @@ declare_args() {
   sl_ot_efr32_root =
       "${efr32_sdk_root}/protocol/openthread/platform-abstraction/efr32"
   sl_openthread_root = "${efr32_sdk_root}/util/third_party/openthread"
+}
+
+if (enable_openthread_cli == -1) {
+  # enable by default for thread/non-wifi-ncp builds
+  enable_openthread_cli = !(use_rs9116 || use_wf200 || use_SiWx917)
 }
 
 # Defines an efr32 SDK build target.


### PR DESCRIPTION
This pr fix an issue where `enable_openthread_cli` default value was defining some values and adding multiple uart files to the build when it was not needed for wifi ncp builds. 


tested by building lighting app for thread and all 3 wifi ncp board supported and validating outputs