### PR TITLE
[Silabs] WiFi 917SoC including header file

### DIFF
--- a/examples/platform/silabs/SiWx917/LEDWidget.h
+++ b/examples/platform/silabs/SiWx917/LEDWidget.h
@@ -21,7 +21,7 @@
 
 #include <stdint.h>
 
-extern "C" void RSI_Board_LED_Set(int, bool);
+extern "C" void RSI_Board_LED_Set(int, int);
 extern "C" void RSI_Board_LED_Toggle(int);
 extern "C" bool RSI_Board_LED_GetState(int);
 

--- a/examples/platform/silabs/SiWx917/LEDWidget.h
+++ b/examples/platform/silabs/SiWx917/LEDWidget.h
@@ -20,10 +20,7 @@
 #pragma once
 
 #include <stdint.h>
-
-extern "C" void RSI_Board_LED_Set(int, int);
-extern "C" void RSI_Board_LED_Toggle(int);
-extern "C" bool RSI_Board_LED_GetState(int);
+#include "rsi_board.h"
 
 class LEDWidget
 {

--- a/examples/platform/silabs/SiWx917/LEDWidget.h
+++ b/examples/platform/silabs/SiWx917/LEDWidget.h
@@ -19,8 +19,8 @@
 
 #pragma once
 
-#include <stdint.h>
 #include "rsi_board.h"
+#include <stdint.h>
 
 class LEDWidget
 {

--- a/src/platform/silabs/efr32/BUILD.gn
+++ b/src/platform/silabs/efr32/BUILD.gn
@@ -131,7 +131,7 @@ static_library("efr32") {
       "wifi/wifi_config.h",
     ]
 
-    if (use_wf200 || use_rs9116) {
+    if (use_wf200 || use_rs9116 || use_SiWx917) {
       sources += [
         "wifi/dhcp_client.cpp",
         "wifi/dhcp_client.h",

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -273,7 +273,7 @@ template("efr32_sdk") {
         ]
       }
 
-      if (use_wf200 || use_rs9116) {
+      if (use_wf200 || use_rs9116 || use_SiWx917) {
         import("${chip_root}/src/platform/silabs/efr32/wifi_args.gni")
 
         defines += [ "LWIP_NETIF_API=1" ]


### PR DESCRIPTION
#### An argument change is required for the latest 917 SDK package
> Issue: With the latest 917 wisemcu package, the build is failing because of a declaration conflict.
> The required declaration is already done in rsi_board.h file. So instead of declaring in multiple files (LEDWidget.h), including the header file (rsi_board.h) directly.
#### Added fix for 917NCP build error caused by socket macro cleanup (https://github.com/project-chip/connectedhomeip/pull/25941)
