### PR TITLE
[Silabs]Remove unused error code check. This error value can't be returned

### DIFF
--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -435,12 +435,6 @@ CHIP_ERROR SilabsConfig::FactoryResetConfig(void)
                             return err2;
                         });
 
-    // Return success at end of iterations.
-    if (err == CHIP_END_OF_INPUT)
-    {
-        err = CHIP_NO_ERROR;
-    }
-
     return err;
 }
 


### PR DESCRIPTION
`CHIP_END_OF_INPUT` can't be returned by the previous calls. Remove this dead code
