### PR TITLE
Add a way to disable the spec-mandated 2-minute floor on OTA retries.

### DIFF
--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -41,6 +41,12 @@ _zap_cluster_list_script = get_path_info("zap_cluster_list.py", "abspath")
 template("chip_data_model") {
   _data_model_name = target_name
 
+  declare_args() {
+    # Allow building ota-requestor-app with a non-spec-compliant floor
+    # (i.e. smaller than 2 minutes) for action delays.
+    non_spec_compliant_ota_action_delay_floor = -1
+  }
+
   if (defined(invoker.idl)) {
     _idl = invoker.idl
   } else {
@@ -284,6 +290,10 @@ template("chip_data_model") {
     }
 
     cflags += [ "-Wconversion" ]
+
+    if (non_spec_compliant_ota_action_delay_floor >= 0) {
+      cflags += [ "-DNON_SPEC_COMPLIANT_OTA_ACTION_DELAY_FLOOR=${non_spec_compliant_ota_action_delay_floor}" ]
+    }
 
     if (!defined(public_configs)) {
       public_configs = []

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -48,7 +48,12 @@ using namespace app::Clusters::OtaSoftwareUpdateRequestor::Structs;
 constexpr uint8_t kMaxInvalidSessionRetries        = 1;  // Max # of query image retries to perform on invalid session error
 constexpr uint32_t kDelayQueryUponCommissioningSec = 30; // Delay before sending the initial image query after commissioning
 constexpr uint32_t kImmediateStartDelaySec         = 1;  // Delay before sending a query in response to UrgentUpdateAvailable
+
+#ifdef NON_SPEC_COMPLIANT_OTA_ACTION_DELAY_FLOOR
+constexpr System::Clock::Seconds32 kDefaultDelayedActionTime = System::Clock::Seconds32(NON_SPEC_COMPLIANT_OTA_ACTION_DELAY_FLOOR);
+#else
 constexpr System::Clock::Seconds32 kDefaultDelayedActionTime = System::Clock::Seconds32(120);
+#endif // NON_SPEC_COMPLIANT_OTA_ACTION_DELAY_FLOOR
 
 DefaultOTARequestorDriver * ToDriver(void * context)
 {
@@ -511,7 +516,7 @@ CHIP_ERROR DefaultOTARequestorDriver::ScheduleQueryRetry(bool trySameProvider, S
 
     if (status == CHIP_NO_ERROR)
     {
-        ChipLogProgress(SoftwareUpdate, "Scheduling a retry");
+        ChipLogProgress(SoftwareUpdate, "Scheduling a retry; delay: %" PRIu32, delay.count());
         ScheduleDelayedAction(delay, StartDelayTimerHandler, this);
     }
 


### PR DESCRIPTION
This makes unit testing of OTA providers take a lot less time.

Fixes https://github.com/project-chip/connectedhomeip/issues/25922
