### PR TITLE
[Linux] Run functions on GLib event loop in a sync way

### DIFF
--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -266,8 +266,8 @@ void PlatformManagerImpl::_Shutdown()
 
 #if CHIP_DEVICE_CONFIG_WITH_GLIB_MAIN_LOOP
     g_main_loop_quit(mGLibMainLoop);
-    g_main_loop_unref(mGLibMainLoop);
     g_thread_join(mGLibMainLoopThread);
+    g_main_loop_unref(mGLibMainLoop);
 #endif
 }
 

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -56,24 +56,11 @@ PlatformManagerImpl PlatformManagerImpl::sInstance;
 namespace {
 
 #if CHIP_DEVICE_CONFIG_WITH_GLIB_MAIN_LOOP
-
-struct GLibMatterContextInvokeData
-{
-    CHIP_ERROR (*mFunc)(void *);
-    void * mFuncUserData;
-    CHIP_ERROR mFuncResult;
-    // Sync primitives to wait for the function to be executed
-    std::mutex mDoneMutex;
-    std::condition_variable mDoneCond;
-    bool mDone = false;
-};
-
 void * GLibMainLoopThread(void * loop)
 {
     g_main_loop_run(static_cast<GMainLoop *>(loop));
     return nullptr;
 }
-
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
@@ -265,22 +252,40 @@ void PlatformManagerImpl::_Shutdown()
 #if CHIP_DEVICE_CONFIG_WITH_GLIB_MAIN_LOOP
 CHIP_ERROR PlatformManagerImpl::_GLibMatterContextInvokeSync(CHIP_ERROR (*func)(void *), void * userData)
 {
+    // Because of TSAN false positives, we need to use a mutex to synchronize access to all members of
+    // the GLibMatterContextInvokeData object (including constructor and destructor). This is a temporary
+    // workaround until TSAN-enabled GLib will be used in our CI.
+    std::unique_lock<std::mutex> lock(mGLibMainLoopCallbackIndirectionMutex);
+
     GLibMatterContextInvokeData invokeData{ func, userData };
+
+    lock.unlock();
 
     g_main_context_invoke_full(
         g_main_loop_get_context(mGLibMainLoop), G_PRIORITY_HIGH_IDLE,
         [](void * userData_) {
-            auto * data       = reinterpret_cast<GLibMatterContextInvokeData *>(userData_);
-            data->mFuncResult = data->mFunc(data->mFuncUserData);
-            data->mDoneMutex.lock();
-            data->mDone = true;
-            data->mDoneMutex.unlock();
+            auto * data = reinterpret_cast<GLibMatterContextInvokeData *>(userData_);
+
+            // XXX: Temporary workaround for TSAN false positives.
+            std::unique_lock<std::mutex> lock(PlatformMgrImpl().mGLibMainLoopCallbackIndirectionMutex);
+
+            auto func     = data->mFunc;
+            auto userData = data->mFuncUserData;
+
+            lock.unlock();
+            auto result = func(userData);
+            lock.lock();
+
+            data->mDone       = true;
+            data->mFuncResult = result;
             data->mDoneCond.notify_one();
+
             return G_SOURCE_REMOVE;
         },
         &invokeData, nullptr);
 
-    std::unique_lock<std::mutex> lock(invokeData.mDoneMutex);
+    lock.lock();
+
     invokeData.mDoneCond.wait(lock, [&invokeData]() { return invokeData.mDone; });
 
     return invokeData.mFuncResult;

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -267,14 +267,14 @@ CHIP_ERROR PlatformManagerImpl::_GLibMatterContextInvokeSync(CHIP_ERROR (*func)(
             auto * data = reinterpret_cast<GLibMatterContextInvokeData *>(userData_);
 
             // XXX: Temporary workaround for TSAN false positives.
-            std::unique_lock<std::mutex> lock(PlatformMgrImpl().mGLibMainLoopCallbackIndirectionMutex);
+            std::unique_lock<std::mutex> lock_(PlatformMgrImpl().mGLibMainLoopCallbackIndirectionMutex);
 
-            auto func     = data->mFunc;
-            auto userData = data->mFuncUserData;
+            auto mFunc     = data->mFunc;
+            auto mUserData = data->mFuncUserData;
 
-            lock.unlock();
-            auto result = func(userData);
-            lock.lock();
+            lock_.unlock();
+            auto result = mFunc(mUserData);
+            lock_.lock();
 
             data->mDone       = true;
             data->mFuncResult = result;

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -54,7 +54,7 @@ class PlatformManagerImpl final : public PlatformManager, public Internal::Gener
 public:
     // ===== Platform-specific members that may be accessed directly by the application.
 
-#if CHIP_DEVICE_CONFIG_WITH_GLIB_MAIN_LOOP && CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+#if CHIP_DEVICE_CONFIG_WITH_GLIB_MAIN_LOOP
 
     /**
      * @brief Invoke a function on the Matter GLib context.

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -123,7 +123,7 @@ CHIP_ERROR ChipDeviceScanner::StartScan(System::Clock::Timeout timeout)
     ReturnErrorCodeIf(mIsScanning, CHIP_ERROR_INCORRECT_STATE);
 
     mIsScanning = true; // optimistic, to allow all callbacks to check this
-    if (PlatformMgrImpl().ScheduleOnGLibMainLoopThread(MainLoopStartScan, this, true) != CHIP_NO_ERROR)
+    if (PlatformMgrImpl().GLibMatterContextInvokeSync(MainLoopStartScan, this) != CHIP_NO_ERROR)
     {
         ChipLogError(Ble, "Failed to schedule BLE scan start.");
         mIsScanning = false;
@@ -174,7 +174,7 @@ CHIP_ERROR ChipDeviceScanner::StopScan()
         mInterfaceChangedSignal = 0;
     }
 
-    if (PlatformMgrImpl().ScheduleOnGLibMainLoopThread(MainLoopStopScan, this, true) != CHIP_NO_ERROR)
+    if (PlatformMgrImpl().GLibMatterContextInvokeSync(MainLoopStopScan, this) != CHIP_NO_ERROR)
     {
         ChipLogError(Ble, "Failed to schedule BLE scan stop.");
         return CHIP_ERROR_INTERNAL;
@@ -183,7 +183,7 @@ CHIP_ERROR ChipDeviceScanner::StopScan()
     return CHIP_NO_ERROR;
 }
 
-int ChipDeviceScanner::MainLoopStopScan(ChipDeviceScanner * self)
+CHIP_ERROR ChipDeviceScanner::MainLoopStopScan(ChipDeviceScanner * self)
 {
     GError * error = nullptr;
 
@@ -199,7 +199,7 @@ int ChipDeviceScanner::MainLoopStopScan(ChipDeviceScanner * self)
     // references to 'self' here)
     delegate->OnScanComplete();
 
-    return 0;
+    return CHIP_NO_ERROR;
 }
 
 void ChipDeviceScanner::SignalObjectAdded(GDBusObjectManager * manager, GDBusObject * object, ChipDeviceScanner * self)
@@ -266,7 +266,7 @@ void ChipDeviceScanner::RemoveDevice(BluezDevice1 * device)
     }
 }
 
-int ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
+CHIP_ERROR ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
 {
     GError * error = nullptr;
 
@@ -308,7 +308,7 @@ int ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
         self->mDelegate->OnScanComplete();
     }
 
-    return 0;
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Internal

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -79,8 +79,8 @@ public:
 
 private:
     static void TimerExpiredCallback(chip::System::Layer * layer, void * appState);
-    static int MainLoopStartScan(ChipDeviceScanner * self);
-    static int MainLoopStopScan(ChipDeviceScanner * self);
+    static CHIP_ERROR MainLoopStartScan(ChipDeviceScanner * self);
+    static CHIP_ERROR MainLoopStopScan(ChipDeviceScanner * self);
     static void SignalObjectAdded(GDBusObjectManager * manager, GDBusObject * object, ChipDeviceScanner * self);
     static void SignalInterfaceChanged(GDBusObjectManagerClient * manager, GDBusObjectProxy * object, GDBusProxy * aInterface,
                                        GVariant * aChangedProperties, const gchar * const * aInvalidatedProps,


### PR DESCRIPTION
### Problem

It's not possible to easily retrieve error from callback function passed to the `RunOnGLibMainLoopThread()` function.

This PR is a first step for using Matter dedicated GLib context in GLib event loop thread instead of global main context (using global main context causes issues with using Matter SDK with Qt framework on Linux).

### Changes

- make `RunOnGLibMainLoopThread` synchronous in all cases (if one want's async processing there is the `ScheduleWork()` function) and forward the callbacks's  return value to the caller
- rename `ScheduleOnGLibMainLoopThread` to `GLibMatterContextInvokeSync` so the name will be more descriptive

### Testing

Tested BLE commissioning with
```
./chip-lighting-app --wifi
```
```
./out/linux-x64-chip-tool/chip-tool pairing ble-wifi 1 <SSID> <password> 20202021 3840
```