### PR TITLE
Generate all client structs

### DIFF
--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -253,18 +253,18 @@ client cluster AccessControl = 31 {
     kRemoved = 2;
   }
 
+  struct Target {
+    nullable cluster_id cluster = 0;
+    nullable endpoint_no endpoint = 1;
+    nullable devtype_id deviceType = 2;
+  }
+
   fabric_scoped struct AccessControlEntryStruct {
     fabric_sensitive AccessControlEntryPrivilegeEnum privilege = 1;
     fabric_sensitive AccessControlEntryAuthModeEnum authMode = 2;
     nullable fabric_sensitive int64u subjects[] = 3;
     nullable fabric_sensitive Target targets[] = 4;
     fabric_idx fabricIndex = 254;
-  }
-
-  struct Target {
-    nullable cluster_id cluster = 0;
-    nullable endpoint_no endpoint = 1;
-    nullable devtype_id deviceType = 2;
   }
 
   fabric_scoped struct AccessControlExtensionStruct {

--- a/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
+++ b/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
@@ -1295,6 +1295,12 @@ client cluster Thermostat = 513 {
     kAutoMode = 0x20;
   }
 
+  struct ThermostatScheduleTransition {
+    int16u transitionTime = 0;
+    nullable int16s heatSetpoint = 1;
+    nullable int16s coolSetpoint = 2;
+  }
+
   readonly attribute nullable int16s localTemperature = 0;
   readonly attribute nullable int16s outdoorTemperature = 1;
   readonly attribute bitmap8 occupancy = 2;

--- a/examples/dynamic-bridge-app/bridge-common/bridge-app.matter
+++ b/examples/dynamic-bridge-app/bridge-common/bridge-app.matter
@@ -253,18 +253,18 @@ client cluster AccessControl = 31 {
     kRemoved = 2;
   }
 
+  struct Target {
+    nullable cluster_id cluster = 0;
+    nullable endpoint_no endpoint = 1;
+    nullable devtype_id deviceType = 2;
+  }
+
   fabric_scoped struct AccessControlEntryStruct {
     fabric_sensitive AccessControlEntryPrivilegeEnum privilege = 1;
     fabric_sensitive AccessControlEntryAuthModeEnum authMode = 2;
     nullable fabric_sensitive int64u subjects[] = 3;
     nullable fabric_sensitive Target targets[] = 4;
     fabric_idx fabricIndex = 254;
-  }
-
-  struct Target {
-    nullable cluster_id cluster = 0;
-    nullable endpoint_no endpoint = 1;
-    nullable devtype_id deviceType = 2;
   }
 
   fabric_scoped struct AccessControlExtensionStruct {

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -157,14 +157,14 @@ client cluster Scenes = 5 {
     kCopyAllScenes = 0x1;
   }
 
-  struct ExtensionFieldSet {
-    cluster_id clusterID = 0;
-    AttributeValuePair attributeValueList[] = 1;
-  }
-
   struct AttributeValuePair {
     optional attrib_id attributeID = 0;
     int8u attributeValue[] = 1;
+  }
+
+  struct ExtensionFieldSet {
+    cluster_id clusterID = 0;
+    AttributeValuePair attributeValueList[] = 1;
   }
 
   readonly attribute int8u sceneCount = 0;

--- a/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
+++ b/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
@@ -45,18 +45,18 @@ client cluster AccessControl = 31 {
     kRemoved = 2;
   }
 
+  struct Target {
+    nullable cluster_id cluster = 0;
+    nullable endpoint_no endpoint = 1;
+    nullable devtype_id deviceType = 2;
+  }
+
   fabric_scoped struct AccessControlEntryStruct {
     fabric_sensitive AccessControlEntryPrivilegeEnum privilege = 1;
     fabric_sensitive AccessControlEntryAuthModeEnum authMode = 2;
     nullable fabric_sensitive int64u subjects[] = 3;
     nullable fabric_sensitive Target targets[] = 4;
     fabric_idx fabricIndex = 254;
-  }
-
-  struct Target {
-    nullable cluster_id cluster = 0;
-    nullable endpoint_no endpoint = 1;
-    nullable devtype_id deviceType = 2;
   }
 
   fabric_scoped struct AccessControlExtensionStruct {

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -1673,6 +1673,12 @@ client cluster OperationalCredentials = 62 {
     fabric_idx fabricIndex = 254;
   }
 
+  fabric_scoped struct NOCStruct {
+    fabric_sensitive octet_string noc = 1;
+    nullable fabric_sensitive octet_string icac = 2;
+    fabric_idx fabricIndex = 254;
+  }
+
   readonly attribute access(read: administer) NOCStruct NOCs[] = 0;
   readonly attribute FabricDescriptorStruct fabrics[] = 1;
   readonly attribute int8u supportedFabrics = 2;
@@ -1843,6 +1849,11 @@ server cluster OperationalCredentials = 62 {
 }
 
 client cluster FixedLabel = 64 {
+  struct LabelStruct {
+    char_string<16> label = 0;
+    char_string<16> value = 1;
+  }
+
   readonly attribute LabelStruct labelList[] = 0;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
@@ -1891,15 +1902,15 @@ client cluster ModeSelect = 80 {
     kDeponoff = 0x1;
   }
 
+  struct SemanticTagStruct {
+    vendor_id mfgCode = 0;
+    enum16 value = 1;
+  }
+
   struct ModeOptionStruct {
     char_string<64> label = 0;
     int8u mode = 1;
     SemanticTagStruct semanticTags[] = 2;
-  }
-
-  struct SemanticTagStruct {
-    vendor_id mfgCode = 0;
-    enum16 value = 1;
   }
 
   readonly attribute char_string<32> description = 0;
@@ -2931,8 +2942,15 @@ client cluster ContentLauncher = 1290 {
     kHls = 0x2;
   }
 
-  struct ContentSearchStruct {
-    ParameterStruct parameterList[] = 0;
+  struct DimensionStruct {
+    double width = 0;
+    double height = 1;
+    MetricTypeEnum metric = 2;
+  }
+
+  struct AdditionalInfoStruct {
+    char_string name = 0;
+    char_string value = 1;
   }
 
   struct ParameterStruct {
@@ -2941,9 +2959,14 @@ client cluster ContentLauncher = 1290 {
     optional AdditionalInfoStruct externalIDList[] = 2;
   }
 
-  struct AdditionalInfoStruct {
-    char_string name = 0;
-    char_string value = 1;
+  struct ContentSearchStruct {
+    ParameterStruct parameterList[] = 0;
+  }
+
+  struct StyleInformationStruct {
+    optional char_string imageURL = 0;
+    optional char_string color = 1;
+    optional DimensionStruct size = 2;
   }
 
   struct BrandingInformationStruct {
@@ -2953,18 +2976,6 @@ client cluster ContentLauncher = 1290 {
     optional StyleInformationStruct progressBar = 3;
     optional StyleInformationStruct splash = 4;
     optional StyleInformationStruct waterMark = 5;
-  }
-
-  struct StyleInformationStruct {
-    optional char_string imageURL = 0;
-    optional char_string color = 1;
-    optional DimensionStruct size = 2;
-  }
-
-  struct DimensionStruct {
-    double width = 0;
-    double height = 1;
-    MetricTypeEnum metric = 2;
   }
 
   readonly attribute CHAR_STRING acceptHeader[] = 0;

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -1642,6 +1642,12 @@ client cluster OperationalCredentials = 62 {
     fabric_idx fabricIndex = 254;
   }
 
+  fabric_scoped struct NOCStruct {
+    fabric_sensitive octet_string noc = 1;
+    nullable fabric_sensitive octet_string icac = 2;
+    fabric_idx fabricIndex = 254;
+  }
+
   readonly attribute access(read: administer) NOCStruct NOCs[] = 0;
   readonly attribute FabricDescriptorStruct fabrics[] = 1;
   readonly attribute int8u supportedFabrics = 2;
@@ -1812,6 +1818,11 @@ server cluster OperationalCredentials = 62 {
 }
 
 client cluster FixedLabel = 64 {
+  struct LabelStruct {
+    char_string<16> label = 0;
+    char_string<16> value = 1;
+  }
+
   readonly attribute LabelStruct labelList[] = 0;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
@@ -1860,15 +1871,15 @@ client cluster ModeSelect = 80 {
     kDeponoff = 0x1;
   }
 
+  struct SemanticTagStruct {
+    vendor_id mfgCode = 0;
+    enum16 value = 1;
+  }
+
   struct ModeOptionStruct {
     char_string<64> label = 0;
     int8u mode = 1;
     SemanticTagStruct semanticTags[] = 2;
-  }
-
-  struct SemanticTagStruct {
-    vendor_id mfgCode = 0;
-    enum16 value = 1;
   }
 
   readonly attribute char_string<32> description = 0;
@@ -2900,8 +2911,15 @@ client cluster ContentLauncher = 1290 {
     kHls = 0x2;
   }
 
-  struct ContentSearchStruct {
-    ParameterStruct parameterList[] = 0;
+  struct DimensionStruct {
+    double width = 0;
+    double height = 1;
+    MetricTypeEnum metric = 2;
+  }
+
+  struct AdditionalInfoStruct {
+    char_string name = 0;
+    char_string value = 1;
   }
 
   struct ParameterStruct {
@@ -2910,9 +2928,14 @@ client cluster ContentLauncher = 1290 {
     optional AdditionalInfoStruct externalIDList[] = 2;
   }
 
-  struct AdditionalInfoStruct {
-    char_string name = 0;
-    char_string value = 1;
+  struct ContentSearchStruct {
+    ParameterStruct parameterList[] = 0;
+  }
+
+  struct StyleInformationStruct {
+    optional char_string imageURL = 0;
+    optional char_string color = 1;
+    optional DimensionStruct size = 2;
   }
 
   struct BrandingInformationStruct {
@@ -2922,18 +2945,6 @@ client cluster ContentLauncher = 1290 {
     optional StyleInformationStruct progressBar = 3;
     optional StyleInformationStruct splash = 4;
     optional StyleInformationStruct waterMark = 5;
-  }
-
-  struct StyleInformationStruct {
-    optional char_string imageURL = 0;
-    optional char_string color = 1;
-    optional DimensionStruct size = 2;
-  }
-
-  struct DimensionStruct {
-    double width = 0;
-    double height = 1;
-    MetricTypeEnum metric = 2;
   }
 
   readonly attribute CHAR_STRING acceptHeader[] = 0;

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -636,15 +636,6 @@ client cluster NetworkCommissioning = 49 {
     boolean connected = 1;
   }
 
-  struct WiFiInterfaceScanResult {
-    WiFiSecurity security = 0;
-    octet_string<32> ssid = 1;
-    octet_string<6> bssid = 2;
-    int16u channel = 3;
-    WiFiBand wiFiBand = 4;
-    int8s rssi = 5;
-  }
-
   struct ThreadInterfaceScanResult {
     int16u panId = 0;
     int64u extendedPanId = 1;
@@ -654,6 +645,15 @@ client cluster NetworkCommissioning = 49 {
     octet_string<8> extendedAddress = 5;
     int8s rssi = 6;
     int8u lqi = 7;
+  }
+
+  struct WiFiInterfaceScanResult {
+    WiFiSecurity security = 0;
+    octet_string<32> ssid = 1;
+    octet_string<6> bssid = 2;
+    int16u channel = 3;
+    WiFiBand wiFiBand = 4;
+    int8s rssi = 5;
   }
 
   readonly attribute access(read: administer) int8u maxNetworks = 0;
@@ -1366,18 +1366,18 @@ client cluster OperationalCredentials = 62 {
     kInvalidFabricIndex = 11;
   }
 
-  fabric_scoped struct NOCStruct {
-    fabric_sensitive octet_string noc = 1;
-    nullable fabric_sensitive octet_string icac = 2;
-    fabric_idx fabricIndex = 254;
-  }
-
   fabric_scoped struct FabricDescriptorStruct {
     octet_string<65> rootPublicKey = 1;
     vendor_id vendorID = 2;
     fabric_id fabricID = 3;
     node_id nodeID = 4;
     char_string<32> label = 5;
+    fabric_idx fabricIndex = 254;
+  }
+
+  fabric_scoped struct NOCStruct {
+    fabric_sensitive octet_string noc = 1;
+    nullable fabric_sensitive octet_string icac = 2;
     fabric_idx fabricIndex = 254;
   }
 

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -1917,6 +1917,11 @@ client cluster MediaPlayback = 1286 {
     kVariableSpeed = 0x2;
   }
 
+  struct PlaybackPositionStruct {
+    epoch_us updatedAt = 0;
+    nullable int64u position = 1;
+  }
+
   readonly attribute PlaybackStateEnum currentState = 0;
   readonly attribute nullable epoch_us startTime = 1;
   readonly attribute nullable int64u duration = 2;
@@ -2162,8 +2167,15 @@ client cluster ContentLauncher = 1290 {
     kHls = 0x2;
   }
 
-  struct ContentSearchStruct {
-    ParameterStruct parameterList[] = 0;
+  struct DimensionStruct {
+    double width = 0;
+    double height = 1;
+    MetricTypeEnum metric = 2;
+  }
+
+  struct AdditionalInfoStruct {
+    char_string name = 0;
+    char_string value = 1;
   }
 
   struct ParameterStruct {
@@ -2172,9 +2184,14 @@ client cluster ContentLauncher = 1290 {
     optional AdditionalInfoStruct externalIDList[] = 2;
   }
 
-  struct AdditionalInfoStruct {
-    char_string name = 0;
-    char_string value = 1;
+  struct ContentSearchStruct {
+    ParameterStruct parameterList[] = 0;
+  }
+
+  struct StyleInformationStruct {
+    optional char_string imageURL = 0;
+    optional char_string color = 1;
+    optional DimensionStruct size = 2;
   }
 
   struct BrandingInformationStruct {
@@ -2184,18 +2201,6 @@ client cluster ContentLauncher = 1290 {
     optional StyleInformationStruct progressBar = 3;
     optional StyleInformationStruct splash = 4;
     optional StyleInformationStruct waterMark = 5;
-  }
-
-  struct StyleInformationStruct {
-    optional char_string imageURL = 0;
-    optional char_string color = 1;
-    optional DimensionStruct size = 2;
-  }
-
-  struct DimensionStruct {
-    double width = 0;
-    double height = 1;
-    MetricTypeEnum metric = 2;
   }
 
   readonly attribute CHAR_STRING acceptHeader[] = 0;
@@ -2281,6 +2286,11 @@ client cluster ApplicationLauncher = 1292 {
     char_string applicationID = 1;
   }
 
+  struct ApplicationEPStruct {
+    ApplicationStruct application = 0;
+    optional endpoint_no endpoint = 1;
+  }
+
   readonly attribute INT16U catalogList[] = 0;
   attribute nullable ApplicationEPStruct currentApp = 1;
   readonly attribute command_id generatedCommandList[] = 65528;
@@ -2314,6 +2324,11 @@ client cluster ApplicationBasic = 1293 {
     kActiveVisibleFocus = 1;
     kActiveHidden = 2;
     kActiveVisibleNotFocus = 3;
+  }
+
+  struct ApplicationStruct {
+    int16u catalogVendorID = 0;
+    char_string applicationID = 1;
   }
 
   readonly attribute char_string<32> vendorName = 0;

--- a/src/app/zap-templates/templates/app/MatterIDL.zapt
+++ b/src/app/zap-templates/templates/app/MatterIDL.zapt
@@ -25,10 +25,17 @@
   }
 
   {{/zcl_bitmaps}}
-  {{#chip_cluster_specific_structs}}
+  {{#if (is_client side)~}}
+    {{#zcl_structs}}
     {{~>idl_structure_definition extraIndent=1}}
 
-  {{/chip_cluster_specific_structs}}
+    {{/zcl_structs}}
+  {{~else~}}
+    {{#chip_cluster_specific_structs}}
+    {{~>idl_structure_definition extraIndent=1}}
+
+    {{/chip_cluster_specific_structs}}
+  {{/if}}
   {{#zcl_events}}
   {{#if isFabricSensitive}}fabric_sensitive {{/if~}} {{priority}} event {{!ensure space}}
   {{~#chip_access_elements entity="event"~}}

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -129,14 +129,14 @@ client cluster Scenes = 5 {
     kCopyAllScenes = 0x1;
   }
 
-  struct ExtensionFieldSet {
-    cluster_id clusterID = 0;
-    AttributeValuePair attributeValueList[] = 1;
-  }
-
   struct AttributeValuePair {
     optional attrib_id attributeID = 0;
     int8u attributeValue[] = 1;
+  }
+
+  struct ExtensionFieldSet {
+    cluster_id clusterID = 0;
+    AttributeValuePair attributeValueList[] = 1;
   }
 
   readonly attribute int8u sceneCount = 0;
@@ -491,18 +491,18 @@ client cluster AccessControl = 31 {
     kRemoved = 2;
   }
 
+  struct Target {
+    nullable cluster_id cluster = 0;
+    nullable endpoint_no endpoint = 1;
+    nullable devtype_id deviceType = 2;
+  }
+
   fabric_scoped struct AccessControlEntryStruct {
     fabric_sensitive AccessControlEntryPrivilegeEnum privilege = 1;
     fabric_sensitive AccessControlEntryAuthModeEnum authMode = 2;
     nullable fabric_sensitive int64u subjects[] = 3;
     nullable fabric_sensitive Target targets[] = 4;
     fabric_idx fabricIndex = 254;
-  }
-
-  struct Target {
-    nullable cluster_id cluster = 0;
-    nullable endpoint_no endpoint = 1;
-    nullable devtype_id deviceType = 2;
   }
 
   fabric_scoped struct AccessControlExtensionStruct {
@@ -1153,6 +1153,21 @@ client cluster PowerSource = 47 {
     kReplaceable = 0x8;
   }
 
+  struct BatChargeFaultChangeType {
+    BatChargeFaultEnum current[] = 0;
+    BatChargeFaultEnum previous[] = 1;
+  }
+
+  struct BatFaultChangeType {
+    BatFaultEnum current[] = 0;
+    BatFaultEnum previous[] = 1;
+  }
+
+  struct WiredFaultChangeType {
+    WiredFaultEnum current[] = 0;
+    WiredFaultEnum previous[] = 1;
+  }
+
   info event WiredFaultChange = 0 {
     WiredFaultEnum current[] = 0;
     WiredFaultEnum previous[] = 1;
@@ -1314,15 +1329,6 @@ client cluster NetworkCommissioning = 49 {
     boolean connected = 1;
   }
 
-  struct WiFiInterfaceScanResult {
-    WiFiSecurity security = 0;
-    octet_string<32> ssid = 1;
-    octet_string<6> bssid = 2;
-    int16u channel = 3;
-    WiFiBand wiFiBand = 4;
-    int8s rssi = 5;
-  }
-
   struct ThreadInterfaceScanResult {
     int16u panId = 0;
     int64u extendedPanId = 1;
@@ -1332,6 +1338,15 @@ client cluster NetworkCommissioning = 49 {
     octet_string<8> extendedAddress = 5;
     int8s rssi = 6;
     int8u lqi = 7;
+  }
+
+  struct WiFiInterfaceScanResult {
+    WiFiSecurity security = 0;
+    octet_string<32> ssid = 1;
+    octet_string<6> bssid = 2;
+    int16u channel = 3;
+    WiFiBand wiFiBand = 4;
+    int8s rssi = 5;
   }
 
   readonly attribute access(read: administer) int8u maxNetworks = 0;
@@ -1635,6 +1650,21 @@ client cluster ThreadNetworkDiagnostics = 53 {
     boolean isChild = 13;
   }
 
+  struct OperationalDatasetComponents {
+    boolean activeTimestampPresent = 0;
+    boolean pendingTimestampPresent = 1;
+    boolean masterKeyPresent = 2;
+    boolean networkNamePresent = 3;
+    boolean extendedPanIdPresent = 4;
+    boolean meshLocalPrefixPresent = 5;
+    boolean delayPresent = 6;
+    boolean panIdPresent = 7;
+    boolean channelPresent = 8;
+    boolean pskcPresent = 9;
+    boolean securityPolicyPresent = 10;
+    boolean channelMaskPresent = 11;
+  }
+
   struct RouteTable {
     int64u extAddress = 0;
     int16u rloc16 = 1;
@@ -1651,21 +1681,6 @@ client cluster ThreadNetworkDiagnostics = 53 {
   struct SecurityPolicy {
     int16u rotationTime = 0;
     int16u flags = 1;
-  }
-
-  struct OperationalDatasetComponents {
-    boolean activeTimestampPresent = 0;
-    boolean pendingTimestampPresent = 1;
-    boolean masterKeyPresent = 2;
-    boolean networkNamePresent = 3;
-    boolean extendedPanIdPresent = 4;
-    boolean meshLocalPrefixPresent = 5;
-    boolean delayPresent = 6;
-    boolean panIdPresent = 7;
-    boolean channelPresent = 8;
-    boolean pskcPresent = 9;
-    boolean securityPolicyPresent = 10;
-    boolean channelMaskPresent = 11;
   }
 
   info event ConnectionStatus = 0 {
@@ -2007,18 +2022,18 @@ client cluster OperationalCredentials = 62 {
     kInvalidFabricIndex = 11;
   }
 
-  fabric_scoped struct NOCStruct {
-    fabric_sensitive octet_string noc = 1;
-    nullable fabric_sensitive octet_string icac = 2;
-    fabric_idx fabricIndex = 254;
-  }
-
   fabric_scoped struct FabricDescriptorStruct {
     octet_string<65> rootPublicKey = 1;
     vendor_id vendorID = 2;
     fabric_id fabricID = 3;
     node_id nodeID = 4;
     char_string<32> label = 5;
+    fabric_idx fabricIndex = 254;
+  }
+
+  fabric_scoped struct NOCStruct {
+    fabric_sensitive octet_string noc = 1;
+    nullable fabric_sensitive octet_string icac = 2;
     fabric_idx fabricIndex = 254;
   }
 
@@ -2109,16 +2124,16 @@ client cluster GroupKeyManagement = 63 {
     kCacheAndSync = 1;
   }
 
-  fabric_scoped struct GroupKeyMapStruct {
-    group_id groupId = 1;
-    int16u groupKeySetID = 2;
-    fabric_idx fabricIndex = 254;
-  }
-
   fabric_scoped struct GroupInfoMapStruct {
     group_id groupId = 1;
     endpoint_no endpoints[] = 2;
     optional char_string<16> groupName = 3;
+    fabric_idx fabricIndex = 254;
+  }
+
+  fabric_scoped struct GroupKeyMapStruct {
+    group_id groupId = 1;
+    int16u groupKeySetID = 2;
     fabric_idx fabricIndex = 254;
   }
 
@@ -2175,6 +2190,11 @@ client cluster GroupKeyManagement = 63 {
 }
 
 client cluster FixedLabel = 64 {
+  struct LabelStruct {
+    char_string<16> label = 0;
+    char_string<16> value = 1;
+  }
+
   readonly attribute LabelStruct labelList[] = 0;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
@@ -2185,6 +2205,11 @@ client cluster FixedLabel = 64 {
 }
 
 client cluster UserLabel = 65 {
+  struct LabelStruct {
+    char_string<16> label = 0;
+    char_string<16> value = 1;
+  }
+
   attribute access(write: manage) LabelStruct labelList[] = 0;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
@@ -2213,15 +2238,15 @@ client cluster ModeSelect = 80 {
     kDeponoff = 0x1;
   }
 
+  struct SemanticTagStruct {
+    vendor_id mfgCode = 0;
+    enum16 value = 1;
+  }
+
   struct ModeOptionStruct {
     char_string<64> label = 0;
     int8u mode = 1;
     SemanticTagStruct semanticTags[] = 2;
-  }
-
-  struct SemanticTagStruct {
-    vendor_id mfgCode = 0;
-    enum16 value = 1;
   }
 
   readonly attribute char_string<32> description = 0;
@@ -4189,8 +4214,15 @@ client cluster ContentLauncher = 1290 {
     kHls = 0x2;
   }
 
-  struct ContentSearchStruct {
-    ParameterStruct parameterList[] = 0;
+  struct DimensionStruct {
+    double width = 0;
+    double height = 1;
+    MetricTypeEnum metric = 2;
+  }
+
+  struct AdditionalInfoStruct {
+    char_string name = 0;
+    char_string value = 1;
   }
 
   struct ParameterStruct {
@@ -4199,9 +4231,14 @@ client cluster ContentLauncher = 1290 {
     optional AdditionalInfoStruct externalIDList[] = 2;
   }
 
-  struct AdditionalInfoStruct {
-    char_string name = 0;
-    char_string value = 1;
+  struct ContentSearchStruct {
+    ParameterStruct parameterList[] = 0;
+  }
+
+  struct StyleInformationStruct {
+    optional char_string imageURL = 0;
+    optional char_string color = 1;
+    optional DimensionStruct size = 2;
   }
 
   struct BrandingInformationStruct {
@@ -4211,18 +4248,6 @@ client cluster ContentLauncher = 1290 {
     optional StyleInformationStruct progressBar = 3;
     optional StyleInformationStruct splash = 4;
     optional StyleInformationStruct waterMark = 5;
-  }
-
-  struct StyleInformationStruct {
-    optional char_string imageURL = 0;
-    optional char_string color = 1;
-    optional DimensionStruct size = 2;
-  }
-
-  struct DimensionStruct {
-    double width = 0;
-    double height = 1;
-    MetricTypeEnum metric = 2;
   }
 
   readonly attribute CHAR_STRING acceptHeader[] = 0;
@@ -4308,6 +4333,11 @@ client cluster ApplicationLauncher = 1292 {
     kApplicationPlatform = 0x1;
   }
 
+  struct ApplicationStruct {
+    int16u catalogVendorID = 0;
+    char_string applicationID = 1;
+  }
+
   struct ApplicationEPStruct {
     ApplicationStruct application = 0;
     optional endpoint_no endpoint = 1;
@@ -4351,6 +4381,11 @@ client cluster ApplicationBasic = 1293 {
     kActiveVisibleFocus = 1;
     kActiveHidden = 2;
     kActiveVisibleNotFocus = 3;
+  }
+
+  struct ApplicationStruct {
+    int16u catalogVendorID = 0;
+    char_string applicationID = 1;
   }
 
   readonly attribute char_string<32> vendorName = 0;
@@ -4606,26 +4641,6 @@ client cluster UnitTesting = 4294048773 {
     kValueC = 0x4;
   }
 
-  struct TestListStructOctet {
-    int64u member1 = 0;
-    octet_string<32> member2 = 1;
-  }
-
-  struct NullablesAndOptionalsStruct {
-    nullable int16u nullableInt = 0;
-    optional int16u optionalInt = 1;
-    optional nullable int16u nullableOptionalInt = 2;
-    nullable char_string nullableString = 3;
-    optional char_string optionalString = 4;
-    optional nullable char_string nullableOptionalString = 5;
-    nullable SimpleStruct nullableStruct = 6;
-    optional SimpleStruct optionalStruct = 7;
-    optional nullable SimpleStruct nullableOptionalStruct = 8;
-    nullable SimpleEnum nullableList[] = 9;
-    optional SimpleEnum optionalList[] = 10;
-    optional nullable SimpleEnum nullableOptionalList[] = 11;
-  }
-
   struct SimpleStruct {
     int8u a = 0;
     boolean b = 1;
@@ -4648,6 +4663,21 @@ client cluster UnitTesting = 4294048773 {
     fabric_idx fabricIndex = 254;
   }
 
+  struct NullablesAndOptionalsStruct {
+    nullable int16u nullableInt = 0;
+    optional int16u optionalInt = 1;
+    optional nullable int16u nullableOptionalInt = 2;
+    nullable char_string nullableString = 3;
+    optional char_string optionalString = 4;
+    optional nullable char_string nullableOptionalString = 5;
+    nullable SimpleStruct nullableStruct = 6;
+    optional SimpleStruct optionalStruct = 7;
+    optional nullable SimpleStruct nullableOptionalStruct = 8;
+    nullable SimpleEnum nullableList[] = 9;
+    optional SimpleEnum optionalList[] = 10;
+    optional nullable SimpleEnum nullableOptionalList[] = 11;
+  }
+
   struct NestedStruct {
     int8u a = 0;
     boolean b = 1;
@@ -4662,6 +4692,15 @@ client cluster UnitTesting = 4294048773 {
     int32u e[] = 4;
     octet_string f[] = 5;
     int8u g[] = 6;
+  }
+
+  struct DoubleNestedStructList {
+    NestedStructList a[] = 0;
+  }
+
+  struct TestListStructOctet {
+    int64u member1 = 0;
+    octet_string<32> member2 = 1;
   }
 
   info event TestEvent = 1 {


### PR DESCRIPTION
It seems that matter idl codegen would still use cluster enabling when deciding what structures to codegen.

Switched client-side to iterate over ALL structs, so clients have access to all cluster specific structures.
