### PR TITLE
Allow code pre-generation to accept files outside of chip-root

### DIFF
--- a/docs/code_generation.md
+++ b/docs/code_generation.md
@@ -251,10 +251,10 @@ scripts/tools/zap/generate.py ${ZAP_FILE_PATH}
 The above will use the template `src/app/zap-templates/matter-idl.json` to
 generate a `.matter` file corresponding to the input `.zap` file.
 
-`.matter` files are designed to be human readable. It is recommended to take a look
-at the generated file and see if it contains what is expected and also lint it.
-If anything seems wrong, the `.zap` file should be fixed
-(` .matter` represents the content of `.zap`). To lint use:
+`.matter` files are designed to be human readable. It is recommended to take a
+look at the generated file and see if it contains what is expected and also lint
+it. If anything seems wrong, the `.zap` file should be fixed (`.matter`
+represents the content of `.zap`). To lint use:
 
 ```bash
 scripts/idl_lint.py ${MATTER_FILE_PATH}

--- a/docs/code_generation.md
+++ b/docs/code_generation.md
@@ -263,7 +263,7 @@ scripts/idl_lint.py ${MATTER_FILE_PATH}
 #### Running pre-generation
 
 If you have zap files outside the CHIP repository (i.e. not in `src` or
-`examples`) you should provide the root of your external root(s) to the script:
+`examples`) you should provide the root of your application source.
 
 ```bash
 scripts/codepregen.py --external-root ${PATH_TO_SOURCE_ROOT} ${OUTPUT_DIRECTORY:-./zzz_pregenerated/}
@@ -274,7 +274,7 @@ zap/matter files as the code pre-generation will generate files based on the
 path inside the root:
 
 -   if files are `$PATH_TO_SOURCE_ROOT/some/path/foo.zap` this will generate
-    files into `$OUTPUT_DIRECTORY/some/path/foo/`
+    files into `$OUTPUT_DIRECTORY/some/path/foo/...`
 
 ### Using pre-generated code
 

--- a/docs/code_generation.md
+++ b/docs/code_generation.md
@@ -248,18 +248,17 @@ have a `.zap` file, you can create the corresponding matter via:
 scripts/tools/zap/generate.py ${ZAP_FILE_PATH}
 ```
 
-The above will use the template `src/app/zap-templates/matter-idl.json` to generate a
-`.matter`.
+The above will use the template `src/app/zap-templates/matter-idl.json` to
+generate a `.matter`.
 
 Matter files are designed to be human readable. It is recommended to take a look
 at the generated file and see if it contains what is expected and also lint it.
-If anything seems wrong, the `.zap` file should be fixed (`.matter`` represents the
-content of `.zap`). To lint use:
+If anything seems wrong, the `.zap` file should be fixed
+(` .matter`` represents the content of `.zap`). To lint use:
 
 ```bash
 scripts/idl_lint.py ${MATTER_FILE_PATH}
 ```
-
 
 #### Running pre-generation
 

--- a/docs/code_generation.md
+++ b/docs/code_generation.md
@@ -251,7 +251,7 @@ scripts/tools/zap/generate.py ${ZAP_FILE_PATH}
 The above will use the template `src/app/zap-templates/matter-idl.json` to
 generate a `.matter`.
 
-Matter files are designed to be human readable. It is recommended to take a look
+`.matter` files are designed to be human readable. It is recommended to take a look
 at the generated file and see if it contains what is expected and also lint it.
 If anything seems wrong, the `.zap` file should be fixed
 (` .matter`` represents the content of `.zap`). To lint use:

--- a/docs/code_generation.md
+++ b/docs/code_generation.md
@@ -249,7 +249,7 @@ scripts/tools/zap/generate.py ${ZAP_FILE_PATH}
 ```
 
 The above will use the template `src/app/zap-templates/matter-idl.json` to
-generate a `.matter`.
+generate a `.matter` file corresponding to the input `.zap` file.
 
 `.matter` files are designed to be human readable. It is recommended to take a look
 at the generated file and see if it contains what is expected and also lint it.

--- a/docs/code_generation.md
+++ b/docs/code_generation.md
@@ -254,7 +254,7 @@ generate a `.matter`.
 `.matter` files are designed to be human readable. It is recommended to take a look
 at the generated file and see if it contains what is expected and also lint it.
 If anything seems wrong, the `.zap` file should be fixed
-(` .matter`` represents the content of `.zap`). To lint use:
+(` .matter` represents the content of `.zap`). To lint use:
 
 ```bash
 scripts/idl_lint.py ${MATTER_FILE_PATH}

--- a/docs/code_generation.md
+++ b/docs/code_generation.md
@@ -239,6 +239,30 @@ scripts/codepregen.py --input-glob "*all-clusters*" --input-glob "*controller*" 
 
 ### External applications/zap files
 
+#### Ensure you have a `.matter` file
+
+Code generation generally will use both `.zap` or `.matter` files. If you only
+have a `.zap` file, you can create the corresponding matter via:
+
+```bash
+scripts/tools/zap/generate.py ${ZAP_FILE_PATH}
+```
+
+The above will use the template `src/app/zap-templates/matter-idl.json` to generate a
+`.matter`.
+
+Matter files are designed to be human readable. It is recommended to take a look
+at the generated file and see if it contains what is expected and also lint it.
+If anything seems wrong, the `.zap` file should be fixed (`.matter`` represents the
+content of `.zap`). To lint use:
+
+```bash
+scripts/idl_lint.py ${MATTER_FILE_PATH}
+```
+
+
+#### Running pre-generation
+
 If you have zap files outside the CHIP repository (i.e. not in `src` or
 `examples`) you should provide the root of your external root(s) to the script:
 

--- a/docs/code_generation.md
+++ b/docs/code_generation.md
@@ -234,8 +234,24 @@ scripts/codepregen.py ${OUTPUT_DIRECTORY:-./zzz_pregenerated/}
 
 # To generate a single output you can use `--input-glob`:
 
-scripts/codepregen.py --input-glob "*all-clusters*" ${OUTPUT_DIRECTORY:-./zzz_pregenerated/}
+scripts/codepregen.py --input-glob "*all-clusters*" --input-glob "*controller*" ${OUTPUT_DIRECTORY:-./zzz_pregenerated/}
 ```
+
+### External applications/zap files
+
+If you have zap files outside the CHIP repository (i.e. not in `src` or `examples`) you should provide
+the root of your external root(s) to the script:
+
+```bash
+scripts/codepregen.py --external-root ${PATH_TO_SOURCE_ROOT} ${OUTPUT_DIRECTORY:-./zzz_pregenerated/}
+```
+
+NOTE: `$PATH_TO_SOURCE_ROOT` should be a top-level directory containing zap/matter files as the code 
+pre-generation will generate files based on the path inside the root: 
+
+- if files are `$PATH_TO_SOURCE_ROOT/some/path/foo.zap` this will generate files into
+  `$OUTPUT_DIRECTORY/some/path/foo/`
+
 
 ### Using pre-generated code
 

--- a/docs/code_generation.md
+++ b/docs/code_generation.md
@@ -242,7 +242,7 @@ scripts/codepregen.py --input-glob "*all-clusters*" --input-glob "*controller*" 
 #### Ensure you have a `.matter` file
 
 Code generation generally will use both `.zap` or `.matter` files. If you only
-have a `.zap` file, you can create the corresponding matter via:
+have a `.zap` file, you can create the corresponding `.matter` file via:
 
 ```bash
 scripts/tools/zap/generate.py ${ZAP_FILE_PATH}

--- a/docs/code_generation.md
+++ b/docs/code_generation.md
@@ -239,19 +239,19 @@ scripts/codepregen.py --input-glob "*all-clusters*" --input-glob "*controller*" 
 
 ### External applications/zap files
 
-If you have zap files outside the CHIP repository (i.e. not in `src` or `examples`) you should provide
-the root of your external root(s) to the script:
+If you have zap files outside the CHIP repository (i.e. not in `src` or
+`examples`) you should provide the root of your external root(s) to the script:
 
 ```bash
 scripts/codepregen.py --external-root ${PATH_TO_SOURCE_ROOT} ${OUTPUT_DIRECTORY:-./zzz_pregenerated/}
 ```
 
-NOTE: `$PATH_TO_SOURCE_ROOT` should be a top-level directory containing zap/matter files as the code 
-pre-generation will generate files based on the path inside the root: 
+NOTE: `$PATH_TO_SOURCE_ROOT` should be a top-level directory containing
+zap/matter files as the code pre-generation will generate files based on the
+path inside the root:
 
-- if files are `$PATH_TO_SOURCE_ROOT/some/path/foo.zap` this will generate files into
-  `$OUTPUT_DIRECTORY/some/path/foo/`
-
+-   if files are `$PATH_TO_SOURCE_ROOT/some/path/foo.zap` this will generate
+    files into `$OUTPUT_DIRECTORY/some/path/foo/`
 
 ### Using pre-generated code
 

--- a/scripts/codepregen.py
+++ b/scripts/codepregen.py
@@ -85,8 +85,13 @@ def _ParallelGenerateOne(arg):
     '--sdk-root',
     default=None,
     help='Path to the SDK root (where .zap/.matter files exist).')
+@click.option(
+    '--external-root',
+    default=None,
+    multiple=True,
+    help='Path to an external app root (where .zap/.matter files exist).')
 @click.argument('output_dir')
-def main(log_level, parallel, dry_run, generator, input_glob, sdk_root, output_dir):
+def main(log_level, parallel, dry_run, generator, input_glob, sdk_root, external_root, output_dir):
     if _has_coloredlogs:
         coloredlogs.install(level=__LOG_LEVELS__[
                             log_level], fmt='%(asctime)s %(levelname)-7s %(message)s')
@@ -122,7 +127,7 @@ def main(log_level, parallel, dry_run, generator, input_glob, sdk_root, output_d
     elif generator == 'codegen':
         filter.file_type = IdlFileType.MATTER
 
-    targets = FindPregenerationTargets(sdk_root, filter, runner)
+    targets = FindPregenerationTargets(sdk_root, external_root, filter, runner)
 
     runner.ensure_directory_exists(output_dir)
     if parallel:

--- a/scripts/pregenerate/__init__.py
+++ b/scripts/pregenerate/__init__.py
@@ -26,16 +26,16 @@ from .using_zap import ZapApplicationPregenerator
 
 
 def _IdlsInDirectory(top_directory_name: str, truncate_length: int):
-     for root, dirs, files in os.walk(top_directory_name):
-          for file in files:
-               if file.endswith('.zap'):
-                    yield InputIdlFile(file_type=IdlFileType.ZAP,
-                                       full_path=os.path.join(root, file),
-                                       relative_path=os.path.join(root[truncate_length:], file))
-               if file.endswith('.matter'):
-                    yield InputIdlFile(file_type=IdlFileType.MATTER,
-                                       full_path=os.path.join(root, file),
-                                       relative_path=os.path.join(root[truncate_length:], file))
+    for root, dirs, files in os.walk(top_directory_name):
+        for file in files:
+            if file.endswith('.zap'):
+                yield InputIdlFile(file_type=IdlFileType.ZAP,
+                                   full_path=os.path.join(root, file),
+                                   relative_path=os.path.join(root[truncate_length:], file))
+            if file.endswith('.matter'):
+                yield InputIdlFile(file_type=IdlFileType.MATTER,
+                                   full_path=os.path.join(root, file),
+                                   relative_path=os.path.join(root[truncate_length:], file))
 
 
 def _FindAllIdls(sdk_root: str, external_roots: Optional[List[str]]) -> Iterator[InputIdlFile]:

--- a/scripts/pregenerate/__init__.py
+++ b/scripts/pregenerate/__init__.py
@@ -91,7 +91,7 @@ def FindPregenerationTargets(sdk_root: str, external_roots: Optional[List[str]],
     """
 
     generators = _GeneratorsForRoot(sdk_root)
-    if extenral_roots:
+    if external_roots:
         for root in external_roots:
             generators.extend(_GeneratorsForRoot(root))
 

--- a/scripts/pregenerate/__init__.py
+++ b/scripts/pregenerate/__init__.py
@@ -58,6 +58,7 @@ def _FindAllIdls(sdk_root: str, external_roots: Optional[List[str]]) -> Iterator
     # next external roots
     if external_roots:
         for root in external_roots:
+            root = os.path.normpath(root)
             for idl in _IdlsInDirectory(root, len(root) + 1):
                 yield idl
 

--- a/scripts/pregenerate/__init__.py
+++ b/scripts/pregenerate/__init__.py
@@ -66,8 +66,22 @@ class GlobMatcher:
     def matches(self, s: str):
         return fnmatch.fnmatch(s, self.pattern)
 
+def _GeneratorsForRoot(root: str):
+    """Define all generators for the given source root."""
 
-def FindPregenerationTargets(sdk_root: str, filter: TargetFilter, runner):
+    return [
+        # Jinja-based codegen
+        CodegenBridgePregenerator(root),
+        CodegenJavaJNIPregenerator(root),
+        CodegenJavaClassPregenerator(root),
+        CodegenCppAppPregenerator(root),
+
+        # ZAP codegen
+        ZapApplicationPregenerator(root),
+    ]
+
+
+def FindPregenerationTargets(sdk_root: str, external_roots: Optional[List[str]], filter: TargetFilter, runner):
     """Finds all relevand pre-generation targets in the given
        SDK root.
 
@@ -75,16 +89,10 @@ def FindPregenerationTargets(sdk_root: str, filter: TargetFilter, runner):
        on what rules to pregenerate and how.
     """
 
-    generators = [
-        # Jinja-based codegen
-        CodegenBridgePregenerator(sdk_root),
-        CodegenJavaJNIPregenerator(sdk_root),
-        CodegenJavaClassPregenerator(sdk_root),
-        CodegenCppAppPregenerator(sdk_root),
-
-        # ZAP codegen
-        ZapApplicationPregenerator(sdk_root),
-    ]
+    generators = _GeneratorsForRoot(sdk_root)
+    if extenral_roots:
+        for root in external_roots:
+            generators.extend(_GeneratorsForRoot(root))
 
     path_matchers = [GlobMatcher(pattern) for pattern in filter.path_glob]
 

--- a/scripts/pregenerate/__init__.py
+++ b/scripts/pregenerate/__init__.py
@@ -25,7 +25,18 @@ from .using_codegen import (CodegenBridgePregenerator, CodegenCppAppPregenerator
 from .using_zap import ZapApplicationPregenerator
 
 
-def FindAllIdls(sdk_root: str) -> Iterator[InputIdlFile]:
+def _IdlsInDirectory(top_directory_name: str, truncate_length: int):
+     for root, dirs, files in os.walk(top_directory_name):
+          for file in files:
+               if file.endswith('.zap'):
+                    yield InputIdlFile(file_type=IdlFileType.ZAP,
+                                       relative_path=os.path.join(root[truncate_length:], file))
+               if file.endswith('.matter'):
+                    yield InputIdlFile(file_type=IdlFileType.MATTER,
+                                       relative_path=os.path.join(root[truncate_length:], file))
+
+
+def _FindAllIdls(sdk_root: str, external_roots: Optional[List[str]]) -> Iterator[InputIdlFile]:
     relevant_subdirs = [
         'examples',  # all example apps
         'src',      # realistically only controller/data_model
@@ -35,17 +46,18 @@ def FindAllIdls(sdk_root: str) -> Iterator[InputIdlFile]:
         sdk_root = sdk_root[:-1]
     sdk_root_length = len(sdk_root)
 
+    # first go over SDK items
     for subdir_name in relevant_subdirs:
         top_directory_name = os.path.join(sdk_root, subdir_name)
         logging.debug(f"Searching {top_directory_name}")
-        for root, dirs, files in os.walk(top_directory_name):
-            for file in files:
-                if file.endswith('.zap'):
-                    yield InputIdlFile(file_type=IdlFileType.ZAP,
-                                       relative_path=os.path.join(root[sdk_root_length+1:], file))
-                if file.endswith('.matter'):
-                    yield InputIdlFile(file_type=IdlFileType.MATTER,
-                                       relative_path=os.path.join(root[sdk_root_length+1:], file))
+        for idl in _IdlsInDirectory(top_directory_name, sdk_root_length+1):
+            yield idl
+
+    # next external roots
+    if external_roots:
+        for root in external_roots:
+            for idl in _IdlsInDirectory(root, len(root) + 1):
+                yield idl
 
 
 @dataclass
@@ -67,21 +79,6 @@ class GlobMatcher:
         return fnmatch.fnmatch(s, self.pattern)
 
 
-def _GeneratorsForRoot(root: str):
-    """Define all generators for the given source root."""
-
-    return [
-        # Jinja-based codegen
-        CodegenBridgePregenerator(root),
-        CodegenJavaJNIPregenerator(root),
-        CodegenJavaClassPregenerator(root),
-        CodegenCppAppPregenerator(root),
-
-        # ZAP codegen
-        ZapApplicationPregenerator(root),
-    ]
-
-
 def FindPregenerationTargets(sdk_root: str, external_roots: Optional[List[str]], filter: TargetFilter, runner):
     """Finds all relevand pre-generation targets in the given
        SDK root.
@@ -90,14 +87,20 @@ def FindPregenerationTargets(sdk_root: str, external_roots: Optional[List[str]],
        on what rules to pregenerate and how.
     """
 
-    generators = _GeneratorsForRoot(sdk_root)
-    if external_roots:
-        for root in external_roots:
-            generators.extend(_GeneratorsForRoot(root))
+    generators = [
+        # Jinja-based codegen
+        CodegenBridgePregenerator(sdk_root),
+        CodegenJavaJNIPregenerator(sdk_root),
+        CodegenJavaClassPregenerator(sdk_root),
+        CodegenCppAppPregenerator(sdk_root),
+
+        # ZAP codegen
+        ZapApplicationPregenerator(sdk_root),
+    ]
 
     path_matchers = [GlobMatcher(pattern) for pattern in filter.path_glob]
 
-    for idl in FindAllIdls(sdk_root):
+    for idl in _FindAllIdls(sdk_root, external_roots):
         if filter.file_type is not None:
             if idl.file_type != filter.file_type:
                 logging.debug(f"Will not process file of type {idl.file_type}: {idl.relative_path}")

--- a/scripts/pregenerate/__init__.py
+++ b/scripts/pregenerate/__init__.py
@@ -30,9 +30,11 @@ def _IdlsInDirectory(top_directory_name: str, truncate_length: int):
           for file in files:
                if file.endswith('.zap'):
                     yield InputIdlFile(file_type=IdlFileType.ZAP,
+                                       full_path=os.path.join(root, file),
                                        relative_path=os.path.join(root[truncate_length:], file))
                if file.endswith('.matter'):
                     yield InputIdlFile(file_type=IdlFileType.MATTER,
+                                       full_path=os.path.join(root, file),
                                        relative_path=os.path.join(root[truncate_length:], file))
 
 

--- a/scripts/pregenerate/__init__.py
+++ b/scripts/pregenerate/__init__.py
@@ -66,6 +66,7 @@ class GlobMatcher:
     def matches(self, s: str):
         return fnmatch.fnmatch(s, self.pattern)
 
+
 def _GeneratorsForRoot(root: str):
     """Define all generators for the given source root."""
 

--- a/scripts/pregenerate/types.py
+++ b/scripts/pregenerate/types.py
@@ -26,6 +26,7 @@ class IdlFileType(Enum):
 class InputIdlFile:
     file_type: IdlFileType
     relative_path: str
+    full_path: str
 
     @property
     def pregen_subdir(self):

--- a/scripts/pregenerate/using_codegen.py
+++ b/scripts/pregenerate/using_codegen.py
@@ -44,14 +44,14 @@ class CodegenTarget:
             output_root, self.idl.pregen_subdir, self.generator)
 
         logging.info(
-            f"Generating: {self.generator}:{self.idl.relative_path} into {output_dir}")
+            f"Generating: {self.generator}:{self.idl.full_path} into {output_dir}")
 
         cmd = [
             CODEGEN_PY_PATH,
             '--log-level', 'fatal',
             '--generator', self.generator,
             '--output-dir', output_dir,
-            os.path.join(self.sdk_root, self.idl.relative_path)
+            self.idl.full_path
         ]
 
         logging.debug(f"Executing {cmd}")

--- a/scripts/pregenerate/using_zap.py
+++ b/scripts/pregenerate/using_zap.py
@@ -56,16 +56,21 @@ class ZapTarget:
 
         output_dir = os.path.join(output_root, self.idl.pregen_subdir, self.generation_type.subdir)
 
-        logging.info(f"Generating: {self.generation_type}:{self.idl.relative_path} into {output_dir}")
+        logging.info(f"Generating: {self.generation_type}:{self.idl.full_path} into {output_dir}")
 
         self.runner.ensure_directory_exists(output_dir)
+
+        if self.idl.full_path.startswith(self.sdk_root):
+            idl_path = self.idl.relative_path
+        else:
+            idl_path = self.idl.full_path
 
         cmd = [
             ZAP_GENERATE_PATH,
             '--templates', self.generation_type.generation_template,
             '--output-dir', output_dir,
             '--parallel',
-            self.idl.relative_path
+            idl_path
         ]
         logging.debug(f"Executing {cmd}")
         self.runner.run(cmd, cwd=self.sdk_root)


### PR DESCRIPTION
This allows passing `external-root` to the script to include codegen outside $CHIP_ROOT.

Updated documentation to describe how to generate `.matter` files and how to use this new option.