### PR TITLE
Added build flag to allow/skip building Example Credential files

### DIFF
--- a/src/credentials/BUILD.gn
+++ b/src/credentials/BUILD.gn
@@ -17,6 +17,10 @@ import("//build_overrides/nlassert.gni")
 import("${chip_root}/src/crypto/crypto.gni")
 import("${chip_root}/src/platform/device.gni")
 
+declare_args() {
+  chip_build_example_creds = true
+}
+
 static_library("credentials") {
   output_name = "libCredentials"
 
@@ -47,15 +51,20 @@ static_library("credentials") {
     "attestation_verifier/DeviceAttestationDelegate.h",
     "attestation_verifier/DeviceAttestationVerifier.cpp",
     "attestation_verifier/DeviceAttestationVerifier.h",
-    "examples/DeviceAttestationCredsExample.cpp",
-    "examples/DeviceAttestationCredsExample.h",
-    "examples/ExampleDACs.cpp",
-    "examples/ExampleDACs.h",
-    "examples/ExamplePAI.cpp",
-    "examples/ExamplePAI.h",
-    "examples/LastKnownGoodTimeCertificateValidityPolicyExample.h",
-    "examples/StrictCertificateValidityPolicyExample.h",
   ]
+
+  if (chip_build_example_creds) {
+    sources += [
+      "examples/DeviceAttestationCredsExample.cpp",
+      "examples/DeviceAttestationCredsExample.h",
+      "examples/ExampleDACs.cpp",
+      "examples/ExampleDACs.h",
+      "examples/ExamplePAI.cpp",
+      "examples/ExamplePAI.h",
+      "examples/LastKnownGoodTimeCertificateValidityPolicyExample.h",
+      "examples/StrictCertificateValidityPolicyExample.h",
+    ]
+  }
 
   # TODO: These tests files should be removed after the DeviceAttestationCredsExample implementation
   # is changed to generate it's own credentials instead of using Test credentials.


### PR DESCRIPTION
Related to https://github.com/project-chip/connectedhomeip/issues/25388 

### Change summary
This change adds a build flag chip_build_example_creds that will allow an example app to skip building Example Credential classes (by setting it to false). Note: this flag will be set to false in the examples/tv-casting-app in a separate PR to follow.

### Testing
Built and ran example/tv-casting-app successfully.