### PR TITLE
chip-build-android: Use NDK r23c and OpenSSL 1.1.1t

### DIFF
--- a/integrations/docker/images/chip-build-android/Dockerfile
+++ b/integrations/docker/images/chip-build-android/Dockerfile
@@ -37,31 +37,32 @@ RUN set -x \
 # Download and install android NDK
 RUN set -x \
     && cd /tmp \
-    && wget https://dl.google.com/android/repository/android-ndk-r21b-linux-x86_64.zip \
+    && wget https://dl.google.com/android/repository/android-ndk-r23c-linux.zip \
     && mkdir -p /opt/android \
     && cd /opt/android \
-    && unzip /tmp/android-ndk-r21b-linux-x86_64.zip \
-    && rm -f /tmp/android-ndk-r21b-linux-x86_64.zip \
+    && unzip /tmp/android-ndk-r23c-linux.zip \
+    && rm -f /tmp/android-ndk-r23c-linux.zip \
     && : # last line
 
 # Install specific release of openssl and compile for x86/armv7-a
-# Leaves compiled .so's in /usr/local/src/{arch}/openssl-1.1.1g dirs
+# Leaves compiled .so's in /usr/local/src/{arch}/openssl-{version} dirs
 # CHIP builds may configure with --with-openssl using one of the arch dirs
 # NOTE: CHIP builds will also need to either link or copy libc++_shared.so from
 # the NDK and libcrypto.so (and any other deps) into the jniLibs for any APK that
 # is to be built with this image.
+# See also: https://github.com/openssl/openssl/issues/18561#issuecomment-1155298077
 RUN set -x \
     && export OPENSSL_ARMV7=/usr/local/src/armeabi-v7a \
     && export OPENSSL_X86=/usr/local/src/x86 \
-    && export ANDROID_NDK_HOME=/opt/android/android-ndk-r21b \
+    && export ANDROID_NDK_HOME=/opt/android/android-ndk-r23c \
     && export PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH \
-    && cd /tmp && wget https://www.openssl.org/source/openssl-1.1.1g.tar.gz \
-    && mkdir -p $OPENSSL_ARMV7 && cd $OPENSSL_ARMV7 && tar xfz /tmp/openssl-1.1.1g.tar.gz \
-    && cd $OPENSSL_ARMV7/openssl-1.1.1g && CC=clang ANDROID_API=26 ./Configure android-arm -D__ANDROID_API__=26 && make SHLIB_VERSION_NUMBER= SHLIB_EXT=.so \
-    && mkdir -p $OPENSSL_X86 && cd $OPENSSL_X86 && tar xfz /tmp/openssl-1.1.1g.tar.gz \
-    && cd $OPENSSL_X86/openssl-1.1.1g && CC=clang ANDROID_API=26 ./Configure android-x86 -D__ANDROID_API__=26 && make SHLIB_VERSION_NUMBER= SHLIB_EXT=.so \
-    && rm -rf /tmp/OpenSSL_1_1_1g.zip \
+    && cd /tmp && wget https://www.openssl.org/source/openssl-1.1.1t.tar.gz \
+    && mkdir -p $OPENSSL_ARMV7 && cd $OPENSSL_ARMV7 && tar xfz /tmp/openssl-1.1.1t.tar.gz \
+    && cd $OPENSSL_ARMV7/openssl-1.1.1t && CC=clang ANDROID_API=26 ./Configure android-arm -U__ANDROID_API__ -D__ANDROID_API__=26 && make SHLIB_VERSION_NUMBER= SHLIB_EXT=.so \
+    && mkdir -p $OPENSSL_X86 && cd $OPENSSL_X86 && tar xfz /tmp/openssl-1.1.1t.tar.gz \
+    && cd $OPENSSL_X86/openssl-1.1.1t && CC=clang ANDROID_API=26 ./Configure android-x86 -U__ANDROID_API__ -D__ANDROID_API__=26 && make SHLIB_VERSION_NUMBER= SHLIB_EXT=.so \
+    && rm -rf /tmp/openssl-1.1.1t.tar.gz \
     && : # last line
 
 ENV ANDROID_HOME=/opt/android/sdk
-ENV ANDROID_NDK_HOME=/opt/android/android-ndk-r21b
+ENV ANDROID_NDK_HOME=/opt/android/android-ndk-r23c

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.54 Version bump reason: [Ameba] Store wifi ssid and password into dct
+0.7.0 Version bump reason: [Android] Use NDK r23c and OpenSSL 1.1.1t


### PR DESCRIPTION
Upate NDK to r23c for a clang that supports -fmacro-prefix-map.
Update OpenSSL to 1.1.1t to avoid build issues with NDK (https://github.com/openssl/openssl/issues/13685)

This is to enable https://github.com/project-chip/connectedhomeip/pull/25939