### PR TITLE
android/tv-casting-app: Adding ConfigurationManager as AppParameter

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
@@ -11,6 +11,7 @@ import com.chip.casting.DACProviderStub;
 import com.chip.casting.DiscoveredNodeData;
 import com.chip.casting.TvCastingApp;
 import com.chip.casting.util.GlobalCastingConstants;
+import com.chip.casting.util.PreferencesConfigurationManager;
 import java.util.Random;
 
 public class MainActivity extends AppCompatActivity
@@ -81,6 +82,9 @@ public class MainActivity extends AppCompatActivity
     Context applicationContext = this.getApplicationContext();
 
     AppParameters appParameters = new AppParameters();
+    appParameters.setConfigurationManager(
+        new PreferencesConfigurationManager(
+            this.getApplicationContext(), "chip.platform.ConfigurationManager"));
     byte[] rotatingDeviceIdUniqueId =
         new byte[AppParameters.MIN_ROTATING_DEVICE_ID_UNIQUE_ID_LENGTH];
     new Random().nextBytes(rotatingDeviceIdUniqueId);

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/util/PreferencesConfigurationManager.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/util/PreferencesConfigurationManager.java
@@ -1,0 +1,153 @@
+/*
+ *   Copyright (c) 2021-2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.chip.casting.util;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+import chip.platform.AndroidChipPlatformException;
+import chip.platform.ConfigurationManager;
+import chip.platform.KeyValueStoreManager;
+import java.util.Base64;
+import java.util.Map;
+import java.util.UUID;
+
+/** Java interface for ConfigurationManager */
+public class PreferencesConfigurationManager implements ConfigurationManager {
+
+  private final String TAG = KeyValueStoreManager.class.getSimpleName();
+  private SharedPreferences preferences;
+
+  public PreferencesConfigurationManager(Context context, String preferenceFileKey) {
+    preferences = context.getSharedPreferences(preferenceFileKey, Context.MODE_PRIVATE);
+
+    try {
+      String keyUniqueId = getKey(kConfigNamespace_ChipFactory, kConfigKey_UniqueId);
+      if (!preferences.contains(keyUniqueId)) {
+        preferences
+            .edit()
+            .putString(keyUniqueId, UUID.randomUUID().toString().replaceAll("-", ""))
+            .apply();
+      }
+    } catch (AndroidChipPlatformException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public long readConfigValueLong(String namespace, String name)
+      throws AndroidChipPlatformException {
+    String key = getKey(namespace, name);
+    if (preferences.contains(key)) {
+      long value = preferences.getLong(key, Long.MAX_VALUE);
+      return value;
+    } else {
+      Log.d(TAG, "Key '" + key + "' not found in shared preferences");
+      throw new AndroidChipPlatformException();
+    }
+  }
+
+  @Override
+  public String readConfigValueStr(String namespace, String name)
+      throws AndroidChipPlatformException {
+    String key = getKey(namespace, name);
+    if (preferences.contains(key)) {
+      String value = preferences.getString(key, null);
+      return value;
+    } else {
+      Log.d(TAG, "Key '" + key + "' not found in shared preferences");
+      throw new AndroidChipPlatformException();
+    }
+  }
+
+  @Override
+  public byte[] readConfigValueBin(String namespace, String name)
+      throws AndroidChipPlatformException {
+    String key = getKey(namespace, name);
+    if (preferences.contains(key)) {
+      String value = preferences.getString(key, null);
+      byte[] byteValue = Base64.getDecoder().decode(value);
+      return byteValue;
+    } else {
+      Log.d(TAG, "Key '" + key + "' not found in shared preferences");
+      throw new AndroidChipPlatformException();
+    }
+  }
+
+  @Override
+  public void writeConfigValueLong(String namespace, String name, long val)
+      throws AndroidChipPlatformException {
+    String key = getKey(namespace, name);
+    preferences.edit().putLong(key, val).apply();
+  }
+
+  @Override
+  public void writeConfigValueStr(String namespace, String name, String val)
+      throws AndroidChipPlatformException {
+    String key = getKey(namespace, name);
+    preferences.edit().putString(key, val).apply();
+  }
+
+  @Override
+  public void writeConfigValueBin(String namespace, String name, byte[] val)
+      throws AndroidChipPlatformException {
+    String key = getKey(namespace, name);
+    if (val != null) {
+      String valStr = Base64.getEncoder().encodeToString(val);
+      preferences.edit().putString(key, valStr).apply();
+    } else {
+      preferences.edit().remove(key).apply();
+    }
+  }
+
+  @Override
+  public void clearConfigValue(String namespace, String name) throws AndroidChipPlatformException {
+    if (namespace != null && name != null) {
+      preferences.edit().remove(getKey(namespace, name)).apply();
+    } else if (namespace != null && name == null) {
+      String pre = getKey(namespace, null);
+      SharedPreferences.Editor editor = preferences.edit();
+      Map<String, ?> allEntries = preferences.getAll();
+      for (Map.Entry<String, ?> entry : allEntries.entrySet()) {
+        String key = entry.getKey();
+        if (key.startsWith(pre)) {
+          editor.remove(key);
+        }
+      }
+      editor.apply();
+    } else if (namespace == null && name == null) {
+      preferences.edit().clear().apply();
+    }
+  }
+
+  @Override
+  public boolean configValueExists(String namespace, String name)
+      throws AndroidChipPlatformException {
+    return preferences.contains(getKey(namespace, name));
+  }
+
+  private String getKey(String namespace, String name) throws AndroidChipPlatformException {
+    if (namespace != null && name != null) {
+      return namespace + ":" + name;
+    } else if (namespace != null && name == null) {
+      return namespace + ":";
+    }
+
+    throw new AndroidChipPlatformException();
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/AppParameters.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/AppParameters.java
@@ -18,6 +18,7 @@
 package com.chip.casting;
 
 import android.util.Log;
+import chip.platform.ConfigurationManager;
 import java.math.BigInteger;
 import java.util.Arrays;
 
@@ -28,6 +29,7 @@ public class AppParameters {
   private static final int TEST_DISCRIMINATOR = 0xF00;
   private DACProvider TEST_DAC_PROVIDER = new DACProviderStub();
 
+  private ConfigurationManager configurationManager;
   private byte[] rotatingDeviceIdUniqueId;
   private DACProvider dacProvider = TEST_DAC_PROVIDER;
   private String spake2pVerifierBase64;
@@ -35,6 +37,14 @@ public class AppParameters {
   private int spake2pIterationCount;
   private int setupPasscode = TEST_SETUP_PASSCODE;
   private int discriminator = TEST_DISCRIMINATOR;
+
+  public ConfigurationManager getConfigurationManager() {
+    return configurationManager;
+  }
+
+  public void setConfigurationManager(ConfigurationManager configurationManager) {
+    this.configurationManager = configurationManager;
+  }
 
   public void setRotatingDeviceIdUniqueId(byte[] rotatingDeviceIdUniqueId) {
     Log.d(

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -28,7 +28,6 @@ import chip.platform.ChipMdnsCallbackImpl;
 import chip.platform.DiagnosticDataProviderImpl;
 import chip.platform.NsdManagerServiceBrowser;
 import chip.platform.NsdManagerServiceResolver;
-import chip.platform.PreferencesConfigurationManager;
 import chip.platform.PreferencesKeyValueStoreManager;
 import java.util.Arrays;
 import java.util.List;
@@ -62,7 +61,7 @@ public class TvCastingApp {
         new AndroidChipPlatform(
             new AndroidBleManager(),
             new PreferencesKeyValueStoreManager(applicationContext),
-            new PreferencesConfigurationManager(applicationContext),
+            appParameters.getConfigurationManager(),
             nsdManagerServiceResolver,
             new NsdManagerServiceBrowser(applicationContext),
             new ChipMdnsCallbackImpl(),


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/25975

### Change summary
* Introduced an AppParameter that lets the tv-casting-app pass in its implementation of the ConfigurationManager.
* Copied the PreferencesConfigurationManager from https://github.com/project-chip/connectedhomeip/blob/master/src/platform/android/java/chip/platform/PreferencesConfigurationManager.java into the tv-casting-app and plugged that in as reference for the sample app

### Testing
Tested that commissioning works when running an Android tv-casting-app against a Linux tv-app