### PR TITLE
Fix bridge FALLTHROUGH annotation

### DIFF
--- a/examples/dynamic-bridge-app/linux/include/data-model/DataModel.h
+++ b/examples/dynamic-bridge-app/linux/include/data-model/DataModel.h
@@ -277,7 +277,7 @@ CHIP_ERROR Decode(const ConcreteDataAttributePath & aPath, AttributeValueDecoder
 
     case ConcreteDataAttributePath::ListOperation::ReplaceAll:
         x.clear();
-        // fallthrough
+        FALLTHROUGH;
     default:
         x.emplace_back();
         return aDecoder.Decode(x.back());


### PR DESCRIPTION
Make linux-arm64-dynamic-bridge-ipv6only-clang compile again after #25854.