### PR TITLE
Don't modify global git safe.directory config outside of CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Try to ensure the directories for core dumping exist and we
                   can write them.
               run: |
@@ -177,7 +177,7 @@ jobs:
             #   with:
             #      languages: "cpp"
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Try to ensure the directories for core dumping exist and we
                   can write them.
               run: |
@@ -342,7 +342,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
               uses: actions/cache@v3
@@ -398,7 +398,7 @@ jobs:
             #  with:
             #     languages: "cpp"
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform darwin
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform darwin
             - name: Try to ensure the directory for diagnostic log collection exists
               run: |
                   mkdir -p ~/Library/Logs/DiagnosticReports || true
@@ -501,7 +501,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
               uses: actions/cache@v3

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -43,7 +43,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Bootstrap cache
               uses: actions/cache@v3
               timeout-minutes: 10
@@ -79,7 +79,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform esp32
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
             - name: Bootstrap cache
               uses: actions/cache@v3
               timeout-minutes: 10
@@ -115,7 +115,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform nrfconnect
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform nrfconnect
             - name: Bootstrap cache
               uses: actions/cache@v3
               timeout-minutes: 10

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -58,7 +58,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
               uses: actions/cache@v3

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -54,7 +54,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform darwin
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform darwin
             - name: Setup Environment
               # coreutils for stdbuf
               run: brew install coreutils

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -42,7 +42,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform darwin
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform darwin
             - name: Setup Environment
               run: brew install python@3.9
 

--- a/.github/workflows/examples-ameba.yaml
+++ b/.github/workflows/examples-ameba.yaml
@@ -49,7 +49,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform ameba
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform ameba
             - name: Bootstrap cache
               uses: actions/cache@v3
               timeout-minutes: 10

--- a/.github/workflows/examples-bouffalolab.yaml
+++ b/.github/workflows/examples-bouffalolab.yaml
@@ -49,7 +49,7 @@ jobs:
           attempt_limit: 3
           attempt_delay: 2000
       - name: Checkout submodules
-        run: scripts/checkout_submodules.py --shallow --platform bouffalolab --recursive
+        run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform bouffalolab --recursive
 
       - name: Set up environment for size reports
         if: ${{ !env.ACT }}

--- a/.github/workflows/examples-cc13x2x7_26x2x7.yaml
+++ b/.github/workflows/examples-cc13x2x7_26x2x7.yaml
@@ -51,7 +51,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform cc13x2_26x2
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform cc13x2_26x2
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}
               env:

--- a/.github/workflows/examples-cc32xx.yaml
+++ b/.github/workflows/examples-cc32xx.yaml
@@ -48,7 +48,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform cc32xx
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform cc32xx
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}
               env:

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -52,7 +52,7 @@ jobs:
           attempt_limit: 3
           attempt_delay: 2000
       - name: Checkout submodules
-        run: scripts/checkout_submodules.py --shallow --platform silabs_docker
+        run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform silabs_docker
 
       # - name: Out of Tree verification
       #   run: third_party/silabs/out_of_tree_verification.sh

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -49,7 +49,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform esp32
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}
@@ -172,7 +172,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform esp32
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
 
             - name: Bootstrap cache
               uses: actions/cache@v3

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -49,7 +49,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform infineon
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform infineon
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -51,7 +51,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform k32w0
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform k32w0
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -49,7 +49,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -47,7 +47,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
               uses: actions/cache@v3

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -49,7 +49,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -55,7 +55,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform mbed
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform mbed
 
             - name: Detect changed paths
               uses: dorny/paths-filter@v2

--- a/.github/workflows/examples-mw320.yaml
+++ b/.github/workflows/examples-mw320.yaml
@@ -51,7 +51,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform mw320
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform mw320
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -52,7 +52,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform nrfconnect
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform nrfconnect
             - name: Detect changed paths
               uses: dorny/paths-filter@v2
               id: changed_paths

--- a/.github/workflows/examples-openiotsdk.yaml
+++ b/.github/workflows/examples-openiotsdk.yaml
@@ -51,7 +51,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --recursive --platform openiotsdk
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --recursive --platform openiotsdk
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -51,7 +51,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform qpg
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform qpg
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -50,7 +50,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform telink
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform telink
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}
@@ -132,7 +132,7 @@ jobs:
 
             - name: Build example Telink Lighting App with Factory Data
               run: |
-                  ./scripts/checkout_submodules.py --shallow --platform linux
+                  ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
                   ./scripts/build/gn_gen.sh
                   ./scripts/run_in_build_env.sh "ninja -C ./out/$BUILD_TYPE chip-cert chip-tool spake2p"
                   ./scripts/run_in_build_env.sh \

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -50,7 +50,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform tizen
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform tizen
 
             - name: Bootstrap cache
               uses: actions/cache@v3

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -61,7 +61,7 @@ jobs:
               if: ${{ env.ACT }}
               name: Checkout (ACT for local build)
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform android
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform android
 
             - name: Bootstrap cache
               uses: actions/cache@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,7 +54,7 @@ jobs:
             # Bootstrap and checkout for internal scripts (like idl_lint)
             # to run
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Bootstrap cache
               uses: actions/cache@v3
               timeout-minutes: 10

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -53,7 +53,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform esp32
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
 
             - name: Bootstrap cache
               uses: actions/cache@v3
@@ -117,7 +117,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform tizen
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform tizen
 
             - name: Bootstrap cache
               uses: actions/cache@v3

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -52,7 +52,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform android
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform android
 
             - name: Bootstrap cache
               uses: actions/cache@v3

--- a/.github/workflows/smoketest-darwin.yaml
+++ b/.github/workflows/smoketest-darwin.yaml
@@ -42,7 +42,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform darwin
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform darwin
             - name: Setup Environment
               run: brew install python@3.9
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,7 +72,7 @@ jobs:
               if: ${{ env.ACT }}
               name: Checkout (ACT for local build)
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Try to ensure the directories for core dumping exist and we
                   can write them.
               run: |
@@ -324,7 +324,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform darwin
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform darwin
             - name: Setup Environment
               # coreutils for stdbuf
               run: brew install coreutils
@@ -450,7 +450,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v3
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Try to ensure the directories for core dumping exist and we
                   can write them.
               run: |
@@ -536,7 +536,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v3
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Try to ensure the directories for core dumping exist and we
                   can write them.
               run: |
@@ -705,7 +705,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v3
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform darwin
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform darwin
             - name: Setup Environment
               # coreutils for stdbuf
               run: brew install coreutils

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -53,7 +53,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Bootstrap
               timeout-minutes: 10
               run: |

--- a/.github/workflows/zap_regeneration.yaml
+++ b/.github/workflows/zap_regeneration.yaml
@@ -45,7 +45,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
               uses: actions/cache@v3

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -46,7 +46,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
+              run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
               uses: actions/cache@v3

--- a/examples/chef/README.md
+++ b/examples/chef/README.md
@@ -146,7 +146,8 @@ chef_$PLATFORM:
               attempt_limit: 3
               attempt_delay: 2000
         - name: Checkout submodules
-          run: scripts/checkout_submodules.py --shallow --platform $PLATFORM
+          run: |
+              scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform $PLATFORM
         - name: Bootstrap
           timeout-minutes: 25
           run: scripts/build/gn_bootstrap.sh

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -200,7 +200,7 @@ RUN mkdir /root/connectedhomeip
 RUN git clone https://github.com/project-chip/connectedhomeip.git /root/connectedhomeip
 WORKDIR /root/connectedhomeip/
 RUN git checkout ${COMMITHASH}
-RUN ./scripts/checkout_submodules.py --shallow --platform linux
+RUN ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 RUN scripts/build/gn_bootstrap.sh
 SHELL ["/bin/bash", "-c"]
 RUN set -x && \

--- a/scripts/build/gn_gen_cirque.sh
+++ b/scripts/build/gn_gen_cirque.sh
@@ -30,7 +30,7 @@ env
 cd "$ROOT_PATH"
 
 echo "Ensure submodules for Linux builds are checked out"
-./scripts/checkout_submodules.py --shallow --platform linux
+./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
 echo "Setup build environment"
 source "./scripts/activate.sh"


### PR DESCRIPTION
Adding CHIP_ROOT as a safe directory is now gated by a `--allow-changing-global-git-config` flag which is added to all the calls from CI scripts (but not e.g. the Darwin chip_xcode_build_connector). Also avoid adding the directory again if it's already in the list.