### PR TITLE
[ESP32] Fixed lock app crash

### DIFF
--- a/examples/lock-app/esp32/main/AppTask.cpp
+++ b/examples/lock-app/esp32/main/AppTask.cpp
@@ -59,7 +59,6 @@ StackType_t appStack[APP_TASK_STACK_SIZE / sizeof(StackType_t)];
 
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::System;
-// using namespace ESP32DoorLock::LockInitParams;
 
 AppTask AppTask::sAppTask;
 
@@ -86,7 +85,10 @@ CHIP_ERROR AppTask::Init()
                                   (void *) this,    // init timer id = app task obj context
                                   TimerEventHandler // timer callback handler
     );
+
+    PlatformMgr().LockChipStack();
     CHIP_ERROR err = BoltLockMgr().InitLockState();
+    PlatformMgr().UnlockChipStack();
 
     BoltLockMgr().SetCallbacks(ActionInitiated, ActionCompleted);
 

--- a/examples/lock-app/esp32/main/AppTask.cpp
+++ b/examples/lock-app/esp32/main/AppTask.cpp
@@ -86,9 +86,8 @@ CHIP_ERROR AppTask::Init()
                                   TimerEventHandler // timer callback handler
     );
 
-    PlatformMgr().LockChipStack();
+    chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = BoltLockMgr().InitLockState();
-    PlatformMgr().UnlockChipStack();
 
     BoltLockMgr().SetCallbacks(ActionInitiated, ActionCompleted);
 


### PR DESCRIPTION
Problem:

- Fixes #25874 and #24913.

Changes:

- See above.

Testing:

- Tested commissioning and cluster control.