### PR TITLE
Stop disabling warnings in some public configs.

### DIFF
--- a/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h
+++ b/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h
@@ -81,7 +81,7 @@ public:
             {
                 mDacVerifier->EnableCdTestKeySupport(isEnabled);
             }
-
+            break;
         default:
             break;
         }

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -85,6 +85,7 @@ public:
             break;
         case PairingMode::Code:
             AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
+            FALLTHROUGH;
         case PairingMode::CodePaseOnly:
             AddArgument("payload", &mOnboardingPayload);
             AddArgument("discover-once", 0, 1, &mDiscoverOnce);

--- a/examples/common/websocket-server/BUILD.gn
+++ b/examples/common/websocket-server/BUILD.gn
@@ -15,6 +15,11 @@
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
+config("websocket_server_config_disable_warnings") {
+  # Unfortunately, some of the libwebsockets headers include -Wshadow failures.
+  cflags = [ "-Wno-shadow" ]
+}
+
 static_library("websocket-server") {
   output_name = "libWebSocketServer"
 
@@ -28,4 +33,6 @@ static_library("websocket-server") {
     "${chip_root}/src/lib/support",
     "${chip_root}/third_party/libwebsockets",
   ]
+
+  configs += [ ":websocket_server_config_disable_warnings" ]
 }

--- a/examples/darwin-framework-tool/commands/common/MTRError.mm
+++ b/examples/darwin-framework-tool/commands/common/MTRError.mm
@@ -87,6 +87,7 @@ CHIP_ERROR MTRErrorToCHIPErrorCode(NSError * error)
             break;
         }
         // Weird error we did not create.  Fall through.
+        FALLTHROUGH;
     default:
         code = CHIP_ERROR_INTERNAL.AsInteger();
         break;

--- a/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
@@ -236,8 +236,6 @@ public:
 
     MTRBaseDevice * _Nullable GetDevice(const char * _Nullable identity)
     {
-        MTRDeviceController * controller = GetCommissioner(identity);
-
         SetIdentity(identity);
         return mConnectedDevices[identity];
     }

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -677,6 +677,8 @@ inline void chipDie(void)
 
 #if defined(__clang__)
 #define FALLTHROUGH [[clang::fallthrough]]
+#elif defined(__GNUC__)
+#define FALLTHROUGH __attribute__((fallthrough))
 #else
 #define FALLTHROUGH (void) 0
 #endif

--- a/third_party/boringssl/repo/BUILD.gn
+++ b/third_party/boringssl/repo/BUILD.gn
@@ -20,6 +20,12 @@ import("BUILD.generated.gni")
 config("boringssl_config") {
   include_dirs = [ "src/include" ]
 
+  # We want the basic crypto impl with no asm primitives until we hook-up platform-based
+  # support to the build later.
+  defines = [ "OPENSSL_NO_ASM=1" ]
+}
+
+config("boringssl_config_disable_warnings") {
   cflags = [
     "-Wno-unused-variable",
     "-Wno-conversion",
@@ -28,11 +34,8 @@ config("boringssl_config") {
   if (is_clang) {
     cflags += [ "-Wno-shorten-64-to-32" ]
   }
-
-  # We want the basic crypto impl with no asm primitives until we hook-up platform-based
-  # support to the build later.
-  defines = [ "OPENSSL_NO_ASM=1" ]
 }
+
 all_sources = crypto_sources
 
 all_headers = crypto_headers
@@ -45,4 +48,9 @@ static_library("boringssl") {
   sources = all_sources
 
   public_configs = [ ":boringssl_config" ]
+
+  # The disable-warnings config should not be a public config, since
+  # that would make it apply to compilations of anything that depends
+  # on boringssl, not just boringssl itself.
+  configs += [ ":boringssl_config_disable_warnings" ]
 }

--- a/third_party/editline/BUILD.gn
+++ b/third_party/editline/BUILD.gn
@@ -17,7 +17,9 @@ import("${build_root}/config/compiler/compiler.gni")
 
 config("editline_config") {
   include_dirs = [ "repo/include" ]
+}
 
+config("editline_config_disable_warnings") {
   cflags = [ "-Wno-conversion" ]
 
   if (is_clang) {
@@ -37,6 +39,8 @@ static_library("editline") {
   ]
 
   public_configs = [ ":editline_config" ]
+
+  configs += [ ":editline_config_disable_warnings" ]
 
   include_dirs = [ "include" ]
 }

--- a/third_party/jsoncpp/BUILD.gn
+++ b/third_party/jsoncpp/BUILD.gn
@@ -17,7 +17,9 @@ import("//build_overrides/chip.gni")
 
 config("jsoncpp_config") {
   include_dirs = [ "repo/include" ]
+}
 
+config("jsoncpp_config_disable_warnings") {
   cflags = [ "-Wno-implicit-fallthrough" ]
 }
 
@@ -40,6 +42,8 @@ source_set("jsoncpp") {
   ]
 
   public_configs = [ ":jsoncpp_config" ]
+
+  configs += [ ":jsoncpp_config_disable_warnings" ]
 
   defines = [
     "JSON_USE_EXCEPTION=0",

--- a/third_party/libwebsockets/BUILD.gn
+++ b/third_party/libwebsockets/BUILD.gn
@@ -18,14 +18,16 @@ config("libwebsockets_config") {
     "repo/include",
   ]
 
+  defines = []
+}
+
+config("libwebsockets_config_disable_warnings") {
   cflags = [
     "-Wno-shadow",
     "-Wno-unreachable-code",
     "-Wno-format-nonliteral",
     "-Wno-implicit-fallthrough",
   ]
-
-  defines = []
 }
 
 source_set("libwebsockets") {
@@ -107,4 +109,5 @@ source_set("libwebsockets") {
   }
 
   public_configs = [ ":libwebsockets_config" ]
+  configs += [ ":libwebsockets_config_disable_warnings" ]
 }

--- a/third_party/nlunit-test/BUILD.gn
+++ b/third_party/nlunit-test/BUILD.gn
@@ -17,7 +17,9 @@ import("${build_root}/config/compiler/compiler.gni")
 
 config("nlunit-test_config") {
   include_dirs = [ "repo/src" ]
+}
 
+config("nlunit-test_config_disable_warnings") {
   cflags = [ "-Wno-conversion" ]
 
   if (is_clang) {
@@ -36,4 +38,5 @@ static_library("nlunit-test") {
   ]
 
   public_configs = [ ":nlunit-test_config" ]
+  configs += [ ":nlunit-test_config_disable_warnings" ]
 }


### PR DESCRIPTION
Disabling warnings in a public config will disable those warnings for anything that depends on the thing using the config.  This led to a bunch of warnings being disabled incorrectly for consumers of third-party libraries.


