### PR TITLE
[esp32] Fix fail to establish CASE connection with ESP32 M5

### DIFF
--- a/examples/lighting-app/esp32/sdkconfig.optimize.defaults
+++ b/examples/lighting-app/esp32/sdkconfig.optimize.defaults
@@ -1,0 +1,93 @@
+#
+#    Copyright (c) 2023 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#    Description:
+#      Some useful defaults for the demo app configuration.
+#
+
+# Default to 921600 baud when flashing and monitoring device
+CONFIG_ESPTOOLPY_BAUD_921600B=y
+CONFIG_ESPTOOLPY_BAUD=921600
+CONFIG_ESPTOOLPY_COMPRESSED=y
+CONFIG_ESPTOOLPY_MONITOR_BAUD_115200B=y
+CONFIG_ESPTOOLPY_MONITOR_BAUD=115200
+
+#enable BT
+CONFIG_BT_ENABLED=y
+CONFIG_BT_NIMBLE_ENABLED=y
+
+#disable BT connection reattempt
+CONFIG_BT_NIMBLE_ENABLE_CONN_REATTEMPT=n
+
+#enable lwip ipv6 autoconfig
+CONFIG_LWIP_IPV6_AUTOCONFIG=y
+
+#enable debug shell
+CONFIG_ENABLE_CHIP_SHELL=n
+
+# Use a custom partition table
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
+
+#enable lwIP route hooks
+CONFIG_LWIP_HOOK_IP6_ROUTE_DEFAULT=y
+CONFIG_LWIP_HOOK_ND6_GET_GW_DEFAULT=y
+
+# Serial Flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="4MB"
+
+# Disable softap support by default
+CONFIG_ESP_WIFI_SOFTAP_SUPPORT=n
+# This example uses the older version of RMT driver to work with both
+# idf-v4.4.3 and idf-v5.0, so supressing the warnings by setting below option
+CONFIG_RMT_SUPPRESS_DEPRECATE_WARN=y
+
+# Compiler options new options--
+CONFIG_COMPILER_OPTIMIZATION_SIZE=y
+CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE=y
+
+# Bluetooth controller
+CONFIG_BTDM_CTRL_BLE_MAX_CONN=1
+CONFIG_BTDM_CTRL_BLE_MAX_CONN_EFF=1
+
+# NimBLE Options 
+CONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
+
+# Wi-Fi
+CONFIG_ESP32_WIFI_STATIC_RX_BUFFER_NUM=4
+CONFIG_ESP32_WIFI_DYNAMIC_RX_BUFFER_NUM=8
+CONFIG_ESP32_WIFI_DYNAMIC_TX_BUFFER_NUM=16
+
+# FreeRTOS
+CONFIG_FREERTOS_UNICORE=y
+
+# Add RTC memory to system heap
+CONFIG_ESP_SYSTEM_ALLOW_RTC_FAST_MEM_AS_HEAP=y
+
+# LWIP
+CONFIG_LWIP_TCPIP_RECVMBOX_SIZE=16
+
+# TCP
+CONFIG_LWIP_TCP_SYNMAXRTX=6
+
+# Compatibility options
+CONFIG_BTDM_CONTROLLER_BLE_MAX_CONN=1
+CONFIG_BTDM_CONTROLLER_BLE_MAX_CONN_EFF=1
+CONFIG_NIMBLE_MAX_CONNECTIONS=1
+CONFIG_TCPIP_RECVMBOX_SIZE=16
+CONFIG_TCP_SYNMAXRTX=6
+


### PR DESCRIPTION
Use this memory configuration could increase the free heap from 

`I (2171) light-app-callbacks: Current free heap: 87440`

to

`I (2023) light-app-callbacks: Current free heap: 119400`

This significantly improve the success rate of CASE connection with ESP32 M5

Fix: https://github.com/project-chip/connectedhomeip/issues/25833

