### PR TITLE
[ESP32] Sync BLE error codes with CHIP error codes

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -683,7 +683,7 @@ CHIP_ERROR BLEManagerImpl::MapBLEError(int bleErr)
     case ESP_OK:
         return CHIP_NO_ERROR;
     case BLE_HS_EMSGSIZE:
-        return CHIP_ERROR_INVALID_MESSAGE_LENGTH;
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
     case BLE_HS_ENOMEM:
     case ESP_ERR_NO_MEM:
         return CHIP_ERROR_NO_MEMORY;
@@ -692,7 +692,7 @@ CHIP_ERROR BLEManagerImpl::MapBLEError(int bleErr)
     case BLE_HS_ENOTSUP:
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     case BLE_HS_EAPP:
-        return CHIP_ERROR_READ_FAILED;
+        return CHIP_ERROR_INCORRECT_STATE;
     case BLE_HS_EBADDATA:
         return CHIP_ERROR_DATA_NOT_ALIGNED;
     case BLE_HS_ETIMEOUT:


### PR DESCRIPTION
Problem:

- BLE error codes and CHIP error codes was not synced.

Changes:

- Sync BLE error codes with CHIP error codes.

Testing: 

- Successfully build the application.