### PR TITLE
doc: Fix dependancy version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ Sphinx>=4.5
 sphinx-book-theme
 myst-parser
 breathe>=4.34
+pydata-sphinx-theme==0.13.1


### PR DESCRIPTION
Fix version of dependancy pydata-sphinx-theme to 0.13.1 since v0.13.2 introduced changes that breaks the documentation build.

