### PR TITLE
[Ameba] use example test provider if fail to read factorydata

### DIFF
--- a/config/ameba/chip.cmake
+++ b/config/ameba/chip.cmake
@@ -107,7 +107,7 @@ string(APPEND CHIP_GN_ARGS "ameba_cc = \"arm-none-eabi-gcc\"\n")
 string(APPEND CHIP_GN_ARGS "ameba_cxx = \"arm-none-eabi-c++\"\n")
 string(APPEND CHIP_GN_ARGS "ameba_cpu = \"ameba\"\n")
 string(APPEND CHIP_GN_ARGS "chip_inet_config_enable_ipv4 = false\n")
-string(APPEND CHIP_GN_ARGS "chip_use_transitional_commissionable_data_provider = false\n")
+string(APPEND CHIP_GN_ARGS "chip_use_transitional_commissionable_data_provider = true\n")
 
 # Enable persistent storage audit
 if (matter_enable_persistentstorage_audit)

--- a/examples/all-clusters-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/all-clusters-app/ameba/main/CHIPDeviceManager.cpp
@@ -28,17 +28,23 @@
 #include "CHIPDeviceManager.h"
 #include <app/ConcreteAttributePath.h>
 #include <app/util/basic-types.h>
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <platform/Ameba/FactoryDataProvider.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
 
 using namespace ::chip;
+using namespace ::chip::Credentials;
 
 namespace chip {
 
 namespace DeviceManager {
 
 using namespace ::chip::DeviceLayer;
+
+chip::DeviceLayer::FactoryDataProvider mFactoryDataProvider;
 
 void CHIPDeviceManager::CommonDeviceEventHandler(const ChipDeviceEvent * event, intptr_t arg)
 {
@@ -60,6 +66,19 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
+
+    err = mFactoryDataProvider.Init();
+    if (err == CHIP_NO_ERROR)
+    {
+        SetCommissionableDataProvider(&mFactoryDataProvider);
+        SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
+        SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
+    }
+    else
+    {
+        ChipLogProgress(DeviceLayer, "Using example DAC provider");
+        SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    }
 
     if (CONFIG_NETWORK_LAYER_BLE)
     {

--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -31,11 +31,8 @@
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/af.h>
-#include <credentials/DeviceAttestationCredsProvider.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <lib/support/ErrorStr.h>
 #include <platform/Ameba/AmebaConfig.h>
-#include <platform/Ameba/FactoryDataProvider.h>
 #include <platform/Ameba/NetworkCommissioningDriver.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
@@ -51,7 +48,6 @@
 #endif
 
 using namespace ::chip;
-using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::System;
@@ -122,7 +118,6 @@ Identify gIdentify1 = {
 
 static DeviceCallbacks EchoCallbacks;
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
-chip::DeviceLayer::FactoryDataProvider mFactoryDataProvider;
 
 static void InitServer(intptr_t context)
 {
@@ -158,10 +153,6 @@ extern "C" void ChipTest(void)
 
     initPref();
 
-    mFactoryDataProvider.Init();
-    SetCommissionableDataProvider(&mFactoryDataProvider);
-    SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
-
     CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
 
     err = deviceMgr.Init(&EchoCallbacks);
@@ -169,10 +160,6 @@ extern "C" void ChipTest(void)
     {
         ChipLogError(DeviceLayer, "DeviceManagerInit() - ERROR!\r\n");
     }
-
-    // Set DeviceInstanceInfoProvider after CHIPDeviceManager init
-    // CHIPDeviceManager init will set GenericDeviceInsanceInfoProvider first
-    SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, 0);
 

--- a/examples/light-switch-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/light-switch-app/ameba/main/CHIPDeviceManager.cpp
@@ -28,17 +28,23 @@
 #include "CHIPDeviceManager.h"
 #include <app/ConcreteAttributePath.h>
 #include <app/util/basic-types.h>
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <platform/Ameba/FactoryDataProvider.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
 
 using namespace ::chip;
+using namespace ::chip::Credentials;
 
 namespace chip {
 
 namespace DeviceManager {
 
 using namespace ::chip::DeviceLayer;
+
+chip::DeviceLayer::FactoryDataProvider mFactoryDataProvider;
 
 void CHIPDeviceManager::CommonDeviceEventHandler(const ChipDeviceEvent * event, intptr_t arg)
 {
@@ -60,6 +66,19 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
+
+    err = mFactoryDataProvider.Init();
+    if (err == CHIP_NO_ERROR)
+    {
+        SetCommissionableDataProvider(&mFactoryDataProvider);
+        SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
+        SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
+    }
+    else
+    {
+        ChipLogProgress(DeviceLayer, "Using example DAC provider");
+        SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    }
 
     if (CONFIG_NETWORK_LAYER_BLE)
     {

--- a/examples/light-switch-app/ameba/main/chipinterface.cpp
+++ b/examples/light-switch-app/ameba/main/chipinterface.cpp
@@ -31,11 +31,8 @@
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/af.h>
-#include <credentials/DeviceAttestationCredsProvider.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <lib/support/ErrorStr.h>
 #include <platform/Ameba/AmebaConfig.h>
-#include <platform/Ameba/FactoryDataProvider.h>
 #include <platform/Ameba/NetworkCommissioningDriver.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
@@ -51,7 +48,6 @@
 #endif
 
 using namespace ::chip;
-using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::System;
@@ -97,7 +93,6 @@ Identify gIdentify1 = {
 
 static DeviceCallbacks EchoCallbacks;
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
-chip::DeviceLayer::FactoryDataProvider mFactoryDataProvider;
 
 static void InitServer(intptr_t context)
 {
@@ -132,10 +127,6 @@ extern "C" void ChipTest(void)
 
     initPref();
 
-    mFactoryDataProvider.Init();
-    SetCommissionableDataProvider(&mFactoryDataProvider);
-    SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
-
     CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
 
     err = deviceMgr.Init(&EchoCallbacks);
@@ -147,10 +138,6 @@ extern "C" void ChipTest(void)
     {
         ChipLogProgress(DeviceLayer, "DeviceManagerInit() - OK\r\n");
     }
-
-    // Set DeviceInstanceInfoProvider after CHIPDeviceManager init
-    // CHIPDeviceManager init will set GenericDeviceInsanceInfoProvider first
-    SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, 0);
 

--- a/examples/lighting-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/lighting-app/ameba/main/CHIPDeviceManager.cpp
@@ -26,6 +26,9 @@
 
 #include "CHIPDeviceManager.h"
 #include <app/util/basic-types.h>
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <platform/Ameba/FactoryDataProvider.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
@@ -41,12 +44,15 @@
 #include <app/util/util.h>
 
 using namespace ::chip;
+using namespace ::chip::Credentials;
 
 namespace chip {
 
 namespace DeviceManager {
 
 using namespace ::chip::DeviceLayer;
+
+chip::DeviceLayer::FactoryDataProvider mFactoryDataProvider;
 
 void CHIPDeviceManager::CommonDeviceEventHandler(const ChipDeviceEvent * event, intptr_t arg)
 {
@@ -67,6 +73,19 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
 
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
+
+    err = mFactoryDataProvider.Init();
+    if (err == CHIP_NO_ERROR)
+    {
+        SetCommissionableDataProvider(&mFactoryDataProvider);
+        SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
+        SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
+    }
+    else
+    {
+        ChipLogProgress(DeviceLayer, "Using example DAC provider");
+        SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    }
 
     if (CONFIG_NETWORK_LAYER_BLE)
     {

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -25,8 +25,6 @@
 #include <DeviceInfoProviderImpl.h>
 
 #include "chip_porting.h"
-#include <credentials/DeviceAttestationCredsProvider.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <support/CHIPMem.h>
 
@@ -36,7 +34,6 @@
 #include <app/util/af.h>
 #include <lib/support/ErrorStr.h>
 #include <platform/Ameba/AmebaConfig.h>
-#include <platform/Ameba/FactoryDataProvider.h>
 #include <platform/Ameba/NetworkCommissioningDriver.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
@@ -49,7 +46,6 @@
 #endif
 
 using namespace ::chip;
-using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::System;
@@ -81,7 +77,6 @@ void NetWorkCommissioningInstInit()
 
 static DeviceCallbacks EchoCallbacks;
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
-chip::DeviceLayer::FactoryDataProvider mFactoryDataProvider;
 
 void OnIdentifyStart(Identify *)
 {
@@ -148,10 +143,6 @@ extern "C" void ChipTest(void)
 
     initPref();
 
-    mFactoryDataProvider.Init();
-    SetCommissionableDataProvider(&mFactoryDataProvider);
-    SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
-
     CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
 
     err = deviceMgr.Init(&EchoCallbacks);
@@ -163,10 +154,6 @@ extern "C" void ChipTest(void)
     {
         ChipLogProgress(DeviceLayer, "DeviceManagerInit() - OK\r\n");
     }
-
-    // Set DeviceInstanceInfoProvider after CHIPDeviceManager init
-    // CHIPDeviceManager init will set GenericDeviceInsanceInfoProvider first
-    SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, 0);
 

--- a/examples/ota-requestor-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/ota-requestor-app/ameba/main/CHIPDeviceManager.cpp
@@ -28,17 +28,23 @@
 #include "CHIPDeviceManager.h"
 #include <app/ConcreteAttributePath.h>
 #include <app/util/basic-types.h>
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <platform/Ameba/FactoryDataProvider.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
 
 using namespace ::chip;
+using namespace ::chip::Credentials;
 
 namespace chip {
 
 namespace DeviceManager {
 
 using namespace ::chip::DeviceLayer;
+
+chip::DeviceLayer::FactoryDataProvider mFactoryDataProvider;
 
 void CHIPDeviceManager::CommonDeviceEventHandler(const ChipDeviceEvent * event, intptr_t arg)
 {
@@ -60,6 +66,19 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
+
+    err = mFactoryDataProvider.Init();
+    if (err == CHIP_NO_ERROR)
+    {
+        SetCommissionableDataProvider(&mFactoryDataProvider);
+        SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
+        SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
+    }
+    else
+    {
+        ChipLogProgress(DeviceLayer, "Using example DAC provider");
+        SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    }
 
     if (CONFIG_NETWORK_LAYER_BLE)
     {

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -25,12 +25,9 @@
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
 #include <app/util/af.h>
-#include <credentials/DeviceAttestationCredsProvider.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
 
 #include <lib/support/ErrorStr.h>
 #include <platform/Ameba/AmebaConfig.h>
-#include <platform/Ameba/FactoryDataProvider.h>
 #include <platform/Ameba/NetworkCommissioningDriver.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <support/CHIPMem.h>
@@ -51,7 +48,6 @@ using namespace chip::Messaging;
 using namespace chip::app::Clusters::OtaSoftwareUpdateProvider::Commands;
 
 using namespace ::chip;
-using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 
@@ -74,7 +70,6 @@ void NetWorkCommissioningInstInit()
 
 static DeviceCallbacks EchoCallbacks;
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
-chip::DeviceLayer::FactoryDataProvider mFactoryDataProvider;
 
 static void InitServer(intptr_t context)
 {
@@ -95,10 +90,6 @@ extern "C" void ChipTest(void)
 
     initPref();
 
-    mFactoryDataProvider.Init();
-    SetCommissionableDataProvider(&mFactoryDataProvider);
-    SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
-
     CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
     err                           = deviceMgr.Init(&EchoCallbacks);
     if (err != CHIP_NO_ERROR)
@@ -109,10 +100,6 @@ extern "C" void ChipTest(void)
     {
         ChipLogProgress(DeviceLayer, "DeviceManagerInit() - OK\r\n");
     }
-
-    // Set DeviceInstanceInfoProvider after CHIPDeviceManager init
-    // CHIPDeviceManager init will set GenericDeviceInsanceInfoProvider first
-    SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, 0);
 }


### PR DESCRIPTION
- don't crash when failed to read factorydata, enable transitional commissionable data provider for fallback
- move factorydata init to chipdevicemanager
- init factorydata after initchipstack and before ble adv

