### PR TITLE
TC-CGEN-2.4 - fix commented out test step

### DIFF
--- a/src/python_testing/TC_CGEN_2_4.py
+++ b/src/python_testing/TC_CGEN_2_4.py
@@ -20,6 +20,7 @@ import time
 
 import chip.CertificateAuthority
 import chip.clusters as Clusters
+import chip.clusters.enum
 import chip.FabricAdmin
 from chip import ChipDeviceCtrl
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main
@@ -106,21 +107,13 @@ class TC_CGEN_2_4(MatterBaseTest):
         elif cap == Clusters.GeneralCommissioning.Enums.RegulatoryLocationType.kOutdoor:
             newloc = Clusters.GeneralCommissioning.Enums.RegulatoryLocationType.kIndoor
         else:
-            # TODO: figure out how to use the extender
-            # newloc = MatterIntEnum.extend_enum_if_value_doesnt_exist(
-            #     Clusters.GeneralCommissioning.Enums.RegulatoryLocationType, 3)
-            newloc = cap
+             newloc = Clusters.GeneralCommissioning.Enums.RegulatoryLocationType.extend_enum_if_value_doesnt_exist(3)
 
-        _ = newloc
-
-        logging.info('Step 19 Send SetRgulatoryConfig with incorrect location')
-        # cmd = Clusters.GeneralCommissioning.Commands.SetRegulatoryConfig(
-        #     newRegulatoryConfig=newloc, countryCode="XX", breadcrumb=0)
-        # try:
-        #    await self.th1.SendCommand(nodeid=self.dut_node_id, endpoint=0, payload=cmd)
-        # except InteractionModelError as ex:
-        #    print("got the real error")
-        #    pass
+        logging.info('Step 19 Send SetRgulatoryConfig with incorrect location newloc = {}'.format(newloc))
+        cmd = Clusters.GeneralCommissioning.Commands.SetRegulatoryConfig(
+            newRegulatoryConfig=newloc, countryCode="XX", breadcrumb=0)
+        ret = await self.th1.SendCommand(nodeid=self.dut_node_id, endpoint=0, payload=cmd)
+        asserts.assert_true(ret.errorCode, Clusters.GeneralCommissioning.Enums.CommissioningError.kValueOutsideRange)
 
         logging.info('Step 20 - TH2 sends CommissioningComplete')
         cmd = Clusters.GeneralCommissioning.Commands.CommissioningComplete()

--- a/src/python_testing/TC_CGEN_2_4.py
+++ b/src/python_testing/TC_CGEN_2_4.py
@@ -107,7 +107,7 @@ class TC_CGEN_2_4(MatterBaseTest):
         elif cap == Clusters.GeneralCommissioning.Enums.RegulatoryLocationType.kOutdoor:
             newloc = Clusters.GeneralCommissioning.Enums.RegulatoryLocationType.kIndoor
         else:
-             newloc = Clusters.GeneralCommissioning.Enums.RegulatoryLocationType.extend_enum_if_value_doesnt_exist(3)
+            newloc = Clusters.GeneralCommissioning.Enums.RegulatoryLocationType.extend_enum_if_value_doesnt_exist(3)
 
         logging.info('Step 19 Send SetRgulatoryConfig with incorrect location newloc = {}'.format(newloc))
         cmd = Clusters.GeneralCommissioning.Commands.SetRegulatoryConfig(


### PR DESCRIPTION
Fixes https://github.com/CHIP-Specifications/chip-certification-tool/issues/721. 

Summary - I forgot to uncomment one of the steps. Whoops.