### PR TITLE
[Telink] Update Telink Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/chip-build-telink/Dockerfile
@@ -23,7 +23,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=bc0f7ba490a45f58610cc2df25f4cadff2d6820b
+ARG ZEPHYR_REVISION=79e02527e04b369180ceef7c4cd682b24889801e
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.51 Version bump reason: Update to Android SDK 26
+0.6.52 Version bump reason: Update Telink Zephyr branch


### PR DESCRIPTION
Change overview

Use main branch of Telink Zephyr
Clean up BLE start/stop sequence (driver)
Clean up OpenThread start/stop sequece (driver)
Clen up GPIO wake-up sequence
Testing
Tested manually.

Steps:

Build image
Run docker
Check if Telink examples able to be built successfully