### PR TITLE
Allow generators to override loader paths and loaders

### DIFF
--- a/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
@@ -14,7 +14,6 @@
 
 import os
 
-import jinja2
 from matter_idl.generators import CodeGenerator, GeneratorStorage
 from matter_idl.matter_idl_types import Cluster, ClusterSide, Command, Field, Idl
 

--- a/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
@@ -199,13 +199,7 @@ class CustomGenerator(CodeGenerator):
         Inintialization is specific for java generation and will add
         filters as required by the java .jinja templates to function.
         """
-        super().__init__(storage, idl)
-
-        # Override the template path to use local templates within this plugin directory
-        self.jinja_env = jinja2.Environment(
-            loader=jinja2.FileSystemLoader(
-                searchpath=os.path.dirname(__file__)),
-            keep_trailing_newline=True)
+        super().__init__(storage, idl, fs_loader_searchpath=os.path.dirname(__file__))
 
         # String helpers
         self.jinja_env.filters['toLowerSnakeCase'] = toLowerSnakeCase
@@ -241,7 +235,7 @@ class CustomGenerator(CodeGenerator):
 
             # Header containing a macro to initialize all cluster plugins
             self.internal_render_one_output(
-                template_path="./matter_cluster_proto.jinja",
+                template_path="matter_cluster_proto.jinja",
                 output_file_name=filename,
                 vars={
                     'cluster': cluster,

--- a/scripts/py_matter_idl/matter_idl/generators/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/__init__.py
@@ -15,7 +15,7 @@
 
 import logging
 import os
-from typing import Dict
+from typing import Dict, Optional
 
 import jinja2
 from matter_idl.matter_idl_types import Idl
@@ -106,16 +106,24 @@ class CodeGenerator:
     write time of files do not change and rebuilds are not triggered).
     """
 
-    def __init__(self, storage: GeneratorStorage, idl: Idl):
+    def __init__(self, storage: GeneratorStorage, idl: Idl, loader: Optional[jinja2.BaseLoader] = None, fs_loader_searchpath: Optional[str] = None):
         """
         A code generator will render a parsed IDL (a AST) into a given storage.
+
+        Args:
+           storage: Storage to use to read/save data
+           loader: if given, use a custom loader for templates
+           fs_loader_searchpath: if a loader is NOT given, this controls the search path
+              of a default FileSystemLoader that will be used
         """
+        if not loader:
+            if not fs_loader_searchpath:
+                fs_loader_searchpath=os.path.dirname(__file__)
+            loader=jinja2.FileSystemLoader(searchpath=fs_loader_searchpath)
+
         self.storage = storage
         self.idl = idl
-        self.jinja_env = jinja2.Environment(
-            loader=jinja2.FileSystemLoader(
-                searchpath=os.path.dirname(__file__)),
-            keep_trailing_newline=True)
+        self.jinja_env = jinja2.Environment(loader=loader, keep_trailing_newline=True)
         self.dry_run = False
 
         RegisterCommonFilters(self.jinja_env.filters)

--- a/scripts/py_matter_idl/matter_idl/generators/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/__init__.py
@@ -118,12 +118,13 @@ class CodeGenerator:
         """
         if not loader:
             if not fs_loader_searchpath:
-                fs_loader_searchpath=os.path.dirname(__file__)
-            loader=jinja2.FileSystemLoader(searchpath=fs_loader_searchpath)
+                fs_loader_searchpath = os.path.dirname(__file__)
+            loader = jinja2.FileSystemLoader(searchpath=fs_loader_searchpath)
 
         self.storage = storage
         self.idl = idl
-        self.jinja_env = jinja2.Environment(loader=loader, keep_trailing_newline=True)
+        self.jinja_env = jinja2.Environment(
+            loader=loader, keep_trailing_newline=True)
         self.dry_run = False
 
         RegisterCommonFilters(self.jinja_env.filters)

--- a/scripts/py_matter_idl/matter_idl/generators/bridge/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/bridge/__init__.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import logging
+import os
 import re
 
 from matter_idl.generators import CodeGenerator, GeneratorStorage
@@ -137,7 +138,7 @@ class BridgeGenerator(CodeGenerator):
         Inintialization is specific for cpp generation and will add
         filters as required by the cpp .jinja templates to function.
         """
-        super().__init__(storage, idl)
+        super().__init__(storage, idl, fs_loader_searchpath=os.path.dirname(__file__))
 
         self.jinja_env.filters['getType'] = get_attr_type
         self.jinja_env.filters['getRawSizeAndType'] = get_raw_size_and_type
@@ -163,7 +164,7 @@ class BridgeGenerator(CodeGenerator):
                 output_file_name = "bridge/%s.h" % cluster.name
 
             self.internal_render_one_output(
-                template_path="bridge/BridgeClustersCpp.jinja",
+                template_path="BridgeClustersCpp.jinja",
                 output_file_name=output_file_name,
                 vars={
                     'cluster': cluster,
@@ -172,7 +173,7 @@ class BridgeGenerator(CodeGenerator):
             )
 
         self.internal_render_one_output(
-            template_path="bridge/BridgeClustersCommon.jinja",
+            template_path="BridgeClustersCommon.jinja",
             output_file_name="bridge/BridgeClustersImpl.h",
             vars={
                 'clusters': self.idl.clusters,
@@ -181,7 +182,7 @@ class BridgeGenerator(CodeGenerator):
         )
 
         self.internal_render_one_output(
-            template_path="bridge/BridgeClustersGlobalStructs.jinja",
+            template_path="BridgeClustersGlobalStructs.jinja",
             output_file_name="bridge/BridgeGlobalStructs.h",
             vars={
                 'idl': self.idl,

--- a/scripts/py_matter_idl/matter_idl/generators/cpp/application/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/cpp/application/__init__.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 import os
+from typing import List
 
 from matter_idl.generators import CodeGenerator, GeneratorStorage
 from matter_idl.matter_idl_types import Cluster, ClusterSide, Idl

--- a/scripts/py_matter_idl/matter_idl/generators/cpp/application/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/cpp/application/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import List
+import os
 
 from matter_idl.generators import CodeGenerator, GeneratorStorage
 from matter_idl.matter_idl_types import Cluster, ClusterSide, Idl
@@ -32,7 +33,7 @@ class CppApplicationGenerator(CodeGenerator):
         Inintialization is specific for java generation and will add
         filters as required by the java .jinja templates to function.
         """
-        super().__init__(storage, idl)
+        super().__init__(storage, idl, fs_loader_searchpath=os.path.dirname(__file__))
 
         self.jinja_env.filters['serverClustersOnly'] = serverClustersOnly
 
@@ -43,7 +44,7 @@ class CppApplicationGenerator(CodeGenerator):
 
         # Header containing a macro to initialize all cluster plugins
         self.internal_render_one_output(
-            template_path="cpp/application/PluginApplicationCallbacksHeader.jinja",
+            template_path="PluginApplicationCallbacksHeader.jinja",
             output_file_name="app/PluginApplicationCallbacks.h",
             vars={
                 'clusters': self.idl.clusters,
@@ -53,7 +54,7 @@ class CppApplicationGenerator(CodeGenerator):
         # Source for __attribute__(weak) implementations of all cluster
         # initialization methods
         self.internal_render_one_output(
-            template_path="cpp/application/CallbackStubSource.jinja",
+            template_path="CallbackStubSource.jinja",
             output_file_name="app/callback-stub.cpp",
             vars={
                 'clusters': self.idl.clusters,

--- a/scripts/py_matter_idl/matter_idl/generators/java/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/java/__init__.py
@@ -15,6 +15,7 @@
 
 import enum
 import logging
+import os
 from typing import List, Set, Union
 
 from matter_idl.generators import CodeGenerator, GeneratorStorage
@@ -405,7 +406,7 @@ class __JavaCodeGenerator(CodeGenerator):
         Inintialization is specific for java generation and will add
         filters as required by the java .jinja templates to function.
         """
-        super().__init__(storage, idl)
+        super().__init__(storage, idl, fs_loader_searchpath=os.path.dirname(__file__))
 
         self.jinja_env.filters['attributesWithCallback'] = attributesWithSupportedCallback
         self.jinja_env.filters['callbackName'] = CallbackName
@@ -434,7 +435,7 @@ class JavaJNIGenerator(__JavaCodeGenerator):
         """
 
         self.internal_render_one_output(
-            template_path="java/CHIPCallbackTypes.jinja",
+            template_path="CHIPCallbackTypes.jinja",
             output_file_name="jni/CHIPCallbackTypes.h",
             vars={
                 'idl': self.idl,
@@ -449,7 +450,7 @@ class JavaJNIGenerator(__JavaCodeGenerator):
                 continue
 
             self.internal_render_one_output(
-                template_path="java/ChipClustersRead.jinja",
+                template_path="ChipClustersRead.jinja",
                 output_file_name="jni/%sClient-ReadImpl.cpp" % cluster.name,
                 vars={
                     'cluster': cluster,
@@ -458,7 +459,7 @@ class JavaJNIGenerator(__JavaCodeGenerator):
             )
 
             self.internal_render_one_output(
-                template_path="java/ChipClustersCpp.jinja",
+                template_path="ChipClustersCpp.jinja",
                 output_file_name="jni/%sClient-InvokeSubscribeImpl.cpp" % cluster.name,
                 vars={
                     'cluster': cluster,
@@ -482,7 +483,7 @@ class JavaClassGenerator(__JavaCodeGenerator):
             c for c in self.idl.clusters if c.side == ClusterSide.CLIENT]
 
         self.internal_render_one_output(
-            template_path="java/ClusterReadMapping.jinja",
+            template_path="ClusterReadMapping.jinja",
             output_file_name="java/chip/devicecontroller/ClusterReadMapping.java",
             vars={
                 'idl': self.idl,
@@ -491,7 +492,7 @@ class JavaClassGenerator(__JavaCodeGenerator):
         )
 
         self.internal_render_one_output(
-            template_path="java/ClusterWriteMapping.jinja",
+            template_path="ClusterWriteMapping.jinja",
             output_file_name="java/chip/devicecontroller/ClusterWriteMapping.java",
             vars={
                 'idl': self.idl,


### PR DESCRIPTION
Since generators can in theory support external loaders, allow them to configure the jinja loader logic.