### PR TITLE
Use -fmacro-prefix-map to tidy up CHIPError source file names

### DIFF
--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -38,7 +38,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-android:0.6.51
+            image: connectedhomeip/chip-build-android:0.7.0
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -26,6 +26,10 @@ declare_args() {
   chip_monolithic_tests = false
 }
 
+# chip_root relative to root_build_dir for macro-prefix-map.
+# "/." avoids trailing "/" in result when chip_root is "//"
+build_relative_chip_root = rebase_path("${chip_root}/.", root_build_dir)
+
 config("includes") {
   include_dirs = [
     "include",
@@ -37,6 +41,9 @@ config("includes") {
   include_dirs += [ "${chip_root}/zzz_generated/app-common" ]
 
   defines = [ "CHIP_HAVE_CONFIG_H=1" ]
+
+  # Make __FILE__ and related macros relative to chip_root
+  cflags = [ "-fmacro-prefix-map=${build_relative_chip_root}/=" ]
 }
 
 if (chip_build_tests) {

--- a/src/darwin/Framework/CHIPTests/MTRErrorTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRErrorTests.m
@@ -1,0 +1,94 @@
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Matter/Matter.h>
+#import <XCTest/XCTest.h>
+
+#import "MTRTestKeys.h"
+#import "MTRTestStorage.h"
+
+@interface MTRErrorTests : XCTestCase
+
+@end
+
+@implementation MTRErrorTests
+
+- (void)testErrorSourcePaths
+{
+    // Capture error logging
+    os_unfair_lock lock = OS_UNFAIR_LOCK_INIT;
+    os_unfair_lock_t lockPtr = &lock;
+    NSMutableSet<NSString *> * errors = [[NSMutableSet alloc] init];
+    MTRSetLogCallback(MTRLogTypeError, ^(MTRLogType type, NSString * moduleName, NSString * message) {
+        os_unfair_lock_lock(lockPtr);
+        [errors addObject:message];
+        os_unfair_lock_unlock(lockPtr);
+    });
+
+    // Provoke an error in the C++ layer
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
+    XCTAssertNotNil(factory);
+    XCTAssertFalse([factory isRunning]);
+    __auto_type * storage = [[MTRTestStorage alloc] init];
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:NULL]);
+    __auto_type * testKeys = [[MTRTestKeys alloc] init];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@1 nocSigner:testKeys];
+    params.vendorID = @0xFFF1u;
+    [storage setStorageData:[NSData data] forKey:@"f/1/n"]; // fabric table will refuse to overwrite
+    NSError * error;
+    XCTAssertNil([factory createControllerOnNewFabric:params error:&error]);
+    XCTAssertNotNil(error);
+    [factory stopControllerFactory];
+    MTRSetLogCallback(MTRLogTypeError, nil);
+
+    // Check the source paths baked into SDK and framework error messages
+    NSString * sdkError = [[errors objectsPassingTest:^BOOL(NSString * error, BOOL * stop) {
+        return [error containsString:@".cpp:"];
+    }] anyObject];
+
+    NSString * sdkSource = [self sourceFileFromErrorString:sdkError];
+    XCTAssertTrue([sdkSource hasPrefix:@"src/"], @"sdkSource: %@", sdkSource);
+
+    NSString * frameworkError = [[errors objectsPassingTest:^BOOL(NSString * error, BOOL * stop) {
+        return [error containsString:@".mm:"];
+    }] anyObject];
+    NSString * frameworkSource = [self sourceFileFromErrorString:frameworkError];
+    XCTAssertTrue([frameworkSource scriptingEndsWith:@".mm"]);
+    XCTAssertFalse([frameworkSource containsString:@"/"], @"frameworkSource: %@", frameworkSource);
+}
+
+- (NSString *)sourceFileFromErrorString:(NSString *)error
+{
+    // "... Error(path/to/source.cpp:123: CHIP Error ...)..."
+    // "Creating NSError from path/to/source.cpp:456 CHIP Error ..."
+    NSRegularExpression * regex = [NSRegularExpression regularExpressionWithPattern:@"[ (]([^ :]+):[0-9]+: CHIP Error"
+                                                                            options:0
+                                                                              error:NULL];
+    NSTextCheckingResult * result = [regex firstMatchInString:error options:0 range:NSMakeRange(0, error.length)];
+    if (!result) {
+        return nil;
+    }
+
+    return [error substringWithRange:[result rangeAtIndex:1]];
+}
+
+- (void)tearDown
+{
+    [MTRDeviceControllerFactory.sharedInstance stopControllerFactory];
+}
+
+@end

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		3CF134AB289D8DF70017A19E /* MTRDeviceAttestationInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CF134AA289D8DF70017A19E /* MTRDeviceAttestationInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3CF134AD289D8E570017A19E /* MTRDeviceAttestationInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3CF134AC289D8E570017A19E /* MTRDeviceAttestationInfo.mm */; };
 		3CF134AF289D90FF0017A19E /* MTROperationalCertificateIssuer.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CF134AE289D90FF0017A19E /* MTROperationalCertificateIssuer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3D0C484B29DA4FA0006D811F /* MTRErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D0C484A29DA4FA0006D811F /* MTRErrorTests.m */; };
 		3D69868529383096007314E7 /* com.csa.matter.plist in Copy Logging Preferences */ = {isa = PBXBuildFile; fileRef = 3D69868029382EF4007314E7 /* com.csa.matter.plist */; };
 		3D843711294977000070D20A /* NSStringSpanConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D84370E294977000070D20A /* NSStringSpanConversion.h */; };
 		3D843712294977000070D20A /* MTRCallbackBridgeBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D84370F294977000070D20A /* MTRCallbackBridgeBase.h */; };
@@ -370,6 +371,7 @@
 		3CF134AA289D8DF70017A19E /* MTRDeviceAttestationInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRDeviceAttestationInfo.h; sourceTree = "<group>"; };
 		3CF134AC289D8E570017A19E /* MTRDeviceAttestationInfo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDeviceAttestationInfo.mm; sourceTree = "<group>"; };
 		3CF134AE289D90FF0017A19E /* MTROperationalCertificateIssuer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTROperationalCertificateIssuer.h; sourceTree = "<group>"; };
+		3D0C484A29DA4FA0006D811F /* MTRErrorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRErrorTests.m; sourceTree = "<group>"; };
 		3D69868029382EF4007314E7 /* com.csa.matter.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = com.csa.matter.plist; sourceTree = "<group>"; };
 		3D84370E294977000070D20A /* NSStringSpanConversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSStringSpanConversion.h; sourceTree = "<group>"; };
 		3D84370F294977000070D20A /* MTRCallbackBridgeBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRCallbackBridgeBase.h; sourceTree = "<group>"; };
@@ -1043,6 +1045,7 @@
 				3DFCB3282966684500332B35 /* MTRCertificateInfoTests.m */,
 				99C65E0F267282F1003402F6 /* MTRControllerTests.m */,
 				5AE6D4E327A99041001F2493 /* MTRDeviceTests.m */,
+				3D0C484A29DA4FA0006D811F /* MTRErrorTests.m */,
 				5A6FEC9C27B5E48800F25F42 /* MTRXPCProtocolTests.m */,
 				5A7947DD27BEC3F500434CF2 /* MTRXPCListenerSampleTests.m */,
 				B2F53AF1245B0DCF0010745E /* MTRSetupPayloadParserTests.m */,
@@ -1453,6 +1456,7 @@
 				1E5801C328941C050033A199 /* MTRTestOTAProvider.m in Sources */,
 				5A6FEC9D27B5E48900F25F42 /* MTRXPCProtocolTests.m in Sources */,
 				5173A47929C0E82300F67F48 /* MTRFabricInfoTests.m in Sources */,
+				3D0C484B29DA4FA0006D811F /* MTRErrorTests.m in Sources */,
 				51742B4A29CB5FC1009974FE /* MTRTestResetCommissioneeHelper.m in Sources */,
 				5AE6D4E427A99041001F2493 /* MTRDeviceTests.m in Sources */,
 				510CECA8297F72970064E0B3 /* MTROperationalCertificateIssuerTests.m in Sources */,
@@ -1634,12 +1638,6 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-Wformat",
-					"-Wformat-nonliteral",
-					"-Wformat-security",
-					"-Wconversion",
-				);
 				OTHER_LDFLAGS = "-Wl,-unexported_symbol,\"__Z*\"";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos appletvos appletvsimulator watchos watchsimulator";
@@ -1647,6 +1645,12 @@
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WARNING_CFLAGS = (
+					"-Wformat",
+					"-Wformat-nonliteral",
+					"-Wformat-security",
+					"-Wconversion",
+				);
 			};
 			name = Debug;
 		};
@@ -1687,6 +1691,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LIBRARY_SEARCH_PATHS = "$(TEMP_DIR)/out/lib";
+				OTHER_CFLAGS = "-fmacro-prefix-map=$(SRCROOT)/CHIP/=";
 				OTHER_LDFLAGS = "";
 				"OTHER_LDFLAGS[sdk=*]" = (
 					"-framework",
@@ -1785,12 +1790,6 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-Wformat",
-					"-Wformat-nonliteral",
-					"-Wformat-security",
-					"-Wconversion",
-				);
 				OTHER_LDFLAGS = "-Wl,-unexported_symbol,\"__Z*\"";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos appletvos appletvsimulator watchos watchsimulator";
@@ -1799,6 +1798,12 @@
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WARNING_CFLAGS = (
+					"-Wformat",
+					"-Wformat-nonliteral",
+					"-Wformat-security",
+					"-Wconversion",
+				);
 			};
 			name = Release;
 		};
@@ -1839,6 +1844,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LIBRARY_SEARCH_PATHS = "$(TEMP_DIR)/out/lib";
+				OTHER_CFLAGS = "-fmacro-prefix-map=$(SRCROOT)/CHIP/=";
 				OTHER_LDFLAGS = "";
 				"OTHER_LDFLAGS[sdk=*]" = (
 					"-framework",

--- a/src/lib/core/tests/TestCHIPErrorStr.cpp
+++ b/src/lib/core/tests/TestCHIPErrorStr.cpp
@@ -194,6 +194,13 @@ static void CheckCoreErrorStr(nlTestSuite * inSuite, void * inContext)
         // by a presence of a colon proceeding the description.
         NL_TEST_ASSERT(inSuite, (strchr(errStr, ':') != nullptr));
 #endif // !CHIP_CONFIG_SHORT_ERROR_STR
+
+#if CHIP_CONFIG_ERROR_SOURCE
+        // GetFile() should be relative to ${chip_root}
+        char const * const file = err.GetFile();
+        NL_TEST_ASSERT(inSuite, file != nullptr);
+        NL_TEST_ASSERT(inSuite, strstr(file, "src/lib/core/") == file);
+#endif // CHIP_CONFIG_ERROR_SOURCE
     }
 }
 


### PR DESCRIPTION
This makes CHIPError source paths relative to chip_root, e.g. `"src/core/*"` instead of ending up with long path prefixes relative to the build directory. Especially for the Darwin framework we otherwise end up with paths like `"../../../../../../../../Sources/CHIPFramework/connectedhomeip/*"`

Also move warnings options from `OTHER_CFLAGS` to `WARNING_CFLAGS` in the Xcode project.

Depends on #25952 for android smoke tests to pass.