### PR TITLE
[Silabs] WiFi 917SoC power cycle and lib shell fix

### DIFF
--- a/examples/platform/silabs/SiWx917/BUILD.gn
+++ b/examples/platform/silabs/SiWx917/BUILD.gn
@@ -35,6 +35,9 @@ declare_args() {
   # Argument to force enable WPA3 security on rs91x
   rs91x_wpa3_only = false
 
+  # use commissionable data for SiWx917
+  siwx917_commissionable_data = false
+
   #default WiFi SSID
   chip_default_wifi_ssid = ""
 
@@ -145,6 +148,10 @@ source_set("siwx917-attestation-credentials") {
 }
 
 source_set("siwx917-factory-data-provider") {
+  if (siwx917_commissionable_data) {
+    defines = [ "SIWX917_USE_COMISSIONABLE_DATA=1" ]
+  }
+
   sources = [
     "SiWx917DeviceDataProvider.cpp",
     "SiWx917DeviceDataProvider.h",

--- a/examples/platform/silabs/SiWx917/SiWx917DeviceDataProvider.h
+++ b/examples/platform/silabs/SiWx917/SiWx917DeviceDataProvider.h
@@ -39,8 +39,10 @@ public:
 
     static SIWx917DeviceDataProvider & GetDeviceDataProvider();
     CHIP_ERROR GetSetupPayload(MutableCharSpan & payloadBuf);
+#ifdef SIWX917_USE_COMISSIONABLE_DATA
     void setupPayload(uint8_t * outBuf);
     CHIP_ERROR FlashFactoryData();
+#endif /* SIWX917_USE_COMISSIONABLE_DATA */
     // ===== Members functions that implement the CommissionableDataProvider
     CHIP_ERROR GetSetupDiscriminator(uint16_t & setupDiscriminator) override;
     CHIP_ERROR SetSetupDiscriminator(uint16_t setupDiscriminator) override { return CHIP_ERROR_NOT_IMPLEMENTED; }

--- a/examples/platform/silabs/SiWx917/ldscripts/SiWx917.ld
+++ b/examples/platform/silabs/SiWx917/ldscripts/SiWx917.ld
@@ -203,7 +203,7 @@ SECTIONS
   } > FLASH
 
   /* Last page of flash is reserved for the manufacturing token space */
-  linker_nvm_end = __main_flash_end__ - 2048;
+  linker_nvm_end = __main_flash_end__ - 4096;
   linker_nvm_begin = linker_nvm_end - SIZEOF(.nvm);
   linker_nvm_size = SIZEOF(.nvm);
   __nvm3Base = linker_nvm_begin;

--- a/examples/platform/silabs/SiWx917/uart.cpp
+++ b/examples/platform/silabs/SiWx917/uart.cpp
@@ -82,7 +82,9 @@ void uartConsoleInit(void)
 
     status = UARTdrv->Initialize(ARM_USART_SignalEvent);
     // Setting the GPIO 30 of the radio board (TX)
+    // Setting the GPIO 29 of the radio board (RX)
     RSI_EGPIO_HostPadsGpioModeEnable(30);
+    RSI_EGPIO_HostPadsGpioModeEnable(29);
 
     // Initialized board UART
     DEBUGINIT();


### PR DESCRIPTION
* Added fix for 917SoC power cycle issue
> Modified the NVM3 page size to 4096
> Updated the .ld file for alignment 
> After power cycle DUT will connect to the old AP if it is connected previously
* Enabled the UART pin for matter lib shell
*  Added the commissionable data provider at common location