### PR TITLE
[Silabs] Fix test value fallback for hardware version string read

### DIFF
--- a/examples/platform/silabs/SiWx917/SiWx917DeviceDataProvider.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917DeviceDataProvider.cpp
@@ -355,13 +355,13 @@ CHIP_ERROR SIWx917DeviceDataProvider::GetHardwareVersionString(char * buf, size_
     size_t hardwareVersionStringLen = 0; // without counting null-terminator
     CHIP_ERROR err =
         SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_HardwareVersionString, buf, bufSize, hardwareVersionStringLen);
-#if defined(CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION_STRING)
+#if defined(CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_HARDWARE_VERSION_STRING)
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
-        memcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION_STRING, sizeof(bufSize));
+        memcpy(buf, CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_HARDWARE_VERSION_STRING, bufSize);
         err = CHIP_NO_ERROR;
     }
-#endif // CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION_STRING
+#endif // CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_HARDWARE_VERSION_STRING
     return err;
 }
 

--- a/examples/platform/silabs/efr32/EFR32DeviceDataProvider.cpp
+++ b/examples/platform/silabs/efr32/EFR32DeviceDataProvider.cpp
@@ -224,13 +224,13 @@ CHIP_ERROR EFR32DeviceDataProvider::GetHardwareVersionString(char * buf, size_t 
     size_t hardwareVersionStringLen = 0; // without counting null-terminator
     CHIP_ERROR err =
         SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_HardwareVersionString, buf, bufSize, hardwareVersionStringLen);
-#if defined(CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION_STRING)
+#if defined(CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_HARDWARE_VERSION_STRING)
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
-        memcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION_STRING, sizeof(bufSize));
+        memcpy(buf, CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_HARDWARE_VERSION_STRING, bufSize);
         err = CHIP_NO_ERROR;
     }
-#endif // CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION_STRING
+#endif // CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_HARDWARE_VERSION_STRING
     return err;
 }
 

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -224,7 +224,7 @@
 #endif
 
 /**
- * CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION_STRING
+ * CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_HARDWARE_VERSION_STRING
  *
  * Human readable string identifying version of the product assigned by the device vendor.
  */


### PR DESCRIPTION
Silabs Device data provider has a fallback to test values when the requested data hasn't been provided to the device.

The fallback for the Hardware version String was using a define that isn't defined anywhere in Matter. 

Replace that undefined name with the correct default test value `CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_HARDWARE_VERSION_STRING`

The size provide in the memcpy was also wrong. 

tested on an _unprovided_ EFR32 with chip-tool
`chip-tool basicinformation read hardware-version-string $NODE_ID 0`
now correctly receives the test value _(TEST_VERSION)_
