### PR TITLE
Make implementing handleBDXTransferSessionEndForNodeID actually optional.

### DIFF
--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -316,11 +316,13 @@ private:
         auto nodeId = @(mNodeId.Value());
 
         auto strongDelegate = mDelegate;
-        dispatch_async(mDelegateNotificationQueue, ^{
-            [strongDelegate handleBDXTransferSessionEndForNodeID:nodeId
-                                                      controller:controller
-                                                           error:[MTRError errorForCHIPErrorCode:error]];
-        });
+        if ([strongDelegate respondsToSelector:@selector(handleBDXTransferSessionEndForNodeID:controller:error:)]) {
+            dispatch_async(mDelegateNotificationQueue, ^{
+                [strongDelegate handleBDXTransferSessionEndForNodeID:nodeId
+                                                          controller:controller
+                                                               error:[MTRError errorForCHIPErrorCode:error]];
+            });
+        }
 
         ResetState();
         return CHIP_NO_ERROR;


### PR DESCRIPTION
It's marked @optional in the API, but we're calling it unconditionally.
