### PR TITLE
Gracefully handle an exchange delegate evicting the session on timeout.

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -480,6 +480,11 @@ void ExchangeContext::NotifyResponseTimeout(bool aCloseIfNeeded)
 {
     SetResponseExpected(false);
 
+    // Hold a ref to ourselves so we can make calls into our delegate that might
+    // decrease our refcount (e.g. by expiring out session) without worrying
+    // about use-after-free.
+    ExchangeHandle ref(*this);
+
     // mSession might be null if this timeout is due to the session being
     // evicted.
     if (mSession)


### PR DESCRIPTION
Otherwise the session eviction (which closes our exchange) would destroy it, and then we would unwind into ExchangeContext::NotifyResponseTimeout and try to use the exchange's members.


