### PR TITLE
[Silabs] fix non SLC build script

### DIFF
--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -138,6 +138,7 @@ elif [ "$#" -lt "2" ]; then
     $USAGE"
 else
     ROOT=$1
+    PYTHON_PATH=$VIRTUAL_ENV"/bin/python3"
     OUTDIR=$2
 
     if [ "$#" -gt "2" ]; then
@@ -149,109 +150,109 @@ else
     shift
     while [ $# -gt 0 ]; do
         case $1 in
-            --clean)
-                DIR_CLEAN=true
-                shift
-                ;;
-            --wifi)
-                if [ -z "$2" ]; then
-                    echo "--wifi requires rs9116 or SiWx917 or wf200"
-                    exit 1
-                fi
-                if [ "$2" = "rs9116" ]; then
-                    optArgs+="use_rs9116=true "
-                elif [ "$2" = "SiWx917" ]; then
-                    optArgs+="use_SiWx917=true "
-                elif [ "$2" = "wf200" ]; then
-                    optArgs+="use_wf200=true "
-                else
-                    echo "Wifi usage: --wifi rs9116|SiWx917|wf200"
-                    exit 1
-                fi
-                USE_WIFI=true
-                shift
-                shift
-                ;;
-            --sed)
-                optArgs+="enable_sleepy_device=true chip_openthread_ftd=false "
-                shift
-                ;;
-            --low-power)
-                optArgs+="chip_build_libshell=false enable_openthread_cli=false show_qr_code=false disable_lcd=true "
-                shift
-                ;;
-            --chip_enable_wifi_ipv4)
-                ipArgs="chip_enable_wifi_ipv4=true chip_inet_config_enable_ipv4=true "
-                shift
-                ;;
-            --additional_data_advertising)
-                optArgs+="chip_enable_additional_data_advertising=true chip_enable_rotating_device_id=true "
-                shift
-                ;;
-            --use_ot_lib)
-                optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" "
-                shift
-                ;;
-            --use_ot_coap_lib)
-                optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" use_thread_coap_lib=true "
-                shift
-                ;;
-            --use_chip_lwip_lib)
-                optArgs+="lwip_root=\""//third_party/connectedhomeip/third_party/lwip"\" "
-                shift
-                ;;
-            # Option not to be used until ot-efr32 github is updated
-            # --use_ot_github_sources)
-            #   optArgs+="openthread_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/openthread\" openthread_efr32_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/src/src\""
-            #    shift
-            #    ;;
-            --release)
-                optArgs+="is_debug=false disable_lcd=true chip_build_libshell=false enable_openthread_cli=false use_external_flash=false chip_logging=false silabs_log_enabled=false "
-                shift
-                ;;
-            --docker)
-                optArgs+="efr32_sdk_root=\"$GSDK_ROOT\" "
-                USE_DOCKER=true
-                shift
-                ;;
-            --uart_log)
-                optArgs+="sl_uart_log_output=true "
-                shift
-                ;;
+        --clean)
+            DIR_CLEAN=true
+            shift
+            ;;
+        --wifi)
+            if [ -z "$2" ]; then
+                echo "--wifi requires rs9116 or SiWx917 or wf200"
+                exit 1
+            fi
+            if [ "$2" = "rs9116" ]; then
+                optArgs+="use_rs9116=true "
+            elif [ "$2" = "SiWx917" ]; then
+                optArgs+="use_SiWx917=true "
+            elif [ "$2" = "wf200" ]; then
+                optArgs+="use_wf200=true "
+            else
+                echo "Wifi usage: --wifi rs9116|SiWx917|wf200"
+                exit 1
+            fi
+            USE_WIFI=true
+            shift
+            shift
+            ;;
+        --sed)
+            optArgs+="enable_sleepy_device=true chip_openthread_ftd=false "
+            shift
+            ;;
+        --low-power)
+            optArgs+="chip_build_libshell=false enable_openthread_cli=false show_qr_code=false disable_lcd=true "
+            shift
+            ;;
+        --chip_enable_wifi_ipv4)
+            ipArgs="chip_enable_wifi_ipv4=true chip_inet_config_enable_ipv4=true "
+            shift
+            ;;
+        --additional_data_advertising)
+            optArgs+="chip_enable_additional_data_advertising=true chip_enable_rotating_device_id=true "
+            shift
+            ;;
+        --use_ot_lib)
+            optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" "
+            shift
+            ;;
+        --use_ot_coap_lib)
+            optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" use_thread_coap_lib=true "
+            shift
+            ;;
+        --use_chip_lwip_lib)
+            optArgs+="lwip_root=\""//third_party/connectedhomeip/third_party/lwip"\" "
+            shift
+            ;;
+        # Option not to be used until ot-efr32 github is updated
+        # --use_ot_github_sources)
+        #   optArgs+="openthread_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/openthread\" openthread_efr32_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/src/src\""
+        #    shift
+        #    ;;
+        --release)
+            optArgs+="is_debug=false disable_lcd=true chip_build_libshell=false enable_openthread_cli=false use_external_flash=false chip_logging=false silabs_log_enabled=false "
+            shift
+            ;;
+        --docker)
+            optArgs+="efr32_sdk_root=\"$GSDK_ROOT\" "
+            USE_DOCKER=true
+            shift
+            ;;
+        --uart_log)
+            optArgs+="sl_uart_log_output=true "
+            shift
+            ;;
 
-            --slc_generate)
-                optArgs+="slc_generate=true "
-                USE_SLC=true
-                shift
-                ;;
-            --slc_reuse_files)
-                optArgs+="slc_reuse_files=true "
-                USE_SLC=true
-                shift
-                ;;
-            --gn_path)
-                if [ -z "$2" ]; then
-                    echo "--gn_path requires a path to GN"
-                    exit 1
-                else
-                    GN_PATH="$2"
-                fi
-                GN_PATH_PROVIDED=true
-                shift
-                shift
-                ;;
-            *"sl_matter_version_str="*)
-                optArgs+="$1 "
-                USE_GIT_SHA_FOR_VERSION=false
-                shift
-                ;;
-            *)
-                if [ "$1" =~ *"use_rs9116=true"* ] || [ "$1" =~ *"use_SiWx917=true"* ] || [ "$1" =~ *"use_wf200=true"* ]; then
-                    USE_WIFI=true
-                fi
-                optArgs+=$1" "
-                shift
-                ;;
+        --slc_generate)
+            optArgs+="slc_generate=true "
+            USE_SLC=true
+            shift
+            ;;
+        --slc_reuse_files)
+            optArgs+="slc_reuse_files=true "
+            USE_SLC=true
+            shift
+            ;;
+        --gn_path)
+            if [ -z "$2" ]; then
+                echo "--gn_path requires a path to GN"
+                exit 1
+            else
+                GN_PATH="$2"
+            fi
+            GN_PATH_PROVIDED=true
+            shift
+            shift
+            ;;
+        *"sl_matter_version_str="*)
+            optArgs+="$1 "
+            USE_GIT_SHA_FOR_VERSION=false
+            shift
+            ;;
+        *)
+            if [ "$1" =~ *"use_rs9116=true"* ] || [ "$1" =~ *"use_SiWx917=true"* ] || [ "$1" =~ *"use_wf200=true"* ]; then
+                USE_WIFI=true
+            fi
+            optArgs+=$1" "
+            shift
+            ;;
         esac
     done
 
@@ -268,8 +269,11 @@ else
         } &>/dev/null
     fi
 
-    if [ "$USE_SLC" == true ] && [ "$GN_PATH_PROVIDED" == false ]; then
-        GN_PATH=./.environment/cipd/packages/pigweed/gn
+    if [ "$USE_SLC" == true ]; then
+        PYTHON_PATH="/usr/bin/python3"
+        if [ "$GN_PATH_PROVIDED" == false ]; then
+            GN_PATH=./.environment/cipd/packages/pigweed/gn
+        fi
     elif [ "$USE_SLC" == false ]; then
         # Activation needs to be after SLC generation which is done in gn gen.
         # Zap generation requires activation and is done in the build phase
@@ -296,9 +300,9 @@ else
         fi
 
         if [ -z "$optArgs" ]; then
-            "$GN_PATH" gen --check --script-executable="/usr/bin/python3" --root="$ROOT" --args="silabs_board=\"$SILABS_BOARD\"" "$BUILD_DIR"
+            "$GN_PATH" gen --check --script-executable=$PYTHON_PATH --fail-on-unused-args --export-compile-commands --root="$ROOT" --args="silabs_board=\"$SILABS_BOARD\"" "$BUILD_DIR"
         else
-            "$GN_PATH" gen --check --script-executable="/usr/bin/python3" --root="$ROOT" --args="silabs_board=\"$SILABS_BOARD\" $optArgs" "$BUILD_DIR"
+            "$GN_PATH" gen --check --script-executable=$PYTHON_PATH --fail-on-unused-args --export-compile-commands --root="$ROOT" --args="silabs_board=\"$SILABS_BOARD\" $optArgs" "$BUILD_DIR"
         fi
     fi
 

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -300,9 +300,9 @@ else
         fi
 
         if [ -z "$optArgs" ]; then
-            "$GN_PATH" gen --check --script-executable=$PYTHON_PATH --fail-on-unused-args --export-compile-commands --root="$ROOT" --args="silabs_board=\"$SILABS_BOARD\"" "$BUILD_DIR"
+            "$GN_PATH" gen --check --script-executable="$PYTHON_PATH" --fail-on-unused-args --export-compile-commands --root="$ROOT" --args="silabs_board=\"$SILABS_BOARD\"" "$BUILD_DIR"
         else
-            "$GN_PATH" gen --check --script-executable=$PYTHON_PATH --fail-on-unused-args --export-compile-commands --root="$ROOT" --args="silabs_board=\"$SILABS_BOARD\" $optArgs" "$BUILD_DIR"
+            "$GN_PATH" gen --check --script-executable="$PYTHON_PATH" --fail-on-unused-args --export-compile-commands --root="$ROOT" --args="silabs_board=\"$SILABS_BOARD\" $optArgs" "$BUILD_DIR"
         fi
     fi
 

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -149,109 +149,109 @@ else
     shift
     while [ $# -gt 0 ]; do
         case $1 in
-        --clean)
-            DIR_CLEAN=true
-            shift
-            ;;
-        --wifi)
-            if [ -z "$2" ]; then
-                echo "--wifi requires rs9116 or SiWx917 or wf200"
-                exit 1
-            fi
-            if [ "$2" = "rs9116" ]; then
-                optArgs+="use_rs9116=true "
-            elif [ "$2" = "SiWx917" ]; then
-                optArgs+="use_SiWx917=true "
-            elif [ "$2" = "wf200" ]; then
-                optArgs+="use_wf200=true "
-            else
-                echo "Wifi usage: --wifi rs9116|SiWx917|wf200"
-                exit 1
-            fi
-            USE_WIFI=true
-            shift
-            shift
-            ;;
-        --sed)
-            optArgs+="enable_sleepy_device=true chip_openthread_ftd=false "
-            shift
-            ;;
-        --low-power)
-            optArgs+="chip_build_libshell=false enable_openthread_cli=false show_qr_code=false disable_lcd=true "
-            shift
-            ;;
-        --chip_enable_wifi_ipv4)
-            ipArgs="chip_enable_wifi_ipv4=true chip_inet_config_enable_ipv4=true "
-            shift
-            ;;
-        --additional_data_advertising)
-            optArgs+="chip_enable_additional_data_advertising=true chip_enable_rotating_device_id=true "
-            shift
-            ;;
-        --use_ot_lib)
-            optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" "
-            shift
-            ;;
-        --use_ot_coap_lib)
-            optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" use_thread_coap_lib=true "
-            shift
-            ;;
-        --use_chip_lwip_lib)
-            optArgs+="lwip_root=\""//third_party/connectedhomeip/third_party/lwip"\" "
-            shift
-            ;;
-        # Option not to be used until ot-efr32 github is updated
-        # --use_ot_github_sources)
-        #   optArgs+="openthread_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/openthread\" openthread_efr32_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/src/src\""
-        #    shift
-        #    ;;
-        --release)
-            optArgs+="is_debug=false disable_lcd=true chip_build_libshell=false enable_openthread_cli=false use_external_flash=false chip_logging=false silabs_log_enabled=false "
-            shift
-            ;;
-        --docker)
-            optArgs+="efr32_sdk_root=\"$GSDK_ROOT\" "
-            USE_DOCKER=true
-            shift
-            ;;
-        --uart_log)
-            optArgs+="sl_uart_log_output=true "
-            shift
-            ;;
-
-        --slc_generate)
-            optArgs+="slc_generate=true "
-            USE_SLC=true
-            shift
-            ;;
-        --slc_reuse_files)
-            optArgs+="slc_reuse_files=true "
-            USE_SLC=true
-            shift
-            ;;
-        --gn_path)
-            if [ -z "$2" ]; then
-                echo "--gn_path requires a path to GN"
-                exit 1
-            else
-                GN_PATH="$2"
-            fi
-            GN_PATH_PROVIDED=true
-            shift
-            shift
-            ;;
-        *"sl_matter_version_str="*)
-            optArgs+="$1 "
-            USE_GIT_SHA_FOR_VERSION=false
-            shift
-            ;;
-        *)
-            if [ "$1" =~ *"use_rs9116=true"* ] || [ "$1" =~ *"use_SiWx917=true"* ] || [ "$1" =~ *"use_wf200=true"* ]; then
+            --clean)
+                DIR_CLEAN=true
+                shift
+                ;;
+            --wifi)
+                if [ -z "$2" ]; then
+                    echo "--wifi requires rs9116 or SiWx917 or wf200"
+                    exit 1
+                fi
+                if [ "$2" = "rs9116" ]; then
+                    optArgs+="use_rs9116=true "
+                elif [ "$2" = "SiWx917" ]; then
+                    optArgs+="use_SiWx917=true "
+                elif [ "$2" = "wf200" ]; then
+                    optArgs+="use_wf200=true "
+                else
+                    echo "Wifi usage: --wifi rs9116|SiWx917|wf200"
+                    exit 1
+                fi
                 USE_WIFI=true
-            fi
-            optArgs+=$1" "
-            shift
-            ;;
+                shift
+                shift
+                ;;
+            --sed)
+                optArgs+="enable_sleepy_device=true chip_openthread_ftd=false "
+                shift
+                ;;
+            --low-power)
+                optArgs+="chip_build_libshell=false enable_openthread_cli=false show_qr_code=false disable_lcd=true "
+                shift
+                ;;
+            --chip_enable_wifi_ipv4)
+                ipArgs="chip_enable_wifi_ipv4=true chip_inet_config_enable_ipv4=true "
+                shift
+                ;;
+            --additional_data_advertising)
+                optArgs+="chip_enable_additional_data_advertising=true chip_enable_rotating_device_id=true "
+                shift
+                ;;
+            --use_ot_lib)
+                optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" "
+                shift
+                ;;
+            --use_ot_coap_lib)
+                optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" use_thread_coap_lib=true "
+                shift
+                ;;
+            --use_chip_lwip_lib)
+                optArgs+="lwip_root=\""//third_party/connectedhomeip/third_party/lwip"\" "
+                shift
+                ;;
+            # Option not to be used until ot-efr32 github is updated
+            # --use_ot_github_sources)
+            #   optArgs+="openthread_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/openthread\" openthread_efr32_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/src/src\""
+            #    shift
+            #    ;;
+            --release)
+                optArgs+="is_debug=false disable_lcd=true chip_build_libshell=false enable_openthread_cli=false use_external_flash=false chip_logging=false silabs_log_enabled=false "
+                shift
+                ;;
+            --docker)
+                optArgs+="efr32_sdk_root=\"$GSDK_ROOT\" "
+                USE_DOCKER=true
+                shift
+                ;;
+            --uart_log)
+                optArgs+="sl_uart_log_output=true "
+                shift
+                ;;
+
+            --slc_generate)
+                optArgs+="slc_generate=true "
+                USE_SLC=true
+                shift
+                ;;
+            --slc_reuse_files)
+                optArgs+="slc_reuse_files=true "
+                USE_SLC=true
+                shift
+                ;;
+            --gn_path)
+                if [ -z "$2" ]; then
+                    echo "--gn_path requires a path to GN"
+                    exit 1
+                else
+                    GN_PATH="$2"
+                fi
+                GN_PATH_PROVIDED=true
+                shift
+                shift
+                ;;
+            *"sl_matter_version_str="*)
+                optArgs+="$1 "
+                USE_GIT_SHA_FOR_VERSION=false
+                shift
+                ;;
+            *)
+                if [ "$1" =~ *"use_rs9116=true"* ] || [ "$1" =~ *"use_SiWx917=true"* ] || [ "$1" =~ *"use_wf200=true"* ]; then
+                    USE_WIFI=true
+                fi
+                optArgs+=$1" "
+                shift
+                ;;
         esac
     done
 

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -138,7 +138,6 @@ elif [ "$#" -lt "2" ]; then
     $USAGE"
 else
     ROOT=$1
-    PYTHON_PATH=$VIRTUAL_ENV"/bin/python3"
     OUTDIR=$2
 
     if [ "$#" -gt "2" ]; then
@@ -150,109 +149,109 @@ else
     shift
     while [ $# -gt 0 ]; do
         case $1 in
-            --clean)
-                DIR_CLEAN=true
-                shift
-                ;;
-            --wifi)
-                if [ -z "$2" ]; then
-                    echo "--wifi requires rs9116 or SiWx917 or wf200"
-                    exit 1
-                fi
-                if [ "$2" = "rs9116" ]; then
-                    optArgs+="use_rs9116=true "
-                elif [ "$2" = "SiWx917" ]; then
-                    optArgs+="use_SiWx917=true "
-                elif [ "$2" = "wf200" ]; then
-                    optArgs+="use_wf200=true "
-                else
-                    echo "Wifi usage: --wifi rs9116|SiWx917|wf200"
-                    exit 1
-                fi
-                USE_WIFI=true
-                shift
-                shift
-                ;;
-            --sed)
-                optArgs+="enable_sleepy_device=true chip_openthread_ftd=false "
-                shift
-                ;;
-            --low-power)
-                optArgs+="chip_build_libshell=false enable_openthread_cli=false show_qr_code=false disable_lcd=true "
-                shift
-                ;;
-            --chip_enable_wifi_ipv4)
-                ipArgs="chip_enable_wifi_ipv4=true chip_inet_config_enable_ipv4=true "
-                shift
-                ;;
-            --additional_data_advertising)
-                optArgs+="chip_enable_additional_data_advertising=true chip_enable_rotating_device_id=true "
-                shift
-                ;;
-            --use_ot_lib)
-                optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" "
-                shift
-                ;;
-            --use_ot_coap_lib)
-                optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" use_thread_coap_lib=true "
-                shift
-                ;;
-            --use_chip_lwip_lib)
-                optArgs+="lwip_root=\""//third_party/connectedhomeip/third_party/lwip"\" "
-                shift
-                ;;
-            # Option not to be used until ot-efr32 github is updated
-            # --use_ot_github_sources)
-            #   optArgs+="openthread_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/openthread\" openthread_efr32_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/src/src\""
-            #    shift
-            #    ;;
-            --release)
-                optArgs+="is_debug=false disable_lcd=true chip_build_libshell=false enable_openthread_cli=false use_external_flash=false chip_logging=false silabs_log_enabled=false "
-                shift
-                ;;
-            --docker)
-                optArgs+="efr32_sdk_root=\"$GSDK_ROOT\" "
-                USE_DOCKER=true
-                shift
-                ;;
-            --uart_log)
-                optArgs+="sl_uart_log_output=true "
-                shift
-                ;;
+        --clean)
+            DIR_CLEAN=true
+            shift
+            ;;
+        --wifi)
+            if [ -z "$2" ]; then
+                echo "--wifi requires rs9116 or SiWx917 or wf200"
+                exit 1
+            fi
+            if [ "$2" = "rs9116" ]; then
+                optArgs+="use_rs9116=true "
+            elif [ "$2" = "SiWx917" ]; then
+                optArgs+="use_SiWx917=true "
+            elif [ "$2" = "wf200" ]; then
+                optArgs+="use_wf200=true "
+            else
+                echo "Wifi usage: --wifi rs9116|SiWx917|wf200"
+                exit 1
+            fi
+            USE_WIFI=true
+            shift
+            shift
+            ;;
+        --sed)
+            optArgs+="enable_sleepy_device=true chip_openthread_ftd=false "
+            shift
+            ;;
+        --low-power)
+            optArgs+="chip_build_libshell=false enable_openthread_cli=false show_qr_code=false disable_lcd=true "
+            shift
+            ;;
+        --chip_enable_wifi_ipv4)
+            ipArgs="chip_enable_wifi_ipv4=true chip_inet_config_enable_ipv4=true "
+            shift
+            ;;
+        --additional_data_advertising)
+            optArgs+="chip_enable_additional_data_advertising=true chip_enable_rotating_device_id=true "
+            shift
+            ;;
+        --use_ot_lib)
+            optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" "
+            shift
+            ;;
+        --use_ot_coap_lib)
+            optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" use_thread_coap_lib=true "
+            shift
+            ;;
+        --use_chip_lwip_lib)
+            optArgs+="lwip_root=\""//third_party/connectedhomeip/third_party/lwip"\" "
+            shift
+            ;;
+        # Option not to be used until ot-efr32 github is updated
+        # --use_ot_github_sources)
+        #   optArgs+="openthread_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/openthread\" openthread_efr32_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/src/src\""
+        #    shift
+        #    ;;
+        --release)
+            optArgs+="is_debug=false disable_lcd=true chip_build_libshell=false enable_openthread_cli=false use_external_flash=false chip_logging=false silabs_log_enabled=false "
+            shift
+            ;;
+        --docker)
+            optArgs+="efr32_sdk_root=\"$GSDK_ROOT\" "
+            USE_DOCKER=true
+            shift
+            ;;
+        --uart_log)
+            optArgs+="sl_uart_log_output=true "
+            shift
+            ;;
 
-            --slc_generate)
-                optArgs+="slc_generate=true "
-                USE_SLC=true
-                shift
-                ;;
-            --slc_reuse_files)
-                optArgs+="slc_reuse_files=true "
-                USE_SLC=true
-                shift
-                ;;
-            --gn_path)
-                if [ -z "$2" ]; then
-                    echo "--gn_path requires a path to GN"
-                    exit 1
-                else
-                    GN_PATH="$2"
-                fi
-                GN_PATH_PROVIDED=true
-                shift
-                shift
-                ;;
-            *"sl_matter_version_str="*)
-                optArgs+="$1 "
-                USE_GIT_SHA_FOR_VERSION=false
-                shift
-                ;;
-            *)
-                if [ "$1" =~ *"use_rs9116=true"* ] || [ "$1" =~ *"use_SiWx917=true"* ] || [ "$1" =~ *"use_wf200=true"* ]; then
-                    USE_WIFI=true
-                fi
-                optArgs+=$1" "
-                shift
-                ;;
+        --slc_generate)
+            optArgs+="slc_generate=true "
+            USE_SLC=true
+            shift
+            ;;
+        --slc_reuse_files)
+            optArgs+="slc_reuse_files=true "
+            USE_SLC=true
+            shift
+            ;;
+        --gn_path)
+            if [ -z "$2" ]; then
+                echo "--gn_path requires a path to GN"
+                exit 1
+            else
+                GN_PATH="$2"
+            fi
+            GN_PATH_PROVIDED=true
+            shift
+            shift
+            ;;
+        *"sl_matter_version_str="*)
+            optArgs+="$1 "
+            USE_GIT_SHA_FOR_VERSION=false
+            shift
+            ;;
+        *)
+            if [ "$1" =~ *"use_rs9116=true"* ] || [ "$1" =~ *"use_SiWx917=true"* ] || [ "$1" =~ *"use_wf200=true"* ]; then
+                USE_WIFI=true
+            fi
+            optArgs+=$1" "
+            shift
+            ;;
         esac
     done
 
@@ -278,6 +277,7 @@ else
         # Activation needs to be after SLC generation which is done in gn gen.
         # Zap generation requires activation and is done in the build phase
         source "$CHIP_ROOT/scripts/activate.sh"
+        PYTHON_PATH=$VIRTUAL_ENV"/bin/python3"
     fi
 
     BUILD_DIR=$OUTDIR/$SILABS_BOARD

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -150,109 +150,109 @@ else
     shift
     while [ $# -gt 0 ]; do
         case $1 in
-        --clean)
-            DIR_CLEAN=true
-            shift
-            ;;
-        --wifi)
-            if [ -z "$2" ]; then
-                echo "--wifi requires rs9116 or SiWx917 or wf200"
-                exit 1
-            fi
-            if [ "$2" = "rs9116" ]; then
-                optArgs+="use_rs9116=true "
-            elif [ "$2" = "SiWx917" ]; then
-                optArgs+="use_SiWx917=true "
-            elif [ "$2" = "wf200" ]; then
-                optArgs+="use_wf200=true "
-            else
-                echo "Wifi usage: --wifi rs9116|SiWx917|wf200"
-                exit 1
-            fi
-            USE_WIFI=true
-            shift
-            shift
-            ;;
-        --sed)
-            optArgs+="enable_sleepy_device=true chip_openthread_ftd=false "
-            shift
-            ;;
-        --low-power)
-            optArgs+="chip_build_libshell=false enable_openthread_cli=false show_qr_code=false disable_lcd=true "
-            shift
-            ;;
-        --chip_enable_wifi_ipv4)
-            ipArgs="chip_enable_wifi_ipv4=true chip_inet_config_enable_ipv4=true "
-            shift
-            ;;
-        --additional_data_advertising)
-            optArgs+="chip_enable_additional_data_advertising=true chip_enable_rotating_device_id=true "
-            shift
-            ;;
-        --use_ot_lib)
-            optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" "
-            shift
-            ;;
-        --use_ot_coap_lib)
-            optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" use_thread_coap_lib=true "
-            shift
-            ;;
-        --use_chip_lwip_lib)
-            optArgs+="lwip_root=\""//third_party/connectedhomeip/third_party/lwip"\" "
-            shift
-            ;;
-        # Option not to be used until ot-efr32 github is updated
-        # --use_ot_github_sources)
-        #   optArgs+="openthread_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/openthread\" openthread_efr32_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/src/src\""
-        #    shift
-        #    ;;
-        --release)
-            optArgs+="is_debug=false disable_lcd=true chip_build_libshell=false enable_openthread_cli=false use_external_flash=false chip_logging=false silabs_log_enabled=false "
-            shift
-            ;;
-        --docker)
-            optArgs+="efr32_sdk_root=\"$GSDK_ROOT\" "
-            USE_DOCKER=true
-            shift
-            ;;
-        --uart_log)
-            optArgs+="sl_uart_log_output=true "
-            shift
-            ;;
-
-        --slc_generate)
-            optArgs+="slc_generate=true "
-            USE_SLC=true
-            shift
-            ;;
-        --slc_reuse_files)
-            optArgs+="slc_reuse_files=true "
-            USE_SLC=true
-            shift
-            ;;
-        --gn_path)
-            if [ -z "$2" ]; then
-                echo "--gn_path requires a path to GN"
-                exit 1
-            else
-                GN_PATH="$2"
-            fi
-            GN_PATH_PROVIDED=true
-            shift
-            shift
-            ;;
-        *"sl_matter_version_str="*)
-            optArgs+="$1 "
-            USE_GIT_SHA_FOR_VERSION=false
-            shift
-            ;;
-        *)
-            if [ "$1" =~ *"use_rs9116=true"* ] || [ "$1" =~ *"use_SiWx917=true"* ] || [ "$1" =~ *"use_wf200=true"* ]; then
+            --clean)
+                DIR_CLEAN=true
+                shift
+                ;;
+            --wifi)
+                if [ -z "$2" ]; then
+                    echo "--wifi requires rs9116 or SiWx917 or wf200"
+                    exit 1
+                fi
+                if [ "$2" = "rs9116" ]; then
+                    optArgs+="use_rs9116=true "
+                elif [ "$2" = "SiWx917" ]; then
+                    optArgs+="use_SiWx917=true "
+                elif [ "$2" = "wf200" ]; then
+                    optArgs+="use_wf200=true "
+                else
+                    echo "Wifi usage: --wifi rs9116|SiWx917|wf200"
+                    exit 1
+                fi
                 USE_WIFI=true
-            fi
-            optArgs+=$1" "
-            shift
-            ;;
+                shift
+                shift
+                ;;
+            --sed)
+                optArgs+="enable_sleepy_device=true chip_openthread_ftd=false "
+                shift
+                ;;
+            --low-power)
+                optArgs+="chip_build_libshell=false enable_openthread_cli=false show_qr_code=false disable_lcd=true "
+                shift
+                ;;
+            --chip_enable_wifi_ipv4)
+                ipArgs="chip_enable_wifi_ipv4=true chip_inet_config_enable_ipv4=true "
+                shift
+                ;;
+            --additional_data_advertising)
+                optArgs+="chip_enable_additional_data_advertising=true chip_enable_rotating_device_id=true "
+                shift
+                ;;
+            --use_ot_lib)
+                optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" "
+                shift
+                ;;
+            --use_ot_coap_lib)
+                optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" use_thread_coap_lib=true "
+                shift
+                ;;
+            --use_chip_lwip_lib)
+                optArgs+="lwip_root=\""//third_party/connectedhomeip/third_party/lwip"\" "
+                shift
+                ;;
+            # Option not to be used until ot-efr32 github is updated
+            # --use_ot_github_sources)
+            #   optArgs+="openthread_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/openthread\" openthread_efr32_root=\"//third_party/connectedhomeip/third_party/openthread/ot-efr32/src/src\""
+            #    shift
+            #    ;;
+            --release)
+                optArgs+="is_debug=false disable_lcd=true chip_build_libshell=false enable_openthread_cli=false use_external_flash=false chip_logging=false silabs_log_enabled=false "
+                shift
+                ;;
+            --docker)
+                optArgs+="efr32_sdk_root=\"$GSDK_ROOT\" "
+                USE_DOCKER=true
+                shift
+                ;;
+            --uart_log)
+                optArgs+="sl_uart_log_output=true "
+                shift
+                ;;
+
+            --slc_generate)
+                optArgs+="slc_generate=true "
+                USE_SLC=true
+                shift
+                ;;
+            --slc_reuse_files)
+                optArgs+="slc_reuse_files=true "
+                USE_SLC=true
+                shift
+                ;;
+            --gn_path)
+                if [ -z "$2" ]; then
+                    echo "--gn_path requires a path to GN"
+                    exit 1
+                else
+                    GN_PATH="$2"
+                fi
+                GN_PATH_PROVIDED=true
+                shift
+                shift
+                ;;
+            *"sl_matter_version_str="*)
+                optArgs+="$1 "
+                USE_GIT_SHA_FOR_VERSION=false
+                shift
+                ;;
+            *)
+                if [ "$1" =~ *"use_rs9116=true"* ] || [ "$1" =~ *"use_SiWx917=true"* ] || [ "$1" =~ *"use_wf200=true"* ]; then
+                    USE_WIFI=true
+                fi
+                optArgs+=$1" "
+                shift
+                ;;
         esac
     done
 


### PR DESCRIPTION
Added a variable to let the script use the venv python when not using SLC.
Put --fail-on-unused-args and --export-compile-commands back into thread build scripts.
