### PR TITLE
script: Use absolute path for module_initialized check

### DIFF
--- a/scripts/checkout_submodules.py
+++ b/scripts/checkout_submodules.py
@@ -73,7 +73,7 @@ def module_matches_platforms(module: Module, platforms: set) -> bool:
 
 
 def module_initialized(module: Module) -> bool:
-    return bool(os.listdir(module.path))
+    return bool(os.listdir(os.path.join(CHIP_ROOT, module.path)))
 
 
 def make_chip_root_safe_directory() -> None:


### PR DESCRIPTION
We should use absolute path for module_initialized check so that we will not get an error when we run the checkout_submodule.py script in non-CHIP_ROOT directory.
