### PR TITLE
Make Darwin HostNameRegistrar safer to use.

### DIFF
--- a/src/platform/Darwin/DnssdHostNameRegistrar.h
+++ b/src/platform/Darwin/DnssdHostNameRegistrar.h
@@ -36,7 +36,9 @@ namespace Dnssd {
 
     class HostNameRegistrar {
     public:
-        void Init(const char * hostname, Inet::IPAddressType addressType, uint32_t interfaceId);
+        ~HostNameRegistrar();
+
+        DNSServiceErrorType Init(const char * hostname, Inet::IPAddressType addressType, uint32_t interfaceId);
 
         CHIP_ERROR Register();
         void Unregister();
@@ -61,15 +63,24 @@ namespace Dnssd {
         CHIP_ERROR StartSharedConnection();
         void StopSharedConnection();
         CHIP_ERROR ResetSharedConnection();
-        DNSServiceRef mServiceRef;
 
         CHIP_ERROR StartMonitorInterfaces(OnInterfaceChanges interfaceChangesBlock);
         void StopMonitorInterfaces();
-        nw_path_monitor_t mInterfaceMonitor;
+
+        DNSServiceRef mServiceRef = nullptr;
+        nw_path_monitor_t mInterfaceMonitor = nullptr;
 
         std::string mHostname;
-        uint32_t mInterfaceId;
+        // Default to kDNSServiceInterfaceIndexLocalOnly so we don't mess around
+        // with un-registration if we never get Init() called.
+        uint32_t mInterfaceId = kDNSServiceInterfaceIndexLocalOnly;
         Inet::IPAddressType mAddressType;
+
+        // We use mLivenessTracker to indicate to blocks that close over us that
+        // we've been destroyed.  This is needed because we're not a refcounted
+        // object, so the blocks can't keep us alive; they just close over the
+        // raw pointer to "this".
+        std::shared_ptr<bool> mLivenessTracker;
     };
 
 } // namespace Dnssd

--- a/src/platform/Darwin/MdnsError.cpp
+++ b/src/platform/Darwin/MdnsError.cpp
@@ -102,6 +102,8 @@ CHIP_ERROR ToChipError(DNSServiceErrorType errorCode)
         return CHIP_NO_ERROR;
     case kDNSServiceErr_NameConflict:
         return CHIP_ERROR_MDNS_COLLISION;
+    case kDNSServiceErr_NoMemory:
+        return CHIP_ERROR_NO_MEMORY;
     default:
         return CHIP_ERROR_INTERNAL;
     }


### PR DESCRIPTION
There are two main changes here:

1) When we shut down the Matter stack, we should remove all our advertisements adn stop monitoring for network interface changes.  That's what the change to ChipDnssdShutdown does.

2) It's theoretically possible for the block HostNameRegistrar passes to nw_path_monitor_set_update_handler to run after the HostNameRegistrar is destroyed.  Guard against that with a shared_ptr that keeps track of the liveness state of the HostNameRegistrar.

The changes to the member initialization of HostNameRegistrar are just for safety's sake, in case its destructor ever gets called without Init() having been called first.  Right now that is not possible, but better to not rely on that.
