### PR TITLE
[ESP32] Set default apply update action to proceed

### DIFF
--- a/examples/ota-provider-app/esp32/main/main.cpp
+++ b/examples/ota-provider-app/esp32/main/main.cpp
@@ -134,7 +134,7 @@ static void InitServer(intptr_t context)
     {
         otaProvider.SetQueryImageStatus(OTAQueryStatus::kUpdateAvailable);
         otaProvider.SetOTAFilePath(otaImagePath);
-		otaProvider.SetApplyUpdateAction(OTAApplyUpdateAction::kProceed);
+        otaProvider.SetApplyUpdateAction(OTAApplyUpdateAction::kProceed);
     }
     fclose(otaImageFile);
     otaImageFile = NULL;

--- a/examples/ota-provider-app/esp32/main/main.cpp
+++ b/examples/ota-provider-app/esp32/main/main.cpp
@@ -134,6 +134,7 @@ static void InitServer(intptr_t context)
     {
         otaProvider.SetQueryImageStatus(OTAQueryStatus::kUpdateAvailable);
         otaProvider.SetOTAFilePath(otaImagePath);
+		otaProvider.SetApplyUpdateAction(OTAApplyUpdateAction::kProceed);
     }
     fclose(otaImageFile);
     otaImageFile = NULL;

--- a/examples/ota-requestor-app/esp32/README.md
+++ b/examples/ota-requestor-app/esp32/README.md
@@ -53,5 +53,5 @@ application of OTA image.
 ### Note
 
 While trying out example ota-requestor-app bump the software version from
-`CMakeList.txt` and not from `idf.py menuconfig`. And software version of the 
+`CMakeList.txt` and not from `idf.py menuconfig`. And software version of the
 image which is being ota should be greater than current software version.

--- a/examples/ota-requestor-app/esp32/README.md
+++ b/examples/ota-requestor-app/esp32/README.md
@@ -52,5 +52,6 @@ application of OTA image.
 
 ### Note
 
-While trying out example ota-requestor-app change the software version from
-`CMakeList.txt` and not from `idf.py menuconfig`
+While trying out example ota-requestor-app bump the software version from
+`CMakeList.txt` and not from `idf.py menuconfig`. And software version of the 
+image which is being ota should be greater than current software version.

--- a/examples/ota-requestor-app/esp32/README.md
+++ b/examples/ota-requestor-app/esp32/README.md
@@ -16,7 +16,6 @@ guides to get started.
 -   [RPC console and Device Tracing](../../../docs/guides/esp32/rpc_console.md)
 
 ---
-
 ## Prerequisite
 
 Before moving ahead, make sure you have
@@ -49,3 +48,7 @@ application of OTA image.
 ```
 ./out/debug/chip-tool pairing onnetwork 12345 20202021
 ```
+
+### Note
+
+While trying out example ota-requestor-app change the software version from `CMakeList.txt` and not from `idf.py menuconfig`

--- a/examples/ota-requestor-app/esp32/README.md
+++ b/examples/ota-requestor-app/esp32/README.md
@@ -16,6 +16,7 @@ guides to get started.
 -   [RPC console and Device Tracing](../../../docs/guides/esp32/rpc_console.md)
 
 ---
+
 ## Prerequisite
 
 Before moving ahead, make sure you have
@@ -51,4 +52,5 @@ application of OTA image.
 
 ### Note
 
-While trying out example ota-requestor-app change the software version from `CMakeList.txt` and not from `idf.py menuconfig`
+While trying out example ota-requestor-app change the software version from
+`CMakeList.txt` and not from `idf.py menuconfig`


### PR DESCRIPTION
Problem:

- Default action for `applyUpdateResponse` command was `discontinue` .

Changes:

- Set default `applyUpdateResponse` action to `proceed`
- Updated readme about how to bump software version to try ota example

Testing:

- Tested ota for esp32