### PR TITLE
[Android] Fix Attestation crash

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/attestation/ExampleAttestationTrustStoreDelegate.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/attestation/ExampleAttestationTrustStoreDelegate.kt
@@ -1,6 +1,7 @@
 package com.google.chip.chiptool.attestation
 
 import android.util.Base64
+import android.util.Log
 import chip.devicecontroller.AttestationTrustStoreDelegate
 import chip.devicecontroller.ChipDeviceController
 import java.util.*
@@ -13,7 +14,7 @@ class ExampleAttestationTrustStoreDelegate(val chipDeviceController: ChipDeviceC
   override fun getProductAttestationAuthorityCert(skid: ByteArray): ByteArray? {
     return paaCerts
       .map { Base64.decode(it, Base64.DEFAULT) }
-      .firstOrNull { cert -> chipDeviceController.extractSkidFromPaaCert(cert) == skid }
+      .firstOrNull { cert -> Arrays.equals(chipDeviceController.extractSkidFromPaaCert(cert), skid) }
   }
 
   companion object {


### PR DESCRIPTION
Fixes #25705 

1. Fix Attestation skid comparison. ( == -> Arrays.equals)
2. Add AlertDialog exception handling, Added movement to the initial screen when an error occurs.