### PR TITLE
Standardise feature names

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -52,7 +52,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -116,12 +116,12 @@ server cluster Groups = 4 {
 }
 
 server cluster Scenes = 5 {
-  bitmap SceneFeatures : BITMAP32 {
-    kSceneNames = 0x1;
-  }
-
   bitmap ScenesCopyMode : BITMAP8 {
     kCopyAllScenes = 0x1;
+  }
+
+  bitmap ScenesFeature : BITMAP32 {
+    kSceneNames = 0x1;
   }
 
   struct ExtensionFieldSet {
@@ -2734,14 +2734,6 @@ server cluster WindowCovering = 258 {
     kTiltEncoderControlled = 0x40;
   }
 
-  bitmap Feature : BITMAP32 {
-    kLift = 0x1;
-    kTilt = 0x2;
-    kPositionAwareLift = 0x4;
-    kAbsolutePosition = 0x8;
-    kPositionAwareTilt = 0x10;
-  }
-
   bitmap Mode : BITMAP8 {
     kMotorDirectionReversed = 0x1;
     kCalibrationMode = 0x2;
@@ -2768,6 +2760,14 @@ server cluster WindowCovering = 258 {
     kHardwareFailure = 0x200;
     kManualOperation = 0x400;
     kProtection = 0x800;
+  }
+
+  bitmap WindowCoveringFeature : BITMAP32 {
+    kLift = 0x1;
+    kTilt = 0x2;
+    kPositionAwareLift = 0x4;
+    kAbsolutePosition = 0x8;
+    kPositionAwareTilt = 0x10;
   }
 
   readonly attribute Type type = 0;
@@ -2861,7 +2861,7 @@ server cluster PumpConfigurationAndControl = 512 {
     kLocal = 3;
   }
 
-  bitmap PumpFeature : BITMAP32 {
+  bitmap PumpConfigurationAndControlFeature : BITMAP32 {
     kConstantPressure = 0x1;
     kCompensatedPressure = 0x2;
     kConstantFlow = 0x4;
@@ -3487,7 +3487,7 @@ server cluster TemperatureMeasurement = 1026 {
 }
 
 server cluster PressureMeasurement = 1027 {
-  bitmap PressureFeature : BITMAP32 {
+  bitmap PressureMeasurementFeature : BITMAP32 {
     kExtended = 0x1;
   }
 

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -51,7 +51,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -115,12 +115,12 @@ server cluster Groups = 4 {
 }
 
 server cluster Scenes = 5 {
-  bitmap SceneFeatures : BITMAP32 {
-    kSceneNames = 0x1;
-  }
-
   bitmap ScenesCopyMode : BITMAP8 {
     kCopyAllScenes = 0x1;
+  }
+
+  bitmap ScenesFeature : BITMAP32 {
+    kSceneNames = 0x1;
   }
 
   struct ExtensionFieldSet {
@@ -2376,14 +2376,6 @@ server cluster WindowCovering = 258 {
     kTiltEncoderControlled = 0x40;
   }
 
-  bitmap Feature : BITMAP32 {
-    kLift = 0x1;
-    kTilt = 0x2;
-    kPositionAwareLift = 0x4;
-    kAbsolutePosition = 0x8;
-    kPositionAwareTilt = 0x10;
-  }
-
   bitmap Mode : BITMAP8 {
     kMotorDirectionReversed = 0x1;
     kCalibrationMode = 0x2;
@@ -2410,6 +2402,14 @@ server cluster WindowCovering = 258 {
     kHardwareFailure = 0x200;
     kManualOperation = 0x400;
     kProtection = 0x800;
+  }
+
+  bitmap WindowCoveringFeature : BITMAP32 {
+    kLift = 0x1;
+    kTilt = 0x2;
+    kPositionAwareLift = 0x4;
+    kAbsolutePosition = 0x8;
+    kPositionAwareTilt = 0x10;
   }
 
   readonly attribute Type type = 0;
@@ -2446,7 +2446,7 @@ server cluster PumpConfigurationAndControl = 512 {
     kLocal = 3;
   }
 
-  bitmap PumpFeature : BITMAP32 {
+  bitmap PumpConfigurationAndControlFeature : BITMAP32 {
     kConstantPressure = 0x1;
     kCompensatedPressure = 0x2;
     kConstantFlow = 0x4;
@@ -2813,7 +2813,7 @@ server cluster TemperatureMeasurement = 1026 {
 }
 
 server cluster PressureMeasurement = 1027 {
-  bitmap PressureFeature : BITMAP32 {
+  bitmap PressureMeasurementFeature : BITMAP32 {
     kExtended = 0x1;
   }
 

--- a/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.matter
+++ b/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.matter
@@ -47,7 +47,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
+++ b/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
+++ b/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
+++ b/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_fan_7N2TobIlOX.matter
+++ b/examples/chef/devices/rootnode_fan_7N2TobIlOX.matter
@@ -47,7 +47,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
+++ b/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 client cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -105,7 +105,7 @@ client cluster Groups = 4 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
+++ b/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
+++ b/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 client cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -105,7 +105,7 @@ client cluster Groups = 4 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
+++ b/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 client cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -105,7 +105,7 @@ client cluster Groups = 4 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
+++ b/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 client cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -105,7 +105,7 @@ client cluster Groups = 4 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
+++ b/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
+++ b/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
+++ b/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
+++ b/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
@@ -46,7 +46,7 @@ server cluster Identify = 3 {
 }
 
 client cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -110,7 +110,7 @@ client cluster Groups = 4 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -1171,7 +1171,7 @@ server cluster UserLabel = 65 {
 }
 
 server cluster PressureMeasurement = 1027 {
-  bitmap PressureFeature : BITMAP32 {
+  bitmap PressureMeasurementFeature : BITMAP32 {
     kExtended = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
+++ b/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
+++ b/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 client cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -105,7 +105,7 @@ client cluster Groups = 4 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
+++ b/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
+++ b/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
@@ -41,7 +41,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -1149,14 +1149,6 @@ server cluster WindowCovering = 258 {
     kTiltEncoderControlled = 0x40;
   }
 
-  bitmap Feature : BITMAP32 {
-    kLift = 0x1;
-    kTilt = 0x2;
-    kPositionAwareLift = 0x4;
-    kAbsolutePosition = 0x8;
-    kPositionAwareTilt = 0x10;
-  }
-
   bitmap Mode : BITMAP8 {
     kMotorDirectionReversed = 0x1;
     kCalibrationMode = 0x2;
@@ -1183,6 +1175,14 @@ server cluster WindowCovering = 258 {
     kHardwareFailure = 0x200;
     kManualOperation = 0x400;
     kProtection = 0x800;
+  }
+
+  bitmap WindowCoveringFeature : BITMAP32 {
+    kLift = 0x1;
+    kTilt = 0x2;
+    kPositionAwareLift = 0x4;
+    kAbsolutePosition = 0x8;
+    kPositionAwareTilt = 0x10;
   }
 
   readonly attribute Type type = 0;

--- a/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.matter
+++ b/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.matter
@@ -52,7 +52,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -97,7 +97,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -161,12 +161,12 @@ server cluster Groups = 4 {
 }
 
 client cluster Scenes = 5 {
-  bitmap SceneFeatures : BITMAP32 {
-    kSceneNames = 0x1;
-  }
-
   bitmap ScenesCopyMode : BITMAP8 {
     kCopyAllScenes = 0x1;
+  }
+
+  bitmap ScenesFeature : BITMAP32 {
+    kSceneNames = 0x1;
   }
 
   struct AttributeValuePair {

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -52,7 +52,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/lighting-app/nxp/zap/lighting-on-off.matter
+++ b/examples/lighting-app/nxp/zap/lighting-on-off.matter
@@ -47,7 +47,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/lighting-app/qpg/zap/light.matter
+++ b/examples/lighting-app/qpg/zap/light.matter
@@ -52,7 +52,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/lighting-app/silabs/SiWx917/data_model/lighting-wifi-app.matter
+++ b/examples/lighting-app/silabs/SiWx917/data_model/lighting-wifi-app.matter
@@ -52,7 +52,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/lighting-app/silabs/efr32/data_model/lighting-thread-app.matter
+++ b/examples/lighting-app/silabs/efr32/data_model/lighting-thread-app.matter
@@ -52,7 +52,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/lighting-app/silabs/efr32/data_model/lighting-wifi-app.matter
+++ b/examples/lighting-app/silabs/efr32/data_model/lighting-wifi-app.matter
@@ -52,7 +52,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/lock-app/qpg/zap/lock.matter
+++ b/examples/lock-app/qpg/zap/lock.matter
@@ -52,7 +52,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
@@ -52,7 +52,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -52,7 +52,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -116,12 +116,12 @@ server cluster Groups = 4 {
 }
 
 server cluster Scenes = 5 {
-  bitmap SceneFeatures : BITMAP32 {
-    kSceneNames = 0x1;
-  }
-
   bitmap ScenesCopyMode : BITMAP8 {
     kCopyAllScenes = 0x1;
+  }
+
+  bitmap ScenesFeature : BITMAP32 {
+    kSceneNames = 0x1;
   }
 
   struct ExtensionFieldSet {
@@ -2056,14 +2056,6 @@ server cluster WindowCovering = 258 {
     kTiltEncoderControlled = 0x40;
   }
 
-  bitmap Feature : BITMAP32 {
-    kLift = 0x1;
-    kTilt = 0x2;
-    kPositionAwareLift = 0x4;
-    kAbsolutePosition = 0x8;
-    kPositionAwareTilt = 0x10;
-  }
-
   bitmap Mode : BITMAP8 {
     kMotorDirectionReversed = 0x1;
     kCalibrationMode = 0x2;
@@ -2090,6 +2082,14 @@ server cluster WindowCovering = 258 {
     kHardwareFailure = 0x200;
     kManualOperation = 0x400;
     kProtection = 0x800;
+  }
+
+  bitmap WindowCoveringFeature : BITMAP32 {
+    kLift = 0x1;
+    kTilt = 0x2;
+    kPositionAwareLift = 0x4;
+    kAbsolutePosition = 0x8;
+    kPositionAwareTilt = 0x10;
   }
 
   readonly attribute Type type = 0;
@@ -2159,7 +2159,7 @@ server cluster PumpConfigurationAndControl = 512 {
     kLocal = 3;
   }
 
-  bitmap PumpFeature : BITMAP32 {
+  bitmap PumpConfigurationAndControlFeature : BITMAP32 {
     kConstantPressure = 0x1;
     kCompensatedPressure = 0x2;
     kConstantFlow = 0x4;
@@ -2532,7 +2532,7 @@ server cluster TemperatureMeasurement = 1026 {
 }
 
 server cluster PressureMeasurement = 1027 {
-  bitmap PressureFeature : BITMAP32 {
+  bitmap PressureMeasurementFeature : BITMAP32 {
     kExtended = 0x1;
   }
 

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -52,7 +52,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -116,12 +116,12 @@ server cluster Groups = 4 {
 }
 
 server cluster Scenes = 5 {
-  bitmap SceneFeatures : BITMAP32 {
-    kSceneNames = 0x1;
-  }
-
   bitmap ScenesCopyMode : BITMAP8 {
     kCopyAllScenes = 0x1;
+  }
+
+  bitmap ScenesFeature : BITMAP32 {
+    kSceneNames = 0x1;
   }
 
   struct ExtensionFieldSet {
@@ -2025,14 +2025,6 @@ server cluster WindowCovering = 258 {
     kTiltEncoderControlled = 0x40;
   }
 
-  bitmap Feature : BITMAP32 {
-    kLift = 0x1;
-    kTilt = 0x2;
-    kPositionAwareLift = 0x4;
-    kAbsolutePosition = 0x8;
-    kPositionAwareTilt = 0x10;
-  }
-
   bitmap Mode : BITMAP8 {
     kMotorDirectionReversed = 0x1;
     kCalibrationMode = 0x2;
@@ -2059,6 +2051,14 @@ server cluster WindowCovering = 258 {
     kHardwareFailure = 0x200;
     kManualOperation = 0x400;
     kProtection = 0x800;
+  }
+
+  bitmap WindowCoveringFeature : BITMAP32 {
+    kLift = 0x1;
+    kTilt = 0x2;
+    kPositionAwareLift = 0x4;
+    kAbsolutePosition = 0x8;
+    kPositionAwareTilt = 0x10;
   }
 
   readonly attribute Type type = 0;
@@ -2128,7 +2128,7 @@ server cluster PumpConfigurationAndControl = 512 {
     kLocal = 3;
   }
 
-  bitmap PumpFeature : BITMAP32 {
+  bitmap PumpConfigurationAndControlFeature : BITMAP32 {
     kConstantPressure = 0x1;
     kCompensatedPressure = 0x2;
     kConstantFlow = 0x4;
@@ -2501,7 +2501,7 @@ server cluster TemperatureMeasurement = 1026 {
 }
 
 server cluster PressureMeasurement = 1027 {
-  bitmap PressureFeature : BITMAP32 {
+  bitmap PressureMeasurementFeature : BITMAP32 {
     kExtended = 0x1;
   }
 

--- a/examples/pump-app/pump-common/pump-app.matter
+++ b/examples/pump-app/pump-common/pump-app.matter
@@ -1127,7 +1127,7 @@ server cluster PumpConfigurationAndControl = 512 {
     kLocal = 3;
   }
 
-  bitmap PumpFeature : BITMAP32 {
+  bitmap PumpConfigurationAndControlFeature : BITMAP32 {
     kConstantPressure = 0x1;
     kCompensatedPressure = 0x2;
     kConstantFlow = 0x4;
@@ -1245,7 +1245,7 @@ server cluster TemperatureMeasurement = 1026 {
 }
 
 server cluster PressureMeasurement = 1027 {
-  bitmap PressureFeature : BITMAP32 {
+  bitmap PressureMeasurementFeature : BITMAP32 {
     kExtended = 0x1;
   }
 

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
@@ -1047,7 +1047,7 @@ client cluster PumpConfigurationAndControl = 512 {
     kLocal = 3;
   }
 
-  bitmap PumpFeature : BITMAP32 {
+  bitmap PumpConfigurationAndControlFeature : BITMAP32 {
     kConstantPressure = 0x1;
     kCompensatedPressure = 0x2;
     kConstantFlow = 0x4;
@@ -1165,7 +1165,7 @@ client cluster TemperatureMeasurement = 1026 {
 }
 
 client cluster PressureMeasurement = 1027 {
-  bitmap PressureFeature : BITMAP32 {
+  bitmap PressureMeasurementFeature : BITMAP32 {
     kExtended = 0x1;
   }
 

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -97,7 +97,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -161,12 +161,12 @@ server cluster Groups = 4 {
 }
 
 server cluster Scenes = 5 {
-  bitmap SceneFeatures : BITMAP32 {
-    kSceneNames = 0x1;
-  }
-
   bitmap ScenesCopyMode : BITMAP8 {
     kCopyAllScenes = 0x1;
+  }
+
+  bitmap ScenesFeature : BITMAP32 {
+    kSceneNames = 0x1;
   }
 
   struct ExtensionFieldSet {

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -46,7 +46,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -110,12 +110,12 @@ server cluster Groups = 4 {
 }
 
 server cluster Scenes = 5 {
-  bitmap SceneFeatures : BITMAP32 {
-    kSceneNames = 0x1;
-  }
-
   bitmap ScenesCopyMode : BITMAP8 {
     kCopyAllScenes = 0x1;
+  }
+
+  bitmap ScenesFeature : BITMAP32 {
+    kSceneNames = 0x1;
   }
 
   struct ExtensionFieldSet {

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -52,7 +52,7 @@ server cluster Identify = 3 {
 }
 
 server cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -116,12 +116,12 @@ server cluster Groups = 4 {
 }
 
 server cluster Scenes = 5 {
-  bitmap SceneFeatures : BITMAP32 {
-    kSceneNames = 0x1;
-  }
-
   bitmap ScenesCopyMode : BITMAP8 {
     kCopyAllScenes = 0x1;
+  }
+
+  bitmap ScenesFeature : BITMAP32 {
+    kSceneNames = 0x1;
   }
 
   struct ExtensionFieldSet {
@@ -1696,14 +1696,6 @@ server cluster WindowCovering = 258 {
     kTiltEncoderControlled = 0x40;
   }
 
-  bitmap Feature : BITMAP32 {
-    kLift = 0x1;
-    kTilt = 0x2;
-    kPositionAwareLift = 0x4;
-    kAbsolutePosition = 0x8;
-    kPositionAwareTilt = 0x10;
-  }
-
   bitmap Mode : BITMAP8 {
     kMotorDirectionReversed = 0x1;
     kCalibrationMode = 0x2;
@@ -1730,6 +1722,14 @@ server cluster WindowCovering = 258 {
     kHardwareFailure = 0x200;
     kManualOperation = 0x400;
     kProtection = 0x800;
+  }
+
+  bitmap WindowCoveringFeature : BITMAP32 {
+    kLift = 0x1;
+    kTilt = 0x2;
+    kPositionAwareLift = 0x4;
+    kAbsolutePosition = 0x8;
+    kPositionAwareTilt = 0x10;
   }
 
   readonly attribute Type type = 0;

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -129,7 +129,7 @@ void emberAfGroupsClusterServerInitCallback(EndpointId endpointId)
         ChipLogDetail(Zcl, "ERR: writing NameSupport %x", status);
     }
 
-    status = Attributes::FeatureMap::Set(endpointId, static_cast<uint32_t>(GroupClusterFeature::kGroupNames));
+    status = Attributes::FeatureMap::Set(endpointId, static_cast<uint32_t>(GroupsFeature::kGroupNames));
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         ChipLogDetail(Zcl, "ERR: writing group feature map %x", status);

--- a/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
+++ b/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
@@ -228,7 +228,7 @@ static void setEffectiveModes(EndpointId endpoint)
     }
 }
 
-bool HasFeature(EndpointId endpoint, PumpFeature feature)
+bool HasFeature(EndpointId endpoint, PumpConfigurationAndControlFeature feature)
 {
     bool hasFeature;
     uint32_t featureMap;
@@ -267,37 +267,37 @@ chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClust
         switch (controlMode)
         {
         case ControlModeEnum::kConstantFlow:
-            if (!HasFeature(attributePath.mEndpointId, PumpFeature::kConstantFlow))
+            if (!HasFeature(attributePath.mEndpointId, PumpConfigurationAndControlFeature::kConstantFlow))
             {
                 status = Protocols::InteractionModel::Status::ConstraintError;
             }
             break;
         case ControlModeEnum::kConstantPressure:
-            if (!HasFeature(attributePath.mEndpointId, PumpFeature::kConstantPressure))
+            if (!HasFeature(attributePath.mEndpointId, PumpConfigurationAndControlFeature::kConstantPressure))
             {
                 status = Protocols::InteractionModel::Status::ConstraintError;
             }
             break;
         case ControlModeEnum::kConstantSpeed:
-            if (!HasFeature(attributePath.mEndpointId, PumpFeature::kConstantSpeed))
+            if (!HasFeature(attributePath.mEndpointId, PumpConfigurationAndControlFeature::kConstantSpeed))
             {
                 status = Protocols::InteractionModel::Status::ConstraintError;
             }
             break;
         case ControlModeEnum::kConstantTemperature:
-            if (!HasFeature(attributePath.mEndpointId, PumpFeature::kConstantTemperature))
+            if (!HasFeature(attributePath.mEndpointId, PumpConfigurationAndControlFeature::kConstantTemperature))
             {
                 status = Protocols::InteractionModel::Status::ConstraintError;
             }
             break;
         case ControlModeEnum::kProportionalPressure:
-            if (!HasFeature(attributePath.mEndpointId, PumpFeature::kCompensatedPressure))
+            if (!HasFeature(attributePath.mEndpointId, PumpConfigurationAndControlFeature::kCompensatedPressure))
             {
                 status = Protocols::InteractionModel::Status::ConstraintError;
             }
             break;
         case ControlModeEnum::kAutomatic:
-            if (!HasFeature(attributePath.mEndpointId, PumpFeature::kAutomatic))
+            if (!HasFeature(attributePath.mEndpointId, PumpConfigurationAndControlFeature::kAutomatic))
             {
                 status = Protocols::InteractionModel::Status::ConstraintError;
             }
@@ -318,19 +318,19 @@ chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClust
         switch (operationMode)
         {
         case OperationModeEnum::kMinimum:
-            if (!HasFeature(attributePath.mEndpointId, PumpFeature::kConstantSpeed))
+            if (!HasFeature(attributePath.mEndpointId, PumpConfigurationAndControlFeature::kConstantSpeed))
             {
                 status = Protocols::InteractionModel::Status::ConstraintError;
             }
             break;
         case OperationModeEnum::kMaximum:
-            if (!HasFeature(attributePath.mEndpointId, PumpFeature::kConstantSpeed))
+            if (!HasFeature(attributePath.mEndpointId, PumpConfigurationAndControlFeature::kConstantSpeed))
             {
                 status = Protocols::InteractionModel::Status::ConstraintError;
             }
             break;
         case OperationModeEnum::kLocal:
-            if (!HasFeature(attributePath.mEndpointId, PumpFeature::kLocalOperation))
+            if (!HasFeature(attributePath.mEndpointId, PumpConfigurationAndControlFeature::kLocalOperation))
             {
                 status = Protocols::InteractionModel::Status::ConstraintError;
             }

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -113,7 +113,7 @@ namespace app {
 namespace Clusters {
 namespace WindowCovering {
 
-bool HasFeature(chip::EndpointId endpoint, Feature feature)
+bool HasFeature(chip::EndpointId endpoint, WindowCoveringFeature feature)
 {
     bool hasFeature     = false;
     uint32_t featureMap = 0;
@@ -129,12 +129,12 @@ bool HasFeature(chip::EndpointId endpoint, Feature feature)
 
 bool HasFeaturePaLift(chip::EndpointId endpoint)
 {
-    return (HasFeature(endpoint, Feature::kLift) && HasFeature(endpoint, Feature::kPositionAwareLift));
+    return (HasFeature(endpoint, WindowCoveringFeature::kLift) && HasFeature(endpoint, WindowCoveringFeature::kPositionAwareLift));
 }
 
 bool HasFeaturePaTilt(chip::EndpointId endpoint)
 {
-    return (HasFeature(endpoint, Feature::kTilt) && HasFeature(endpoint, Feature::kPositionAwareTilt));
+    return (HasFeature(endpoint, WindowCoveringFeature::kTilt) && HasFeature(endpoint, WindowCoveringFeature::kPositionAwareTilt));
 }
 
 void TypeSet(chip::EndpointId endpoint, Type type)
@@ -635,11 +635,11 @@ bool emberAfWindowCoveringClusterUpOrOpenCallback(app::CommandHandler * commandO
         return true;
     }
 
-    if (HasFeature(endpoint, Feature::kPositionAwareLift))
+    if (HasFeature(endpoint, WindowCoveringFeature::kPositionAwareLift))
     {
         Attributes::TargetPositionLiftPercent100ths::Set(endpoint, WC_PERCENT100THS_MIN_OPEN);
     }
-    if (HasFeature(endpoint, Feature::kPositionAwareTilt))
+    if (HasFeature(endpoint, WindowCoveringFeature::kPositionAwareTilt))
     {
         Attributes::TargetPositionTiltPercent100ths::Set(endpoint, WC_PERCENT100THS_MIN_OPEN);
     }
@@ -647,12 +647,12 @@ bool emberAfWindowCoveringClusterUpOrOpenCallback(app::CommandHandler * commandO
     Delegate * delegate = GetDelegate(endpoint);
     if (delegate)
     {
-        if (HasFeature(endpoint, Feature::kPositionAwareLift))
+        if (HasFeature(endpoint, WindowCoveringFeature::kPositionAwareLift))
         {
             LogErrorOnFailure(delegate->HandleMovement(WindowCoveringType::Lift));
         }
 
-        if (HasFeature(endpoint, Feature::kPositionAwareTilt))
+        if (HasFeature(endpoint, WindowCoveringFeature::kPositionAwareTilt))
         {
             LogErrorOnFailure(delegate->HandleMovement(WindowCoveringType::Tilt));
         }
@@ -685,11 +685,11 @@ bool emberAfWindowCoveringClusterDownOrCloseCallback(app::CommandHandler * comma
         return true;
     }
 
-    if (HasFeature(endpoint, Feature::kPositionAwareLift))
+    if (HasFeature(endpoint, WindowCoveringFeature::kPositionAwareLift))
     {
         Attributes::TargetPositionLiftPercent100ths::Set(endpoint, WC_PERCENT100THS_MAX_CLOSED);
     }
-    if (HasFeature(endpoint, Feature::kPositionAwareTilt))
+    if (HasFeature(endpoint, WindowCoveringFeature::kPositionAwareTilt))
     {
         Attributes::TargetPositionTiltPercent100ths::Set(endpoint, WC_PERCENT100THS_MAX_CLOSED);
     }
@@ -698,12 +698,12 @@ bool emberAfWindowCoveringClusterDownOrCloseCallback(app::CommandHandler * comma
     Delegate * delegate = GetDelegate(endpoint);
     if (delegate)
     {
-        if (HasFeature(endpoint, Feature::kPositionAwareLift))
+        if (HasFeature(endpoint, WindowCoveringFeature::kPositionAwareLift))
         {
             LogErrorOnFailure(delegate->HandleMovement(WindowCoveringType::Lift));
         }
 
-        if (HasFeature(endpoint, Feature::kPositionAwareTilt))
+        if (HasFeature(endpoint, WindowCoveringFeature::kPositionAwareTilt))
         {
             LogErrorOnFailure(delegate->HandleMovement(WindowCoveringType::Tilt));
         }
@@ -781,7 +781,7 @@ bool emberAfWindowCoveringClusterGoToLiftValueCallback(app::CommandHandler * com
         return true;
     }
 
-    if (HasFeature(endpoint, Feature::kAbsolutePosition) && HasFeaturePaLift(endpoint))
+    if (HasFeature(endpoint, WindowCoveringFeature::kAbsolutePosition) && HasFeaturePaLift(endpoint))
     {
         Attributes::TargetPositionLiftPercent100ths::Set(endpoint, LiftToPercent100ths(endpoint, liftValue));
         Delegate * delegate = GetDelegate(endpoint);
@@ -873,7 +873,7 @@ bool emberAfWindowCoveringClusterGoToTiltValueCallback(app::CommandHandler * com
         return true;
     }
 
-    if (HasFeature(endpoint, Feature::kAbsolutePosition) && HasFeaturePaTilt(endpoint))
+    if (HasFeature(endpoint, WindowCoveringFeature::kAbsolutePosition) && HasFeaturePaTilt(endpoint))
     {
         Attributes::TargetPositionTiltPercent100ths::Set(endpoint, TiltToPercent100ths(endpoint, tiltValue));
         Delegate * delegate = GetDelegate(endpoint);

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -69,7 +69,7 @@ struct AbsoluteLimits
     uint16_t closed;
 };
 
-bool HasFeature(chip::EndpointId endpoint, Feature feature);
+bool HasFeature(chip::EndpointId endpoint, WindowCoveringFeature feature);
 bool HasFeaturePaLift(chip::EndpointId endpoint);
 bool HasFeaturePaTilt(chip::EndpointId endpoint);
 

--- a/src/app/zap-templates/zcl/data-model/chip/groups-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/groups-cluster.xml
@@ -17,7 +17,7 @@ limitations under the License.
 <configurator>
   <domain name="General"/>
 
-  <bitmap name="GroupClusterFeature" type="BITMAP32">
+  <bitmap name="GroupsFeature" type="BITMAP32">
       <cluster code="0x0004"/>
       <field name="GroupNames" mask="0x1"/>
   </bitmap>

--- a/src/app/zap-templates/zcl/data-model/chip/pressure-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/pressure-measurement-cluster.xml
@@ -36,7 +36,7 @@ limitations under the License.
     <attribute side="server" code="0x0014" define="PRESSURE_SCALE" type="INT8S" writable="false" optional="true" default="0">Scale</attribute>
   </cluster>
 
-  <bitmap name="PressureFeature" type="BITMAP32">
+  <bitmap name="PressureMeasurementFeature" type="BITMAP32">
     <cluster code="0x0403"/>
     <field name="Extended" mask="0x1"/>
   </bitmap>

--- a/src/app/zap-templates/zcl/data-model/chip/pump-configuration-and-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/pump-configuration-and-control-cluster.xml
@@ -149,7 +149,7 @@ limitations under the License.
     <item name="Automatic" value="0x7"/>
   </enum>
 
-  <bitmap name="PumpFeature" type="BITMAP32">
+  <bitmap name="PumpConfigurationAndControlFeature" type="BITMAP32">
     <cluster code="0x0200"/>
     <field mask="0x01" name="ConstantPressure" />
     <field mask="0x02" name="CompensatedPressure" />

--- a/src/app/zap-templates/zcl/data-model/chip/scene.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/scene.xml
@@ -230,7 +230,7 @@ limitations under the License.
     </command>
   </cluster>
 
-  <bitmap name="SceneFeatures" type="BITMAP32">
+  <bitmap name="ScenesFeature" type="BITMAP32">
     <cluster code="0x0005" />
     <field name="SceneNames" mask="0x01" />
   </bitmap>

--- a/src/app/zap-templates/zcl/data-model/chip/window-covering.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/window-covering.xml
@@ -211,7 +211,7 @@ limitations under the License.
     <field mask="0x0800" name="Protection"/>
   </bitmap>
 
-  <bitmap name="Feature" type="BITMAP32">
+  <bitmap name="WindowCoveringFeature" type="BITMAP32">
     <cluster code="0x0102"/>
     <field mask="0x01" name="Lift" />
     <field mask="0x02" name="Tilt" />

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -57,7 +57,7 @@ client cluster Identify = 3 {
 }
 
 client cluster Groups = 4 {
-  bitmap GroupClusterFeature : BITMAP32 {
+  bitmap GroupsFeature : BITMAP32 {
     kGroupNames = 0x1;
   }
 
@@ -121,12 +121,12 @@ client cluster Groups = 4 {
 }
 
 client cluster Scenes = 5 {
-  bitmap SceneFeatures : BITMAP32 {
-    kSceneNames = 0x1;
-  }
-
   bitmap ScenesCopyMode : BITMAP8 {
     kCopyAllScenes = 0x1;
+  }
+
+  bitmap ScenesFeature : BITMAP32 {
+    kSceneNames = 0x1;
   }
 
   struct AttributeValuePair {
@@ -2965,14 +2965,6 @@ client cluster WindowCovering = 258 {
     kTiltEncoderControlled = 0x40;
   }
 
-  bitmap Feature : BITMAP32 {
-    kLift = 0x1;
-    kTilt = 0x2;
-    kPositionAwareLift = 0x4;
-    kAbsolutePosition = 0x8;
-    kPositionAwareTilt = 0x10;
-  }
-
   bitmap Mode : BITMAP8 {
     kMotorDirectionReversed = 0x1;
     kCalibrationMode = 0x2;
@@ -2999,6 +2991,14 @@ client cluster WindowCovering = 258 {
     kHardwareFailure = 0x200;
     kManualOperation = 0x400;
     kProtection = 0x800;
+  }
+
+  bitmap WindowCoveringFeature : BITMAP32 {
+    kLift = 0x1;
+    kTilt = 0x2;
+    kPositionAwareLift = 0x4;
+    kAbsolutePosition = 0x8;
+    kPositionAwareTilt = 0x10;
   }
 
   readonly attribute Type type = 0;
@@ -3098,7 +3098,7 @@ client cluster PumpConfigurationAndControl = 512 {
     kLocal = 3;
   }
 
-  bitmap PumpFeature : BITMAP32 {
+  bitmap PumpConfigurationAndControlFeature : BITMAP32 {
     kConstantPressure = 0x1;
     kCompensatedPressure = 0x2;
     kConstantFlow = 0x4;
@@ -3781,7 +3781,7 @@ client cluster TemperatureMeasurement = 1026 {
 }
 
 client cluster PressureMeasurement = 1027 {
-  bitmap PressureFeature : BITMAP32 {
+  bitmap PressureMeasurementFeature : BITMAP32 {
     kExtended = 0x1;
   }
 

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -290,7 +290,7 @@ class Groups(Cluster):
     clusterRevision: 'uint' = None
 
     class Bitmaps:
-        class GroupClusterFeature(IntFlag):
+        class GroupsFeature(IntFlag):
             kGroupNames = 0x1
 
     class Commands:
@@ -615,11 +615,11 @@ class Scenes(Cluster):
     clusterRevision: 'uint' = None
 
     class Bitmaps:
-        class SceneFeatures(IntFlag):
-            kSceneNames = 0x1
-
         class ScenesCopyMode(IntFlag):
             kCopyAllScenes = 0x1
+
+        class ScenesFeature(IntFlag):
+            kSceneNames = 0x1
 
     class Structs:
         @dataclass
@@ -16325,13 +16325,6 @@ class WindowCovering(Cluster):
             kLiftEncoderControlled = 0x20
             kTiltEncoderControlled = 0x40
 
-        class Feature(IntFlag):
-            kLift = 0x1
-            kTilt = 0x2
-            kPositionAwareLift = 0x4
-            kAbsolutePosition = 0x8
-            kPositionAwareTilt = 0x10
-
         class Mode(IntFlag):
             kMotorDirectionReversed = 0x1
             kCalibrationMode = 0x2
@@ -16356,6 +16349,13 @@ class WindowCovering(Cluster):
             kHardwareFailure = 0x200
             kManualOperation = 0x400
             kProtection = 0x800
+
+        class WindowCoveringFeature(IntFlag):
+            kLift = 0x1
+            kTilt = 0x2
+            kPositionAwareLift = 0x4
+            kAbsolutePosition = 0x8
+            kPositionAwareTilt = 0x10
 
     class Commands:
         @dataclass
@@ -17337,7 +17337,7 @@ class PumpConfigurationAndControl(Cluster):
             kUnknownEnumValue = 4,
 
     class Bitmaps:
-        class PumpFeature(IntFlag):
+        class PumpConfigurationAndControlFeature(IntFlag):
             kConstantPressure = 0x1
             kCompensatedPressure = 0x2
             kConstantFlow = 0x4
@@ -22259,7 +22259,7 @@ class PressureMeasurement(Cluster):
     clusterRevision: 'uint' = None
 
     class Bitmaps:
-        class PressureFeature(IntFlag):
+        class PressureMeasurementFeature(IntFlag):
             kExtended = 0x1
 
     class Attributes:

--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -4126,7 +4126,10 @@
               - DoorLockFeature
           WindowCovering:
               - ConfigStatus
-              - Feature
+              # WindowCoveringFeature was originally just named Feature, but we
+              # generate the same API for both of those names, so the name can
+              # just change here.
+              - WindowCoveringFeature
               - Mode
               - OperationalStatus
               - SafetyStatus
@@ -4349,7 +4352,10 @@
                   - TiltPositionAware
                   - LiftEncoderControlled
                   - TiltEncoderControlled
-              Feature:
+              # WindowCoveringFeature was originally just named Feature, but we
+              # generate the same API for both of those names, so the name can
+              # just change here.
+              WindowCoveringFeature:
                   - Lift
                   - Tilt
                   - PositionAwareLift
@@ -6192,13 +6198,6 @@
                   - Dual
               CredentialRuleEnum:
                   - Double
-      bitmaps:
-          Scenes:
-              # All the other feature map bitmaps have names ending in
-              # "Feature", so let's not ship this one until it aligns
-              # with the others.
-              # See https://github.com/project-chip/connectedhomeip/issues/24681
-              - SceneFeatures
   renames:
       clusters:
           UnitTesting: TestCluster
@@ -7004,3 +7003,48 @@
 
 - release: "TBD"
   versions: "future"
+  introduced:
+      bitmaps:
+          Groups:
+              - GroupsFeature
+          PressureMeasurement:
+              - PressureMeasurementFeature
+          PumpConfigurationAndControl:
+              - PumpConfigurationAndControlFeature
+          Scenes:
+              - ScenesFeature
+      bitmap values:
+          Groups:
+              GroupsFeature:
+                  - GroupNames
+          PressureMeasurement:
+              PressureMeasurementFeature:
+                  - Extended
+          PumpConfigurationAndControl:
+              PumpConfigurationAndControlFeature:
+                  - ConstantPressure
+                  - CompensatedPressure
+                  - ConstantFlow
+                  - ConstantSpeed
+                  - ConstantTemperature
+                  - Automatic
+                  - LocalOperation
+          Scenes:
+              ScenesFeature:
+                  - SceneNames
+  deprecated:
+      bitmaps:
+          Groups:
+              - GroupClusterFeature
+          PressureMeasurement:
+              - PressureFeature
+          PumpConfigurationAndControl:
+              - PumpFeature
+  renames:
+      bitmaps:
+          Groups:
+              GroupsFeature: GroupClusterFeature
+          PressureMeasurement:
+              PressureMeasurementFeature: PressureFeature
+          PumpConfigurationAndControl:
+              PumpConfigurationAndControlFeature: PumpFeature

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -18822,6 +18822,12 @@ typedef NS_OPTIONS(uint32_t, MTRGroupsFeature) {
     MTRGroupsFeatureGroupNames MTR_NEWLY_AVAILABLE = 0x1,
 } MTR_NEWLY_AVAILABLE;
 
+typedef NS_OPTIONS(uint32_t, MTRGroupsGroupClusterFeature) {
+    MTRGroupsGroupClusterFeatureGroupNames API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRGroupsFeatureGroupNames")
+    = 0x1,
+} API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) MTR_NEWLY_DEPRECATED("Please use MTRGroupsFeature");
+
 typedef NS_OPTIONS(uint8_t, MTRScenesCopyMode) {
     MTRScenesCopyModeCopyAllScenes API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x1,
 } API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
@@ -20813,12 +20819,12 @@ typedef NS_OPTIONS(uint16_t, MTRWindowCoveringSafetyStatus) {
 } API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 typedef NS_OPTIONS(uint32_t, MTRWindowCoveringFeature) {
-    MTRWindowCoveringFeatureLift MTR_NEWLY_AVAILABLE = 0x1,
-    MTRWindowCoveringFeatureTilt MTR_NEWLY_AVAILABLE = 0x2,
-    MTRWindowCoveringFeaturePositionAwareLift MTR_NEWLY_AVAILABLE = 0x4,
-    MTRWindowCoveringFeatureAbsolutePosition MTR_NEWLY_AVAILABLE = 0x8,
-    MTRWindowCoveringFeaturePositionAwareTilt MTR_NEWLY_AVAILABLE = 0x10,
-} MTR_NEWLY_AVAILABLE;
+    MTRWindowCoveringFeatureLift API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x1,
+    MTRWindowCoveringFeatureTilt API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x2,
+    MTRWindowCoveringFeaturePositionAwareLift API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x4,
+    MTRWindowCoveringFeatureAbsolutePosition API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x8,
+    MTRWindowCoveringFeaturePositionAwareTilt API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x10,
+} API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 typedef NS_ENUM(uint8_t, MTRPumpConfigurationAndControlControlMode) {
     MTRPumpConfigurationAndControlControlModeConstantSpeed API_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5)) = 0x00,
@@ -20896,6 +20902,34 @@ typedef NS_OPTIONS(uint32_t, MTRPumpConfigurationAndControlFeature) {
     MTRPumpConfigurationAndControlFeatureAutomatic MTR_NEWLY_AVAILABLE = 0x20,
     MTRPumpConfigurationAndControlFeatureLocalOperation MTR_NEWLY_AVAILABLE = 0x40,
 } MTR_NEWLY_AVAILABLE;
+
+typedef NS_OPTIONS(uint32_t, MTRPumpConfigurationAndControlPumpFeature) {
+    MTRPumpConfigurationAndControlPumpFeatureConstantPressure API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
+        MTR_NEWLY_DEPRECATED("Please use MTRPumpConfigurationAndControlFeatureConstantPressure")
+    = 0x1,
+    MTRPumpConfigurationAndControlPumpFeatureCompensatedPressure API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
+        MTR_NEWLY_DEPRECATED("Please use MTRPumpConfigurationAndControlFeatureCompensatedPressure")
+    = 0x2,
+    MTRPumpConfigurationAndControlPumpFeatureConstantFlow API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
+        MTR_NEWLY_DEPRECATED("Please use MTRPumpConfigurationAndControlFeatureConstantFlow")
+    = 0x4,
+    MTRPumpConfigurationAndControlPumpFeatureConstantSpeed API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
+        MTR_NEWLY_DEPRECATED("Please use MTRPumpConfigurationAndControlFeatureConstantSpeed")
+    = 0x8,
+    MTRPumpConfigurationAndControlPumpFeatureConstantTemperature API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
+        MTR_NEWLY_DEPRECATED("Please use MTRPumpConfigurationAndControlFeatureConstantTemperature")
+    = 0x10,
+    MTRPumpConfigurationAndControlPumpFeatureAutomatic API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
+        MTR_NEWLY_DEPRECATED("Please use MTRPumpConfigurationAndControlFeatureAutomatic")
+    = 0x20,
+    MTRPumpConfigurationAndControlPumpFeatureLocalOperation API_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5))
+        MTR_NEWLY_DEPRECATED("Please use MTRPumpConfigurationAndControlFeatureLocalOperation")
+    = 0x40,
+    MTRPumpConfigurationAndControlPumpFeatureLocal MTR_DEPRECATED("Please use MTRPumpConfigurationAndControlFeatureLocalOperation",
+        ios(16.4, 16.5), macos(13.3, 13.4), watchos(9.4, 9.5), tvos(16.4, 16.5))
+    = 0x40,
+} API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
+    MTR_NEWLY_DEPRECATED("Please use MTRPumpConfigurationAndControlFeature");
 
 typedef NS_OPTIONS(uint16_t, MTRPumpConfigurationAndControlPumpStatusBitmap) {
     MTRPumpConfigurationAndControlPumpStatusBitmapDeviceFault API_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5)) = 0x1,
@@ -21162,6 +21196,15 @@ typedef NS_ENUM(uint8_t, MTRIlluminanceMeasurementLightSensorType) {
 typedef NS_OPTIONS(uint32_t, MTRPressureMeasurementFeature) {
     MTRPressureMeasurementFeatureExtended MTR_NEWLY_AVAILABLE = 0x1,
 } MTR_NEWLY_AVAILABLE;
+
+typedef NS_OPTIONS(uint32_t, MTRPressureMeasurementPressureFeature) {
+    MTRPressureMeasurementPressureFeatureExtended API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
+        MTR_NEWLY_DEPRECATED("Please use MTRPressureMeasurementFeatureExtended")
+    = 0x1,
+    MTRPressureMeasurementPressureFeatureEXT MTR_DEPRECATED(
+        "Please use MTRPressureMeasurementFeatureExtended", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
+    = 0x1,
+} API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) MTR_NEWLY_DEPRECATED("Please use MTRPressureMeasurementFeature");
 
 typedef NS_ENUM(uint8_t, MTROccupancySensingOccupancySensorType) {
     MTROccupancySensingOccupancySensorTypePIR API_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5)) = 0x00,

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -18818,13 +18818,17 @@ typedef NS_ENUM(uint8_t, MTRIdentifyType) {
     MTRIdentifyTypeActuator API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x05,
 } API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
-typedef NS_OPTIONS(uint32_t, MTRGroupsGroupClusterFeature) {
-    MTRGroupsGroupClusterFeatureGroupNames API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x1,
-} API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
+typedef NS_OPTIONS(uint32_t, MTRGroupsFeature) {
+    MTRGroupsFeatureGroupNames MTR_NEWLY_AVAILABLE = 0x1,
+} MTR_NEWLY_AVAILABLE;
 
 typedef NS_OPTIONS(uint8_t, MTRScenesCopyMode) {
     MTRScenesCopyModeCopyAllScenes API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x1,
 } API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
+
+typedef NS_OPTIONS(uint32_t, MTRScenesFeature) {
+    MTRScenesFeatureSceneNames MTR_NEWLY_AVAILABLE = 0x1,
+} MTR_NEWLY_AVAILABLE;
 
 typedef NS_ENUM(uint8_t, MTROnOffDelayedAllOffEffectVariant) {
     MTROnOffDelayedAllOffEffectVariantFadeToOffIn0p8Seconds API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x00,
@@ -20780,14 +20784,6 @@ typedef NS_OPTIONS(uint8_t, MTRWindowCoveringConfigStatus) {
     MTRWindowCoveringConfigStatusTiltEncoderControlled API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x40,
 } API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
-typedef NS_OPTIONS(uint32_t, MTRWindowCoveringFeature) {
-    MTRWindowCoveringFeatureLift API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x1,
-    MTRWindowCoveringFeatureTilt API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x2,
-    MTRWindowCoveringFeaturePositionAwareLift API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x4,
-    MTRWindowCoveringFeatureAbsolutePosition API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x8,
-    MTRWindowCoveringFeaturePositionAwareTilt API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x10,
-} API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
-
 typedef NS_OPTIONS(uint8_t, MTRWindowCoveringMode) {
     MTRWindowCoveringModeMotorDirectionReversed API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x1,
     MTRWindowCoveringModeCalibrationMode API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x2,
@@ -20815,6 +20811,14 @@ typedef NS_OPTIONS(uint16_t, MTRWindowCoveringSafetyStatus) {
     MTRWindowCoveringSafetyStatusManualOperation API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x400,
     MTRWindowCoveringSafetyStatusProtection API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x800,
 } API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
+
+typedef NS_OPTIONS(uint32_t, MTRWindowCoveringFeature) {
+    MTRWindowCoveringFeatureLift MTR_NEWLY_AVAILABLE = 0x1,
+    MTRWindowCoveringFeatureTilt MTR_NEWLY_AVAILABLE = 0x2,
+    MTRWindowCoveringFeaturePositionAwareLift MTR_NEWLY_AVAILABLE = 0x4,
+    MTRWindowCoveringFeatureAbsolutePosition MTR_NEWLY_AVAILABLE = 0x8,
+    MTRWindowCoveringFeaturePositionAwareTilt MTR_NEWLY_AVAILABLE = 0x10,
+} MTR_NEWLY_AVAILABLE;
 
 typedef NS_ENUM(uint8_t, MTRPumpConfigurationAndControlControlMode) {
     MTRPumpConfigurationAndControlControlModeConstantSpeed API_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5)) = 0x00,
@@ -20883,21 +20887,15 @@ typedef NS_ENUM(uint8_t, MTRPumpConfigurationAndControlPumpOperationMode) {
 } MTR_DEPRECATED("Please use MTRPumpConfigurationAndControlOperationMode", ios(16.1, 16.5), macos(13.0, 13.4), watchos(9.1, 9.5),
     tvos(16.1, 16.5));
 
-typedef NS_OPTIONS(uint32_t, MTRPumpConfigurationAndControlPumpFeature) {
-    MTRPumpConfigurationAndControlPumpFeatureConstantPressure API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4)) = 0x1,
-    MTRPumpConfigurationAndControlPumpFeatureCompensatedPressure API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
-    = 0x2,
-    MTRPumpConfigurationAndControlPumpFeatureConstantFlow API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4)) = 0x4,
-    MTRPumpConfigurationAndControlPumpFeatureConstantSpeed API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4)) = 0x8,
-    MTRPumpConfigurationAndControlPumpFeatureConstantTemperature API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
-    = 0x10,
-    MTRPumpConfigurationAndControlPumpFeatureAutomatic API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4)) = 0x20,
-    MTRPumpConfigurationAndControlPumpFeatureLocalOperation API_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5)) = 0x40,
-    MTRPumpConfigurationAndControlPumpFeatureLocal MTR_DEPRECATED(
-        "Please use MTRPumpConfigurationAndControlPumpFeatureLocalOperation", ios(16.4, 16.5), macos(13.3, 13.4), watchos(9.4, 9.5),
-        tvos(16.4, 16.5))
-    = 0x40,
-} API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+typedef NS_OPTIONS(uint32_t, MTRPumpConfigurationAndControlFeature) {
+    MTRPumpConfigurationAndControlFeatureConstantPressure MTR_NEWLY_AVAILABLE = 0x1,
+    MTRPumpConfigurationAndControlFeatureCompensatedPressure MTR_NEWLY_AVAILABLE = 0x2,
+    MTRPumpConfigurationAndControlFeatureConstantFlow MTR_NEWLY_AVAILABLE = 0x4,
+    MTRPumpConfigurationAndControlFeatureConstantSpeed MTR_NEWLY_AVAILABLE = 0x8,
+    MTRPumpConfigurationAndControlFeatureConstantTemperature MTR_NEWLY_AVAILABLE = 0x10,
+    MTRPumpConfigurationAndControlFeatureAutomatic MTR_NEWLY_AVAILABLE = 0x20,
+    MTRPumpConfigurationAndControlFeatureLocalOperation MTR_NEWLY_AVAILABLE = 0x40,
+} MTR_NEWLY_AVAILABLE;
 
 typedef NS_OPTIONS(uint16_t, MTRPumpConfigurationAndControlPumpStatusBitmap) {
     MTRPumpConfigurationAndControlPumpStatusBitmapDeviceFault API_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5)) = 0x1,
@@ -21161,12 +21159,9 @@ typedef NS_ENUM(uint8_t, MTRIlluminanceMeasurementLightSensorType) {
     MTRIlluminanceMeasurementLightSensorTypeCMOS API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x01,
 } API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
-typedef NS_OPTIONS(uint32_t, MTRPressureMeasurementPressureFeature) {
-    MTRPressureMeasurementPressureFeatureExtended API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4)) = 0x1,
-    MTRPressureMeasurementPressureFeatureEXT MTR_DEPRECATED("Please use MTRPressureMeasurementPressureFeatureExtended",
-        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
-    = 0x1,
-} API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
+typedef NS_OPTIONS(uint32_t, MTRPressureMeasurementFeature) {
+    MTRPressureMeasurementFeatureExtended MTR_NEWLY_AVAILABLE = 0x1,
+} MTR_NEWLY_AVAILABLE;
 
 typedef NS_ENUM(uint8_t, MTROccupancySensingOccupancySensorType) {
     MTROccupancySensingOccupancySensorTypePIR API_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5)) = 0x00,

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -98,8 +98,8 @@ static IdentifyIdentifyType __attribute__((unused)) kIdentifyIdentifyTypekUnknow
 
 namespace Groups {
 
-// Bitmap for GroupClusterFeature
-enum class GroupClusterFeature : uint32_t
+// Bitmap for GroupsFeature
+enum class GroupsFeature : uint32_t
 {
     kGroupNames = 0x1,
 };
@@ -107,16 +107,16 @@ enum class GroupClusterFeature : uint32_t
 
 namespace Scenes {
 
-// Bitmap for SceneFeatures
-enum class SceneFeatures : uint32_t
-{
-    kSceneNames = 0x1,
-};
-
 // Bitmap for ScenesCopyMode
 enum class ScenesCopyMode : uint8_t
 {
     kCopyAllScenes = 0x1,
+};
+
+// Bitmap for ScenesFeature
+enum class ScenesFeature : uint32_t
+{
+    kSceneNames = 0x1,
 };
 } // namespace Scenes
 
@@ -1940,16 +1940,6 @@ enum class ConfigStatus : uint8_t
     kTiltEncoderControlled = 0x40,
 };
 
-// Bitmap for Feature
-enum class Feature : uint32_t
-{
-    kLift              = 0x1,
-    kTilt              = 0x2,
-    kPositionAwareLift = 0x4,
-    kAbsolutePosition  = 0x8,
-    kPositionAwareTilt = 0x10,
-};
-
 // Bitmap for Mode
 enum class Mode : uint8_t
 {
@@ -1982,6 +1972,16 @@ enum class SafetyStatus : uint16_t
     kHardwareFailure     = 0x200,
     kManualOperation     = 0x400,
     kProtection          = 0x800,
+};
+
+// Bitmap for WindowCoveringFeature
+enum class WindowCoveringFeature : uint32_t
+{
+    kLift              = 0x1,
+    kTilt              = 0x2,
+    kPositionAwareLift = 0x4,
+    kAbsolutePosition  = 0x8,
+    kPositionAwareTilt = 0x10,
 };
 } // namespace WindowCovering
 
@@ -2019,8 +2019,8 @@ enum class OperationModeEnum : uint8_t
     kUnknownEnumValue = 4,
 };
 
-// Bitmap for PumpFeature
-enum class PumpFeature : uint32_t
+// Bitmap for PumpConfigurationAndControlFeature
+enum class PumpConfigurationAndControlFeature : uint32_t
 {
     kConstantPressure    = 0x1,
     kCompensatedPressure = 0x2,
@@ -2372,8 +2372,8 @@ namespace TemperatureMeasurement {} // namespace TemperatureMeasurement
 
 namespace PressureMeasurement {
 
-// Bitmap for PressureFeature
-enum class PressureFeature : uint32_t
+// Bitmap for PressureMeasurementFeature
+enum class PressureMeasurementFeature : uint32_t
 {
     kExtended = 0x1,
 };


### PR DESCRIPTION
Most feature flags we have contain names like `<CLUSTER>Feature`. However there were a few exceptions, which this PR corrected.

Only first commit is the manual change, 2nd commit is the zap regen.

Also fixes #24681
