### PR TITLE
Deprecating Stateful Helpers

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -7,7 +7,7 @@ ARG COMMITHASH=7b99e6399c6069037c613782d78132c69b9dcabb
 # ZAP Development install, so that it runs on both x64 and arm64
 # Generally this should match with the ZAP version that is used for codegen within the
 # specified SHA
-ARG ZAP_VERSION=v2023.03.27-nightly
+ARG ZAP_VERSION=v2023.03.29-nightly
 
 # Ensure TARGETPLATFORM is set
 RUN case ${TARGETPLATFORM} in \

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -7,7 +7,7 @@ ARG COMMITHASH=7b99e6399c6069037c613782d78132c69b9dcabb
 # ZAP Development install, so that it runs on both x64 and arm64
 # Generally this should match with the ZAP version that is used for codegen within the
 # specified SHA
-ARG ZAP_VERSION=v2023.03.29-nightly
+ARG ZAP_VERSION=v2023.03.30-nightly
 
 # Ensure TARGETPLATFORM is set
 RUN case ${TARGETPLATFORM} in \

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -8,7 +8,7 @@
                 "mac-arm64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2023.03.27-nightly.1"]
+            "tags": ["version:2@v2023.03.29-nightly.1"]
         }
     ]
 }

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -8,7 +8,7 @@
                 "mac-arm64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2023.03.29-nightly.1"]
+            "tags": ["version:2@v2023.03.30-nightly.1"]
         }
     ]
 }

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2023.3.27'
+MIN_ZAP_VERSION = '2023.3.29'
 
 
 class ZapTool:

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2023.3.29'
+MIN_ZAP_VERSION = '2023.3.30'
 
 
 class ZapTool:

--- a/src/controller/java/templates/CHIPAttributeTLVValueDecoder-src.zapt
+++ b/src/controller/java/templates/CHIPAttributeTLVValueDecoder-src.zapt
@@ -37,7 +37,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
     
     switch (aPath.mClusterId)
     {
-        {{#chip_client_clusters}}
+        {{#all_user_clusters side='client'}}
         case app::Clusters::{{asUpperCamelCase name}}::Id: {
             using namespace app::Clusters::{{asUpperCamelCase name}};
             switch (aPath.mAttributeId)
@@ -61,7 +61,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
             }
             break;
         }
-        {{/chip_client_clusters}}
+        {{/all_user_clusters}}
         default:
             *aError = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB;
             break;

--- a/src/controller/java/templates/CHIPClustersWrite-JNI.zapt
+++ b/src/controller/java/templates/CHIPClustersWrite-JNI.zapt
@@ -29,7 +29,7 @@
 using namespace chip;
 using namespace chip::Controller;
 
-{{#chip_client_clusters}}
+{{#all_user_clusters side='client'}}
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{#if_unsupported_attribute_callback type isArray ../id}}
 {{else}}
@@ -77,7 +77,7 @@ JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, write{{asUpperCamelCase na
 {{/if}}
 {{/if_unsupported_attribute_callback}}
 {{/zcl_attributes_server}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 {{/if}}
 
 #pragma clang diagnostic pop

--- a/src/controller/java/templates/CHIPEventTLVValueDecoder-src.zapt
+++ b/src/controller/java/templates/CHIPEventTLVValueDecoder-src.zapt
@@ -37,7 +37,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
     
     switch (aPath.mClusterId)
     {
-        {{#chip_client_clusters}}
+        {{#all_user_clusters side='client'}}
         case app::Clusters::{{asUpperCamelCase name}}::Id: {
             using namespace app::Clusters::{{asUpperCamelCase name}};
             switch (aPath.mEventId)
@@ -82,7 +82,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
             break;
         }
-        {{/chip_client_clusters}}
+        {{/all_user_clusters}}
         default:
             *aError = CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB;
             break;

--- a/src/controller/java/templates/CHIPReadCallbacks-src.zapt
+++ b/src/controller/java/templates/CHIPReadCallbacks-src.zapt
@@ -85,7 +85,7 @@ void CHIP{{chipCallback.name}}AttributeCallback::CallbackFn(void * context, {{ch
 {{/unless}}
 {{/chip_server_global_responses}}
 
-{{#chip_client_clusters}}
+{{#all_user_clusters side='client'}}
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{! TODO: Add support for struct-typed attributes }}
 {{#if_unsupported_attribute_callback type isArray ../id}}
@@ -173,6 +173,6 @@ void CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallb
 {{/if}}
 {{/if_unsupported_attribute_callback}}
 {{/zcl_attributes_server}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
 {{/if}}

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -112,8 +112,9 @@ public class ChipClusters {
 
     @Override
     public native long initWithDevice(long devicePtr, int endpointId);
-  {{#zcl_commands}}
-    {{#if (is_str_equal source 'client')}}
+  {{#all_user_cluster_generated_commands}}
+    {{#if_compare clusterId ../id operator='=='}}
+      {{#if (is_str_equal commandSource 'client')}}
 
     {{#unless mustUseTimedInvoke}}
     public void {{asLowerCamelCase name}}({{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback
@@ -127,15 +128,18 @@ public class ChipClusters {
       , int timedInvokeTimeoutMs) {
       {{asLowerCamelCase name}}(chipClusterPtr, callback{{#zcl_command_arguments}}, {{asLowerCamelCase label}}{{/zcl_command_arguments}}, timedInvokeTimeoutMs);
     }
-    {{/if}}
-  {{/zcl_commands}}
-  {{#zcl_commands}}
-    {{#if (is_str_equal source 'client')}}
+      {{/if}}
+    {{/if_compare}}
+  {{/all_user_cluster_generated_commands}}
+  {{#all_user_cluster_generated_commands}}
+    {{#if_compare clusterId ../id operator='=='}}
+      {{#if (is_str_equal commandSource 'client')}}
     private native void {{asLowerCamelCase name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} Callback
       {{#zcl_command_arguments}}, {{asJavaType type chipType parent.parent.name includeAnnotations=true clusterId=parent.parent.id}} {{asLowerCamelCase label}}{{/zcl_command_arguments}}
       , @Nullable Integer timedInvokeTimeoutMs);
       {{/if}}
-  {{/zcl_commands}}
+    {{/if_compare}}
+  {{/all_user_cluster_generated_commands}}
     {{#all_user_cluster_generated_commands}}
       {{#if_compare clusterId ../id operator='=='}}
         {{#if (is_str_equal commandSource 'server')}}

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -102,7 +102,7 @@ public class ChipClusters {
     }
   }
 
-  {{#chip_client_clusters}}
+  {{#all_user_clusters side='client'}}
   public static class {{asUpperCamelCase name}}Cluster extends BaseChipCluster {
     public static final long CLUSTER_ID = {{code}}L;
 
@@ -112,34 +112,42 @@ public class ChipClusters {
 
     @Override
     public native long initWithDevice(long devicePtr, int endpointId);
-  {{#chip_cluster_commands}}
+  {{#zcl_commands}}
+    {{#if (is_str_equal source 'client')}}
 
     {{#unless mustUseTimedInvoke}}
     public void {{asLowerCamelCase name}}({{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback
-      {{#chip_cluster_command_arguments}}, {{asJavaType type chipType parent.parent.name includeAnnotations=true}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments}}) {
-      {{asLowerCamelCase name}}(chipClusterPtr, callback{{#chip_cluster_command_arguments}}, {{asLowerCamelCase label}}{{/chip_cluster_command_arguments}}, null);
+      {{#zcl_command_arguments}}, {{asJavaType type chipType parent.parent.name includeAnnotations=true clusterId=parent.parent.id}} {{asLowerCamelCase label}}{{/zcl_command_arguments}}) {
+      {{asLowerCamelCase name}}(chipClusterPtr, callback{{#zcl_command_arguments}}, {{asLowerCamelCase label}}{{/zcl_command_arguments}}, null);
     }
     {{/unless}}
 
     public void {{asLowerCamelCase name}}({{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback
-      {{#chip_cluster_command_arguments}}, {{asJavaType type chipType parent.parent.name includeAnnotations=true}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments}}
+      {{#zcl_command_arguments}}, {{asJavaType type chipType parent.parent.name includeAnnotations=true clusterId=parent.parent.id}} {{asLowerCamelCase label}}{{/zcl_command_arguments}}
       , int timedInvokeTimeoutMs) {
-      {{asLowerCamelCase name}}(chipClusterPtr, callback{{#chip_cluster_command_arguments}}, {{asLowerCamelCase label}}{{/chip_cluster_command_arguments}}, timedInvokeTimeoutMs);
+      {{asLowerCamelCase name}}(chipClusterPtr, callback{{#zcl_command_arguments}}, {{asLowerCamelCase label}}{{/zcl_command_arguments}}, timedInvokeTimeoutMs);
     }
-  {{/chip_cluster_commands}}
-  {{#chip_cluster_commands}}
+    {{/if}}
+  {{/zcl_commands}}
+  {{#zcl_commands}}
+    {{#if (is_str_equal source 'client')}}
     private native void {{asLowerCamelCase name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} Callback
-      {{#chip_cluster_command_arguments}}, {{asJavaType type chipType parent.parent.name includeAnnotations=true}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments}}
+      {{#zcl_command_arguments}}, {{asJavaType type chipType parent.parent.name includeAnnotations=true clusterId=parent.parent.id}} {{asLowerCamelCase label}}{{/zcl_command_arguments}}
       , @Nullable Integer timedInvokeTimeoutMs);
-  {{/chip_cluster_commands}}
-  {{#chip_cluster_responses}}
+      {{/if}}
+  {{/zcl_commands}}
+    {{#all_user_cluster_generated_commands}}
+      {{#if_compare clusterId ../id operator='=='}}
+        {{#if (is_str_equal commandSource 'server')}}
     public interface {{asUpperCamelCase name}}Callback {
-      void onSuccess({{#chip_cluster_response_arguments}}{{#not_first}}, {{/not_first}}{{asJavaType type chipType parent.parent.name includeAnnotations=true}} {{asLowerCamelCase label}}{{/chip_cluster_response_arguments}});
+      void onSuccess({{#zcl_command_arguments}}{{#not_first}}, {{/not_first}}{{asJavaType type chipType parent.parent.name includeAnnotations=true clusterId=parent.parent.id}} {{asLowerCamelCase label}}{{/zcl_command_arguments}});
       
       void onError(Exception error);
     }
 
-  {{/chip_cluster_responses}}
+        {{/if}}
+    {{/if_compare}}
+  {{/all_user_cluster_generated_commands}}
 
   {{#zcl_attributes_server removeKeys='isOptional'}}
   {{#if_unsupported_attribute_callback type isArray ../id}}
@@ -233,6 +241,6 @@ public class ChipClusters {
   {{#not_last}}
 
   {{/not_last}}
-  {{/chip_client_clusters}}
+  {{/all_user_clusters}}
 }
 {{/if}}

--- a/src/controller/java/templates/ChipEventStructs-java.zapt
+++ b/src/controller/java/templates/ChipEventStructs-java.zapt
@@ -11,7 +11,7 @@ import java.util.Optional;
 {{! TODO: Use AutoValue for inner classes. }}
 public class ChipEventStructs {
 {{#if (chip_has_client_clusters)}}
-{{#chip_client_clusters}}
+{{#all_user_clusters side='client'}}
 {{#zcl_events}}
 public static class {{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event {
 {{#zcl_event_fields}}
@@ -54,6 +54,6 @@ public {{asJavaType type null parent.parent.name includeAnnotations=true}} {{asL
 }
 
 {{/zcl_events}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 {{/if}}
 }

--- a/src/controller/java/templates/ChipIdLookup-java.zapt
+++ b/src/controller/java/templates/ChipIdLookup-java.zapt
@@ -9,11 +9,11 @@ public final class ChipIdLookup {
    * ID is found, returns an empty string.
    */
   public static String clusterIdToName(long clusterId) {
-    {{#chip_client_clusters}}
+    {{#all_user_clusters side='client'}}
     if (clusterId == {{code}}L) {
       return "{{asUpperCamelCase name}}";
     }
-    {{/chip_client_clusters}}
+    {{/all_user_clusters}}
     return "";
   }
 
@@ -22,7 +22,7 @@ public final class ChipIdLookup {
    * If no matching IDs are found, returns an empty string.
    */
   public static String attributeIdToName(long clusterId, long attributeId) {
-    {{#chip_client_clusters}}
+    {{#all_user_clusters side='client'}}
     if (clusterId == {{code}}L) {
       {{#zcl_attributes_server}}
       if (attributeId == {{code}}L) {
@@ -31,7 +31,7 @@ public final class ChipIdLookup {
       {{/zcl_attributes_server}}
       return "";
     }
-    {{/chip_client_clusters}}
+    {{/all_user_clusters}}
     return "";
   }
 
@@ -40,7 +40,7 @@ public final class ChipIdLookup {
    * If no matching IDs are found, returns an empty string.
    */
   public static String eventIdToName(long clusterId, long eventId) {
-    {{#chip_client_clusters}}
+    {{#all_user_clusters side='client'}}
     if (clusterId == {{code}}L) {
       {{#chip_server_cluster_events}}
       if (eventId == {{code}}L) {
@@ -49,7 +49,7 @@ public final class ChipIdLookup {
       {{/chip_server_cluster_events}}
       return "";
     }
-    {{/chip_client_clusters}}
+    {{/all_user_clusters}}
     return "";
   }
 }

--- a/src/controller/java/templates/ChipStructs-java.zapt
+++ b/src/controller/java/templates/ChipStructs-java.zapt
@@ -11,7 +11,7 @@ import java.util.Optional;
 {{! TODO: Use AutoValue for inner classes. }}
 public class ChipStructs {
 {{#if (chip_has_client_clusters)}}
-{{#chip_client_clusters}}
+{{#all_user_clusters side='client'}}
 {{#zcl_structs}}
 {{#if itemCnt}}
 public static class {{asUpperCamelCase parent.name}}Cluster{{asUnderlyingType name}} {
@@ -52,6 +52,6 @@ public {{asJavaType type null parent.parent.name includeAnnotations=true}} {{asL
 {{/if}}
 
 {{/zcl_structs}}
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 {{/if}}
 }

--- a/src/controller/java/templates/ClusterInfo-java.zapt
+++ b/src/controller/java/templates/ClusterInfo-java.zapt
@@ -313,8 +313,9 @@ public class ClusterInfoMapping {
      Map<String, Map<String, InteractionInfo>> commandMap = new HashMap<>();
      {{#all_user_clusters side='client'}}
      Map<String, InteractionInfo> {{asLowerCamelCase name}}ClusterInteractionInfoMap = new LinkedHashMap<>();
-     {{#zcl_commands}}
-       {{#if (is_str_equal source 'client')}}
+      {{#all_user_cluster_generated_commands}}
+        {{#if_compare clusterId ../id operator='=='}}
+          {{#if (is_str_equal commandSource 'client')}}
      Map<String, CommandParameterInfo> {{asLowerCamelCase ../name}}{{asLowerCamelCase name}}CommandParams = new LinkedHashMap<String, CommandParameterInfo>();
      {{! TODO: fill out parameter types }}
      {{#if hasArguments}}
@@ -362,8 +363,9 @@ public class ClusterInfoMapping {
        );
      {{/if}}
        {{asLowerCamelCase ../name}}ClusterInteractionInfoMap.put("{{asLowerCamelCase name}}", {{asLowerCamelCase ../name}}{{asLowerCamelCase name}}InteractionInfo);
-       {{/if}}
-     {{/zcl_commands}}
+          {{/if}}
+        {{/if_compare}}
+      {{/all_user_cluster_generated_commands}}
      commandMap.put("{{asLowerCamelCase name}}", {{asLowerCamelCase name}}ClusterInteractionInfoMap);
      {{/all_user_clusters}}
      return commandMap;

--- a/src/controller/java/templates/ClusterInfo-java.zapt
+++ b/src/controller/java/templates/ClusterInfo-java.zapt
@@ -199,8 +199,10 @@ public class ClusterInfoMapping {
       callback.onFailure(e);
     }
   }
-  {{#chip_client_clusters}}
-  {{#chip_cluster_responses}}
+  {{#all_user_clusters side='client'}}
+    {{#all_user_cluster_generated_commands}}
+      {{#if_compare clusterId ../id operator='=='}}
+        {{#if (is_str_equal commandSource 'server')}}
       public static class Delegated{{asUpperCamelCase ../name}}Cluster{{asUpperCamelCase name}}Callback implements ChipClusters.{{asUpperCamelCase ../name}}Cluster.{{asUpperCamelCase name}}Callback, DelegatedClusterCallback {
         private ClusterCommandCallback callback;
         @Override
@@ -209,9 +211,9 @@ public class ClusterInfoMapping {
         }
 
         @Override
-        public void onSuccess({{#chip_cluster_response_arguments}}{{#not_first}}, {{/not_first}}{{asJavaType type chipType parent.parent.name includeAnnotations=true}} {{asSymbol label}}{{/chip_cluster_response_arguments}}) {
+        public void onSuccess({{#zcl_command_arguments}}{{#not_first}}, {{/not_first}}{{asJavaType type chipType parent.parent.name includeAnnotations=true clusterId=parent.parent.id}} {{asSymbol label}}{{/zcl_command_arguments}}) {
            Map<CommandResponseInfo, Object> responseValues = new LinkedHashMap<>();
-           {{#chip_cluster_response_arguments}}
+           {{#zcl_command_arguments}}
              {{#if isArray}}
                // {{asSymbol label}}: {{asUnderlyingZclType type}}
                // Conversion from this type to Java is not properly implemented yet
@@ -220,11 +222,11 @@ public class ClusterInfoMapping {
                // {{asSymbol label}}: Struct {{type}}
                // Conversion from this type to Java is not properly implemented yet
              {{else}}
-               CommandResponseInfo {{asSymbol label}}ResponseValue = new CommandResponseInfo("{{asSymbol label}}", "{{asJavaType type null parent.parent.name}}");
+               CommandResponseInfo {{asSymbol label}}ResponseValue = new CommandResponseInfo("{{asSymbol label}}", "{{asJavaType type null parent.parent.name clusterId=parent.parent.id}}");
                responseValues.put({{asSymbol label}}ResponseValue, {{asSymbol label}});
              {{/if_is_struct}}
              {{/if}}
-           {{/chip_cluster_response_arguments}}
+           {{/zcl_command_arguments}}
            callback.onSuccess(responseValues);
         }
 
@@ -234,7 +236,9 @@ public class ClusterInfoMapping {
         }
       }
 
-  {{/chip_cluster_responses}}
+        {{/if}}
+    {{/if_compare}}
+  {{/all_user_cluster_generated_commands}}
       {{#zcl_attributes_server removeKeys='isOptional'}}
       {{#if_unsupported_attribute_callback type isArray ../id}}
       {{else}}
@@ -275,7 +279,7 @@ public class ClusterInfoMapping {
       {{/if_unsupported_attribute_callback}}
       {{/zcl_attributes_server}}
 
-  {{/chip_client_clusters}}
+  {{/all_user_clusters}}
 
  public Map<String, ClusterInfo> getClusterMap() {
     Map<String, ClusterInfo> clusterMap = initializeClusterMap();
@@ -290,37 +294,38 @@ public class ClusterInfoMapping {
 
  public Map<String, ClusterInfo> initializeClusterMap() {
     Map<String, ClusterInfo> clusterMap = new HashMap<>();
-    {{#chip_client_clusters}}
+    {{#all_user_clusters side='client'}}
       ClusterInfo {{asLowerCamelCase name}}ClusterInfo = new ClusterInfo(
         (ptr, endpointId) -> new ChipClusters.{{asUpperCamelCase name}}Cluster(ptr, endpointId), new HashMap<>());
       clusterMap.put("{{asLowerCamelCase name}}", {{asLowerCamelCase name}}ClusterInfo);
-    {{/chip_client_clusters}}
+    {{/all_user_clusters}}
     return clusterMap;
  }
 
  public void combineCommand(Map<String, ClusterInfo> destination, Map<String, Map<String, InteractionInfo>> source) {
-    {{#chip_client_clusters}}
+    {{#all_user_clusters side='client'}}
       destination.get("{{asLowerCamelCase name}}").combineCommands(source.get("{{asLowerCamelCase name}}"));
-    {{/chip_client_clusters}}
+    {{/all_user_clusters}}
  }
 
  @SuppressWarnings("unchecked")
  public Map<String, Map<String, InteractionInfo>> getCommandMap() {
      Map<String, Map<String, InteractionInfo>> commandMap = new HashMap<>();
-     {{#chip_client_clusters}}
+     {{#all_user_clusters side='client'}}
      Map<String, InteractionInfo> {{asLowerCamelCase name}}ClusterInteractionInfoMap = new LinkedHashMap<>();
-     {{#chip_cluster_commands}}
+     {{#zcl_commands}}
+       {{#if (is_str_equal source 'client')}}
      Map<String, CommandParameterInfo> {{asLowerCamelCase ../name}}{{asLowerCamelCase name}}CommandParams = new LinkedHashMap<String, CommandParameterInfo>();
      {{! TODO: fill out parameter types }}
-     {{#if (zcl_command_arguments_count this.id)}}
-     {{#chip_cluster_command_arguments}}
+     {{#if hasArguments}}
+     {{#zcl_command_arguments}}
      {{#if_is_struct type}}
      {{else}}
-       CommandParameterInfo {{asLowerCamelCase ../../name}}{{asLowerCamelCase ../name}}{{asLowerCamelCase label}}CommandParameterInfo = new CommandParameterInfo("{{asLowerCamelCase label}}", {{asJavaType type null parent.parent.name removeGenericType=true}}.class, {{asJavaType type null parent.parent.name underlyingType=true}}.class);
+       CommandParameterInfo {{asLowerCamelCase ../../name}}{{asLowerCamelCase ../name}}{{asLowerCamelCase label}}CommandParameterInfo = new CommandParameterInfo("{{asLowerCamelCase label}}", {{asJavaType type null parent.parent.name removeGenericType=true clusterId=parent.parent.id}}.class, {{asJavaType type null parent.parent.name underlyingType=true clusterId=parent.parent.id}}.class);
        {{asLowerCamelCase ../../name}}{{asLowerCamelCase ../name}}CommandParams.put("{{asLowerCamelCase label}}",{{asLowerCamelCase ../../name}}{{asLowerCamelCase ../name}}{{asLowerCamelCase label}}CommandParameterInfo);
      {{#not_last}} {{/not_last}}
      {{/if_is_struct}}
-     {{/chip_cluster_command_arguments}}
+     {{/zcl_command_arguments}}
      {{else}}
      {{/if}}
      {{#if hasSpecificResponse}}
@@ -328,10 +333,10 @@ public class ClusterInfoMapping {
          (cluster, callback, commandArguments) -> {
            ((ChipClusters.{{asUpperCamelCase ../name}}Cluster) cluster)
            .{{asLowerCamelCase name}}((ChipClusters.{{asUpperCamelCase ../name}}Cluster.{{asUpperCamelCase responseName}}Callback) callback
-           {{#chip_cluster_command_arguments}}
-           , ({{asJavaType type chipType parent.parent.name}})
+           {{#zcl_command_arguments}}
+           , ({{asJavaType type chipType parent.parent.name clusterId=parent.parent.id}})
            commandArguments.get("{{asLowerCamelCase label}}")
-           {{/chip_cluster_command_arguments}}
+           {{/zcl_command_arguments}}
             {{! TODO: Allow timeout to be passed from client for this and timed write. }}
            {{#if mustUseTimedInvoke}}, 10000{{/if}}
            );
@@ -344,10 +349,10 @@ public class ClusterInfoMapping {
          (cluster, callback, commandArguments) -> {
            ((ChipClusters.{{asUpperCamelCase ../name}}Cluster) cluster)
            .{{asLowerCamelCase name}}((DefaultClusterCallback) callback
-           {{#chip_cluster_command_arguments}}
-           , ({{asJavaType type chipType parent.parent.name}})
+           {{#zcl_command_arguments}}
+           , ({{asJavaType type chipType parent.parent.name clusterId=parent.parent.id}})
            commandArguments.get("{{asLowerCamelCase label}}")
-           {{/chip_cluster_command_arguments}}
+           {{/zcl_command_arguments}}
            {{! TODO: Allow timeout to be passed from client for this and timed write. }}
            {{#if mustUseTimedInvoke}}, 10000{{/if}}
            );
@@ -357,9 +362,10 @@ public class ClusterInfoMapping {
        );
      {{/if}}
        {{asLowerCamelCase ../name}}ClusterInteractionInfoMap.put("{{asLowerCamelCase name}}", {{asLowerCamelCase ../name}}{{asLowerCamelCase name}}InteractionInfo);
-     {{/chip_cluster_commands}}
+       {{/if}}
+     {{/zcl_commands}}
      commandMap.put("{{asLowerCamelCase name}}", {{asLowerCamelCase name}}ClusterInteractionInfoMap);
-     {{/chip_client_clusters}}
+     {{/all_user_clusters}}
      return commandMap;
   }
 

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -755,93 +755,6 @@ public class ChipClusters {
       getSceneMembership(chipClusterPtr, callback, groupID, timedInvokeTimeoutMs);
     }
 
-    public void enhancedAddScene(
-        EnhancedAddSceneResponseCallback callback,
-        Integer groupID,
-        Integer sceneID,
-        Integer transitionTime,
-        String sceneName,
-        ArrayList<ChipStructs.ScenesClusterExtensionFieldSet> extensionFieldSets) {
-      enhancedAddScene(
-          chipClusterPtr,
-          callback,
-          groupID,
-          sceneID,
-          transitionTime,
-          sceneName,
-          extensionFieldSets,
-          null);
-    }
-
-    public void enhancedAddScene(
-        EnhancedAddSceneResponseCallback callback,
-        Integer groupID,
-        Integer sceneID,
-        Integer transitionTime,
-        String sceneName,
-        ArrayList<ChipStructs.ScenesClusterExtensionFieldSet> extensionFieldSets,
-        int timedInvokeTimeoutMs) {
-      enhancedAddScene(
-          chipClusterPtr,
-          callback,
-          groupID,
-          sceneID,
-          transitionTime,
-          sceneName,
-          extensionFieldSets,
-          timedInvokeTimeoutMs);
-    }
-
-    public void enhancedViewScene(
-        EnhancedViewSceneResponseCallback callback, Integer groupID, Integer sceneID) {
-      enhancedViewScene(chipClusterPtr, callback, groupID, sceneID, null);
-    }
-
-    public void enhancedViewScene(
-        EnhancedViewSceneResponseCallback callback,
-        Integer groupID,
-        Integer sceneID,
-        int timedInvokeTimeoutMs) {
-      enhancedViewScene(chipClusterPtr, callback, groupID, sceneID, timedInvokeTimeoutMs);
-    }
-
-    public void copyScene(
-        CopySceneResponseCallback callback,
-        Integer mode,
-        Integer groupIdentifierFrom,
-        Integer sceneIdentifierFrom,
-        Integer groupIdentifierTo,
-        Integer sceneIdentifierTo) {
-      copyScene(
-          chipClusterPtr,
-          callback,
-          mode,
-          groupIdentifierFrom,
-          sceneIdentifierFrom,
-          groupIdentifierTo,
-          sceneIdentifierTo,
-          null);
-    }
-
-    public void copyScene(
-        CopySceneResponseCallback callback,
-        Integer mode,
-        Integer groupIdentifierFrom,
-        Integer sceneIdentifierFrom,
-        Integer groupIdentifierTo,
-        Integer sceneIdentifierTo,
-        int timedInvokeTimeoutMs) {
-      copyScene(
-          chipClusterPtr,
-          callback,
-          mode,
-          groupIdentifierFrom,
-          sceneIdentifierFrom,
-          groupIdentifierTo,
-          sceneIdentifierTo,
-          timedInvokeTimeoutMs);
-    }
-
     private native void addScene(
         long chipClusterPtr,
         AddSceneResponseCallback Callback,
@@ -891,33 +804,6 @@ public class ChipClusters {
         long chipClusterPtr,
         GetSceneMembershipResponseCallback Callback,
         Integer groupID,
-        @Nullable Integer timedInvokeTimeoutMs);
-
-    private native void enhancedAddScene(
-        long chipClusterPtr,
-        EnhancedAddSceneResponseCallback Callback,
-        Integer groupID,
-        Integer sceneID,
-        Integer transitionTime,
-        String sceneName,
-        ArrayList<ChipStructs.ScenesClusterExtensionFieldSet> extensionFieldSets,
-        @Nullable Integer timedInvokeTimeoutMs);
-
-    private native void enhancedViewScene(
-        long chipClusterPtr,
-        EnhancedViewSceneResponseCallback Callback,
-        Integer groupID,
-        Integer sceneID,
-        @Nullable Integer timedInvokeTimeoutMs);
-
-    private native void copyScene(
-        long chipClusterPtr,
-        CopySceneResponseCallback Callback,
-        Integer mode,
-        Integer groupIdentifierFrom,
-        Integer sceneIdentifierFrom,
-        Integer groupIdentifierTo,
-        Integer sceneIdentifierTo,
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface AddSceneResponseCallback {
@@ -1976,15 +1862,6 @@ public class ChipClusters {
       stopWithOnOff(chipClusterPtr, callback, optionsMask, optionsOverride, timedInvokeTimeoutMs);
     }
 
-    public void moveToClosestFrequency(DefaultClusterCallback callback, Integer frequency) {
-      moveToClosestFrequency(chipClusterPtr, callback, frequency, null);
-    }
-
-    public void moveToClosestFrequency(
-        DefaultClusterCallback callback, Integer frequency, int timedInvokeTimeoutMs) {
-      moveToClosestFrequency(chipClusterPtr, callback, frequency, timedInvokeTimeoutMs);
-    }
-
     private native void moveToLevel(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
@@ -2053,12 +1930,6 @@ public class ChipClusters {
         DefaultClusterCallback Callback,
         Integer optionsMask,
         Integer optionsOverride,
-        @Nullable Integer timedInvokeTimeoutMs);
-
-    private native void moveToClosestFrequency(
-        long chipClusterPtr,
-        DefaultClusterCallback Callback,
-        Integer frequency,
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface CurrentLevelAttributeCallback {
@@ -4126,20 +3997,6 @@ public class ChipClusters {
 
     @Override
     public native long initWithDevice(long devicePtr, int endpointId);
-
-    public void mfgSpecificPing(DefaultClusterCallback callback) {
-      mfgSpecificPing(chipClusterPtr, callback, null);
-    }
-
-    public void mfgSpecificPing(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
-
-      mfgSpecificPing(chipClusterPtr, callback, timedInvokeTimeoutMs);
-    }
-
-    private native void mfgSpecificPing(
-        long chipClusterPtr,
-        DefaultClusterCallback Callback,
-        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface GeneratedCommandListAttributeCallback {
       void onSuccess(List<Long> valueList);
@@ -25483,52 +25340,6 @@ public class ChipClusters {
     @Override
     public native long initWithDevice(long devicePtr, int endpointId);
 
-    public void getProfileInfoCommand(DefaultClusterCallback callback) {
-      getProfileInfoCommand(chipClusterPtr, callback, null);
-    }
-
-    public void getProfileInfoCommand(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
-
-      getProfileInfoCommand(chipClusterPtr, callback, timedInvokeTimeoutMs);
-    }
-
-    public void getMeasurementProfileCommand(
-        DefaultClusterCallback callback,
-        Integer attributeId,
-        Long startTime,
-        Integer numberOfIntervals) {
-      getMeasurementProfileCommand(
-          chipClusterPtr, callback, attributeId, startTime, numberOfIntervals, null);
-    }
-
-    public void getMeasurementProfileCommand(
-        DefaultClusterCallback callback,
-        Integer attributeId,
-        Long startTime,
-        Integer numberOfIntervals,
-        int timedInvokeTimeoutMs) {
-      getMeasurementProfileCommand(
-          chipClusterPtr,
-          callback,
-          attributeId,
-          startTime,
-          numberOfIntervals,
-          timedInvokeTimeoutMs);
-    }
-
-    private native void getProfileInfoCommand(
-        long chipClusterPtr,
-        DefaultClusterCallback Callback,
-        @Nullable Integer timedInvokeTimeoutMs);
-
-    private native void getMeasurementProfileCommand(
-        long chipClusterPtr,
-        DefaultClusterCallback Callback,
-        Integer attributeId,
-        Long startTime,
-        Integer numberOfIntervals,
-        @Nullable Integer timedInvokeTimeoutMs);
-
     public interface GeneratedCommandListAttributeCallback {
       void onSuccess(List<Long> valueList);
 
@@ -27780,15 +27591,6 @@ public class ChipClusters {
           chipClusterPtr, callback, clientNodeId, ICid, timedInvokeTimeoutMs);
     }
 
-    public void stayAwakeRequest(DefaultClusterCallback callback) {
-      stayAwakeRequest(chipClusterPtr, callback, null);
-    }
-
-    public void stayAwakeRequest(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
-
-      stayAwakeRequest(chipClusterPtr, callback, timedInvokeTimeoutMs);
-    }
-
     private native void registerClientMonitoring(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
@@ -27801,11 +27603,6 @@ public class ChipClusters {
         DefaultClusterCallback Callback,
         Long clientNodeId,
         Long ICid,
-        @Nullable Integer timedInvokeTimeoutMs);
-
-    private native void stayAwakeRequest(
-        long chipClusterPtr,
-        DefaultClusterCallback Callback,
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface ExpectedClientsAttributeCallback {
@@ -28070,41 +27867,6 @@ public class ChipClusters {
       testAddArguments(chipClusterPtr, callback, arg1, arg2, timedInvokeTimeoutMs);
     }
 
-    public void testSimpleArgumentRequest(
-        TestSimpleArgumentResponseCallback callback, Boolean arg1) {
-      testSimpleArgumentRequest(chipClusterPtr, callback, arg1, null);
-    }
-
-    public void testSimpleArgumentRequest(
-        TestSimpleArgumentResponseCallback callback, Boolean arg1, int timedInvokeTimeoutMs) {
-      testSimpleArgumentRequest(chipClusterPtr, callback, arg1, timedInvokeTimeoutMs);
-    }
-
-    public void testStructArrayArgumentRequest(
-        TestStructArrayArgumentResponseCallback callback,
-        ArrayList<ChipStructs.UnitTestingClusterNestedStructList> arg1,
-        ArrayList<ChipStructs.UnitTestingClusterSimpleStruct> arg2,
-        ArrayList<Integer> arg3,
-        ArrayList<Integer> arg4,
-        Integer arg5,
-        Boolean arg6) {
-      testStructArrayArgumentRequest(
-          chipClusterPtr, callback, arg1, arg2, arg3, arg4, arg5, arg6, null);
-    }
-
-    public void testStructArrayArgumentRequest(
-        TestStructArrayArgumentResponseCallback callback,
-        ArrayList<ChipStructs.UnitTestingClusterNestedStructList> arg1,
-        ArrayList<ChipStructs.UnitTestingClusterSimpleStruct> arg2,
-        ArrayList<Integer> arg3,
-        ArrayList<Integer> arg4,
-        Integer arg5,
-        Boolean arg6,
-        int timedInvokeTimeoutMs) {
-      testStructArrayArgumentRequest(
-          chipClusterPtr, callback, arg1, arg2, arg3, arg4, arg5, arg6, timedInvokeTimeoutMs);
-    }
-
     public void testStructArgumentRequest(
         BooleanResponseCallback callback, ChipStructs.UnitTestingClusterSimpleStruct arg1) {
       testStructArgumentRequest(chipClusterPtr, callback, arg1, null);
@@ -28210,71 +27972,6 @@ public class ChipClusters {
       testNullableOptionalRequest(chipClusterPtr, callback, arg1, timedInvokeTimeoutMs);
     }
 
-    public void testComplexNullableOptionalRequest(
-        TestComplexNullableOptionalResponseCallback callback,
-        @Nullable Integer nullableInt,
-        Optional<Integer> optionalInt,
-        @Nullable Optional<Integer> nullableOptionalInt,
-        @Nullable String nullableString,
-        Optional<String> optionalString,
-        @Nullable Optional<String> nullableOptionalString,
-        @Nullable ChipStructs.UnitTestingClusterSimpleStruct nullableStruct,
-        Optional<ChipStructs.UnitTestingClusterSimpleStruct> optionalStruct,
-        @Nullable Optional<ChipStructs.UnitTestingClusterSimpleStruct> nullableOptionalStruct,
-        @Nullable ArrayList<Integer> nullableList,
-        Optional<ArrayList<Integer>> optionalList,
-        @Nullable Optional<ArrayList<Integer>> nullableOptionalList) {
-      testComplexNullableOptionalRequest(
-          chipClusterPtr,
-          callback,
-          nullableInt,
-          optionalInt,
-          nullableOptionalInt,
-          nullableString,
-          optionalString,
-          nullableOptionalString,
-          nullableStruct,
-          optionalStruct,
-          nullableOptionalStruct,
-          nullableList,
-          optionalList,
-          nullableOptionalList,
-          null);
-    }
-
-    public void testComplexNullableOptionalRequest(
-        TestComplexNullableOptionalResponseCallback callback,
-        @Nullable Integer nullableInt,
-        Optional<Integer> optionalInt,
-        @Nullable Optional<Integer> nullableOptionalInt,
-        @Nullable String nullableString,
-        Optional<String> optionalString,
-        @Nullable Optional<String> nullableOptionalString,
-        @Nullable ChipStructs.UnitTestingClusterSimpleStruct nullableStruct,
-        Optional<ChipStructs.UnitTestingClusterSimpleStruct> optionalStruct,
-        @Nullable Optional<ChipStructs.UnitTestingClusterSimpleStruct> nullableOptionalStruct,
-        @Nullable ArrayList<Integer> nullableList,
-        Optional<ArrayList<Integer>> optionalList,
-        @Nullable Optional<ArrayList<Integer>> nullableOptionalList,
-        int timedInvokeTimeoutMs) {
-      testComplexNullableOptionalRequest(
-          chipClusterPtr,
-          callback,
-          nullableInt,
-          optionalInt,
-          nullableOptionalInt,
-          nullableString,
-          optionalString,
-          nullableOptionalString,
-          nullableStruct,
-          optionalStruct,
-          nullableOptionalStruct,
-          nullableList,
-          optionalList,
-          nullableOptionalList,
-          timedInvokeTimeoutMs);
-    }
-
     public void simpleStructEchoRequest(
         SimpleStructResponseCallback callback, ChipStructs.UnitTestingClusterSimpleStruct arg1) {
       simpleStructEchoRequest(chipClusterPtr, callback, arg1, null);
@@ -28316,18 +28013,6 @@ public class ChipClusters {
       testEmitTestEventRequest(chipClusterPtr, callback, arg1, arg2, arg3, timedInvokeTimeoutMs);
     }
 
-    public void testEmitTestFabricScopedEventRequest(
-        TestEmitTestFabricScopedEventResponseCallback callback, Integer arg1) {
-      testEmitTestFabricScopedEventRequest(chipClusterPtr, callback, arg1, null);
-    }
-
-    public void testEmitTestFabricScopedEventRequest(
-        TestEmitTestFabricScopedEventResponseCallback callback,
-        Integer arg1,
-        int timedInvokeTimeoutMs) {
-      testEmitTestFabricScopedEventRequest(chipClusterPtr, callback, arg1, timedInvokeTimeoutMs);
-    }
-
     private native void test(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
@@ -28353,23 +28038,6 @@ public class ChipClusters {
         TestAddArgumentsResponseCallback Callback,
         Integer arg1,
         Integer arg2,
-        @Nullable Integer timedInvokeTimeoutMs);
-
-    private native void testSimpleArgumentRequest(
-        long chipClusterPtr,
-        TestSimpleArgumentResponseCallback Callback,
-        Boolean arg1,
-        @Nullable Integer timedInvokeTimeoutMs);
-
-    private native void testStructArrayArgumentRequest(
-        long chipClusterPtr,
-        TestStructArrayArgumentResponseCallback Callback,
-        ArrayList<ChipStructs.UnitTestingClusterNestedStructList> arg1,
-        ArrayList<ChipStructs.UnitTestingClusterSimpleStruct> arg2,
-        ArrayList<Integer> arg3,
-        ArrayList<Integer> arg4,
-        Integer arg5,
-        Boolean arg6,
         @Nullable Integer timedInvokeTimeoutMs);
 
     private native void testStructArgumentRequest(
@@ -28427,23 +28095,6 @@ public class ChipClusters {
         @Nullable Optional<Integer> arg1,
         @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void testComplexNullableOptionalRequest(
-        long chipClusterPtr,
-        TestComplexNullableOptionalResponseCallback Callback,
-        @Nullable Integer nullableInt,
-        Optional<Integer> optionalInt,
-        @Nullable Optional<Integer> nullableOptionalInt,
-        @Nullable String nullableString,
-        Optional<String> optionalString,
-        @Nullable Optional<String> nullableOptionalString,
-        @Nullable ChipStructs.UnitTestingClusterSimpleStruct nullableStruct,
-        Optional<ChipStructs.UnitTestingClusterSimpleStruct> optionalStruct,
-        @Nullable Optional<ChipStructs.UnitTestingClusterSimpleStruct> nullableOptionalStruct,
-        @Nullable ArrayList<Integer> nullableList,
-        Optional<ArrayList<Integer>> optionalList,
-        @Nullable Optional<ArrayList<Integer>> nullableOptionalList,
-        @Nullable Integer timedInvokeTimeoutMs);
-
     private native void simpleStructEchoRequest(
         long chipClusterPtr,
         SimpleStructResponseCallback Callback,
@@ -28467,12 +28118,6 @@ public class ChipClusters {
         Integer arg1,
         Integer arg2,
         Boolean arg3,
-        @Nullable Integer timedInvokeTimeoutMs);
-
-    private native void testEmitTestFabricScopedEventRequest(
-        long chipClusterPtr,
-        TestEmitTestFabricScopedEventResponseCallback Callback,
-        Integer arg1,
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface TestSpecificResponseCallback {

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -755,6 +755,93 @@ public class ChipClusters {
       getSceneMembership(chipClusterPtr, callback, groupID, timedInvokeTimeoutMs);
     }
 
+    public void enhancedAddScene(
+        EnhancedAddSceneResponseCallback callback,
+        Integer groupID,
+        Integer sceneID,
+        Integer transitionTime,
+        String sceneName,
+        ArrayList<ChipStructs.ScenesClusterExtensionFieldSet> extensionFieldSets) {
+      enhancedAddScene(
+          chipClusterPtr,
+          callback,
+          groupID,
+          sceneID,
+          transitionTime,
+          sceneName,
+          extensionFieldSets,
+          null);
+    }
+
+    public void enhancedAddScene(
+        EnhancedAddSceneResponseCallback callback,
+        Integer groupID,
+        Integer sceneID,
+        Integer transitionTime,
+        String sceneName,
+        ArrayList<ChipStructs.ScenesClusterExtensionFieldSet> extensionFieldSets,
+        int timedInvokeTimeoutMs) {
+      enhancedAddScene(
+          chipClusterPtr,
+          callback,
+          groupID,
+          sceneID,
+          transitionTime,
+          sceneName,
+          extensionFieldSets,
+          timedInvokeTimeoutMs);
+    }
+
+    public void enhancedViewScene(
+        EnhancedViewSceneResponseCallback callback, Integer groupID, Integer sceneID) {
+      enhancedViewScene(chipClusterPtr, callback, groupID, sceneID, null);
+    }
+
+    public void enhancedViewScene(
+        EnhancedViewSceneResponseCallback callback,
+        Integer groupID,
+        Integer sceneID,
+        int timedInvokeTimeoutMs) {
+      enhancedViewScene(chipClusterPtr, callback, groupID, sceneID, timedInvokeTimeoutMs);
+    }
+
+    public void copyScene(
+        CopySceneResponseCallback callback,
+        Integer mode,
+        Integer groupIdentifierFrom,
+        Integer sceneIdentifierFrom,
+        Integer groupIdentifierTo,
+        Integer sceneIdentifierTo) {
+      copyScene(
+          chipClusterPtr,
+          callback,
+          mode,
+          groupIdentifierFrom,
+          sceneIdentifierFrom,
+          groupIdentifierTo,
+          sceneIdentifierTo,
+          null);
+    }
+
+    public void copyScene(
+        CopySceneResponseCallback callback,
+        Integer mode,
+        Integer groupIdentifierFrom,
+        Integer sceneIdentifierFrom,
+        Integer groupIdentifierTo,
+        Integer sceneIdentifierTo,
+        int timedInvokeTimeoutMs) {
+      copyScene(
+          chipClusterPtr,
+          callback,
+          mode,
+          groupIdentifierFrom,
+          sceneIdentifierFrom,
+          groupIdentifierTo,
+          sceneIdentifierTo,
+          timedInvokeTimeoutMs);
+    }
+
     private native void addScene(
         long chipClusterPtr,
         AddSceneResponseCallback Callback,
@@ -804,6 +891,33 @@ public class ChipClusters {
         long chipClusterPtr,
         GetSceneMembershipResponseCallback Callback,
         Integer groupID,
+        @Nullable Integer timedInvokeTimeoutMs);
+
+    private native void enhancedAddScene(
+        long chipClusterPtr,
+        EnhancedAddSceneResponseCallback Callback,
+        Integer groupID,
+        Integer sceneID,
+        Integer transitionTime,
+        String sceneName,
+        ArrayList<ChipStructs.ScenesClusterExtensionFieldSet> extensionFieldSets,
+        @Nullable Integer timedInvokeTimeoutMs);
+
+    private native void enhancedViewScene(
+        long chipClusterPtr,
+        EnhancedViewSceneResponseCallback Callback,
+        Integer groupID,
+        Integer sceneID,
+        @Nullable Integer timedInvokeTimeoutMs);
+
+    private native void copyScene(
+        long chipClusterPtr,
+        CopySceneResponseCallback Callback,
+        Integer mode,
+        Integer groupIdentifierFrom,
+        Integer sceneIdentifierFrom,
+        Integer groupIdentifierTo,
+        Integer sceneIdentifierTo,
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface AddSceneResponseCallback {
@@ -1862,6 +1976,15 @@ public class ChipClusters {
       stopWithOnOff(chipClusterPtr, callback, optionsMask, optionsOverride, timedInvokeTimeoutMs);
     }
 
+    public void moveToClosestFrequency(DefaultClusterCallback callback, Integer frequency) {
+      moveToClosestFrequency(chipClusterPtr, callback, frequency, null);
+    }
+
+    public void moveToClosestFrequency(
+        DefaultClusterCallback callback, Integer frequency, int timedInvokeTimeoutMs) {
+      moveToClosestFrequency(chipClusterPtr, callback, frequency, timedInvokeTimeoutMs);
+    }
+
     private native void moveToLevel(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
@@ -1930,6 +2053,12 @@ public class ChipClusters {
         DefaultClusterCallback Callback,
         Integer optionsMask,
         Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
+
+    private native void moveToClosestFrequency(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer frequency,
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface CurrentLevelAttributeCallback {
@@ -3997,6 +4126,20 @@ public class ChipClusters {
 
     @Override
     public native long initWithDevice(long devicePtr, int endpointId);
+
+    public void mfgSpecificPing(DefaultClusterCallback callback) {
+      mfgSpecificPing(chipClusterPtr, callback, null);
+    }
+
+    public void mfgSpecificPing(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+
+      mfgSpecificPing(chipClusterPtr, callback, timedInvokeTimeoutMs);
+    }
+
+    private native void mfgSpecificPing(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface GeneratedCommandListAttributeCallback {
       void onSuccess(List<Long> valueList);
@@ -25340,6 +25483,52 @@ public class ChipClusters {
     @Override
     public native long initWithDevice(long devicePtr, int endpointId);
 
+    public void getProfileInfoCommand(DefaultClusterCallback callback) {
+      getProfileInfoCommand(chipClusterPtr, callback, null);
+    }
+
+    public void getProfileInfoCommand(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+
+      getProfileInfoCommand(chipClusterPtr, callback, timedInvokeTimeoutMs);
+    }
+
+    public void getMeasurementProfileCommand(
+        DefaultClusterCallback callback,
+        Integer attributeId,
+        Long startTime,
+        Integer numberOfIntervals) {
+      getMeasurementProfileCommand(
+          chipClusterPtr, callback, attributeId, startTime, numberOfIntervals, null);
+    }
+
+    public void getMeasurementProfileCommand(
+        DefaultClusterCallback callback,
+        Integer attributeId,
+        Long startTime,
+        Integer numberOfIntervals,
+        int timedInvokeTimeoutMs) {
+      getMeasurementProfileCommand(
+          chipClusterPtr,
+          callback,
+          attributeId,
+          startTime,
+          numberOfIntervals,
+          timedInvokeTimeoutMs);
+    }
+
+    private native void getProfileInfoCommand(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
+
+    private native void getMeasurementProfileCommand(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer attributeId,
+        Long startTime,
+        Integer numberOfIntervals,
+        @Nullable Integer timedInvokeTimeoutMs);
+
     public interface GeneratedCommandListAttributeCallback {
       void onSuccess(List<Long> valueList);
 
@@ -27591,6 +27780,15 @@ public class ChipClusters {
           chipClusterPtr, callback, clientNodeId, ICid, timedInvokeTimeoutMs);
     }
 
+    public void stayAwakeRequest(DefaultClusterCallback callback) {
+      stayAwakeRequest(chipClusterPtr, callback, null);
+    }
+
+    public void stayAwakeRequest(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+
+      stayAwakeRequest(chipClusterPtr, callback, timedInvokeTimeoutMs);
+    }
+
     private native void registerClientMonitoring(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
@@ -27603,6 +27801,11 @@ public class ChipClusters {
         DefaultClusterCallback Callback,
         Long clientNodeId,
         Long ICid,
+        @Nullable Integer timedInvokeTimeoutMs);
+
+    private native void stayAwakeRequest(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface ExpectedClientsAttributeCallback {
@@ -27867,6 +28070,41 @@ public class ChipClusters {
       testAddArguments(chipClusterPtr, callback, arg1, arg2, timedInvokeTimeoutMs);
     }
 
+    public void testSimpleArgumentRequest(
+        TestSimpleArgumentResponseCallback callback, Boolean arg1) {
+      testSimpleArgumentRequest(chipClusterPtr, callback, arg1, null);
+    }
+
+    public void testSimpleArgumentRequest(
+        TestSimpleArgumentResponseCallback callback, Boolean arg1, int timedInvokeTimeoutMs) {
+      testSimpleArgumentRequest(chipClusterPtr, callback, arg1, timedInvokeTimeoutMs);
+    }
+
+    public void testStructArrayArgumentRequest(
+        TestStructArrayArgumentResponseCallback callback,
+        ArrayList<ChipStructs.UnitTestingClusterNestedStructList> arg1,
+        ArrayList<ChipStructs.UnitTestingClusterSimpleStruct> arg2,
+        ArrayList<Integer> arg3,
+        ArrayList<Integer> arg4,
+        Integer arg5,
+        Boolean arg6) {
+      testStructArrayArgumentRequest(
+          chipClusterPtr, callback, arg1, arg2, arg3, arg4, arg5, arg6, null);
+    }
+
+    public void testStructArrayArgumentRequest(
+        TestStructArrayArgumentResponseCallback callback,
+        ArrayList<ChipStructs.UnitTestingClusterNestedStructList> arg1,
+        ArrayList<ChipStructs.UnitTestingClusterSimpleStruct> arg2,
+        ArrayList<Integer> arg3,
+        ArrayList<Integer> arg4,
+        Integer arg5,
+        Boolean arg6,
+        int timedInvokeTimeoutMs) {
+      testStructArrayArgumentRequest(
+          chipClusterPtr, callback, arg1, arg2, arg3, arg4, arg5, arg6, timedInvokeTimeoutMs);
+    }
+
     public void testStructArgumentRequest(
         BooleanResponseCallback callback, ChipStructs.UnitTestingClusterSimpleStruct arg1) {
       testStructArgumentRequest(chipClusterPtr, callback, arg1, null);
@@ -27972,6 +28210,71 @@ public class ChipClusters {
       testNullableOptionalRequest(chipClusterPtr, callback, arg1, timedInvokeTimeoutMs);
     }
 
+    public void testComplexNullableOptionalRequest(
+        TestComplexNullableOptionalResponseCallback callback,
+        @Nullable Integer nullableInt,
+        Optional<Integer> optionalInt,
+        @Nullable Optional<Integer> nullableOptionalInt,
+        @Nullable String nullableString,
+        Optional<String> optionalString,
+        @Nullable Optional<String> nullableOptionalString,
+        @Nullable ChipStructs.UnitTestingClusterSimpleStruct nullableStruct,
+        Optional<ChipStructs.UnitTestingClusterSimpleStruct> optionalStruct,
+        @Nullable Optional<ChipStructs.UnitTestingClusterSimpleStruct> nullableOptionalStruct,
+        @Nullable ArrayList<Integer> nullableList,
+        Optional<ArrayList<Integer>> optionalList,
+        @Nullable Optional<ArrayList<Integer>> nullableOptionalList) {
+      testComplexNullableOptionalRequest(
+          chipClusterPtr,
+          callback,
+          nullableInt,
+          optionalInt,
+          nullableOptionalInt,
+          nullableString,
+          optionalString,
+          nullableOptionalString,
+          nullableStruct,
+          optionalStruct,
+          nullableOptionalStruct,
+          nullableList,
+          optionalList,
+          nullableOptionalList,
+          null);
+    }
+
+    public void testComplexNullableOptionalRequest(
+        TestComplexNullableOptionalResponseCallback callback,
+        @Nullable Integer nullableInt,
+        Optional<Integer> optionalInt,
+        @Nullable Optional<Integer> nullableOptionalInt,
+        @Nullable String nullableString,
+        Optional<String> optionalString,
+        @Nullable Optional<String> nullableOptionalString,
+        @Nullable ChipStructs.UnitTestingClusterSimpleStruct nullableStruct,
+        Optional<ChipStructs.UnitTestingClusterSimpleStruct> optionalStruct,
+        @Nullable Optional<ChipStructs.UnitTestingClusterSimpleStruct> nullableOptionalStruct,
+        @Nullable ArrayList<Integer> nullableList,
+        Optional<ArrayList<Integer>> optionalList,
+        @Nullable Optional<ArrayList<Integer>> nullableOptionalList,
+        int timedInvokeTimeoutMs) {
+      testComplexNullableOptionalRequest(
+          chipClusterPtr,
+          callback,
+          nullableInt,
+          optionalInt,
+          nullableOptionalInt,
+          nullableString,
+          optionalString,
+          nullableOptionalString,
+          nullableStruct,
+          optionalStruct,
+          nullableOptionalStruct,
+          nullableList,
+          optionalList,
+          nullableOptionalList,
+          timedInvokeTimeoutMs);
+    }
+
     public void simpleStructEchoRequest(
         SimpleStructResponseCallback callback, ChipStructs.UnitTestingClusterSimpleStruct arg1) {
       simpleStructEchoRequest(chipClusterPtr, callback, arg1, null);
@@ -28013,6 +28316,18 @@ public class ChipClusters {
       testEmitTestEventRequest(chipClusterPtr, callback, arg1, arg2, arg3, timedInvokeTimeoutMs);
     }
 
+    public void testEmitTestFabricScopedEventRequest(
+        TestEmitTestFabricScopedEventResponseCallback callback, Integer arg1) {
+      testEmitTestFabricScopedEventRequest(chipClusterPtr, callback, arg1, null);
+    }
+
+    public void testEmitTestFabricScopedEventRequest(
+        TestEmitTestFabricScopedEventResponseCallback callback,
+        Integer arg1,
+        int timedInvokeTimeoutMs) {
+      testEmitTestFabricScopedEventRequest(chipClusterPtr, callback, arg1, timedInvokeTimeoutMs);
+    }
+
     private native void test(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
@@ -28038,6 +28353,23 @@ public class ChipClusters {
         TestAddArgumentsResponseCallback Callback,
         Integer arg1,
         Integer arg2,
+        @Nullable Integer timedInvokeTimeoutMs);
+
+    private native void testSimpleArgumentRequest(
+        long chipClusterPtr,
+        TestSimpleArgumentResponseCallback Callback,
+        Boolean arg1,
+        @Nullable Integer timedInvokeTimeoutMs);
+
+    private native void testStructArrayArgumentRequest(
+        long chipClusterPtr,
+        TestStructArrayArgumentResponseCallback Callback,
+        ArrayList<ChipStructs.UnitTestingClusterNestedStructList> arg1,
+        ArrayList<ChipStructs.UnitTestingClusterSimpleStruct> arg2,
+        ArrayList<Integer> arg3,
+        ArrayList<Integer> arg4,
+        Integer arg5,
+        Boolean arg6,
         @Nullable Integer timedInvokeTimeoutMs);
 
     private native void testStructArgumentRequest(
@@ -28095,6 +28427,23 @@ public class ChipClusters {
         @Nullable Optional<Integer> arg1,
         @Nullable Integer timedInvokeTimeoutMs);
 
+    private native void testComplexNullableOptionalRequest(
+        long chipClusterPtr,
+        TestComplexNullableOptionalResponseCallback Callback,
+        @Nullable Integer nullableInt,
+        Optional<Integer> optionalInt,
+        @Nullable Optional<Integer> nullableOptionalInt,
+        @Nullable String nullableString,
+        Optional<String> optionalString,
+        @Nullable Optional<String> nullableOptionalString,
+        @Nullable ChipStructs.UnitTestingClusterSimpleStruct nullableStruct,
+        Optional<ChipStructs.UnitTestingClusterSimpleStruct> optionalStruct,
+        @Nullable Optional<ChipStructs.UnitTestingClusterSimpleStruct> nullableOptionalStruct,
+        @Nullable ArrayList<Integer> nullableList,
+        Optional<ArrayList<Integer>> optionalList,
+        @Nullable Optional<ArrayList<Integer>> nullableOptionalList,
+        @Nullable Integer timedInvokeTimeoutMs);
+
     private native void simpleStructEchoRequest(
         long chipClusterPtr,
         SimpleStructResponseCallback Callback,
@@ -28118,6 +28467,12 @@ public class ChipClusters {
         Integer arg1,
         Integer arg2,
         Boolean arg3,
+        @Nullable Integer timedInvokeTimeoutMs);
+
+    private native void testEmitTestFabricScopedEventRequest(
+        long chipClusterPtr,
+        TestEmitTestFabricScopedEventResponseCallback Callback,
+        Integer arg1,
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface TestSpecificResponseCallback {

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
@@ -13780,7 +13780,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> groupsgetGroupMembershipCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo groupsgetGroupMembershipgroupListCommandParameterInfo =
-        new CommandParameterInfo("groupList", ArrayList.class, Object.class);
+        new CommandParameterInfo("groupList", ArrayList.class, Integer.class);
     groupsgetGroupMembershipCommandParams.put(
         "groupList", groupsgetGroupMembershipgroupListCommandParameterInfo);
 
@@ -14017,6 +14017,110 @@ public class ClusterInfoMapping {
             scenesgetSceneMembershipCommandParams);
     scenesClusterInteractionInfoMap.put(
         "getSceneMembership", scenesgetSceneMembershipInteractionInfo);
+    Map<String, CommandParameterInfo> scenesenhancedAddSceneCommandParams =
+        new LinkedHashMap<String, CommandParameterInfo>();
+    CommandParameterInfo scenesenhancedAddScenegroupIDCommandParameterInfo =
+        new CommandParameterInfo("groupID", Integer.class, Integer.class);
+    scenesenhancedAddSceneCommandParams.put(
+        "groupID", scenesenhancedAddScenegroupIDCommandParameterInfo);
+
+    CommandParameterInfo scenesenhancedAddScenesceneIDCommandParameterInfo =
+        new CommandParameterInfo("sceneID", Integer.class, Integer.class);
+    scenesenhancedAddSceneCommandParams.put(
+        "sceneID", scenesenhancedAddScenesceneIDCommandParameterInfo);
+
+    CommandParameterInfo scenesenhancedAddScenetransitionTimeCommandParameterInfo =
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
+    scenesenhancedAddSceneCommandParams.put(
+        "transitionTime", scenesenhancedAddScenetransitionTimeCommandParameterInfo);
+
+    CommandParameterInfo scenesenhancedAddScenesceneNameCommandParameterInfo =
+        new CommandParameterInfo("sceneName", String.class, String.class);
+    scenesenhancedAddSceneCommandParams.put(
+        "sceneName", scenesenhancedAddScenesceneNameCommandParameterInfo);
+
+    InteractionInfo scenesenhancedAddSceneInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.ScenesCluster) cluster)
+                  .enhancedAddScene(
+                      (ChipClusters.ScenesCluster.EnhancedAddSceneResponseCallback) callback,
+                      (Integer) commandArguments.get("groupID"),
+                      (Integer) commandArguments.get("sceneID"),
+                      (Integer) commandArguments.get("transitionTime"),
+                      (String) commandArguments.get("sceneName"),
+                      (ArrayList<ChipStructs.ScenesClusterExtensionFieldSet>)
+                          commandArguments.get("extensionFieldSets"));
+            },
+            () -> new DelegatedScenesClusterEnhancedAddSceneResponseCallback(),
+            scenesenhancedAddSceneCommandParams);
+    scenesClusterInteractionInfoMap.put("enhancedAddScene", scenesenhancedAddSceneInteractionInfo);
+    Map<String, CommandParameterInfo> scenesenhancedViewSceneCommandParams =
+        new LinkedHashMap<String, CommandParameterInfo>();
+    CommandParameterInfo scenesenhancedViewScenegroupIDCommandParameterInfo =
+        new CommandParameterInfo("groupID", Integer.class, Integer.class);
+    scenesenhancedViewSceneCommandParams.put(
+        "groupID", scenesenhancedViewScenegroupIDCommandParameterInfo);
+
+    CommandParameterInfo scenesenhancedViewScenesceneIDCommandParameterInfo =
+        new CommandParameterInfo("sceneID", Integer.class, Integer.class);
+    scenesenhancedViewSceneCommandParams.put(
+        "sceneID", scenesenhancedViewScenesceneIDCommandParameterInfo);
+
+    InteractionInfo scenesenhancedViewSceneInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.ScenesCluster) cluster)
+                  .enhancedViewScene(
+                      (ChipClusters.ScenesCluster.EnhancedViewSceneResponseCallback) callback,
+                      (Integer) commandArguments.get("groupID"),
+                      (Integer) commandArguments.get("sceneID"));
+            },
+            () -> new DelegatedScenesClusterEnhancedViewSceneResponseCallback(),
+            scenesenhancedViewSceneCommandParams);
+    scenesClusterInteractionInfoMap.put(
+        "enhancedViewScene", scenesenhancedViewSceneInteractionInfo);
+    Map<String, CommandParameterInfo> scenescopySceneCommandParams =
+        new LinkedHashMap<String, CommandParameterInfo>();
+    CommandParameterInfo scenescopyScenemodeCommandParameterInfo =
+        new CommandParameterInfo("mode", Integer.class, Integer.class);
+    scenescopySceneCommandParams.put("mode", scenescopyScenemodeCommandParameterInfo);
+
+    CommandParameterInfo scenescopyScenegroupIdentifierFromCommandParameterInfo =
+        new CommandParameterInfo("groupIdentifierFrom", Integer.class, Integer.class);
+    scenescopySceneCommandParams.put(
+        "groupIdentifierFrom", scenescopyScenegroupIdentifierFromCommandParameterInfo);
+
+    CommandParameterInfo scenescopyScenesceneIdentifierFromCommandParameterInfo =
+        new CommandParameterInfo("sceneIdentifierFrom", Integer.class, Integer.class);
+    scenescopySceneCommandParams.put(
+        "sceneIdentifierFrom", scenescopyScenesceneIdentifierFromCommandParameterInfo);
+
+    CommandParameterInfo scenescopyScenegroupIdentifierToCommandParameterInfo =
+        new CommandParameterInfo("groupIdentifierTo", Integer.class, Integer.class);
+    scenescopySceneCommandParams.put(
+        "groupIdentifierTo", scenescopyScenegroupIdentifierToCommandParameterInfo);
+
+    CommandParameterInfo scenescopyScenesceneIdentifierToCommandParameterInfo =
+        new CommandParameterInfo("sceneIdentifierTo", Integer.class, Integer.class);
+    scenescopySceneCommandParams.put(
+        "sceneIdentifierTo", scenescopyScenesceneIdentifierToCommandParameterInfo);
+
+    InteractionInfo scenescopySceneInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.ScenesCluster) cluster)
+                  .copyScene(
+                      (ChipClusters.ScenesCluster.CopySceneResponseCallback) callback,
+                      (Integer) commandArguments.get("mode"),
+                      (Integer) commandArguments.get("groupIdentifierFrom"),
+                      (Integer) commandArguments.get("sceneIdentifierFrom"),
+                      (Integer) commandArguments.get("groupIdentifierTo"),
+                      (Integer) commandArguments.get("sceneIdentifierTo"));
+            },
+            () -> new DelegatedScenesClusterCopySceneResponseCallback(),
+            scenescopySceneCommandParams);
+    scenesClusterInteractionInfoMap.put("copyScene", scenescopySceneInteractionInfo);
     commandMap.put("scenes", scenesClusterInteractionInfoMap);
     Map<String, InteractionInfo> onOffClusterInteractionInfoMap = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> onOffoffCommandParams =
@@ -14396,6 +14500,25 @@ public class ClusterInfoMapping {
             levelControlstopWithOnOffCommandParams);
     levelControlClusterInteractionInfoMap.put(
         "stopWithOnOff", levelControlstopWithOnOffInteractionInfo);
+    Map<String, CommandParameterInfo> levelControlmoveToClosestFrequencyCommandParams =
+        new LinkedHashMap<String, CommandParameterInfo>();
+    CommandParameterInfo levelControlmoveToClosestFrequencyfrequencyCommandParameterInfo =
+        new CommandParameterInfo("frequency", Integer.class, Integer.class);
+    levelControlmoveToClosestFrequencyCommandParams.put(
+        "frequency", levelControlmoveToClosestFrequencyfrequencyCommandParameterInfo);
+
+    InteractionInfo levelControlmoveToClosestFrequencyInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.LevelControlCluster) cluster)
+                  .moveToClosestFrequency(
+                      (DefaultClusterCallback) callback,
+                      (Integer) commandArguments.get("frequency"));
+            },
+            () -> new DelegatedDefaultClusterCallback(),
+            levelControlmoveToClosestFrequencyCommandParams);
+    levelControlClusterInteractionInfoMap.put(
+        "moveToClosestFrequency", levelControlmoveToClosestFrequencyInteractionInfo);
     commandMap.put("levelControl", levelControlClusterInteractionInfoMap);
     Map<String, InteractionInfo> binaryInputBasicClusterInteractionInfoMap = new LinkedHashMap<>();
     commandMap.put("binaryInputBasic", binaryInputBasicClusterInteractionInfoMap);
@@ -14725,6 +14848,18 @@ public class ClusterInfoMapping {
         "disableActionWithDuration", actionsdisableActionWithDurationInteractionInfo);
     commandMap.put("actions", actionsClusterInteractionInfoMap);
     Map<String, InteractionInfo> basicInformationClusterInteractionInfoMap = new LinkedHashMap<>();
+    Map<String, CommandParameterInfo> basicInformationmfgSpecificPingCommandParams =
+        new LinkedHashMap<String, CommandParameterInfo>();
+    InteractionInfo basicInformationmfgSpecificPingInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.BasicInformationCluster) cluster)
+                  .mfgSpecificPing((DefaultClusterCallback) callback);
+            },
+            () -> new DelegatedDefaultClusterCallback(),
+            basicInformationmfgSpecificPingCommandParams);
+    basicInformationClusterInteractionInfoMap.put(
+        "mfgSpecificPing", basicInformationmfgSpecificPingInteractionInfo);
     commandMap.put("basicInformation", basicInformationClusterInteractionInfoMap);
     Map<String, InteractionInfo> otaSoftwareUpdateProviderClusterInteractionInfoMap =
         new LinkedHashMap<>();
@@ -14746,7 +14881,7 @@ public class ClusterInfoMapping {
         "softwareVersion", otaSoftwareUpdateProviderqueryImagesoftwareVersionCommandParameterInfo);
 
     CommandParameterInfo otaSoftwareUpdateProviderqueryImageprotocolsSupportedCommandParameterInfo =
-        new CommandParameterInfo("protocolsSupported", ArrayList.class, Object.class);
+        new CommandParameterInfo("protocolsSupported", ArrayList.class, Integer.class);
     otaSoftwareUpdateProviderqueryImageCommandParams.put(
         "protocolsSupported",
         otaSoftwareUpdateProviderqueryImageprotocolsSupportedCommandParameterInfo);
@@ -15653,7 +15788,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> groupKeyManagementkeySetReadAllIndicesCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo groupKeyManagementkeySetReadAllIndicesgroupKeySetIDsCommandParameterInfo =
-        new CommandParameterInfo("groupKeySetIDs", ArrayList.class, Object.class);
+        new CommandParameterInfo("groupKeySetIDs", ArrayList.class, Integer.class);
     groupKeyManagementkeySetReadAllIndicesCommandParams.put(
         "groupKeySetIDs", groupKeyManagementkeySetReadAllIndicesgroupKeySetIDsCommandParameterInfo);
 
@@ -17819,6 +17954,57 @@ public class ClusterInfoMapping {
     commandMap.put("accountLogin", accountLoginClusterInteractionInfoMap);
     Map<String, InteractionInfo> electricalMeasurementClusterInteractionInfoMap =
         new LinkedHashMap<>();
+    Map<String, CommandParameterInfo> electricalMeasurementgetProfileInfoCommandCommandParams =
+        new LinkedHashMap<String, CommandParameterInfo>();
+    InteractionInfo electricalMeasurementgetProfileInfoCommandInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.ElectricalMeasurementCluster) cluster)
+                  .getProfileInfoCommand((DefaultClusterCallback) callback);
+            },
+            () -> new DelegatedDefaultClusterCallback(),
+            electricalMeasurementgetProfileInfoCommandCommandParams);
+    electricalMeasurementClusterInteractionInfoMap.put(
+        "getProfileInfoCommand", electricalMeasurementgetProfileInfoCommandInteractionInfo);
+    Map<String, CommandParameterInfo>
+        electricalMeasurementgetMeasurementProfileCommandCommandParams =
+            new LinkedHashMap<String, CommandParameterInfo>();
+    CommandParameterInfo
+        electricalMeasurementgetMeasurementProfileCommandattributeIdCommandParameterInfo =
+            new CommandParameterInfo("attributeId", Integer.class, Integer.class);
+    electricalMeasurementgetMeasurementProfileCommandCommandParams.put(
+        "attributeId",
+        electricalMeasurementgetMeasurementProfileCommandattributeIdCommandParameterInfo);
+
+    CommandParameterInfo
+        electricalMeasurementgetMeasurementProfileCommandstartTimeCommandParameterInfo =
+            new CommandParameterInfo("startTime", Long.class, Long.class);
+    electricalMeasurementgetMeasurementProfileCommandCommandParams.put(
+        "startTime",
+        electricalMeasurementgetMeasurementProfileCommandstartTimeCommandParameterInfo);
+
+    CommandParameterInfo
+        electricalMeasurementgetMeasurementProfileCommandnumberOfIntervalsCommandParameterInfo =
+            new CommandParameterInfo("numberOfIntervals", Integer.class, Integer.class);
+    electricalMeasurementgetMeasurementProfileCommandCommandParams.put(
+        "numberOfIntervals",
+        electricalMeasurementgetMeasurementProfileCommandnumberOfIntervalsCommandParameterInfo);
+
+    InteractionInfo electricalMeasurementgetMeasurementProfileCommandInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.ElectricalMeasurementCluster) cluster)
+                  .getMeasurementProfileCommand(
+                      (DefaultClusterCallback) callback,
+                      (Integer) commandArguments.get("attributeId"),
+                      (Long) commandArguments.get("startTime"),
+                      (Integer) commandArguments.get("numberOfIntervals"));
+            },
+            () -> new DelegatedDefaultClusterCallback(),
+            electricalMeasurementgetMeasurementProfileCommandCommandParams);
+    electricalMeasurementClusterInteractionInfoMap.put(
+        "getMeasurementProfileCommand",
+        electricalMeasurementgetMeasurementProfileCommandInteractionInfo);
     commandMap.put("electricalMeasurement", electricalMeasurementClusterInteractionInfoMap);
     Map<String, InteractionInfo> clientMonitoringClusterInteractionInfoMap = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> clientMonitoringregisterClientMonitoringCommandParams =
@@ -17872,6 +18058,18 @@ public class ClusterInfoMapping {
             clientMonitoringunregisterClientMonitoringCommandParams);
     clientMonitoringClusterInteractionInfoMap.put(
         "unregisterClientMonitoring", clientMonitoringunregisterClientMonitoringInteractionInfo);
+    Map<String, CommandParameterInfo> clientMonitoringstayAwakeRequestCommandParams =
+        new LinkedHashMap<String, CommandParameterInfo>();
+    InteractionInfo clientMonitoringstayAwakeRequestInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.ClientMonitoringCluster) cluster)
+                  .stayAwakeRequest((DefaultClusterCallback) callback);
+            },
+            () -> new DelegatedDefaultClusterCallback(),
+            clientMonitoringstayAwakeRequestCommandParams);
+    clientMonitoringClusterInteractionInfoMap.put(
+        "stayAwakeRequest", clientMonitoringstayAwakeRequestInteractionInfo);
     commandMap.put("clientMonitoring", clientMonitoringClusterInteractionInfoMap);
     Map<String, InteractionInfo> unitTestingClusterInteractionInfoMap = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> unitTestingtestCommandParams =
@@ -17946,6 +18144,67 @@ public class ClusterInfoMapping {
             unitTestingtestAddArgumentsCommandParams);
     unitTestingClusterInteractionInfoMap.put(
         "testAddArguments", unitTestingtestAddArgumentsInteractionInfo);
+    Map<String, CommandParameterInfo> unitTestingtestSimpleArgumentRequestCommandParams =
+        new LinkedHashMap<String, CommandParameterInfo>();
+    CommandParameterInfo unitTestingtestSimpleArgumentRequestarg1CommandParameterInfo =
+        new CommandParameterInfo("arg1", Boolean.class, Boolean.class);
+    unitTestingtestSimpleArgumentRequestCommandParams.put(
+        "arg1", unitTestingtestSimpleArgumentRequestarg1CommandParameterInfo);
+
+    InteractionInfo unitTestingtestSimpleArgumentRequestInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.UnitTestingCluster) cluster)
+                  .testSimpleArgumentRequest(
+                      (ChipClusters.UnitTestingCluster.TestSimpleArgumentResponseCallback) callback,
+                      (Boolean) commandArguments.get("arg1"));
+            },
+            () -> new DelegatedUnitTestingClusterTestSimpleArgumentResponseCallback(),
+            unitTestingtestSimpleArgumentRequestCommandParams);
+    unitTestingClusterInteractionInfoMap.put(
+        "testSimpleArgumentRequest", unitTestingtestSimpleArgumentRequestInteractionInfo);
+    Map<String, CommandParameterInfo> unitTestingtestStructArrayArgumentRequestCommandParams =
+        new LinkedHashMap<String, CommandParameterInfo>();
+    CommandParameterInfo unitTestingtestStructArrayArgumentRequestarg3CommandParameterInfo =
+        new CommandParameterInfo("arg3", ArrayList.class, Integer.class);
+    unitTestingtestStructArrayArgumentRequestCommandParams.put(
+        "arg3", unitTestingtestStructArrayArgumentRequestarg3CommandParameterInfo);
+
+    CommandParameterInfo unitTestingtestStructArrayArgumentRequestarg4CommandParameterInfo =
+        new CommandParameterInfo("arg4", ArrayList.class, Integer.class);
+    unitTestingtestStructArrayArgumentRequestCommandParams.put(
+        "arg4", unitTestingtestStructArrayArgumentRequestarg4CommandParameterInfo);
+
+    CommandParameterInfo unitTestingtestStructArrayArgumentRequestarg5CommandParameterInfo =
+        new CommandParameterInfo("arg5", Integer.class, Integer.class);
+    unitTestingtestStructArrayArgumentRequestCommandParams.put(
+        "arg5", unitTestingtestStructArrayArgumentRequestarg5CommandParameterInfo);
+
+    CommandParameterInfo unitTestingtestStructArrayArgumentRequestarg6CommandParameterInfo =
+        new CommandParameterInfo("arg6", Boolean.class, Boolean.class);
+    unitTestingtestStructArrayArgumentRequestCommandParams.put(
+        "arg6", unitTestingtestStructArrayArgumentRequestarg6CommandParameterInfo);
+
+    InteractionInfo unitTestingtestStructArrayArgumentRequestInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.UnitTestingCluster) cluster)
+                  .testStructArrayArgumentRequest(
+                      (ChipClusters.UnitTestingCluster.TestStructArrayArgumentResponseCallback)
+                          callback,
+                      (ArrayList<ChipStructs.UnitTestingClusterNestedStructList>)
+                          commandArguments.get("arg1"),
+                      (ArrayList<ChipStructs.UnitTestingClusterSimpleStruct>)
+                          commandArguments.get("arg2"),
+                      (ArrayList<Integer>) commandArguments.get("arg3"),
+                      (ArrayList<Integer>) commandArguments.get("arg4"),
+                      (Integer) commandArguments.get("arg5"),
+                      (Boolean) commandArguments.get("arg6"));
+            },
+            () -> new DelegatedUnitTestingClusterTestStructArrayArgumentResponseCallback(),
+            unitTestingtestStructArrayArgumentRequestCommandParams);
+    unitTestingClusterInteractionInfoMap.put(
+        "testStructArrayArgumentRequest", unitTestingtestStructArrayArgumentRequestInteractionInfo);
     Map<String, CommandParameterInfo> unitTestingtestStructArgumentRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo unitTestingtestStructArgumentRequestInteractionInfo =
@@ -17993,7 +18252,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> unitTestingtestListInt8UArgumentRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo unitTestingtestListInt8UArgumentRequestarg1CommandParameterInfo =
-        new CommandParameterInfo("arg1", ArrayList.class, Object.class);
+        new CommandParameterInfo("arg1", ArrayList.class, Integer.class);
     unitTestingtestListInt8UArgumentRequestCommandParams.put(
         "arg1", unitTestingtestListInt8UArgumentRequestarg1CommandParameterInfo);
 
@@ -18045,7 +18304,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> unitTestingtestListInt8UReverseRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo unitTestingtestListInt8UReverseRequestarg1CommandParameterInfo =
-        new CommandParameterInfo("arg1", ArrayList.class, Object.class);
+        new CommandParameterInfo("arg1", ArrayList.class, Integer.class);
     unitTestingtestListInt8UReverseRequestCommandParams.put(
         "arg1", unitTestingtestListInt8UReverseRequestarg1CommandParameterInfo);
 
@@ -18107,6 +18366,99 @@ public class ClusterInfoMapping {
             unitTestingtestNullableOptionalRequestCommandParams);
     unitTestingClusterInteractionInfoMap.put(
         "testNullableOptionalRequest", unitTestingtestNullableOptionalRequestInteractionInfo);
+    Map<String, CommandParameterInfo> unitTestingtestComplexNullableOptionalRequestCommandParams =
+        new LinkedHashMap<String, CommandParameterInfo>();
+    CommandParameterInfo
+        unitTestingtestComplexNullableOptionalRequestnullableIntCommandParameterInfo =
+            new CommandParameterInfo("nullableInt", Integer.class, Integer.class);
+    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
+        "nullableInt",
+        unitTestingtestComplexNullableOptionalRequestnullableIntCommandParameterInfo);
+
+    CommandParameterInfo
+        unitTestingtestComplexNullableOptionalRequestoptionalIntCommandParameterInfo =
+            new CommandParameterInfo("optionalInt", Optional.class, Integer.class);
+    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
+        "optionalInt",
+        unitTestingtestComplexNullableOptionalRequestoptionalIntCommandParameterInfo);
+
+    CommandParameterInfo
+        unitTestingtestComplexNullableOptionalRequestnullableOptionalIntCommandParameterInfo =
+            new CommandParameterInfo("nullableOptionalInt", Optional.class, Integer.class);
+    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
+        "nullableOptionalInt",
+        unitTestingtestComplexNullableOptionalRequestnullableOptionalIntCommandParameterInfo);
+
+    CommandParameterInfo
+        unitTestingtestComplexNullableOptionalRequestnullableStringCommandParameterInfo =
+            new CommandParameterInfo("nullableString", String.class, String.class);
+    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
+        "nullableString",
+        unitTestingtestComplexNullableOptionalRequestnullableStringCommandParameterInfo);
+
+    CommandParameterInfo
+        unitTestingtestComplexNullableOptionalRequestoptionalStringCommandParameterInfo =
+            new CommandParameterInfo("optionalString", Optional.class, String.class);
+    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
+        "optionalString",
+        unitTestingtestComplexNullableOptionalRequestoptionalStringCommandParameterInfo);
+
+    CommandParameterInfo
+        unitTestingtestComplexNullableOptionalRequestnullableOptionalStringCommandParameterInfo =
+            new CommandParameterInfo("nullableOptionalString", Optional.class, String.class);
+    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
+        "nullableOptionalString",
+        unitTestingtestComplexNullableOptionalRequestnullableOptionalStringCommandParameterInfo);
+
+    CommandParameterInfo
+        unitTestingtestComplexNullableOptionalRequestnullableListCommandParameterInfo =
+            new CommandParameterInfo("nullableList", ArrayList.class, Integer.class);
+    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
+        "nullableList",
+        unitTestingtestComplexNullableOptionalRequestnullableListCommandParameterInfo);
+
+    CommandParameterInfo
+        unitTestingtestComplexNullableOptionalRequestoptionalListCommandParameterInfo =
+            new CommandParameterInfo("optionalList", Optional.class, Integer.class);
+    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
+        "optionalList",
+        unitTestingtestComplexNullableOptionalRequestoptionalListCommandParameterInfo);
+
+    CommandParameterInfo
+        unitTestingtestComplexNullableOptionalRequestnullableOptionalListCommandParameterInfo =
+            new CommandParameterInfo("nullableOptionalList", Optional.class, Integer.class);
+    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
+        "nullableOptionalList",
+        unitTestingtestComplexNullableOptionalRequestnullableOptionalListCommandParameterInfo);
+
+    InteractionInfo unitTestingtestComplexNullableOptionalRequestInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.UnitTestingCluster) cluster)
+                  .testComplexNullableOptionalRequest(
+                      (ChipClusters.UnitTestingCluster.TestComplexNullableOptionalResponseCallback)
+                          callback,
+                      (Integer) commandArguments.get("nullableInt"),
+                      (Optional<Integer>) commandArguments.get("optionalInt"),
+                      (Optional<Integer>) commandArguments.get("nullableOptionalInt"),
+                      (String) commandArguments.get("nullableString"),
+                      (Optional<String>) commandArguments.get("optionalString"),
+                      (Optional<String>) commandArguments.get("nullableOptionalString"),
+                      (ChipStructs.UnitTestingClusterSimpleStruct)
+                          commandArguments.get("nullableStruct"),
+                      (Optional<ChipStructs.UnitTestingClusterSimpleStruct>)
+                          commandArguments.get("optionalStruct"),
+                      (Optional<ChipStructs.UnitTestingClusterSimpleStruct>)
+                          commandArguments.get("nullableOptionalStruct"),
+                      (ArrayList<Integer>) commandArguments.get("nullableList"),
+                      (Optional<ArrayList<Integer>>) commandArguments.get("optionalList"),
+                      (Optional<ArrayList<Integer>>) commandArguments.get("nullableOptionalList"));
+            },
+            () -> new DelegatedUnitTestingClusterTestComplexNullableOptionalResponseCallback(),
+            unitTestingtestComplexNullableOptionalRequestCommandParams);
+    unitTestingClusterInteractionInfoMap.put(
+        "testComplexNullableOptionalRequest",
+        unitTestingtestComplexNullableOptionalRequestInteractionInfo);
     Map<String, CommandParameterInfo> unitTestingsimpleStructEchoRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo unitTestingsimpleStructEchoRequestInteractionInfo =
@@ -18184,6 +18536,28 @@ public class ClusterInfoMapping {
             unitTestingtestEmitTestEventRequestCommandParams);
     unitTestingClusterInteractionInfoMap.put(
         "testEmitTestEventRequest", unitTestingtestEmitTestEventRequestInteractionInfo);
+    Map<String, CommandParameterInfo> unitTestingtestEmitTestFabricScopedEventRequestCommandParams =
+        new LinkedHashMap<String, CommandParameterInfo>();
+    CommandParameterInfo unitTestingtestEmitTestFabricScopedEventRequestarg1CommandParameterInfo =
+        new CommandParameterInfo("arg1", Integer.class, Integer.class);
+    unitTestingtestEmitTestFabricScopedEventRequestCommandParams.put(
+        "arg1", unitTestingtestEmitTestFabricScopedEventRequestarg1CommandParameterInfo);
+
+    InteractionInfo unitTestingtestEmitTestFabricScopedEventRequestInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.UnitTestingCluster) cluster)
+                  .testEmitTestFabricScopedEventRequest(
+                      (ChipClusters.UnitTestingCluster
+                              .TestEmitTestFabricScopedEventResponseCallback)
+                          callback,
+                      (Integer) commandArguments.get("arg1"));
+            },
+            () -> new DelegatedUnitTestingClusterTestEmitTestFabricScopedEventResponseCallback(),
+            unitTestingtestEmitTestFabricScopedEventRequestCommandParams);
+    unitTestingClusterInteractionInfoMap.put(
+        "testEmitTestFabricScopedEventRequest",
+        unitTestingtestEmitTestFabricScopedEventRequestInteractionInfo);
     commandMap.put("unitTesting", unitTestingClusterInteractionInfoMap);
     return commandMap;
   }

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
@@ -14017,110 +14017,6 @@ public class ClusterInfoMapping {
             scenesgetSceneMembershipCommandParams);
     scenesClusterInteractionInfoMap.put(
         "getSceneMembership", scenesgetSceneMembershipInteractionInfo);
-    Map<String, CommandParameterInfo> scenesenhancedAddSceneCommandParams =
-        new LinkedHashMap<String, CommandParameterInfo>();
-    CommandParameterInfo scenesenhancedAddScenegroupIDCommandParameterInfo =
-        new CommandParameterInfo("groupID", Integer.class, Integer.class);
-    scenesenhancedAddSceneCommandParams.put(
-        "groupID", scenesenhancedAddScenegroupIDCommandParameterInfo);
-
-    CommandParameterInfo scenesenhancedAddScenesceneIDCommandParameterInfo =
-        new CommandParameterInfo("sceneID", Integer.class, Integer.class);
-    scenesenhancedAddSceneCommandParams.put(
-        "sceneID", scenesenhancedAddScenesceneIDCommandParameterInfo);
-
-    CommandParameterInfo scenesenhancedAddScenetransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
-    scenesenhancedAddSceneCommandParams.put(
-        "transitionTime", scenesenhancedAddScenetransitionTimeCommandParameterInfo);
-
-    CommandParameterInfo scenesenhancedAddScenesceneNameCommandParameterInfo =
-        new CommandParameterInfo("sceneName", String.class, String.class);
-    scenesenhancedAddSceneCommandParams.put(
-        "sceneName", scenesenhancedAddScenesceneNameCommandParameterInfo);
-
-    InteractionInfo scenesenhancedAddSceneInteractionInfo =
-        new InteractionInfo(
-            (cluster, callback, commandArguments) -> {
-              ((ChipClusters.ScenesCluster) cluster)
-                  .enhancedAddScene(
-                      (ChipClusters.ScenesCluster.EnhancedAddSceneResponseCallback) callback,
-                      (Integer) commandArguments.get("groupID"),
-                      (Integer) commandArguments.get("sceneID"),
-                      (Integer) commandArguments.get("transitionTime"),
-                      (String) commandArguments.get("sceneName"),
-                      (ArrayList<ChipStructs.ScenesClusterExtensionFieldSet>)
-                          commandArguments.get("extensionFieldSets"));
-            },
-            () -> new DelegatedScenesClusterEnhancedAddSceneResponseCallback(),
-            scenesenhancedAddSceneCommandParams);
-    scenesClusterInteractionInfoMap.put("enhancedAddScene", scenesenhancedAddSceneInteractionInfo);
-    Map<String, CommandParameterInfo> scenesenhancedViewSceneCommandParams =
-        new LinkedHashMap<String, CommandParameterInfo>();
-    CommandParameterInfo scenesenhancedViewScenegroupIDCommandParameterInfo =
-        new CommandParameterInfo("groupID", Integer.class, Integer.class);
-    scenesenhancedViewSceneCommandParams.put(
-        "groupID", scenesenhancedViewScenegroupIDCommandParameterInfo);
-
-    CommandParameterInfo scenesenhancedViewScenesceneIDCommandParameterInfo =
-        new CommandParameterInfo("sceneID", Integer.class, Integer.class);
-    scenesenhancedViewSceneCommandParams.put(
-        "sceneID", scenesenhancedViewScenesceneIDCommandParameterInfo);
-
-    InteractionInfo scenesenhancedViewSceneInteractionInfo =
-        new InteractionInfo(
-            (cluster, callback, commandArguments) -> {
-              ((ChipClusters.ScenesCluster) cluster)
-                  .enhancedViewScene(
-                      (ChipClusters.ScenesCluster.EnhancedViewSceneResponseCallback) callback,
-                      (Integer) commandArguments.get("groupID"),
-                      (Integer) commandArguments.get("sceneID"));
-            },
-            () -> new DelegatedScenesClusterEnhancedViewSceneResponseCallback(),
-            scenesenhancedViewSceneCommandParams);
-    scenesClusterInteractionInfoMap.put(
-        "enhancedViewScene", scenesenhancedViewSceneInteractionInfo);
-    Map<String, CommandParameterInfo> scenescopySceneCommandParams =
-        new LinkedHashMap<String, CommandParameterInfo>();
-    CommandParameterInfo scenescopyScenemodeCommandParameterInfo =
-        new CommandParameterInfo("mode", Integer.class, Integer.class);
-    scenescopySceneCommandParams.put("mode", scenescopyScenemodeCommandParameterInfo);
-
-    CommandParameterInfo scenescopyScenegroupIdentifierFromCommandParameterInfo =
-        new CommandParameterInfo("groupIdentifierFrom", Integer.class, Integer.class);
-    scenescopySceneCommandParams.put(
-        "groupIdentifierFrom", scenescopyScenegroupIdentifierFromCommandParameterInfo);
-
-    CommandParameterInfo scenescopyScenesceneIdentifierFromCommandParameterInfo =
-        new CommandParameterInfo("sceneIdentifierFrom", Integer.class, Integer.class);
-    scenescopySceneCommandParams.put(
-        "sceneIdentifierFrom", scenescopyScenesceneIdentifierFromCommandParameterInfo);
-
-    CommandParameterInfo scenescopyScenegroupIdentifierToCommandParameterInfo =
-        new CommandParameterInfo("groupIdentifierTo", Integer.class, Integer.class);
-    scenescopySceneCommandParams.put(
-        "groupIdentifierTo", scenescopyScenegroupIdentifierToCommandParameterInfo);
-
-    CommandParameterInfo scenescopyScenesceneIdentifierToCommandParameterInfo =
-        new CommandParameterInfo("sceneIdentifierTo", Integer.class, Integer.class);
-    scenescopySceneCommandParams.put(
-        "sceneIdentifierTo", scenescopyScenesceneIdentifierToCommandParameterInfo);
-
-    InteractionInfo scenescopySceneInteractionInfo =
-        new InteractionInfo(
-            (cluster, callback, commandArguments) -> {
-              ((ChipClusters.ScenesCluster) cluster)
-                  .copyScene(
-                      (ChipClusters.ScenesCluster.CopySceneResponseCallback) callback,
-                      (Integer) commandArguments.get("mode"),
-                      (Integer) commandArguments.get("groupIdentifierFrom"),
-                      (Integer) commandArguments.get("sceneIdentifierFrom"),
-                      (Integer) commandArguments.get("groupIdentifierTo"),
-                      (Integer) commandArguments.get("sceneIdentifierTo"));
-            },
-            () -> new DelegatedScenesClusterCopySceneResponseCallback(),
-            scenescopySceneCommandParams);
-    scenesClusterInteractionInfoMap.put("copyScene", scenescopySceneInteractionInfo);
     commandMap.put("scenes", scenesClusterInteractionInfoMap);
     Map<String, InteractionInfo> onOffClusterInteractionInfoMap = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> onOffoffCommandParams =
@@ -14500,25 +14396,6 @@ public class ClusterInfoMapping {
             levelControlstopWithOnOffCommandParams);
     levelControlClusterInteractionInfoMap.put(
         "stopWithOnOff", levelControlstopWithOnOffInteractionInfo);
-    Map<String, CommandParameterInfo> levelControlmoveToClosestFrequencyCommandParams =
-        new LinkedHashMap<String, CommandParameterInfo>();
-    CommandParameterInfo levelControlmoveToClosestFrequencyfrequencyCommandParameterInfo =
-        new CommandParameterInfo("frequency", Integer.class, Integer.class);
-    levelControlmoveToClosestFrequencyCommandParams.put(
-        "frequency", levelControlmoveToClosestFrequencyfrequencyCommandParameterInfo);
-
-    InteractionInfo levelControlmoveToClosestFrequencyInteractionInfo =
-        new InteractionInfo(
-            (cluster, callback, commandArguments) -> {
-              ((ChipClusters.LevelControlCluster) cluster)
-                  .moveToClosestFrequency(
-                      (DefaultClusterCallback) callback,
-                      (Integer) commandArguments.get("frequency"));
-            },
-            () -> new DelegatedDefaultClusterCallback(),
-            levelControlmoveToClosestFrequencyCommandParams);
-    levelControlClusterInteractionInfoMap.put(
-        "moveToClosestFrequency", levelControlmoveToClosestFrequencyInteractionInfo);
     commandMap.put("levelControl", levelControlClusterInteractionInfoMap);
     Map<String, InteractionInfo> binaryInputBasicClusterInteractionInfoMap = new LinkedHashMap<>();
     commandMap.put("binaryInputBasic", binaryInputBasicClusterInteractionInfoMap);
@@ -14848,18 +14725,6 @@ public class ClusterInfoMapping {
         "disableActionWithDuration", actionsdisableActionWithDurationInteractionInfo);
     commandMap.put("actions", actionsClusterInteractionInfoMap);
     Map<String, InteractionInfo> basicInformationClusterInteractionInfoMap = new LinkedHashMap<>();
-    Map<String, CommandParameterInfo> basicInformationmfgSpecificPingCommandParams =
-        new LinkedHashMap<String, CommandParameterInfo>();
-    InteractionInfo basicInformationmfgSpecificPingInteractionInfo =
-        new InteractionInfo(
-            (cluster, callback, commandArguments) -> {
-              ((ChipClusters.BasicInformationCluster) cluster)
-                  .mfgSpecificPing((DefaultClusterCallback) callback);
-            },
-            () -> new DelegatedDefaultClusterCallback(),
-            basicInformationmfgSpecificPingCommandParams);
-    basicInformationClusterInteractionInfoMap.put(
-        "mfgSpecificPing", basicInformationmfgSpecificPingInteractionInfo);
     commandMap.put("basicInformation", basicInformationClusterInteractionInfoMap);
     Map<String, InteractionInfo> otaSoftwareUpdateProviderClusterInteractionInfoMap =
         new LinkedHashMap<>();
@@ -17954,57 +17819,6 @@ public class ClusterInfoMapping {
     commandMap.put("accountLogin", accountLoginClusterInteractionInfoMap);
     Map<String, InteractionInfo> electricalMeasurementClusterInteractionInfoMap =
         new LinkedHashMap<>();
-    Map<String, CommandParameterInfo> electricalMeasurementgetProfileInfoCommandCommandParams =
-        new LinkedHashMap<String, CommandParameterInfo>();
-    InteractionInfo electricalMeasurementgetProfileInfoCommandInteractionInfo =
-        new InteractionInfo(
-            (cluster, callback, commandArguments) -> {
-              ((ChipClusters.ElectricalMeasurementCluster) cluster)
-                  .getProfileInfoCommand((DefaultClusterCallback) callback);
-            },
-            () -> new DelegatedDefaultClusterCallback(),
-            electricalMeasurementgetProfileInfoCommandCommandParams);
-    electricalMeasurementClusterInteractionInfoMap.put(
-        "getProfileInfoCommand", electricalMeasurementgetProfileInfoCommandInteractionInfo);
-    Map<String, CommandParameterInfo>
-        electricalMeasurementgetMeasurementProfileCommandCommandParams =
-            new LinkedHashMap<String, CommandParameterInfo>();
-    CommandParameterInfo
-        electricalMeasurementgetMeasurementProfileCommandattributeIdCommandParameterInfo =
-            new CommandParameterInfo("attributeId", Integer.class, Integer.class);
-    electricalMeasurementgetMeasurementProfileCommandCommandParams.put(
-        "attributeId",
-        electricalMeasurementgetMeasurementProfileCommandattributeIdCommandParameterInfo);
-
-    CommandParameterInfo
-        electricalMeasurementgetMeasurementProfileCommandstartTimeCommandParameterInfo =
-            new CommandParameterInfo("startTime", Long.class, Long.class);
-    electricalMeasurementgetMeasurementProfileCommandCommandParams.put(
-        "startTime",
-        electricalMeasurementgetMeasurementProfileCommandstartTimeCommandParameterInfo);
-
-    CommandParameterInfo
-        electricalMeasurementgetMeasurementProfileCommandnumberOfIntervalsCommandParameterInfo =
-            new CommandParameterInfo("numberOfIntervals", Integer.class, Integer.class);
-    electricalMeasurementgetMeasurementProfileCommandCommandParams.put(
-        "numberOfIntervals",
-        electricalMeasurementgetMeasurementProfileCommandnumberOfIntervalsCommandParameterInfo);
-
-    InteractionInfo electricalMeasurementgetMeasurementProfileCommandInteractionInfo =
-        new InteractionInfo(
-            (cluster, callback, commandArguments) -> {
-              ((ChipClusters.ElectricalMeasurementCluster) cluster)
-                  .getMeasurementProfileCommand(
-                      (DefaultClusterCallback) callback,
-                      (Integer) commandArguments.get("attributeId"),
-                      (Long) commandArguments.get("startTime"),
-                      (Integer) commandArguments.get("numberOfIntervals"));
-            },
-            () -> new DelegatedDefaultClusterCallback(),
-            electricalMeasurementgetMeasurementProfileCommandCommandParams);
-    electricalMeasurementClusterInteractionInfoMap.put(
-        "getMeasurementProfileCommand",
-        electricalMeasurementgetMeasurementProfileCommandInteractionInfo);
     commandMap.put("electricalMeasurement", electricalMeasurementClusterInteractionInfoMap);
     Map<String, InteractionInfo> clientMonitoringClusterInteractionInfoMap = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> clientMonitoringregisterClientMonitoringCommandParams =
@@ -18058,18 +17872,6 @@ public class ClusterInfoMapping {
             clientMonitoringunregisterClientMonitoringCommandParams);
     clientMonitoringClusterInteractionInfoMap.put(
         "unregisterClientMonitoring", clientMonitoringunregisterClientMonitoringInteractionInfo);
-    Map<String, CommandParameterInfo> clientMonitoringstayAwakeRequestCommandParams =
-        new LinkedHashMap<String, CommandParameterInfo>();
-    InteractionInfo clientMonitoringstayAwakeRequestInteractionInfo =
-        new InteractionInfo(
-            (cluster, callback, commandArguments) -> {
-              ((ChipClusters.ClientMonitoringCluster) cluster)
-                  .stayAwakeRequest((DefaultClusterCallback) callback);
-            },
-            () -> new DelegatedDefaultClusterCallback(),
-            clientMonitoringstayAwakeRequestCommandParams);
-    clientMonitoringClusterInteractionInfoMap.put(
-        "stayAwakeRequest", clientMonitoringstayAwakeRequestInteractionInfo);
     commandMap.put("clientMonitoring", clientMonitoringClusterInteractionInfoMap);
     Map<String, InteractionInfo> unitTestingClusterInteractionInfoMap = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> unitTestingtestCommandParams =
@@ -18144,67 +17946,6 @@ public class ClusterInfoMapping {
             unitTestingtestAddArgumentsCommandParams);
     unitTestingClusterInteractionInfoMap.put(
         "testAddArguments", unitTestingtestAddArgumentsInteractionInfo);
-    Map<String, CommandParameterInfo> unitTestingtestSimpleArgumentRequestCommandParams =
-        new LinkedHashMap<String, CommandParameterInfo>();
-    CommandParameterInfo unitTestingtestSimpleArgumentRequestarg1CommandParameterInfo =
-        new CommandParameterInfo("arg1", Boolean.class, Boolean.class);
-    unitTestingtestSimpleArgumentRequestCommandParams.put(
-        "arg1", unitTestingtestSimpleArgumentRequestarg1CommandParameterInfo);
-
-    InteractionInfo unitTestingtestSimpleArgumentRequestInteractionInfo =
-        new InteractionInfo(
-            (cluster, callback, commandArguments) -> {
-              ((ChipClusters.UnitTestingCluster) cluster)
-                  .testSimpleArgumentRequest(
-                      (ChipClusters.UnitTestingCluster.TestSimpleArgumentResponseCallback) callback,
-                      (Boolean) commandArguments.get("arg1"));
-            },
-            () -> new DelegatedUnitTestingClusterTestSimpleArgumentResponseCallback(),
-            unitTestingtestSimpleArgumentRequestCommandParams);
-    unitTestingClusterInteractionInfoMap.put(
-        "testSimpleArgumentRequest", unitTestingtestSimpleArgumentRequestInteractionInfo);
-    Map<String, CommandParameterInfo> unitTestingtestStructArrayArgumentRequestCommandParams =
-        new LinkedHashMap<String, CommandParameterInfo>();
-    CommandParameterInfo unitTestingtestStructArrayArgumentRequestarg3CommandParameterInfo =
-        new CommandParameterInfo("arg3", ArrayList.class, Integer.class);
-    unitTestingtestStructArrayArgumentRequestCommandParams.put(
-        "arg3", unitTestingtestStructArrayArgumentRequestarg3CommandParameterInfo);
-
-    CommandParameterInfo unitTestingtestStructArrayArgumentRequestarg4CommandParameterInfo =
-        new CommandParameterInfo("arg4", ArrayList.class, Integer.class);
-    unitTestingtestStructArrayArgumentRequestCommandParams.put(
-        "arg4", unitTestingtestStructArrayArgumentRequestarg4CommandParameterInfo);
-
-    CommandParameterInfo unitTestingtestStructArrayArgumentRequestarg5CommandParameterInfo =
-        new CommandParameterInfo("arg5", Integer.class, Integer.class);
-    unitTestingtestStructArrayArgumentRequestCommandParams.put(
-        "arg5", unitTestingtestStructArrayArgumentRequestarg5CommandParameterInfo);
-
-    CommandParameterInfo unitTestingtestStructArrayArgumentRequestarg6CommandParameterInfo =
-        new CommandParameterInfo("arg6", Boolean.class, Boolean.class);
-    unitTestingtestStructArrayArgumentRequestCommandParams.put(
-        "arg6", unitTestingtestStructArrayArgumentRequestarg6CommandParameterInfo);
-
-    InteractionInfo unitTestingtestStructArrayArgumentRequestInteractionInfo =
-        new InteractionInfo(
-            (cluster, callback, commandArguments) -> {
-              ((ChipClusters.UnitTestingCluster) cluster)
-                  .testStructArrayArgumentRequest(
-                      (ChipClusters.UnitTestingCluster.TestStructArrayArgumentResponseCallback)
-                          callback,
-                      (ArrayList<ChipStructs.UnitTestingClusterNestedStructList>)
-                          commandArguments.get("arg1"),
-                      (ArrayList<ChipStructs.UnitTestingClusterSimpleStruct>)
-                          commandArguments.get("arg2"),
-                      (ArrayList<Integer>) commandArguments.get("arg3"),
-                      (ArrayList<Integer>) commandArguments.get("arg4"),
-                      (Integer) commandArguments.get("arg5"),
-                      (Boolean) commandArguments.get("arg6"));
-            },
-            () -> new DelegatedUnitTestingClusterTestStructArrayArgumentResponseCallback(),
-            unitTestingtestStructArrayArgumentRequestCommandParams);
-    unitTestingClusterInteractionInfoMap.put(
-        "testStructArrayArgumentRequest", unitTestingtestStructArrayArgumentRequestInteractionInfo);
     Map<String, CommandParameterInfo> unitTestingtestStructArgumentRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo unitTestingtestStructArgumentRequestInteractionInfo =
@@ -18366,99 +18107,6 @@ public class ClusterInfoMapping {
             unitTestingtestNullableOptionalRequestCommandParams);
     unitTestingClusterInteractionInfoMap.put(
         "testNullableOptionalRequest", unitTestingtestNullableOptionalRequestInteractionInfo);
-    Map<String, CommandParameterInfo> unitTestingtestComplexNullableOptionalRequestCommandParams =
-        new LinkedHashMap<String, CommandParameterInfo>();
-    CommandParameterInfo
-        unitTestingtestComplexNullableOptionalRequestnullableIntCommandParameterInfo =
-            new CommandParameterInfo("nullableInt", Integer.class, Integer.class);
-    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
-        "nullableInt",
-        unitTestingtestComplexNullableOptionalRequestnullableIntCommandParameterInfo);
-
-    CommandParameterInfo
-        unitTestingtestComplexNullableOptionalRequestoptionalIntCommandParameterInfo =
-            new CommandParameterInfo("optionalInt", Optional.class, Integer.class);
-    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
-        "optionalInt",
-        unitTestingtestComplexNullableOptionalRequestoptionalIntCommandParameterInfo);
-
-    CommandParameterInfo
-        unitTestingtestComplexNullableOptionalRequestnullableOptionalIntCommandParameterInfo =
-            new CommandParameterInfo("nullableOptionalInt", Optional.class, Integer.class);
-    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
-        "nullableOptionalInt",
-        unitTestingtestComplexNullableOptionalRequestnullableOptionalIntCommandParameterInfo);
-
-    CommandParameterInfo
-        unitTestingtestComplexNullableOptionalRequestnullableStringCommandParameterInfo =
-            new CommandParameterInfo("nullableString", String.class, String.class);
-    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
-        "nullableString",
-        unitTestingtestComplexNullableOptionalRequestnullableStringCommandParameterInfo);
-
-    CommandParameterInfo
-        unitTestingtestComplexNullableOptionalRequestoptionalStringCommandParameterInfo =
-            new CommandParameterInfo("optionalString", Optional.class, String.class);
-    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
-        "optionalString",
-        unitTestingtestComplexNullableOptionalRequestoptionalStringCommandParameterInfo);
-
-    CommandParameterInfo
-        unitTestingtestComplexNullableOptionalRequestnullableOptionalStringCommandParameterInfo =
-            new CommandParameterInfo("nullableOptionalString", Optional.class, String.class);
-    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
-        "nullableOptionalString",
-        unitTestingtestComplexNullableOptionalRequestnullableOptionalStringCommandParameterInfo);
-
-    CommandParameterInfo
-        unitTestingtestComplexNullableOptionalRequestnullableListCommandParameterInfo =
-            new CommandParameterInfo("nullableList", ArrayList.class, Integer.class);
-    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
-        "nullableList",
-        unitTestingtestComplexNullableOptionalRequestnullableListCommandParameterInfo);
-
-    CommandParameterInfo
-        unitTestingtestComplexNullableOptionalRequestoptionalListCommandParameterInfo =
-            new CommandParameterInfo("optionalList", Optional.class, Integer.class);
-    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
-        "optionalList",
-        unitTestingtestComplexNullableOptionalRequestoptionalListCommandParameterInfo);
-
-    CommandParameterInfo
-        unitTestingtestComplexNullableOptionalRequestnullableOptionalListCommandParameterInfo =
-            new CommandParameterInfo("nullableOptionalList", Optional.class, Integer.class);
-    unitTestingtestComplexNullableOptionalRequestCommandParams.put(
-        "nullableOptionalList",
-        unitTestingtestComplexNullableOptionalRequestnullableOptionalListCommandParameterInfo);
-
-    InteractionInfo unitTestingtestComplexNullableOptionalRequestInteractionInfo =
-        new InteractionInfo(
-            (cluster, callback, commandArguments) -> {
-              ((ChipClusters.UnitTestingCluster) cluster)
-                  .testComplexNullableOptionalRequest(
-                      (ChipClusters.UnitTestingCluster.TestComplexNullableOptionalResponseCallback)
-                          callback,
-                      (Integer) commandArguments.get("nullableInt"),
-                      (Optional<Integer>) commandArguments.get("optionalInt"),
-                      (Optional<Integer>) commandArguments.get("nullableOptionalInt"),
-                      (String) commandArguments.get("nullableString"),
-                      (Optional<String>) commandArguments.get("optionalString"),
-                      (Optional<String>) commandArguments.get("nullableOptionalString"),
-                      (ChipStructs.UnitTestingClusterSimpleStruct)
-                          commandArguments.get("nullableStruct"),
-                      (Optional<ChipStructs.UnitTestingClusterSimpleStruct>)
-                          commandArguments.get("optionalStruct"),
-                      (Optional<ChipStructs.UnitTestingClusterSimpleStruct>)
-                          commandArguments.get("nullableOptionalStruct"),
-                      (ArrayList<Integer>) commandArguments.get("nullableList"),
-                      (Optional<ArrayList<Integer>>) commandArguments.get("optionalList"),
-                      (Optional<ArrayList<Integer>>) commandArguments.get("nullableOptionalList"));
-            },
-            () -> new DelegatedUnitTestingClusterTestComplexNullableOptionalResponseCallback(),
-            unitTestingtestComplexNullableOptionalRequestCommandParams);
-    unitTestingClusterInteractionInfoMap.put(
-        "testComplexNullableOptionalRequest",
-        unitTestingtestComplexNullableOptionalRequestInteractionInfo);
     Map<String, CommandParameterInfo> unitTestingsimpleStructEchoRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo unitTestingsimpleStructEchoRequestInteractionInfo =
@@ -18536,28 +18184,6 @@ public class ClusterInfoMapping {
             unitTestingtestEmitTestEventRequestCommandParams);
     unitTestingClusterInteractionInfoMap.put(
         "testEmitTestEventRequest", unitTestingtestEmitTestEventRequestInteractionInfo);
-    Map<String, CommandParameterInfo> unitTestingtestEmitTestFabricScopedEventRequestCommandParams =
-        new LinkedHashMap<String, CommandParameterInfo>();
-    CommandParameterInfo unitTestingtestEmitTestFabricScopedEventRequestarg1CommandParameterInfo =
-        new CommandParameterInfo("arg1", Integer.class, Integer.class);
-    unitTestingtestEmitTestFabricScopedEventRequestCommandParams.put(
-        "arg1", unitTestingtestEmitTestFabricScopedEventRequestarg1CommandParameterInfo);
-
-    InteractionInfo unitTestingtestEmitTestFabricScopedEventRequestInteractionInfo =
-        new InteractionInfo(
-            (cluster, callback, commandArguments) -> {
-              ((ChipClusters.UnitTestingCluster) cluster)
-                  .testEmitTestFabricScopedEventRequest(
-                      (ChipClusters.UnitTestingCluster
-                              .TestEmitTestFabricScopedEventResponseCallback)
-                          callback,
-                      (Integer) commandArguments.get("arg1"));
-            },
-            () -> new DelegatedUnitTestingClusterTestEmitTestFabricScopedEventResponseCallback(),
-            unitTestingtestEmitTestFabricScopedEventRequestCommandParams);
-    unitTestingClusterInteractionInfoMap.put(
-        "testEmitTestFabricScopedEventRequest",
-        unitTestingtestEmitTestFabricScopedEventRequestInteractionInfo);
     commandMap.put("unitTesting", unitTestingClusterInteractionInfoMap);
     return commandMap;
   }

--- a/src/controller/python/templates/python-CHIPClusters-py.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-py.zapt
@@ -13,22 +13,32 @@ class ChipClusters:
     SUCCESS_DELEGATE = ctypes.CFUNCTYPE(None)
     FAILURE_DELEGATE = ctypes.CFUNCTYPE(None, ctypes.c_uint8)
 
-{{#chip_client_clusters}}
+{{#all_user_clusters side='client'}}
     _{{asDelimitedMacro name}}_CLUSTER_INFO = {
         "clusterName": "{{asUpperCamelCase name}}",
         "clusterId": {{asHex code 8}},
         "commands": {
-{{#chip_cluster_commands}}
-            {{asHex code 8}}: {
-                "commandId": {{asHex code 8}},
-                "commandName": "{{asUpperCamelCase name}}",
+{{#all_user_cluster_generated_commands}}
+  {{#if_compare clusterId ../id operator='=='}}
+  {{#if (is_str_equal commandSource 'client')}}
+            {{asHex commandCode 8}}: {
+                "commandId": {{asHex commandCode 8}},
+                "commandName": "{{asUpperCamelCase commandName}}",
                 "args": {
-{{#chip_cluster_command_arguments_with_structs_expanded}}
-                    "{{asLowerCamelCase label}}": "{{#if (isCharString type)}}str{{else}}{{asPythonType chipType}}{{/if}}",
-{{/chip_cluster_command_arguments_with_structs_expanded}}
+{{#zcl_command_arguments}}
+     {{#if_is_struct type}}
+        {{#zcl_struct_items_by_struct_name type}}
+                    "{{asLowerCamelCase label}}": "{{#if (isCharString type)}}str{{else}}{{as_underlying_python_zcl_type type ../../id}}{{/if}}",
+        {{/zcl_struct_items_by_struct_name}}
+    {{else}}
+                    "{{asLowerCamelCase label}}": "{{#if (isCharString type)}}str{{else}}{{as_underlying_python_zcl_type type ../id}}{{/if}}",
+    {{/if_is_struct}}
+{{/zcl_command_arguments}}
                 },
             },
-{{/chip_cluster_commands}}
+  {{/if}}
+  {{/if_compare}}
+{{/all_user_cluster_generated_commands}}
         },
         "attributes": {
 {{#zcl_attributes_server removeKeys='isOptional'}}
@@ -46,18 +56,18 @@ class ChipClusters:
 {{/zcl_attributes_server}}
         },
     }
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
 
     _CLUSTER_ID_DICT = {
-{{#chip_client_clusters}}
+{{#all_user_clusters side='client'}}
         {{asHex code 8}}: _{{asDelimitedMacro name}}_CLUSTER_INFO,
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
     }
 
     _CLUSTER_NAME_DICT = {
-{{#chip_client_clusters}}
+{{#all_user_clusters side='client'}}
         "{{asUpperCamelCase name}}": _{{asDelimitedMacro name}}_CLUSTER_INFO,
-{{/chip_client_clusters}}
+{{/all_user_clusters}}
     }
 
     def __init__(self, chipstack):


### PR DESCRIPTION
- Replacing chip_client_clusters, chip_cluster_commands, chip_cluster_responses and chip_cluster_command_arguments with all_user_clusters, zcl_commands, zcl_command_responses and zcl_command_arguments respectively in templates
- Updating minimum zap vesion
- Github: ZAP#971
