### PR TITLE
Add a test for QueryImage while busy to Darwin OTA CI.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -126,7 +126,7 @@ jobs:
             - name: Build example OTA Requestor
               timeout-minutes: 10
               run: |
-                  scripts/examples/gn_build_example.sh examples/ota-requestor-app/linux out/debug chip_config_network_layer_ble=false
+                  scripts/examples/gn_build_example.sh examples/ota-requestor-app/linux out/debug chip_config_network_layer_ble=false non_spec_compliant_ota_action_delay_floor=0
             - name: Delete Defaults
               run: defaults delete com.apple.dt.xctest.tool
               continue-on-error: true


### PR DESCRIPTION
Also fixes the test so that running individual tests using "-only-testing:MatterTests/..." does not require any compile-time changes.
