### PR TITLE
[Silabs] Removes RS911X legacy socket macro cleanup

### DIFF
--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -233,11 +233,7 @@ static void wfx_rsi_join_cb(uint16_t status, const uint8_t * buf, const uint16_t
          * Join was complete - Do the DHCP
          */
         WFX_RSI_LOG("%s: join completed.", __func__);
-#ifdef RS911X_SOCKETS
-        xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_DO_DHCP);
-#else
         xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_CONN);
-#endif
         wfx_rsi.join_retries = 0;
         retryInterval        = WLAN_MIN_RETRY_TIMER_MS;
     }
@@ -261,34 +257,6 @@ static void wfx_rsi_join_fail_cb(uint16_t status, uint8_t * buf, uint32_t len)
     is_wifi_disconnection_event = true;
     xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_START_JOIN);
 }
-#ifdef RS911X_SOCKETS
-
-/******************************************************************
- * @fn  wfx_rsi_ipchange_cb(uint16_t status, uint8_t *buf, uint32_t len)
- * @brief
- *       DHCP should end up here
- * @param[in] status:
- * @param[in] buf:
- * @param[in] len:
- * @return
- *        None
- *********************************************************************/
-static void wfx_rsi_ipchange_cb(uint16_t status, uint8_t * buf, uint32_t len)
-{
-    WFX_RSI_LOG("%s: status: %02x", __func__, status);
-    if (status != RSI_SUCCESS)
-    {
-        /* Restart DHCP? */
-        xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_DO_DHCP);
-    }
-    else
-    {
-        wfx_rsi.dev_state |= WFX_RSI_ST_STA_DHCP_DONE;
-        xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_DHCP_DONE);
-    }
-}
-
-#else
 /*************************************************************************************
  * @fn  wfx_rsi_wlan_pkt_cb(uint16_t status, uint8_t *buf, uint32_t len)
  * @brief
@@ -308,7 +276,6 @@ static void wfx_rsi_wlan_pkt_cb(uint16_t status, uint8_t * buf, uint32_t len)
     }
     wfx_host_received_sta_frame_cb(buf, len);
 }
-#endif /* !Socket support */
 
 /*************************************************************************************
  * @fn  static int32_t wfx_rsi_init(void)
@@ -403,15 +370,11 @@ static int32_t wfx_rsi_init(void)
         WFX_RSI_LOG("%s: RSI callback register join failed with status: %02x", __func__, status);
         return status;
     }
-#ifdef RS911X_SOCKETS
-    (void) rsi_wlan_register_callbacks(RSI_IP_CHANGE_NOTIFY_CB, wfx_rsi_ipchange_cb);
-#else
     if ((status = rsi_wlan_register_callbacks(RSI_WLAN_DATA_RECEIVE_NOTIFY_CB, wfx_rsi_wlan_pkt_cb)) != RSI_SUCCESS)
     {
         WFX_RSI_LOG("%s: RSI callback register data-notify failed with status: %02x", __func__, status);
         return status;
     }
-#endif
 
 #if (RSI_BLE_ENABLE)
     rsi_semaphore_post(&sl_rs_ble_init_sem);
@@ -590,10 +553,8 @@ static void wfx_rsi_do_join(void)
 void wfx_rsi_task(void * arg)
 {
     EventBits_t flags;
-#ifndef RS911X_SOCKETS
     TickType_t last_dhcp_poll, now;
     struct netif * sta_netif;
-#endif
     (void) arg;
     uint32_t rsi_status = wfx_rsi_init();
     if (rsi_status != RSI_SUCCESS)
@@ -601,11 +562,9 @@ void wfx_rsi_task(void * arg)
         WFX_RSI_LOG("%s: error: wfx_rsi_init with status: %02x", __func__, rsi_status);
         return;
     }
-#ifndef RS911X_SOCKETS
     wfx_lwip_start();
     last_dhcp_poll = xTaskGetTickCount();
     sta_netif      = wfx_get_netif(SL_WFX_STA_INTERFACE);
-#endif
     wfx_started_notify();
 
     WFX_RSI_LOG("%s: starting event wait", __func__);
@@ -618,9 +577,6 @@ void wfx_rsi_task(void * arg)
          */
         flags = xEventGroupWaitBits(wfx_rsi.events,
                                     WFX_EVT_STA_CONN | WFX_EVT_STA_DISCONN | WFX_EVT_STA_START_JOIN
-#ifdef RS911X_SOCKETS
-                                        | WFX_EVT_STA_DO_DHCP | WFX_EVT_STA_DHCP_DONE
-#endif /* RS911X_SOCKETS */
 #ifdef SL_WFX_CONFIG_SOFTAP
                                         | WFX_EVT_AP_START | WFX_EVT_AP_STOP
 #endif /* SL_WFX_CONFIG_SOFTAP */
@@ -636,20 +592,6 @@ void wfx_rsi_task(void * arg)
         {
             WFX_RSI_LOG("%s: wait event encountered: %x", __func__, flags);
         }
-#ifdef RS911X_SOCKETS
-        if (flags & WFX_EVT_STA_DO_DHCP)
-        {
-            /*
-             * Do DHCP -
-             */
-            if ((status = rsi_config_ipaddress(RSI_IP_VERSION_4, RSI_DHCP | RSI_DHCP_UNICAST_OFFER, NULL, NULL, NULL,
-                                               &wfx_rsi.ip4_addr[0], IP_CONF_RSP_BUFF_LENGTH_4, STATION)) != RSI_SUCCESS)
-            {
-                /* We should try this again.. (perhaps sleep) */
-                /* TODO - Figure out what to do here */
-            }
-        }
-#else /* !RS911X_SOCKET - using LWIP */
         /*
          * Let's handle DHCP polling here
          */
@@ -705,7 +647,6 @@ void wfx_rsi_task(void * arg)
                 last_dhcp_poll = now;
             }
         }
-#endif /* RS911X_SOCKETS */
         if (flags & WFX_EVT_STA_START_JOIN)
         {
             // saving the AP related info
@@ -720,14 +661,12 @@ void wfx_rsi_task(void * arg)
              */
             WFX_RSI_LOG("%s: starting LwIP STA", __func__);
             wfx_rsi.dev_state |= WFX_RSI_ST_STA_CONNECTED;
-#ifndef RS911X_SOCKETS
             hasNotifiedWifiConnectivity = false;
 #if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
             hasNotifiedIPV4 = false;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_IPV4
             hasNotifiedIPV6 = false;
             wfx_lwip_set_sta_link_up();
-#endif /* !RS911X_SOCKETS */
             /* We need to get AP Mac - TODO */
             // Uncomment once the hook into MATTER is moved to IP connectivty instead
             // of AP connectivity. wfx_connected_notify(0, &wfx_rsi.ap_mac); // This
@@ -739,7 +678,6 @@ void wfx_rsi_task(void * arg)
                 ~(WFX_RSI_ST_STA_READY | WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED | WFX_RSI_ST_STA_DHCP_DONE);
             WFX_RSI_LOG("%s: disconnect notify", __func__);
             /* TODO: Implement disconnect notify */
-#ifndef RS911X_SOCKETS
             wfx_lwip_set_sta_link_down(); // Internally dhcpclient_poll(netif) ->
                                           // wfx_ip_changed_notify(0) for IPV4
 #if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
@@ -749,7 +687,6 @@ void wfx_rsi_task(void * arg)
             wfx_ipv6_notify(GET_IPV6_FAIL);
             hasNotifiedIPV6             = false;
             hasNotifiedWifiConnectivity = false;
-#endif /* !RS911X_SOCKETS */
         }
 #ifdef SL_WFX_CONFIG_SCAN
         if (flags & WFX_EVT_SCAN)

--- a/examples/platform/silabs/efr32/rs911x/rsi_wlan_config.h
+++ b/examples/platform/silabs/efr32/rs911x/rsi_wlan_config.h
@@ -37,20 +37,8 @@
 #define RSI_FEATURE_BIT_MAP (FEAT_SECURITY_OPEN)
 
 //! TCP IP BYPASS feature check
-#ifdef RS911X_SOCKETS
-#define RSI_TCP_IP_BYPASS RSI_DISABLE
-
-#define RSI_TCP_IP_FEATURE_BIT_MAP                                                                                                 \
-    (TCP_IP_FEAT_DHCPV4_CLIENT |                             /*TCP_IP_FEAT_HTTP_CLIENT | */                                        \
-     TCP_IP_FEAT_EXTENSION_VALID | /*TCP_IP_FEAT_SSL     |*/ /*TCP_IP_FEAT_DNS_CLIENT |*/                                          \
-     0)
-//! To set custom feature select bit map
-#define RSI_CUSTOM_FEATURE_BIT_MAP FEAT_CUSTOM_FEAT_EXTENTION_VALID
-
-#else /* Don't use RSI_SOCKETS */
 #define RSI_TCP_IP_BYPASS RSI_ENABLE
 #define RSI_TCP_IP_FEATURE_BIT_MAP (TCP_IP_FEAT_BYPASS /*| TCP_IP_FEAT_EXTENSION_VALID*/)
-#endif
 
 //! To set Extended custom feature select bit map
 #if WIFI_ENABLE_SECURITY_WPA3

--- a/src/platform/silabs/SiWx917/BUILD.gn
+++ b/src/platform/silabs/SiWx917/BUILD.gn
@@ -30,14 +30,6 @@ if (chip_crypto == "platform") {
 config("siwx917-platform-wifi-config") {
   include_dirs = [ "wifi" ]
   defines = []
-
-  if (use_rs911x_sockets) {
-    include_dirs += [ "wifi/rsi-sockets" ]
-    defines += [
-      "RS911X_SOCKETS",
-      "RSI_IPV6_ENABLE",
-    ]
-  }
 }
 static_library("SiWx917") {
   sources = [

--- a/src/platform/silabs/SiWx917/wifi/lwip_netif.cpp
+++ b/src/platform/silabs/SiWx917/wifi/lwip_netif.cpp
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-#ifndef RS911X_SOCKETS
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -149,5 +148,3 @@ struct netif * wfx_get_netif(sl_wfx_interface_t interface)
 #endif
     return (struct netif *) 0;
 }
-
-#endif /* RS911X_SOCKETS */

--- a/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
+++ b/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
@@ -27,7 +27,6 @@
 #define SL_WFX_SCAN_COMPLETE_ID 4
 #define WFX_RSI_SSID_SIZE 64
 
-#ifndef RS911X_SOCKETS
 /* LwIP includes. */
 #include "lwip/apps/httpd.h"
 #include "lwip/ip_addr.h"
@@ -43,8 +42,6 @@
 #define SL_WFX_SCAN_START (1 << 5)
 #define SL_WFX_SCAN_COMPLETE (1 << 6)
 #define SL_WFX_RETRY_CONNECT (1 << 7)
-
-#endif /* RS911X_SOCKETS */
 
 #include "sl_status.h"
 

--- a/src/platform/silabs/efr32/BUILD.gn
+++ b/src/platform/silabs/efr32/BUILD.gn
@@ -34,14 +34,6 @@ if (chip_crypto == "platform") {
 config("efr32-platform-wifi-config") {
   include_dirs = [ "wifi" ]
   defines = []
-
-  if (use_rs9116 && use_rs911x_sockets) {
-    include_dirs += [ "wifi/rsi-sockets" ]
-    defines += [
-      "RS911X_SOCKETS",
-      "RSI_IPV6_ENABLE",
-    ]
-  }
 }
 
 static_library("efr32") {
@@ -139,7 +131,7 @@ static_library("efr32") {
       "wifi/wifi_config.h",
     ]
 
-    if (use_wf200 || !use_rs911x_sockets) {
+    if (use_wf200 || use_rs9116) {
       sources += [
         "wifi/dhcp_client.cpp",
         "wifi/dhcp_client.h",

--- a/src/platform/silabs/efr32/wifi/lwip_netif.cpp
+++ b/src/platform/silabs/efr32/wifi/lwip_netif.cpp
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-#ifndef RS911X_SOCKETS
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -155,5 +154,3 @@ struct netif * wfx_get_netif(sl_wfx_interface_t interface)
 #endif
     return (struct netif *) 0;
 }
-
-#endif /* RS911X_SOCKETS */

--- a/src/platform/silabs/efr32/wifi/wfx_host_events.h
+++ b/src/platform/silabs/efr32/wifi/wfx_host_events.h
@@ -107,7 +107,6 @@ typedef struct __attribute__((__packed__)) sl_wfx_mib_req_s
 
 #endif /* WF200 */
 
-#ifndef RS911X_SOCKETS
 /* LwIP includes. */
 #include "lwip/apps/httpd.h"
 #include "lwip/ip_addr.h"
@@ -123,8 +122,6 @@ typedef struct __attribute__((__packed__)) sl_wfx_mib_req_s
 #define SL_WFX_SCAN_START (1 << 5)
 #define SL_WFX_SCAN_COMPLETE (1 << 6)
 #define SL_WFX_RETRY_CONNECT (1 << 7)
-
-#endif /* RS911X_SOCKETS */
 
 #include "sl_status.h"
 #include "stdbool.h"

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -113,30 +113,30 @@ template("siwx917_sdk") {
       defines += [ "ENABLE_CHIP_SHELL" ]
     }
 
-      import("${chip_root}/src/platform/silabs/SiWx917/args.gni")
-      defines += [ "LWIP_NETIF_API=1" ]
-      if (lwip_ipv4) {
-        defines += [
-          "LWIP_IPV4=1",
+    import("${chip_root}/src/platform/silabs/SiWx917/args.gni")
+    defines += [ "LWIP_NETIF_API=1" ]
+    if (lwip_ipv4) {
+      defines += [
+        "LWIP_IPV4=1",
 
-          # adds following options to provide
-          # them to .cpp source files
-          # flags ported from lwipopts file
-          # TODO: move lwipopts to one location
-          "LWIP_ARP=1",
-          "LWIP_ICMP=1",
-          "LWIP_IGMP=1",
-          "LWIP_DHCP=1",
-          "LWIP_DNS=0",
-        ]
-      } else {
-        defines += [ "LWIP_IPV4=0" ]
-      }
-      if (lwip_ipv6) {
-        defines += [ "LWIP_IPV6=1" ]
-      } else {
-        defines += [ "LWIP_IPV6=0" ]
-      }
+        # adds following options to provide
+        # them to .cpp source files
+        # flags ported from lwipopts file
+        # TODO: move lwipopts to one location
+        "LWIP_ARP=1",
+        "LWIP_ICMP=1",
+        "LWIP_IGMP=1",
+        "LWIP_DHCP=1",
+        "LWIP_DNS=0",
+      ]
+    } else {
+      defines += [ "LWIP_IPV4=0" ]
+    }
+    if (lwip_ipv6) {
+      defines += [ "LWIP_IPV6=1" ]
+    } else {
+      defines += [ "LWIP_IPV6=0" ]
+    }
 
     defines += board_defines
 

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -113,7 +113,6 @@ template("siwx917_sdk") {
       defines += [ "ENABLE_CHIP_SHELL" ]
     }
 
-    if (!use_rs911x_sockets) {
       import("${chip_root}/src/platform/silabs/SiWx917/args.gni")
       defines += [ "LWIP_NETIF_API=1" ]
       if (lwip_ipv4) {
@@ -138,7 +137,6 @@ template("siwx917_sdk") {
       } else {
         defines += [ "LWIP_IPV6=0" ]
       }
-    }
 
     defines += board_defines
 

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -272,7 +272,7 @@ template("efr32_sdk") {
         ]
       }
 
-      if (use_wf200 || !use_rs911x_sockets) {
+      if (use_wf200 || use_rs9116) {
         import("${chip_root}/src/platform/silabs/efr32/wifi_args.gni")
 
         defines += [ "LWIP_NETIF_API=1" ]

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -34,7 +34,6 @@ declare_args() {
   use_wf200 = false
   use_rs9116 = false
   use_SiWx917 = false
-  use_rs911x_sockets = false
   chip_enable_ble_rs911x = false
 
   #Disable MQTT by default


### PR DESCRIPTION
Removes unused/unsupported `RS911X_SOCKETS` and `use_rs911x_sockets`

