### PR TITLE
Fix mdns client example shutdown sequence.

### DIFF
--- a/examples/minimal-mdns/client.cpp
+++ b/examples/minimal-mdns/client.cpp
@@ -342,7 +342,6 @@ int main(int argc, char ** args)
             gMdnsServer.Shutdown();
 
             DeviceLayer::PlatformMgr().StopEventLoopTask();
-            DeviceLayer::PlatformMgr().Shutdown();
         },
         nullptr);
     if (err != CHIP_NO_ERROR)
@@ -351,6 +350,9 @@ int main(int argc, char ** args)
     }
 
     DeviceLayer::PlatformMgr().RunEventLoop();
+
+    DeviceLayer::PlatformMgr().Shutdown();
+    Platform::MemoryShutdown();
 
     printf("Done...\n");
     return 0;


### PR DESCRIPTION
Shutting down the platform manager while the event loop is not fully shut down (which is the case when StopEventLoopTask is called from inside the event loop itself) is not supported.

Fixes https://github.com/project-chip/connectedhomeip/issues/8917
