### PR TITLE
Replacing stateful helpers with stateless helpers

### DIFF
--- a/examples/chip-tool/templates/logging/DataModelLogger-src.zapt
+++ b/examples/chip-tool/templates/logging/DataModelLogger-src.zapt
@@ -46,7 +46,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const {{
 {{/zcl_events}}
 {{/zcl_clusters}}
 
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#zcl_commands_source_server}}
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const {{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType & value)
 {
@@ -58,7 +58,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const {{
   return CHIP_NO_ERROR;
 }
 {{/zcl_commands_source_server}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
 CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributePath & path, chip::TLV::TLVReader * data)
 {
@@ -67,7 +67,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
 
     switch (path.mClusterId)
     {
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#zcl_attributes_server}}
 {{#first}}
         case {{asUpperCamelCase parent.name}}::Id:
@@ -87,7 +87,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
         }
 {{/last}}
 {{/zcl_attributes_server}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
         default:
           break;
     }
@@ -102,7 +102,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
 
     switch (path.mClusterId)
     {
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#zcl_commands_source_server}}
 {{#first}}
         case {{asUpperCamelCase parent.name}}::Id:
@@ -122,7 +122,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         }
 {{/last}}
 {{/zcl_commands_source_server}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
         default:
           break;
     }
@@ -158,7 +158,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
 
     switch (header.mPath.mClusterId)
     {
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#chip_server_cluster_events}}
 {{#first}}
         case {{asUpperCamelCase parent.name}}::Id:
@@ -178,7 +178,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
         }
 {{/last}}
 {{/chip_server_cluster_events}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
         default:
           break;
     }

--- a/examples/chip-tool/templates/logging/DataModelLogger.zapt
+++ b/examples/chip-tool/templates/logging/DataModelLogger.zapt
@@ -13,8 +13,8 @@ static CHIP_ERROR LogValue(const char * label, size_t indent, const chip::app::C
 {{/zcl_events}}
 {{/zcl_clusters}}
 
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#zcl_commands_source_server}}
 static CHIP_ERROR LogValue(const char * label, size_t indent, const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType & value);
 {{/zcl_commands_source_server}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}

--- a/examples/darwin-framework-tool/templates/commands.zapt
+++ b/examples/darwin-framework-tool/templates/commands.zapt
@@ -17,21 +17,22 @@
 
 {{> clusters_header}}
 
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
 {{> cluster_header}}
 
-{{#chip_cluster_commands}}
-{{#unless (wasRemoved (asUpperCamelCase clusterName preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#zcl_commands}}
+{{#if (is_str_equal source 'client')}}
+{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
 /*
  * Command {{asUpperCamelCase name}}
  */
-class {{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}: public ClusterCommand
+class {{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public ClusterCommand
 {
 public:
-    {{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}(): ClusterCommand("{{cleanse_label_as_kebab_case name}}"){{#zcl_command_arguments}}{{#if_chip_complex}}, mComplex_{{asUpperCamelCase label}}(&mRequest.{{asLowerCamelCase label}}){{/if_chip_complex}}{{/zcl_command_arguments}}
+    {{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ClusterCommand("{{cleanse_label_as_kebab_case name}}"){{#zcl_command_arguments}}{{#if_chip_complex}}, mComplex_{{asUpperCamelCase label}}(&mRequest.{{asLowerCamelCase label}}){{/if_chip_complex}}{{/zcl_command_arguments}}
     {
-        {{#chip_cluster_command_arguments}}
+        {{#zcl_command_arguments}}
         {{#if_chip_complex}}
         AddArgument("{{asUpperCamelCase label}}", &mComplex_{{asUpperCamelCase label}});
         {{else if (isString type)}}
@@ -39,7 +40,7 @@ public:
         {{else}}
         AddArgument("{{asUpperCamelCase label}}", {{as_type_min_value type language='c++'}}, {{as_type_max_value type language='c++'}}, &mRequest.{{asLowerCamelCase label}});
         {{/if_chip_complex}}
-        {{/chip_cluster_command_arguments}}
+        {{/zcl_command_arguments}}
         ClusterCommand::AddArguments();
     }
 
@@ -48,19 +49,19 @@ public:
         ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 8}}) command ({{asHex code 8}}) on endpoint %u", endpointId);
 
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
-        __auto_type * cluster = [[MTRBaseCluster{{asUpperCamelCase clusterName preserveAcronyms=true}} alloc] initWithDevice:device endpointID:@(endpointId) queue:callbackQueue];
-        __auto_type * params = [[MTR{{asUpperCamelCase clusterName preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Params alloc] init];
+        __auto_type * cluster = [[MTRBaseCluster{{asUpperCamelCase parent.name preserveAcronyms=true}} alloc] initWithDevice:device endpointID:@(endpointId) queue:callbackQueue];
+        __auto_type * params = [[MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Params alloc] init];
         params.timedInvokeTimeoutMs = mTimedInteractionTimeoutMs.HasValue() ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()] : nil;
-        {{#chip_cluster_command_arguments}}
-        {{>decodable_value target=(concat "params." (asStructPropertyName label)) source=(concat "mRequest." (asLowerCamelCase label)) cluster=parent.clusterName type=type depth=0}}
-        {{/chip_cluster_command_arguments}}
+        {{#zcl_command_arguments}}
+        {{>decodable_value target=(concat "params." (asStructPropertyName label)) source=(concat "mRequest." (asLowerCamelCase label)) cluster=parent.parent.name type=type depth=0}}
+        {{/zcl_command_arguments}}
         uint16_t repeatCount = mRepeatCount.ValueOr(1);
         uint16_t __block responsesNeeded = repeatCount;
         while (repeatCount--)
         {
             [cluster {{asLowerCamelCase name}}WithParams:params completion:
             {{#if hasSpecificResponse}}
-                ^(MTR{{asUpperCamelCase clusterName preserveAcronyms=true}}Cluster{{asUpperCamelCase responseName}}Params * _Nullable values, NSError * _Nullable error) {
+                ^(MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase responseName}}Params * _Nullable values, NSError * _Nullable error) {
                     NSLog(@"Values: %@", values);
             {{else}}
                 ^(NSError * _Nullable error) {
@@ -79,18 +80,19 @@ public:
     }
 
 private:
-    {{#if (hasArguments)}}
-    chip::app::Clusters::{{asUpperCamelCase clusterName}}::Commands::{{asUpperCamelCase name}}::Type mRequest;
+    {{#if hasArguments}}
+    chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Type mRequest;
     {{/if}}
-    {{#chip_cluster_command_arguments}}
+    {{#zcl_command_arguments}}
     {{#if_chip_complex}}
     TypedComplexArgument<{{zapTypeToEncodableClusterObjectType type ns=parent.parent.name}}> mComplex_{{asUpperCamelCase label}};
     {{/if_chip_complex}}
-    {{/chip_cluster_command_arguments}}
+    {{/zcl_command_arguments}}
 };
 
 {{/unless}}
-{{/chip_cluster_commands}}
+{{/if}}
+{{/zcl_commands}}
 
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
@@ -248,12 +250,12 @@ public:
 {{/unless}}
 {{/zcl_attributes_server}}
 {{/unless}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
 /*----------------------------------------------------------------------------*\
 | Register all Clusters commands                                               |
 \*----------------------------------------------------------------------------*/
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
 void registerCluster{{asUpperCamelCase name}}(Commands & commands)
 {
@@ -263,11 +265,13 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands)
 
     commands_list clusterCommands = {
         make_unique<ClusterCommand>(Id), //
-        {{#chip_cluster_commands}}
-        {{#unless (wasRemoved (asUpperCamelCase clusterName preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
-        make_unique<{{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}>(), //
+        {{#zcl_commands}}
+        {{#if (is_str_equal source 'client')}}
+        {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
+        make_unique<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(), //
         {{/unless}}
-        {{/chip_cluster_commands}}
+        {{/if}}
+        {{/zcl_commands}}
         {{#zcl_attributes_server removeKeys='isOptional'}}
         {{#first}}
          make_unique<ReadAttribute>(Id), //
@@ -303,7 +307,7 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands)
     commands.Register(clusterName, clusterCommands);
 }
 {{/unless}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
 void registerClusterAny(Commands & commands)
 {
@@ -325,9 +329,9 @@ void registerClusterAny(Commands & commands)
 void registerClusters(Commands & commands)
 {
     registerClusterAny(commands);
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
     {{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
     registerCluster{{asUpperCamelCase name}}(commands);
     {{/unless}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 }

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -7,7 +7,7 @@ ARG COMMITHASH=7b99e6399c6069037c613782d78132c69b9dcabb
 # ZAP Development install, so that it runs on both x64 and arm64
 # Generally this should match with the ZAP version that is used for codegen within the
 # specified SHA
-ARG ZAP_VERSION=v2023.03.27-nightly
+ARG ZAP_VERSION=v2023.03.30-nightly
 
 # Ensure TARGETPLATFORM is set
 RUN case ${TARGETPLATFORM} in \

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -8,7 +8,7 @@
                 "mac-arm64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2023.03.27-nightly.1"]
+            "tags": ["version:2@v2023.03.30-nightly.1"]
         }
     ]
 }

--- a/scripts/tools/sdk.json
+++ b/scripts/tools/sdk.json
@@ -2,7 +2,7 @@
     "meta": {
         "sdkRoot": "../..",
         "description": "Matter SDK",
-        "requiredFeatureLevel": 77
+        "requiredFeatureLevel": 95
     },
     "zcl": {
         "main": "src/app/zap-templates/zcl/zcl.json",

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2023.3.27'
+MIN_ZAP_VERSION = '2023.3.30'
 
 
 class ZapTool:

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
@@ -13,12 +13,12 @@
 #include <lib/support/Span.h>
 
 // List specific responses
-{{#chip_client_clusters}}
+{{#all_user_clusters side='client'}}
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{#if isArray}}
 typedef void (*{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback)(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} data);
 {{/if}}
 {{/zcl_attributes_server}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
 {{/if}}

--- a/src/app/zap-templates/templates/app/CHIPClusters.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters.zapt
@@ -14,7 +14,7 @@
 namespace chip {
 namespace Controller {
 
-{{#chip_client_clusters}}
+{{#all_user_clusters side='client'}}
 class DLL_EXPORT {{asUpperCamelCase name}}Cluster : public ClusterBase
 {
 public:
@@ -22,7 +22,7 @@ public:
     ~{{asUpperCamelCase name}}Cluster() {}
 };
 
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 } // namespace Controller
 } // namespace chip
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
@@ -18,7 +18,7 @@ id MTRDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader &
 {
     switch (aPath.mClusterId)
     {
-    {{#chip_client_clusters includeAll=true}}
+    {{#all_user_clusters side='client'}}
     {{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
     case Clusters::{{asUpperCamelCase name}}::Id: {
         using namespace Clusters::{{asUpperCamelCase name}};
@@ -47,7 +47,7 @@ id MTRDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader &
         break;
     }
     {{/unless}}
-    {{/chip_client_clusters}}
+    {{/all_user_clusters}}
     default: {
       *aError = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB;
       break;

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
@@ -26,7 +26,7 @@ using chip::System::Clock::Timeout;
 using chip::System::Clock::Seconds16;
 
 // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks): Linter is unable to locate the delete on these objects.
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
 @implementation MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}}
 
@@ -45,7 +45,8 @@ using chip::System::Clock::Seconds16;
     return self;
 }
 
-{{#chip_cluster_commands}}
+{{#zcl_commands}}
+{{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandImpl"}}
 {{! This is used as the implementation for both the new-name and old-name bits, so check for both here. }}
@@ -59,13 +60,13 @@ MTR{{compatClusterNameRemapping parent.name}}Cluster{{compatCommandNameRemapping
 MTR{{cluster}}Cluster{{command}}Params
 {{/if}}
 {{/inline}}
-{{#unless (hasArguments)}}
+{{#unless hasArguments}}
 - (void){{asLowerCamelCase name}}WithCompletion:({{>command_completion_type command=.}})completion
 {
   [self {{asLowerCamelCase name}}WithParams:nil completion:completion];
 }
 {{/unless}}
-- (void){{asLowerCamelCase name}}WithParams: ({{> paramsType}} * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completion:({{>command_completion_type command=.}})completion
+- (void){{asLowerCamelCase name}}WithParams: ({{> paramsType}} * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params completion:({{>command_completion_type command=.}})completion
 {
     // Make a copy of params before we go async.
     params = [params copy];
@@ -105,19 +106,19 @@ MTR{{cluster}}Cluster{{command}}Params
           timedInvokeTimeoutMs.SetValue(10000);
         }
         {{/if}}
-        {{#chip_cluster_command_arguments}}
+        {{#zcl_command_arguments}}
           {{#first}}
-            {{#unless (commandHasRequiredField parent)}}
+            {{#unless parent.commandHasRequiredField}}
             if (params != nil) {
             {{/unless}}
           {{/first}}
           {{>encode_value target=(concat "request." (asLowerCamelCase label)) source=(concat "params." (asStructPropertyName label)) cluster=parent.parent.name errorCode="return CHIP_ERROR_INVALID_ARGUMENT;" depth=0}}
           {{#last}}
-            {{#unless (commandHasRequiredField parent)}}
+            {{#unless parent.commandHasRequiredField}}
             }
            {{/unless}}
           {{/last}}
-        {{/chip_cluster_command_arguments}}
+        {{/zcl_command_arguments}}
 
         return MTRStartInvokeInteraction(typedBridge, request, exchangeManager, session, successCb, failureCb, self->_endpoint, timedInvokeTimeoutMs, invokeTimeout);
     });
@@ -127,7 +128,8 @@ MTR{{cluster}}Cluster{{command}}Params
 {{/inline}}
 {{> commandImpl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
-{{/chip_cluster_commands}}
+{{/if}}
+{{/zcl_commands}}
 
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{! This is used as the implementation for both the new-name and old-name bits, so check for both here. }}
@@ -248,11 +250,12 @@ reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value
            (not (wasRemoved (compatClusterNameRemapping name))))}}
 @implementation MTRBaseCluster{{compatClusterNameRemapping name}} (Deprecated)
 
-{{#chip_cluster_commands}}
+{{#zcl_commands}}
+{{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandImpl"}}
 {{#unless (wasRemoved cluster command=command)}}
-- (void){{asLowerCamelCase command}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler
+- (void){{asLowerCamelCase command}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler
 {
   [self {{asLowerCamelCase name}}WithParams:params completion:
     {{#if hasSpecificResponse}}
@@ -265,7 +268,7 @@ reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value
     {{/if}}
     ];
 }
-{{#unless (hasArguments)}}
+{{#unless hasArguments}}
 - (void){{asLowerCamelCase command}}WithCompletionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler
 {
   [self {{asLowerCamelCase command}}WithParams:nil completionHandler:completionHandler];
@@ -275,7 +278,8 @@ reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value
 {{/inline}}
 {{> commandImpl cluster=(compatClusterNameRemapping parent.name)
                 command=(compatCommandNameRemapping parent.name name)}}
-{{/chip_cluster_commands}}
+{{/if}}
+{{/zcl_commands}}
 
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))
@@ -345,6 +349,6 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 @end
 {{/if}}
 
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -7,7 +7,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 
 
 {{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
@@ -23,7 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER {{availability (asUpperCamelCase name preserveAcronyms=true) minimalRelease="First major API revamp"}};
 
-{{#chip_cluster_commands}}
+{{#zcl_commands}}
+{{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandDecl"}}
 {{#unless (wasRemoved cluster command=command)}}
@@ -32,15 +33,16 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * {{description}}
  */
-- (void){{asLowerCamelCase name}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completion:({{>command_completion_type command=.}})completion {{availability cluster command=command minimalRelease="First major API revamp"}};
-{{#unless (hasArguments)}}
+- (void){{asLowerCamelCase name}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField }}_Nullable{{/unless}})params completion:({{>command_completion_type command=.}})completion {{availability cluster command=command minimalRelease="First major API revamp"}};
+{{#unless hasArguments}}
 - (void){{asLowerCamelCase name}}WithCompletion:({{>command_completion_type command=.}})completion {{availability cluster command=command minimalRelease="First major API revamp"}};
 {{/unless}}
 {{/unless}}
 {{/inline}}
 {{> commandDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
-{{/chip_cluster_commands}}
+{{/if}}
+{{/zcl_commands}}
 
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
@@ -70,9 +72,9 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 @end
 {{/unless}}
 
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#unless (isStrEqual (asUpperCamelCase name preserveAcronyms=true) (compatClusterNameRemapping name))}}
 {{#unless (wasRemoved (compatClusterNameRemapping name))}}
 {{availability (compatClusterNameRemapping name) deprecationMessage=(concat "Please use MTRBaseCluster" (asUpperCamelCase name preserveAcronyms=true))}}
@@ -81,7 +83,7 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 
 {{/unless}}
 {{/unless}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
 {{#zcl_clusters}}
 {{#zcl_enums}}
@@ -177,7 +179,7 @@ typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName bitm
 {{/zcl_bitmaps}}
 {{/zcl_clusters}}
 
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping name))
            (not (wasRemoved (compatClusterNameRemapping name))))}}
 @interface MTRBaseCluster{{compatClusterNameRemapping name}} (Deprecated)
@@ -186,14 +188,15 @@ typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName bitm
                                endpoint:(uint16_t)endpoint
                                   queue:(dispatch_queue_t)queue {{availability (compatClusterNameRemapping name) deprecatedRelease="First major API revamp" deprecationMessage="Please use initWithDevice:endpointID:queue:"}};
 
-{{#chip_cluster_commands}}
+{{#zcl_commands}}
+{{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandDecl"}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" cluster command=command)
            (not (wasRemoved cluster command=command)))}}
-- (void){{asLowerCamelCase command}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler
+- (void){{asLowerCamelCase command}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField }}_Nullable{{/unless}})params completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler
     {{availability cluster command=command deprecatedRelease="First major API revamp" deprecationMessage=(concat "Please use " (asLowerCamelCase name) "WithParams:completion:")}};
-{{#unless (hasArguments)}}
+{{#unless hasArguments}}
 - (void){{asLowerCamelCase command}}WithCompletionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler
     {{availability cluster command=command deprecatedRelease="First major API revamp" deprecationMessage=(concat "Please use " (asLowerCamelCase name) "WithCompletion:")}};
 {{/unless}}
@@ -201,7 +204,8 @@ typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName bitm
 {{/inline}}
 {{> commandDecl cluster=(compatClusterNameRemapping parent.name)
                 command=(compatCommandNameRemapping parent.name name)}}
-{{/chip_cluster_commands}}
+{{/if}}
+{{/zcl_commands}}
 
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))
@@ -230,6 +234,6 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 @end
 
 {{/if}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Internal.zapt
@@ -7,7 +7,7 @@
 
 #include <zap-generated/CHIPClusters.h>
 
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 
 {{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
 @interface MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}} ()
@@ -16,4 +16,4 @@
 @end
 {{/unless}}
 
-{{/chip_client_clusters}}
+{{/all_user_clusters}}

--- a/src/darwin/Framework/CHIP/templates/MTRCallbackBridge-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCallbackBridge-src.zapt
@@ -37,7 +37,7 @@
 {{#>MTRCallbackBridge type="vendor_id"    isNullable=false ns="chip"}}VendorIdAttributeCallback{{/MTRCallbackBridge}}
 {{#>MTRCallbackBridge type="vendor_id"    isNullable=true  ns="chip"}}NullableVendorIdAttributeCallback{{/MTRCallbackBridge}}
 
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{#unless (wasRemoved (asUpperCamelCase ../name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#if isArray}}
@@ -52,15 +52,15 @@
 {{/if}}
 {{/unless}}
 {{/zcl_attributes_server}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
-{{#chip_client_clusters includeAll=true}}
-{{#chip_cluster_responses}}
+{{#all_user_clusters side='client'}}
+{{#zcl_command_responses}}
 {{#unless (wasRemoved (asUpperCamelCase ../name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#>MTRCallbackBridge partial-type="Command"                        }}{{asUpperCamelCase ../../name preserveAcronyms=true}}Cluster{{asUpperCamelCase ../name preserveAcronyms=true}}Callback{{/MTRCallbackBridge}}
 {{/unless}}
-{{/chip_cluster_responses}}
-{{/chip_client_clusters}}
+{{/zcl_command_responses}}
+{{/all_user_clusters}}
 
 {{#zcl_clusters}}
 {{#zcl_enums}}

--- a/src/darwin/Framework/CHIP/templates/MTRCallbackBridge.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCallbackBridge.zapt
@@ -14,13 +14,13 @@ typedef void (*DefaultSuccessCallbackType)(void *);
 typedef void (*VendorIdAttributeCallback)(void *, chip::VendorId);
 typedef void (*NullableVendorIdAttributeCallback)(void *, const chip::app::DataModel::Nullable<chip::VendorId> &);
 
-{{#chip_client_clusters includeAll=true}}
-{{#chip_cluster_responses}}
+{{#all_user_clusters side='client'}}
+{{#zcl_command_responses}}
 {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
 typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}CallbackType)(void *, const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType &);
 {{/unless}}
-{{/chip_cluster_responses}}
-{{/chip_client_clusters}}
+{{/zcl_command_responses}}
+{{/all_user_clusters}}
 
 {{#zcl_clusters}}
 {{#zcl_enums}}
@@ -31,7 +31,7 @@ typedef void (*Nullable{{asUpperCamelCase parent.name preserveAcronyms=true}}Clu
 {{/zcl_enums}}
 {{/zcl_clusters}}
 
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#if isArray}}
@@ -46,7 +46,7 @@ typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCa
 {{/if}}
 {{/unless}}
 {{/zcl_attributes_server}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
 {{#>MTRCallbackBridge header="1" partial-type="Status"                         }}DefaultSuccessCallback{{/MTRCallbackBridge}}
 {{#>MTRCallbackBridge header="1" partial-type="CommandStatus"                  }}CommandSuccessCallback{{/MTRCallbackBridge}}
@@ -79,7 +79,7 @@ typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCa
 {{#>MTRCallbackBridge header="1" type="vendor_id"    isNullable=false ns="chip"}}VendorIdAttributeCallback{{/MTRCallbackBridge}}
 {{#>MTRCallbackBridge header="1" type="vendor_id"    isNullable=true  ns="chip"}}NullableVendorIdAttributeCallback{{/MTRCallbackBridge}}
 
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#if isArray}}
@@ -94,15 +94,15 @@ typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCa
 {{/if}}
 {{/unless}}
 {{/zcl_attributes_server}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
-{{#chip_client_clusters includeAll=true}}
-{{#chip_cluster_responses}}
+{{#all_user_clusters side='client'}}
+{{#zcl_command_responses}}
 {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#>MTRCallbackBridge header="1" partial-type="Command"                        }}{{asUpperCamelCase ../../name preserveAcronyms=true}}Cluster{{asUpperCamelCase ../name preserveAcronyms=true}}Callback{{/MTRCallbackBridge}}
 {{/unless}}
-{{/chip_cluster_responses}}
-{{/chip_client_clusters}}
+{{/zcl_command_responses}}
+{{/all_user_clusters}}
 
 {{#zcl_clusters}}
 {{#zcl_enums}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
@@ -40,7 +40,7 @@ static void MTRClustersLogCompletion(NSString *logPrefix, id value, NSError *err
 }
 
 // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks): Linter is unable to locate the delete on these objects.
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
 @implementation MTRCluster{{asUpperCamelCase name preserveAcronyms=true}}
 
@@ -59,7 +59,8 @@ static void MTRClustersLogCompletion(NSString *logPrefix, id value, NSError *err
     return self;
 }
 
-{{#chip_cluster_commands}}
+{{#zcl_commands}}
+{{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandImpl"}}
 {{! This is used as the implementation for both the new-name and old-name bits, so check for both here. }}
@@ -75,7 +76,7 @@ MTR{{cluster}}Cluster{{command}}Params
 {{/inline}}
 {{#*inline "clusterId"}}
 {{#if (wasRemoved cluster command=command)}}
-{{asMEI ../manufacturerCode ../code}}
+{{asMEI ../../manufacturerCode ../../code}}
 {{else}}
 MTRClusterIDType{{cluster}}ID
 {{/if}}
@@ -87,13 +88,13 @@ MTRClusterIDType{{cluster}}ID
 MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
 {{/if}}
 {{/inline}}
-{{#unless (hasArguments)}}
+{{#unless hasArguments}}
 - (void){{asLowerCamelCase name}}WithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion
 {
   [self {{asLowerCamelCase name}}WithParams:nil expectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completion];
 }
 {{/unless}}
-- (void){{asLowerCamelCase name}}WithParams: ({{> paramsType}} * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion
+- (void){{asLowerCamelCase name}}WithParams: ({{> paramsType}} * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion
 {
     NSString * logPrefix = [NSString stringWithFormat:@"MTRDevice command %u %u %u %u", self.device.deviceController.fabricIndex, _endpoint, (unsigned int){{> clusterId}}, (unsigned int){{> commandId}}];
     // Make a copy of params before we go async.
@@ -145,19 +146,19 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
               timedInvokeTimeoutMs.SetValue(10000);
             }
             {{/if}}
-            {{#chip_cluster_command_arguments}}
+            {{#zcl_command_arguments}}
               {{#first}}
-                {{#unless (commandHasRequiredField parent)}}
+                {{#unless parent.commandHasRequiredField}}
                 if (params != nil) {
                 {{/unless}}
               {{/first}}
               {{>encode_value target=(concat "request." (asLowerCamelCase label)) source=(concat "params." (asStructPropertyName label)) cluster=parent.parent.name errorCode="return CHIP_ERROR_INVALID_ARGUMENT;" depth=0}}
               {{#last}}
-                {{#unless (commandHasRequiredField parent)}}
+                {{#unless parent.commandHasRequiredField}}
                 }
                {{/unless}}
               {{/last}}
-            {{/chip_cluster_command_arguments}}
+            {{/zcl_command_arguments}}
 
             return MTRStartInvokeInteraction(typedBridge, request, exchangeManager, session, successCb, failureCb, self->_endpoint, timedInvokeTimeoutMs, invokeTimeout);
         });
@@ -180,7 +181,8 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
 {{/inline}}
 {{> commandImpl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
-{{/chip_cluster_commands}}
+{{/if}}
+{{/zcl_commands}}
 
 {{#zcl_attributes_server}}
 {{! This is used as the implementation for both the new-name and old-name bits, so check for both here. }}
@@ -234,11 +236,12 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
     return [self initWithDevice:device endpointID:@(endpoint) queue:queue];
 }
 
-{{#chip_cluster_commands}}
+{{#zcl_commands}}
+{{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandImpl"}}
 {{#unless (wasRemoved cluster command=command)}}
-- (void){{asLowerCamelCase command}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler
+- (void){{asLowerCamelCase command}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler
 {
   [self {{asLowerCamelCase name}}WithParams:params expectedValues:expectedDataValueDictionaries expectedValueInterval:expectedValueIntervalMs completion:
       {{#if hasSpecificResponse}}
@@ -251,7 +254,7 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
     {{/if}}
     ];
 }
-{{#unless (hasArguments)}}
+{{#unless hasArguments}}
 - (void){{asLowerCamelCase command}}WithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler
 {
   [self {{asLowerCamelCase command}}WithParams:nil expectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completionHandler:completionHandler];
@@ -261,7 +264,8 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
 {{/inline}}
 {{> commandImpl cluster=(compatClusterNameRemapping parent.name)
                 command=(compatCommandNameRemapping parent.name name)}}
-{{/chip_cluster_commands}}
+{{/if}}
+{{/zcl_commands}}
 {{~#zcl_attributes_server}}
 {{~#*inline "attributeImpls"}}
 {{#unless (or (isStrEqual attribute (asUpperCamelCase name preserveAcronyms=true))
@@ -287,6 +291,6 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
 @end
 {{/if}}
 
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)

--- a/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
@@ -60,7 +60,6 @@ static void MTRClustersLogCompletion(NSString *logPrefix, id value, NSError *err
 }
 
 {{#zcl_commands}}
-{{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandImpl"}}
 {{! This is used as the implementation for both the new-name and old-name bits, so check for both here. }}
@@ -76,7 +75,7 @@ MTR{{cluster}}Cluster{{command}}Params
 {{/inline}}
 {{#*inline "clusterId"}}
 {{#if (wasRemoved cluster command=command)}}
-{{asMEI ../../manufacturerCode ../../code}}
+{{asMEI ../manufacturerCode ../code}}
 {{else}}
 MTRClusterIDType{{cluster}}ID
 {{/if}}
@@ -179,6 +178,7 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
 }
 {{/unless}}
 {{/inline}}
+{{#if (is_str_equal source 'client')}}
 {{> commandImpl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
@@ -8,7 +8,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 
 
 {{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
@@ -23,19 +23,21 @@ NS_ASSUME_NONNULL_BEGIN
                               endpointID:(NSNumber *)endpointID
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER {{availability (asUpperCamelCase name preserveAcronyms=true) minimalRelease="First major API revamp"}};
 
-{{#chip_cluster_commands}}
+{{#zcl_commands}}
+{{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandDecl"}}
 {{#unless (wasRemoved cluster command=command)}}
-- (void){{asLowerCamelCase name}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion {{availability cluster command=command minimalRelease="First major API revamp"}};
-{{#unless (hasArguments)}}
+- (void){{asLowerCamelCase name}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion {{availability cluster command=command minimalRelease="First major API revamp"}};
+{{#unless hasArguments}}
 - (void){{asLowerCamelCase name}}WithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion {{availability cluster command=command minimalRelease="First major API revamp"}};
 {{/unless}}
 {{/unless}}
 {{/inline}}
 {{> commandDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
-{{/chip_cluster_commands}}
+{{/if}}
+{{/zcl_commands}}
 
 {{#zcl_attributes_server}}
 {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
@@ -57,9 +59,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 {{/unless}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#unless (isStrEqual (asUpperCamelCase name preserveAcronyms=true) (compatClusterNameRemapping name))}}
 {{#unless (wasRemoved (compatClusterNameRemapping name))}}
 {{availability (compatClusterNameRemapping name) deprecationMessage=(concat "Please use MTRCluster" (asUpperCamelCase name preserveAcronyms=true))}}
@@ -68,9 +70,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{/unless}}
 {{/unless}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping name))
            (not (wasRemoved (compatClusterNameRemapping name))))}}
 @interface MTRCluster{{compatClusterNameRemapping name}} (Deprecated)
@@ -79,20 +81,22 @@ NS_ASSUME_NONNULL_BEGIN
                                endpoint:(uint16_t)endpoint
                                   queue:(dispatch_queue_t)queue {{availability (compatClusterNameRemapping name) deprecatedRelease="First major API revamp" deprecationMessage="Please use initWithDevice:endpoindID:queue:"}};
 
-{{#chip_cluster_commands}}
+{{#zcl_commands}}
+{{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandDecl"}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" cluster command=command)
            (not (wasRemoved cluster command=command)))}}
-- (void){{asLowerCamelCase command}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler {{availability cluster command=command deprecatedRelease="First major API revamp" deprecationMessage=(concat "Please use " (asLowerCamelCase name) "WithParams:expectedValues:expectedValueInterval:completion:")}};
-{{#unless (hasArguments)}}
+- (void){{asLowerCamelCase command}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler {{availability cluster command=command deprecatedRelease="First major API revamp" deprecationMessage=(concat "Please use " (asLowerCamelCase name) "WithParams:expectedValues:expectedValueInterval:completion:")}};
+{{#unless hasArguments}}
 - (void){{asLowerCamelCase command}}WithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler {{availability cluster command=command deprecatedRelease="First major API revamp" deprecationMessage=(concat "Please use " (asLowerCamelCase name) "WithExpectedValues:expectedValueInterval:completion:")}};
 {{/unless}}
 {{/if}}
 {{/inline}}
 {{> commandDecl cluster=(compatClusterNameRemapping parent.name)
                 command=(compatCommandNameRemapping parent.name name)}}
-{{/chip_cluster_commands}}
+{{/if}}
+{{/zcl_commands}}
 {{~#zcl_attributes_server}}
 {{~#*inline "attributeDecls"}}
 {{#unless (isStrEqual attribute (asUpperCamelCase name preserveAcronyms=true))}}
@@ -109,6 +113,6 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 {{/if}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/templates/MTRClusters_Internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters_Internal.zapt
@@ -8,7 +8,7 @@
 
 #include <zap-generated/CHIPClusters.h>
 
-{{#chip_client_clusters includeAll=true}}
+{{#all_user_clusters side='client'}}
 
 {{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
 @interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} ()
@@ -17,4 +17,4 @@
 @end
 {{/unless}}
 
-{{/chip_client_clusters}}
+{{/all_user_clusters}}

--- a/src/darwin/Framework/CHIP/templates/MTREventTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTREventTLVValueDecoder-src.zapt
@@ -21,7 +21,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
 {
     switch (aPath.mClusterId)
     {
-    {{#chip_client_clusters includeAll=true}}
+    {{#all_user_clusters side='client'}}
     {{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
     case Clusters::{{asUpperCamelCase name}}::Id: {
         using namespace Clusters::{{asUpperCamelCase name}};
@@ -63,7 +63,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
         break;
     }
     {{/unless}}
-    {{/chip_client_clusters}}
+    {{/all_user_clusters}}
     default: {
       *aError = CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB;
       break;

--- a/src/darwin/Framework/CHIP/templates/partials/MTRCallbackBridge.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/MTRCallbackBridge.zapt
@@ -78,11 +78,11 @@ void MTR{{> @partial-block}}Bridge::OnSuccessFn(void * context
       DispatchSuccess(context, nil);
       {{else if (isStrEqual partial-type "Command")}}
       auto * response = [MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Params new];
-      {{#chip_cluster_response_arguments}}
+      {{#zcl_command_arguments}}
       {
         {{>decode_value target=(concat "response." (asStructPropertyName label)) source=(concat "data." (asLowerCamelCase label)) cluster=parent.parent.name errorCode="OnFailureFn(context, err); return;" depth=0}}
       }
-      {{/chip_cluster_response_arguments}}
+      {{/zcl_command_arguments}}
       DispatchSuccess(context, response);
       {{else if (isStrEqual partial-type "CommandStatus")}}
       DispatchSuccess(context, nil);


### PR DESCRIPTION
- Replacing chip_client_clusters, chip_cluster_commands, chip_cluster_responses and chip_cluster_command_arguments with all_user_clusters, zcl_commands, zcl_command_responses and zcl_command_arguments respectively in templates
- Updating the required zap version in sdk.json
- Github: ZAP#971

