### PR TITLE
Adding chip-repl into runner script

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -90,6 +90,7 @@ exclude = third_party
           src/controller/python/chip/yaml/__init__.py
           src/controller/python/chip/yaml/format_converter.py
           src/controller/python/chip/yaml/runner.py
+          src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/runner.py
           src/lib/asn1/gen_asn1oid.py
           src/pybindings/pycontroller/build-chip-wheel.py
           src/pybindings/pycontroller/pychip/__init__.py

--- a/scripts/py_matter_yamltests/matter_yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/runner.py
@@ -175,7 +175,9 @@ class TestRunner(TestRunnerBase):
                 if config.pseudo_clusters.supports(request):
                     responses, logs = await config.pseudo_clusters.execute(request)
                 else:
-                    responses, logs = config.adapter.decode(await self.execute(config.adapter.encode(request)))
+                    encoded_request = config.adapter.encode(request)
+                    encoded_response = await self.execute(encoded_request)
+                    responses, logs = config.adapter.decode(encoded_response)
                 duration = round((time.time() - start) * 1000, 2)
                 test_duration += duration
 

--- a/scripts/tests/yaml/relative_importer.py
+++ b/scripts/tests/yaml/relative_importer.py
@@ -21,6 +21,7 @@ DEFAULT_CHIP_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 SCRIPT_PATH = os.path.join(DEFAULT_CHIP_ROOT, 'scripts')
 EXAMPLES_PATH = os.path.join(DEFAULT_CHIP_ROOT, 'examples')
+REPL_PATH = os.path.join(DEFAULT_CHIP_ROOT, 'src', 'controller', 'python')
 
 try:
     import matter_idl  # noqa: F401
@@ -41,3 +42,8 @@ try:
     import matter_placeholder_adapter  # noqa: F401
 except ModuleNotFoundError:
     sys.path.append(os.path.join(EXAMPLES_PATH, 'placeholder', 'py_matter_placeholder_adapter'))
+
+try:
+    import matter_yamltest_repl_adapter  # noqa: F401
+except ModuleNotFoundError:
+    sys.path.append(os.path.join(REPL_PATH, 'py_matter_yamltest_repl_adapter'))

--- a/scripts/tests/yaml/runner.py
+++ b/scripts/tests/yaml/runner.py
@@ -71,6 +71,8 @@ def test_runner_options(f):
                      help='Show additional logs provided by the adapter.')(f)
     f = click.option('--show_adapter_logs_on_error', type=bool, default=True, show_default=True,
                      help='Show additional logs provided by the adapter on error.')(f)
+    f = click.option('--runner', type=str, default=None, show_default=True,
+                     help='The runner to run the test with.')(f)
     return f
 
 
@@ -86,6 +88,14 @@ def websocket_runner_options(f):
     f = click.option('--server_arguments', type=str, default=None,
                      help='Optional arguments to pass to the websocket server at launch.')(f)
     return f
+
+def chip_repl_runner_options(f):
+    f = click.option('--repl_storage_path', type=str, default='/tmp/repl-storage.json',
+                     help='Path to persistent storage configuration file.')(f)
+    f = click.option('--commission_on_network_dut', type=bool, default=False,
+                     help='Prior to running test should we try to commission DUT on network.')(f)
+    return f
+
 
 
 @dataclass
@@ -202,6 +212,10 @@ CONTEXT_SETTINGS = dict(
             'server_name': 'chip-app2',
             'server_arguments': '--interactive',
         },
+        'chip-repl': {
+            'adapter': 'matter_yamltest_repl_adapter.adapter',
+            'runner': 'matter_yamltest_repl_adapter.runner',
+        },
     },
     max_content_width=120,
 )
@@ -278,6 +292,21 @@ def websocket(parser_group: ParserGroup, adapter: str, stop_on_error: bool, stop
         server_address, server_port, server_path, server_arguments, websocket_runner_hooks)
 
     runner = WebSocketRunner(websocket_runner_config)
+    return runner.run(parser_group.builder_config, runner_config)
+
+
+@runner_base.command()
+@test_runner_options
+@chip_repl_runner_options
+@pass_parser_group
+def chip_repl(parser_group: ParserGroup, adapter: str, stop_on_error: bool, stop_on_warning: bool, stop_at_number: int, show_adapter_logs: bool, show_adapter_logs_on_error: bool, runner: str, repl_storage_path: str, commission_on_network_dut: bool):
+    """Run the test suite using chip-repl."""
+    adapter = __import__(adapter, fromlist=[None]).Adapter(parser_group.builder_config.parser_config.definitions)
+    runner_options = TestRunnerOptions(stop_on_error, stop_on_warning, stop_at_number)
+    runner_hooks = TestRunnerLogger(show_adapter_logs, show_adapter_logs_on_error)
+    runner_config = TestRunnerConfig(adapter, parser_group.pseudo_clusters, runner_options, runner_hooks)
+
+    runner = __import__(runner, fromlist=[None]).Runner(repl_storage_path, commission_on_network_dut)
     return runner.run(parser_group.builder_config, runner_config)
 
 

--- a/scripts/tests/yaml/runner.py
+++ b/scripts/tests/yaml/runner.py
@@ -89,13 +89,13 @@ def websocket_runner_options(f):
                      help='Optional arguments to pass to the websocket server at launch.')(f)
     return f
 
+
 def chip_repl_runner_options(f):
     f = click.option('--repl_storage_path', type=str, default='/tmp/repl-storage.json',
                      help='Path to persistent storage configuration file.')(f)
     f = click.option('--commission_on_network_dut', type=bool, default=False,
                      help='Prior to running test should we try to commission DUT on network.')(f)
     return f
-
 
 
 @dataclass

--- a/scripts/tests/yaml/runner.py
+++ b/scripts/tests/yaml/runner.py
@@ -71,8 +71,6 @@ def test_runner_options(f):
                      help='Show additional logs provided by the adapter.')(f)
     f = click.option('--show_adapter_logs_on_error', type=bool, default=True, show_default=True,
                      help='Show additional logs provided by the adapter on error.')(f)
-    f = click.option('--runner', type=str, default=None, show_default=True,
-                     help='The runner to run the test with.')(f)
     return f
 
 
@@ -95,6 +93,8 @@ def chip_repl_runner_options(f):
                      help='Path to persistent storage configuration file.')(f)
     f = click.option('--commission_on_network_dut', type=bool, default=False,
                      help='Prior to running test should we try to commission DUT on network.')(f)
+    f = click.option('--runner', type=str, default=None, show_default=True,
+                     help='The runner to run the test with.')(f)
     return f
 
 

--- a/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/adapter.py
+++ b/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/adapter.py
@@ -15,6 +15,7 @@
 from chip.yaml.runner import ReplTestRunner
 from matter_yamltests.adapter import TestAdapter
 
+
 class Adapter(TestAdapter):
     def __init__(self, specifications):
         self._adapter = ReplTestRunner(specifications, None, None)

--- a/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/adapter.py
+++ b/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/adapter.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from chip.yaml.runner import ReplTestRunner
+from matter_yamltests.adapter import TestAdapter
+
+class Adapter(TestAdapter):
+    def __init__(self, specifications):
+        self._adapter = ReplTestRunner(specifications, None, None)
+
+    def encode(self, request):
+        return self._adapter.encode(request)
+
+    def decode(self, response):
+        # TODO We should provide more meaningful logs here, but to adhere to
+        # abstract function definition we do need to return list here.
+        logs = []
+        decoded_response = self._adapter.decode(response)
+        if len(decoded_response) == 0:
+            decoded_response = [{}]
+        return decoded_response, logs

--- a/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/runner.py
+++ b/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/runner.py
@@ -20,6 +20,7 @@ import chip.FabricAdmin  # Needed before chip.CertificateAuthority
 # isort: on
 
 import chip.CertificateAuthority
+import chip.logging
 import chip.native
 from chip.ChipStack import *
 from chip.yaml.runner import ReplTestRunner
@@ -36,6 +37,7 @@ class Runner(TestRunner):
 
     async def start(self):
         chip.native.Init()
+        chip.logging.RedirectToPythonLogging()
         chip_stack = ChipStack(self._repl_storage_path)
         certificate_authority_manager = chip.CertificateAuthority.CertificateAuthorityManager(
             chip_stack, chip_stack.GetStorageManager())

--- a/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/runner.py
+++ b/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/runner.py
@@ -23,8 +23,8 @@ import chip.CertificateAuthority
 import chip.native
 from chip.ChipStack import *
 from chip.yaml.runner import ReplTestRunner
-
 from matter_yamltests.runner import TestRunner
+
 
 class Runner(TestRunner):
     def __init__(self, repl_storage_path: str, commission_on_network_dut: bool):

--- a/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/runner.py
+++ b/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/runner.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# isort: off
+
+from chip import ChipDeviceCtrl  # Needed before chip.FabricAdmin
+import chip.FabricAdmin  # Needed before chip.CertificateAuthority
+
+# isort: on
+
+import chip.CertificateAuthority
+import chip.native
+from chip.ChipStack import *
+from chip.yaml.runner import ReplTestRunner
+
+from matter_yamltests.runner import TestRunner
+
+class Runner(TestRunner):
+    def __init__(self, repl_storage_path: str, commission_on_network_dut: bool):
+        self._repl_runner = None
+        self._chip_stack = None
+        self._certificate_authority_manager = None
+        self._repl_storage_path = repl_storage_path
+        self._commission_on_network_dut = commission_on_network_dut
+
+    async def start(self):
+        chip.native.Init()
+        chip_stack = ChipStack(self._repl_storage_path)
+        certificate_authority_manager = chip.CertificateAuthority.CertificateAuthorityManager(
+            chip_stack, chip_stack.GetStorageManager())
+        certificate_authority_manager.LoadAuthoritiesFromStorage()
+
+        commission_device = False
+        if len(certificate_authority_manager.activeCaList) == 0:
+            if self._commission_on_network_dut == False:
+                raise Exception(
+                    'Provided repl storage does not contain certiciate. Without commission_on_network_dut, there is no reachable DUT')
+            ca = certificate_authority_manager.NewCertificateAuthority()
+            ca.NewFabricAdmin(vendorId=0xFFF1, fabricId=1)
+            commission_device = True
+        elif len(certificate_authority_manager.activeCaList[0].adminList) == 0:
+            certificate_authority_manager.activeCaList[0].NewFabricAdmin(
+                vendorId=0xFFF1, fabricId=1)
+
+        ca_list = certificate_authority_manager.activeCaList
+
+        dev_ctrl = ca_list[0].adminList[0].NewController()
+        if commission_device:
+            # These magic values are the defaults expected for YAML tests
+            dev_ctrl.CommissionWithCode('MT:-24J0AFN00KA0648G00', 0x12344321)
+
+        self._chip_stack = chip_stack
+        self._certificate_authority_manager = certificate_authority_manager
+        self._repl_runner = ReplTestRunner(None, certificate_authority_manager, dev_ctrl)
+
+    async def stop(self):
+        if self._repl_runner:
+            self._repl_runner.shutdown()
+        if self._certificate_authority_manager:
+            self._certificate_authority_manager.Shutdown()
+        if self._chip_stack:
+            self._chip_stack.Shutdown()
+        self._repl_runner = None
+        self._chip_stack = None
+        self._certificate_authority_manager = None
+
+    async def execute(self, request):
+        return await self._repl_runner.execute(request)

--- a/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/runner.py
+++ b/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/runner.py
@@ -47,11 +47,11 @@ class Runner(TestRunner):
         if len(certificate_authority_manager.activeCaList) == 0:
             if self._commission_on_network_dut == False:
                 raise Exception(
-                    'Provided repl storage does not contain certiciate. Without commission_on_network_dut, there is no reachable DUT')
-            ca = certificate_authority_manager.NewCertificateAuthority()
-            ca.NewFabricAdmin(vendorId=0xFFF1, fabricId=1)
+                    'Provided repl storage does not contain certificate. Without commission_on_network_dut, there is no reachable DUT')
+            certificate_authority_manager.NewCertificateAuthority()
             commission_device = True
-        elif len(certificate_authority_manager.activeCaList[0].adminList) == 0:
+
+        if len(certificate_authority_manager.activeCaList[0].adminList) == 0:
             certificate_authority_manager.activeCaList[0].NewFabricAdmin(
                 vendorId=0xFFF1, fabricId=1)
 


### PR DESCRIPTION
Integrate chip-repl runner into scripts/tests/yaml/runner.py that was added in https://github.com/project-chip/connectedhomeip/pull/25155.

Tests: `python3 ./scripts/tests/yaml/runner.py --use_default_pseudo_clusters 0 Test_TC_OO_1_1 chip-repl`
