### PR TITLE
Fix vscode docker image for NDK bump (#25952)

### DIFF
--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=nrf /opt/NordicSemiconductor/nRF5_tools /opt/NordicSemiconductor/nRF
 COPY --from=nrf /opt/NordicSemiconductor/nrfconnect /opt/NordicSemiconductor/nrfconnect
 
 COPY --from=android /opt/android/sdk /opt/android/sdk
-COPY --from=android /opt/android/android-ndk-r21b /opt/android/android-ndk-r21b
+COPY --from=android /opt/android/android-ndk-r23c /opt/android/android-ndk-r23c
 COPY --from=android /usr/lib/kotlinc /usr/lib/kotlinc
 
 COPY --from=mbedos /opt/openocd/ /opt/openocd/
@@ -90,7 +90,7 @@ RUN set -x \
 ENV PATH $PATH:/usr/lib/kotlinc/bin
 ENV AMEBA_PATH=/opt/ameba/ambd_sdk_with_chip_non_NDA
 ENV ANDROID_HOME=/opt/android/sdk
-ENV ANDROID_NDK_HOME=/opt/android/android-ndk-r21b
+ENV ANDROID_NDK_HOME=/opt/android/android-ndk-r23c
 ENV CY_TOOLS_PATHS="/opt/ModusToolbox/tools_2.4"
 ENV SILABS_BOARD=BRD4161A
 ENV IDF_PATH=/opt/espressif/esp-idf/


### PR DESCRIPTION
Fix vscode docker image for NDK bump (#25952)