### PR TITLE
tv-casting-app: Decouple setDAC* API from tv-casting initialization

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
@@ -1,15 +1,14 @@
 package com.chip.casting.app;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 import com.chip.casting.AppParameters;
-import com.chip.casting.DACProviderStub;
 import com.chip.casting.DiscoveredNodeData;
 import com.chip.casting.TvCastingApp;
+import com.chip.casting.util.DACProviderStub;
 import com.chip.casting.util.GlobalCastingConstants;
 import com.chip.casting.util.PreferencesConfigurationManager;
 import java.util.Random;
@@ -79,7 +78,7 @@ public class MainActivity extends AppCompatActivity
   private boolean initJni() {
     tvCastingApp = new TvCastingApp();
 
-    Context applicationContext = this.getApplicationContext();
+    tvCastingApp.setDACProvider(new DACProviderStub());
 
     AppParameters appParameters = new AppParameters();
     appParameters.setConfigurationManager(
@@ -89,10 +88,9 @@ public class MainActivity extends AppCompatActivity
         new byte[AppParameters.MIN_ROTATING_DEVICE_ID_UNIQUE_ID_LENGTH];
     new Random().nextBytes(rotatingDeviceIdUniqueId);
     appParameters.setRotatingDeviceIdUniqueId(rotatingDeviceIdUniqueId);
-    appParameters.setDacProvider(new DACProviderStub());
     appParameters.setSetupPasscode(GlobalCastingConstants.SetupPasscode);
     appParameters.setDiscriminator(GlobalCastingConstants.Discriminator);
-    return tvCastingApp.initApp(applicationContext, appParameters);
+    return tvCastingApp.initApp(this.getApplicationContext(), appParameters);
   }
 
   private void showFragment(Fragment fragment, boolean showOnBack) {

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/util/DACProviderStub.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/util/DACProviderStub.java
@@ -1,6 +1,7 @@
-package com.chip.casting;
+package com.chip.casting.util;
 
 import android.util.Base64;
+import com.chip.casting.DACProvider;
 
 public class DACProviderStub implements DACProvider {
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/AppParameters.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/AppParameters.java
@@ -27,11 +27,9 @@ public class AppParameters {
   public static final int MIN_ROTATING_DEVICE_ID_UNIQUE_ID_LENGTH = 16;
   private static final int TEST_SETUP_PASSCODE = 20202021;
   private static final int TEST_DISCRIMINATOR = 0xF00;
-  private DACProvider TEST_DAC_PROVIDER = new DACProviderStub();
 
   private ConfigurationManager configurationManager;
   private byte[] rotatingDeviceIdUniqueId;
-  private DACProvider dacProvider = TEST_DAC_PROVIDER;
   private String spake2pVerifierBase64;
   private String Spake2pSaltBase64;
   private int spake2pIterationCount;
@@ -61,14 +59,6 @@ public class AppParameters {
         "AppParameters.getRotatingDeviceIdUniqueId returning copyOf "
             + new BigInteger(1, rotatingDeviceIdUniqueId).toString(16));
     return Arrays.copyOf(rotatingDeviceIdUniqueId, rotatingDeviceIdUniqueId.length);
-  }
-
-  public DACProvider getDacProvider() {
-    return dacProvider;
-  }
-
-  public void setDacProvider(DACProvider dacProvider) {
-    this.dacProvider = dacProvider;
   }
 
   public String getSpake2pVerifierBase64() {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -94,11 +94,10 @@ public class TvCastingApp {
       return ret;
     }
 
-    setDACProvider(appParameters.getDacProvider());
     return initJni(appParameters);
   }
 
-  private native void setDACProvider(DACProvider provider);
+  public native void setDACProvider(DACProvider provider);
 
   private native boolean preInitJni(AppParameters appParameters);
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -105,11 +105,11 @@ exit:
 
 JNI_METHOD(void, setDACProvider)(JNIEnv *, jobject, jobject provider)
 {
-    if (!chip::Credentials::IsDeviceAttestationCredentialsProviderSet())
-    {
-        JNIDACProvider * p = new JNIDACProvider(provider);
-        chip::Credentials::SetDeviceAttestationCredentialsProvider(p);
-    }
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "JNI_METHOD setDACProvider called");
+
+    JNIDACProvider * p = new JNIDACProvider(provider);
+    chip::Credentials::SetDeviceAttestationCredentialsProvider(p);
 }
 
 JNI_METHOD(jboolean, openBasicCommissioningWindow)

--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -68,7 +68,6 @@ android_library("java") {
     "App/app/src/main/jni/com/chip/casting/ContentApp.java",
     "App/app/src/main/jni/com/chip/casting/ContentLauncherTypes.java",
     "App/app/src/main/jni/com/chip/casting/DACProvider.java",
-    "App/app/src/main/jni/com/chip/casting/DACProviderStub.java",
     "App/app/src/main/jni/com/chip/casting/DiscoveredNodeData.java",
     "App/app/src/main/jni/com/chip/casting/FailureCallback.java",
     "App/app/src/main/jni/com/chip/casting/MatterCallbackHandler.java",

--- a/examples/tv-casting-app/android/README.md
+++ b/examples/tv-casting-app/android/README.md
@@ -9,12 +9,12 @@ the TV.
 
 <hr>
 
-- [Matter TV Casting Android App Example](#matter-tv-casting-android-app-example)
-  - [Requirements for building](#requirements-for-building)
-    - [ABIs and TARGET\_CPU](#abis-and-target_cpu)
-    - [Gradle \& JDK Version](#gradle--jdk-version)
-  - [Preparing for build](#preparing-for-build)
-  - [Building \& Installing the app](#building--installing-the-app)
+-   [Matter TV Casting Android App Example](#matter-tv-casting-android-app-example)
+    -   [Requirements for building](#requirements-for-building)
+        -   [ABIs and TARGET_CPU](#abis-and-target_cpu)
+        -   [Gradle \& JDK Version](#gradle--jdk-version)
+    -   [Preparing for build](#preparing-for-build)
+    -   [Building \& Installing the app](#building--installing-the-app)
 
 <hr>
 

--- a/examples/tv-casting-app/android/README.md
+++ b/examples/tv-casting-app/android/README.md
@@ -9,18 +9,18 @@ the TV.
 
 <hr>
 
--   [Matter TV Casting Android App Example](#matter-tv-casting-android-app-example)
-    -   [Requirements for building](#requirements-for-building)
-        -   [ABIs and TARGET_CPU](#abis-and-target_cpu)
-        -   [Gradle & JDK Version](#gradle--jdk-version)
-    -   [Preparing for build](#preparing-for-build)
-    -   [Building & Installing the app](#building--installing-the-app)
+- [Matter TV Casting Android App Example](#matter-tv-casting-android-app-example)
+  - [Requirements for building](#requirements-for-building)
+    - [ABIs and TARGET\_CPU](#abis-and-target_cpu)
+    - [Gradle \& JDK Version](#gradle--jdk-version)
+  - [Preparing for build](#preparing-for-build)
+  - [Building \& Installing the app](#building--installing-the-app)
 
 <hr>
 
 ## Requirements for building
 
-You need Android SDK 21 & NDK downloaded to your machine. Set the
+You need Android SDK 21 & NDK 23.2.8568313 downloaded to your machine. Set the
 `$ANDROID_HOME` environment variable to where the SDK is downloaded and the
 `$ANDROID_NDK_HOME` environment variable to point to where the NDK package is
 downloaded.

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/AppParameters.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/AppParameters.h
@@ -35,8 +35,6 @@
 
 @property NSData * spake2pVerifierBase64;
 
-@property DeviceAttestationCredentialsHolder * deviceAttestationCredentials;
-
 @end
 
 #endif /* AppParameters_h */

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
@@ -37,6 +37,10 @@
                             clientQueue:(dispatch_queue_t _Nonnull)clientQueue
                    initAppStatusHandler:(nullable void (^)(bool))initAppStatusHandler;
 
+- (void)setDacHolder:(DeviceAttestationCredentialsHolder * _Nonnull)deviceAttestationCredentials
+           clientQueue:(dispatch_queue_t _Nonnull)clientQueue
+    setDacHolderStatus:(void (^_Nonnull)(MatterError * _Nonnull))setDacHolderStatus;
+
 /*!
  @brief Browse for on-network commissioner TVs
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
@@ -196,7 +196,7 @@
 
  @param responseHandler Called when purgeCache completes
  */
-- (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(void (^)(MatterError * _Nonnull))responseHandler;
+- (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(void (^_Nonnull)(MatterError * _Nonnull))responseHandler;
 
 /*!
  @brief Start the Matter server and reconnect to a previously connected Video Player (if any). This API is async

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -240,57 +240,47 @@
            clientQueue:(dispatch_queue_t _Nonnull)clientQueue
     setDacHolderStatus:(void (^_Nonnull)(MatterError * _Nonnull))setDacHolderStatus
 {
-    [self
-        dispatchOnMatterSDKQueue:@"setDacHolder(...)"
-                           block:^{
-                               NSData * certificationDeclarationNsData = deviceAttestationCredentials.getCertificationDeclaration;
-                               chip::MutableByteSpan certificationDeclaration = chip::MutableByteSpan(
-                                   const_cast<uint8_t *>(static_cast<const uint8_t *>(certificationDeclarationNsData.bytes)),
-                                   certificationDeclarationNsData.length);
+    dispatch_sync(_chipWorkQueue, ^{
+        NSData * certificationDeclarationNsData = deviceAttestationCredentials.getCertificationDeclaration;
+        chip::MutableByteSpan certificationDeclaration
+            = chip::MutableByteSpan(const_cast<uint8_t *>(static_cast<const uint8_t *>(certificationDeclarationNsData.bytes)),
+                certificationDeclarationNsData.length);
 
-                               NSData * firmwareInformationNsData = deviceAttestationCredentials.getFirmwareInformation;
-                               chip::MutableByteSpan firmwareInformation = chip::MutableByteSpan(
-                                   const_cast<uint8_t *>(static_cast<const uint8_t *>(firmwareInformationNsData.bytes)),
-                                   firmwareInformationNsData.length);
+        NSData * firmwareInformationNsData = deviceAttestationCredentials.getFirmwareInformation;
+        chip::MutableByteSpan firmwareInformation = chip::MutableByteSpan(
+            const_cast<uint8_t *>(static_cast<const uint8_t *>(firmwareInformationNsData.bytes)), firmwareInformationNsData.length);
 
-                               NSData * deviceAttestationCertNsData = deviceAttestationCredentials.getDeviceAttestationCert;
-                               chip::MutableByteSpan deviceAttestationCert = chip::MutableByteSpan(
-                                   const_cast<uint8_t *>(static_cast<const uint8_t *>(deviceAttestationCertNsData.bytes)),
-                                   deviceAttestationCertNsData.length);
+        NSData * deviceAttestationCertNsData = deviceAttestationCredentials.getDeviceAttestationCert;
+        chip::MutableByteSpan deviceAttestationCert
+            = chip::MutableByteSpan(const_cast<uint8_t *>(static_cast<const uint8_t *>(deviceAttestationCertNsData.bytes)),
+                deviceAttestationCertNsData.length);
 
-                               NSData * productAttestationIntermediateCertNsData
-                                   = deviceAttestationCredentials.getProductAttestationIntermediateCert;
-                               chip::MutableByteSpan productAttestationIntermediateCert = chip::MutableByteSpan(
-                                   const_cast<uint8_t *>(
-                                       static_cast<const uint8_t *>(productAttestationIntermediateCertNsData.bytes)),
-                                   productAttestationIntermediateCertNsData.length);
+        NSData * productAttestationIntermediateCertNsData = deviceAttestationCredentials.getProductAttestationIntermediateCert;
+        chip::MutableByteSpan productAttestationIntermediateCert = chip::MutableByteSpan(
+            const_cast<uint8_t *>(static_cast<const uint8_t *>(productAttestationIntermediateCertNsData.bytes)),
+            productAttestationIntermediateCertNsData.length);
 
-                               NSData * deviceAttestationCertPrivateKeyNsData
-                                   = deviceAttestationCredentials.getDeviceAttestationCertPrivateKey;
-                               chip::MutableByteSpan deviceAttestationCertPrivateKey = chip::MutableByteSpan(
-                                   const_cast<uint8_t *>(static_cast<const uint8_t *>(deviceAttestationCertPrivateKeyNsData.bytes)),
-                                   deviceAttestationCertPrivateKeyNsData.length);
+        NSData * deviceAttestationCertPrivateKeyNsData = deviceAttestationCredentials.getDeviceAttestationCertPrivateKey;
+        chip::MutableByteSpan deviceAttestationCertPrivateKey = chip::MutableByteSpan(
+            const_cast<uint8_t *>(static_cast<const uint8_t *>(deviceAttestationCertPrivateKeyNsData.bytes)),
+            deviceAttestationCertPrivateKeyNsData.length);
 
-                               NSData * deviceAttestationCertPublicKeyKeyNsData
-                                   = deviceAttestationCredentials.getDeviceAttestationCertPublicKey;
-                               chip::MutableByteSpan deviceAttestationCertPublicKeyKey = chip::MutableByteSpan(
-                                   const_cast<uint8_t *>(
-                                       static_cast<const uint8_t *>(deviceAttestationCertPublicKeyKeyNsData.bytes)),
-                                   deviceAttestationCertPublicKeyKeyNsData.length);
+        NSData * deviceAttestationCertPublicKeyKeyNsData = deviceAttestationCredentials.getDeviceAttestationCertPublicKey;
+        chip::MutableByteSpan deviceAttestationCertPublicKeyKey = chip::MutableByteSpan(
+            const_cast<uint8_t *>(static_cast<const uint8_t *>(deviceAttestationCertPublicKeyKeyNsData.bytes)),
+            deviceAttestationCertPublicKeyKeyNsData.length);
 
-                               self->_deviceAttestationCredentialsProvider
-                                   = new DeviceAttestationCredentialsProviderImpl(&certificationDeclaration, &firmwareInformation,
-                                       &deviceAttestationCert, &productAttestationIntermediateCert,
-                                       &deviceAttestationCertPrivateKey, &deviceAttestationCertPublicKeyKey);
+        self->_deviceAttestationCredentialsProvider
+            = new DeviceAttestationCredentialsProviderImpl(&certificationDeclaration, &firmwareInformation, &deviceAttestationCert,
+                &productAttestationIntermediateCert, &deviceAttestationCertPrivateKey, &deviceAttestationCertPublicKeyKey);
 
-                               SetDeviceAttestationCredentialsProvider(self->_deviceAttestationCredentialsProvider);
+        SetDeviceAttestationCredentialsProvider(self->_deviceAttestationCredentialsProvider);
 
-                               dispatch_async(clientQueue, ^{
-                                   setDacHolderStatus(
-                                       [[MatterError alloc] initWithCode:CHIP_NO_ERROR.AsInteger()
-                                                                 message:[NSString stringWithUTF8String:CHIP_NO_ERROR.AsString()]]);
-                               });
-                           }];
+        dispatch_async(clientQueue, ^{
+            setDacHolderStatus([[MatterError alloc] initWithCode:CHIP_NO_ERROR.AsInteger()
+                                                         message:[NSString stringWithUTF8String:CHIP_NO_ERROR.AsString()]]);
+        });
+    });
 }
 
 - (void)discoverCommissioners:(dispatch_queue_t _Nonnull)clientQueue

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -28,7 +28,6 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <lib/support/CHIPListUtils.h>
 #include <lib/support/CHIPMem.h>
 #include <platform/PlatformManager.h>
@@ -129,7 +128,6 @@
 
     CHIP_ERROR err = CHIP_NO_ERROR;
     _commissionableDataProvider = new CommissionableDataProviderImpl();
-    _deviceAttestationCredentialsProvider = chip::Credentials::Examples::GetExampleDACProvider();
 
     _appParameters = appParameters;
     AppParams cppAppParams;
@@ -171,54 +169,12 @@
             ChipLogError(AppServer, "Failed to initialize CommissionableDataProvider: %s", ErrorStr(err));
             return [[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]];
         }
-
-        if (_appParameters.deviceAttestationCredentials != nil) {
-            NSData * certificationDeclarationNsData = _appParameters.deviceAttestationCredentials.getCertificationDeclaration;
-            chip::MutableByteSpan certificationDeclaration
-                = chip::MutableByteSpan(const_cast<uint8_t *>(static_cast<const uint8_t *>(certificationDeclarationNsData.bytes)),
-                    certificationDeclarationNsData.length);
-
-            NSData * firmwareInformationNsData = _appParameters.deviceAttestationCredentials.getFirmwareInformation;
-            chip::MutableByteSpan firmwareInformation
-                = chip::MutableByteSpan(const_cast<uint8_t *>(static_cast<const uint8_t *>(firmwareInformationNsData.bytes)),
-                    firmwareInformationNsData.length);
-
-            NSData * deviceAttestationCertNsData = _appParameters.deviceAttestationCredentials.getDeviceAttestationCert;
-            chip::MutableByteSpan deviceAttestationCert
-                = chip::MutableByteSpan(const_cast<uint8_t *>(static_cast<const uint8_t *>(deviceAttestationCertNsData.bytes)),
-                    deviceAttestationCertNsData.length);
-
-            NSData * productAttestationIntermediateCertNsData
-                = _appParameters.deviceAttestationCredentials.getProductAttestationIntermediateCert;
-            chip::MutableByteSpan productAttestationIntermediateCert = chip::MutableByteSpan(
-                const_cast<uint8_t *>(static_cast<const uint8_t *>(productAttestationIntermediateCertNsData.bytes)),
-                productAttestationIntermediateCertNsData.length);
-
-            NSData * deviceAttestationCertPrivateKeyNsData
-                = _appParameters.deviceAttestationCredentials.getDeviceAttestationCertPrivateKey;
-            chip::MutableByteSpan deviceAttestationCertPrivateKey = chip::MutableByteSpan(
-                const_cast<uint8_t *>(static_cast<const uint8_t *>(deviceAttestationCertPrivateKeyNsData.bytes)),
-                deviceAttestationCertPrivateKeyNsData.length);
-
-            NSData * deviceAttestationCertPublicKeyKeyNsData
-                = _appParameters.deviceAttestationCredentials.getDeviceAttestationCertPublicKeyKey;
-            chip::MutableByteSpan deviceAttestationCertPublicKeyKey = chip::MutableByteSpan(
-                const_cast<uint8_t *>(static_cast<const uint8_t *>(deviceAttestationCertPublicKeyKeyNsData.bytes)),
-                deviceAttestationCertPublicKeyKeyNsData.length);
-
-            _deviceAttestationCredentialsProvider = new DeviceAttestationCredentialsProviderImpl(&certificationDeclaration,
-                &firmwareInformation, &deviceAttestationCert, &productAttestationIntermediateCert, &deviceAttestationCertPrivateKey,
-                &deviceAttestationCertPublicKeyKey);
-        }
     }
     chip::DeviceLayer::SetCommissionableDataProvider(_commissionableDataProvider);
 
     _commissionableDataProvider->GetSetupPasscode(setupPasscode);
     _commissionableDataProvider->GetSetupDiscriminator(setupDiscriminator);
     _onboardingPayload = [[OnboardingPayload alloc] initWithSetupPasscode:setupPasscode setupDiscriminator:setupDiscriminator];
-
-    // Initialize device attestation config
-    SetDeviceAttestationCredentialsProvider(_deviceAttestationCredentialsProvider);
 
     // Initialize device attestation verifier from a constant version
     {
@@ -278,6 +234,63 @@
 
     return [[MatterError alloc] initWithCode:CHIP_NO_ERROR.AsInteger()
                                      message:[NSString stringWithUTF8String:CHIP_NO_ERROR.AsString()]];
+}
+
+- (void)setDacHolder:(DeviceAttestationCredentialsHolder * _Nonnull)deviceAttestationCredentials
+           clientQueue:(dispatch_queue_t _Nonnull)clientQueue
+    setDacHolderStatus:(void (^_Nonnull)(MatterError * _Nonnull))setDacHolderStatus
+{
+    [self
+        dispatchOnMatterSDKQueue:@"setDacHolder(...)"
+                           block:^{
+                               NSData * certificationDeclarationNsData = deviceAttestationCredentials.getCertificationDeclaration;
+                               chip::MutableByteSpan certificationDeclaration = chip::MutableByteSpan(
+                                   const_cast<uint8_t *>(static_cast<const uint8_t *>(certificationDeclarationNsData.bytes)),
+                                   certificationDeclarationNsData.length);
+
+                               NSData * firmwareInformationNsData = deviceAttestationCredentials.getFirmwareInformation;
+                               chip::MutableByteSpan firmwareInformation = chip::MutableByteSpan(
+                                   const_cast<uint8_t *>(static_cast<const uint8_t *>(firmwareInformationNsData.bytes)),
+                                   firmwareInformationNsData.length);
+
+                               NSData * deviceAttestationCertNsData = deviceAttestationCredentials.getDeviceAttestationCert;
+                               chip::MutableByteSpan deviceAttestationCert = chip::MutableByteSpan(
+                                   const_cast<uint8_t *>(static_cast<const uint8_t *>(deviceAttestationCertNsData.bytes)),
+                                   deviceAttestationCertNsData.length);
+
+                               NSData * productAttestationIntermediateCertNsData
+                                   = deviceAttestationCredentials.getProductAttestationIntermediateCert;
+                               chip::MutableByteSpan productAttestationIntermediateCert = chip::MutableByteSpan(
+                                   const_cast<uint8_t *>(
+                                       static_cast<const uint8_t *>(productAttestationIntermediateCertNsData.bytes)),
+                                   productAttestationIntermediateCertNsData.length);
+
+                               NSData * deviceAttestationCertPrivateKeyNsData
+                                   = deviceAttestationCredentials.getDeviceAttestationCertPrivateKey;
+                               chip::MutableByteSpan deviceAttestationCertPrivateKey = chip::MutableByteSpan(
+                                   const_cast<uint8_t *>(static_cast<const uint8_t *>(deviceAttestationCertPrivateKeyNsData.bytes)),
+                                   deviceAttestationCertPrivateKeyNsData.length);
+
+                               NSData * deviceAttestationCertPublicKeyKeyNsData
+                                   = deviceAttestationCredentials.getDeviceAttestationCertPublicKey;
+                               chip::MutableByteSpan deviceAttestationCertPublicKeyKey = chip::MutableByteSpan(
+                                   const_cast<uint8_t *>(
+                                       static_cast<const uint8_t *>(deviceAttestationCertPublicKeyKeyNsData.bytes)),
+                                   deviceAttestationCertPublicKeyKeyNsData.length);
+
+                               self->_deviceAttestationCredentialsProvider
+                                   = new DeviceAttestationCredentialsProviderImpl(&certificationDeclaration, &firmwareInformation,
+                                       &deviceAttestationCert, &productAttestationIntermediateCert,
+                                       &deviceAttestationCertPrivateKey, &deviceAttestationCertPublicKeyKey);
+
+                               SetDeviceAttestationCredentialsProvider(self->_deviceAttestationCredentialsProvider);
+
+                               dispatch_async(clientQueue, ^{
+                                   setDacHolderStatus(
+                                       [[MatterError alloc] initWithCode:CHIP_NO_ERROR.AsInteger()
+                                                                 message:[NSString stringWithUTF8String:CHIP_NO_ERROR.AsString()]]);
+                               });
+                           }];
 }
 
 - (void)discoverCommissioners:(dispatch_queue_t _Nonnull)clientQueue

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/DeviceAttestationCredentialsHolder.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/DeviceAttestationCredentialsHolder.h
@@ -40,7 +40,7 @@
 
 - (NSData * _Nonnull)getDeviceAttestationCertPrivateKey;
 
-- (NSData * _Nonnull)getDeviceAttestationCertPublicKeyKey;
+- (NSData * _Nonnull)getDeviceAttestationCertPublicKey;
 
 @end
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/DeviceAttestationCredentialsHolder.m
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/DeviceAttestationCredentialsHolder.m
@@ -31,19 +31,19 @@
 
 @property NSData * deviceAttestationCertPrivateKey;
 
-@property NSData * deviceAttestationCertPublicKeyKey;
+@property NSData * deviceAttestationCertPublicKey;
 
 @end
 
 @implementation DeviceAttestationCredentialsHolder
 
-- (DeviceAttestationCredentialsHolder * _Nonnull)
-      initWithCertificationDeclaration:(NSData * _Nonnull)certificationDeclaration
-                   firmwareInformation:(NSData * _Nonnull)firmwareInformation
-                 deviceAttestationCert:(NSData * _Nonnull)deviceAttestationCert
-    productAttestationIntermediateCert:(NSData * _Nonnull)productAttestationIntermediateCert
-       deviceAttestationCertPrivateKey:(NSData * _Nonnull)deviceAttestationCertPrivateKey
-     deviceAttestationCertPublicKeyKey:(NSData * _Nonnull)deviceAttestationCertPublicKeyKey
+- (DeviceAttestationCredentialsHolder * _Nonnull)initWithCertificationDeclaration:(NSData * _Nonnull)certificationDeclaration
+                                                              firmwareInformation:(NSData * _Nonnull)firmwareInformation
+                                                            deviceAttestationCert:(NSData * _Nonnull)deviceAttestationCert
+                                               productAttestationIntermediateCert:
+                                                   (NSData * _Nonnull)productAttestationIntermediateCert
+                                                  deviceAttestationCertPrivateKey:(NSData * _Nonnull)deviceAttestationCertPrivateKey
+                                                deviceAttestationCertPublicKeyKey:(NSData * _Nonnull)deviceAttestationCertPublicKey
 {
     self = [super init];
     if (self) {
@@ -52,7 +52,7 @@
         _deviceAttestationCert = deviceAttestationCert;
         _productAttestationIntermediateCert = productAttestationIntermediateCert;
         _deviceAttestationCertPrivateKey = deviceAttestationCertPrivateKey;
-        _deviceAttestationCertPublicKeyKey = deviceAttestationCertPublicKeyKey;
+        _deviceAttestationCertPublicKey = deviceAttestationCertPublicKey;
     }
     return self;
 }
@@ -82,8 +82,8 @@
     return _deviceAttestationCertPrivateKey;
 }
 
-- (NSData * _Nonnull)getDeviceAttestationCertPublicKeyKey;
+- (NSData * _Nonnull)getDeviceAttestationCertPublicKey;
 {
-    return _deviceAttestationCertPublicKeyKey;
+    return _deviceAttestationCertPublicKey;
 }
 @end

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		3CA1CA7A28E281080023ED44 /* ClusterSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA1CA7928E281080023ED44 /* ClusterSelectorView.swift */; };
 		3CA1CA7C28E282150023ED44 /* MediaPlaybackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA1CA7B28E282150023ED44 /* MediaPlaybackView.swift */; };
 		3CA1CA7E28E284950023ED44 /* MediaPlaybackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA1CA7D28E284950023ED44 /* MediaPlaybackViewModel.swift */; };
+		3CAC955B29BA948700BEA5C3 /* ExampleDAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CAC955A29BA948700BEA5C3 /* ExampleDAC.swift */; };
 		3CC0E8FA2841DD3400EC6A18 /* TvCastingApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC0E8F92841DD3400EC6A18 /* TvCastingApp.swift */; };
 		3CC0E8FC2841DD3400EC6A18 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC0E8FB2841DD3400EC6A18 /* ContentView.swift */; };
 		3CC0E8FE2841DD3500EC6A18 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3CC0E8FD2841DD3500EC6A18 /* Assets.xcassets */; };
@@ -59,6 +60,7 @@
 		3CA1CA7928E281080023ED44 /* ClusterSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClusterSelectorView.swift; sourceTree = "<group>"; };
 		3CA1CA7B28E282150023ED44 /* MediaPlaybackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlaybackView.swift; sourceTree = "<group>"; };
 		3CA1CA7D28E284950023ED44 /* MediaPlaybackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlaybackViewModel.swift; sourceTree = "<group>"; };
+		3CAC955A29BA948700BEA5C3 /* ExampleDAC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleDAC.swift; sourceTree = "<group>"; };
 		3CC0E8F62841DD3400EC6A18 /* TvCasting.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TvCasting.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CC0E8F92841DD3400EC6A18 /* TvCastingApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TvCastingApp.swift; sourceTree = "<group>"; };
 		3CC0E8FB2841DD3400EC6A18 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 				3C7507B62853A3AD00D7DB3A /* CommissionerDiscoveryViewModel.swift */,
 				3C7507AE28529A5F00D7DB3A /* CommissioningView.swift */,
 				3C7507B82853EFF000D7DB3A /* CommissioningViewModel.swift */,
+				3CAC955A29BA948700BEA5C3 /* ExampleDAC.swift */,
 				3CA1CA7928E281080023ED44 /* ClusterSelectorView.swift */,
 				3CA19434285BA780004768D5 /* ContentLauncherView.swift */,
 				3CA19436285BA877004768D5 /* ContentLauncherViewModel.swift */,
@@ -235,6 +238,7 @@
 				EAF14299296D561900E17793 /* CertTestView.swift in Sources */,
 				3CCB8747286A5D0F00771BAD /* CommissioningView.swift in Sources */,
 				3CCB8748286A5D0F00771BAD /* CommissioningViewModel.swift in Sources */,
+				3CAC955B29BA948700BEA5C3 /* ExampleDAC.swift in Sources */,
 				3CA1CA7E28E284950023ED44 /* MediaPlaybackViewModel.swift in Sources */,
 				3CCB8749286A5D0F00771BAD /* ContentLauncherView.swift in Sources */,
 				3CCB874A286A5D0F00771BAD /* ContentLauncherViewModel.swift in Sources */,

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/ExampleDAC.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/ExampleDAC.swift
@@ -1,0 +1,53 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+
+import Foundation
+import os.log
+
+class ExampleDAC : DeviceAttestationCredentialsHolder {
+    let kDevelopmentDAC_Cert_FFF1_8001: Data = Data(base64Encoded: "MIIB5zCCAY6gAwIBAgIIac3xDenlTtEwCgYIKoZIzj0EAwIwPTElMCMGA1UEAwwcTWF0dGVyIERldiBQQUkgMHhGRkYxIG5vIFBJRDEUMBIGCisGAQQBgqJ8AgEMBEZGRjEwIBcNMjIwMjA1MDAwMDAwWhgPOTk5OTEyMzEyMzU5NTlaMFMxJTAjBgNVBAMMHE1hdHRlciBEZXYgREFDIDB4RkZGMS8weDgwMDExFDASBgorBgEEAYKifAIBDARGRkYxMRQwEgYKKwYBBAGConwCAgwEODAwMTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABEY6xpNCkQoOVYj8b/Vrtj5i7M7LFI99TrA+5VJgFBV2fRalxmP3k+SRIyYLgpenzX58/HsxaznZjpDSk3dzjoKjYDBeMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMB0GA1UdDgQWBBSI3eezADgpMs/3NMBGJIEPRBaKbzAfBgNVHSMEGDAWgBRjVA5H9kscONE4hKRi0WwZXY/7PDAKBggqhkjOPQQDAgNHADBEAiABJ6J7S0RhDuL83E0reIVWNmC8D3bxchntagjfsrPBzQIga1ngr0Xz6yqFuRnTVzFSjGAoxBUjlUXhCOTlTnCXE1M=")!;
+    let kDevelopmentDAC_PrivateKey_FFF1_8001: Data = Data(base64Encoded: "qrYAroroqrfXNifCF7fCBHCcppRq9fL3UwgzpStE+/8=")!;
+    let kDevelopmentDAC_PublicKey_FFF1_8001: Data = Data(base64Encoded: "BEY6xpNCkQoOVYj8b/Vrtj5i7M7LFI99TrA+5VJgFBV2fRalxmP3k+SRIyYLgpenzX58/HsxaznZjpDSk3dzjoI=")!;
+    let KPAI_FFF1_8000_Cert_Array: Data = Data(base64Encoded: "MIIByzCCAXGgAwIBAgIIVq2CIq2UW2QwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMjAyMDUwMDAwMDBaGA85OTk5MTIzMTIzNTk1OVowPTElMCMGA1UEAwwcTWF0dGVyIERldiBQQUkgMHhGRkYxIG5vIFBJRDEUMBIGCisGAQQBgqJ8AgEMBEZGRjEwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARBmpMVwhc+DIyHbQPM/JRIUmR/f+xeUIL0BZko7KiUxZQVEwmsYx5MsDOSr2hLC6+35ls7gWLC9Sv5MbjneqqCo2YwZDASBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUY1QOR/ZLHDjROISkYtFsGV2P+zwwHwYDVR0jBBgwFoAUav0idx9RH+y/FkGXZxDc3DGhcX4wCgYIKoZIzj0EAwIDSAAwRQIhALLvJ/Sa6bUPuR7qyUxNC9u415KcbLiPrOUpNo0SBUwMAiBlXckrhr2QmIKmxiF3uCXX0F7b58Ivn+pxIg5+pwP4kQ==")!;
+    let kCertificationDeclaration: Data = Data(base64Encoded: "MIICGQYJKoZIhvcNAQcCoIICCjCCAgYCAQMxDTALBglghkgBZQMEAgEwggFxBgkqhkiG9w0BBwGgggFiBIIBXhUkAAElAfH/NgIFAIAFAYAFAoAFA4AFBIAFBYAFBoAFB4AFCIAFCYAFCoAFC4AFDIAFDYAFDoAFD4AFEIAFEYAFEoAFE4AFFIAFFYAFFoAFF4AFGIAFGYAFGoAFG4AFHIAFHYAFHoAFH4AFIIAFIYAFIoAFI4AFJIAFJYAFJoAFJ4AFKIAFKYAFKoAFK4AFLIAFLYAFLoAFL4AFMIAFMYAFMoAFM4AFNIAFNYAFNoAFN4AFOIAFOYAFOoAFO4AFPIAFPYAFPoAFP4AFQIAFQYAFQoAFQ4AFRIAFRYAFRoAFR4AFSIAFSYAFSoAFS4AFTIAFTYAFToAFT4AFUIAFUYAFUoAFU4AFVIAFVYAFVoAFV4AFWIAFWYAFWoAFW4AFXIAFXYAFXoAFX4AFYIAFYYAFYoAFY4AYJAMWLAQTWklHMjAxNDJaQjMzMDAwMy0yNCQFACQGACUHlCYkCAAYMX0wewIBA4AUYvqCM1ms+qmWPhz6FArd9QTzcWAwCwYJYIZIAWUDBAIBMAoGCCqGSM49BAMCBEcwRQIgJOXR9Hp9ew0gaibvaZt8l1e3LUaQid4xkuZ4x0Xn9gwCIQD4qi+nEfy3m5fjl87aZnuuRk4r0//fw8zteqjKX0wafA==")!;
+
+
+    override func getCertificationDeclaration() -> Data {
+        return kCertificationDeclaration
+    }
+
+    override func getFirmwareInformation() -> Data {
+        return Data()
+    }
+
+    override func getDeviceAttestationCert() -> Data {
+        return kDevelopmentDAC_Cert_FFF1_8001
+    }
+
+    override func getProductAttestationIntermediateCert() -> Data {
+        return KPAI_FFF1_8000_Cert_Array
+    }
+
+    override func getDeviceAttestationCertPrivateKey() -> Data {
+        return kDevelopmentDAC_PrivateKey_FFF1_8001
+    }
+
+    override func getDeviceAttestationCertPublicKey() -> Data {
+        return kDevelopmentDAC_PublicKey_FFF1_8001
+    }
+}

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/ExampleDAC.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/ExampleDAC.swift
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020-2022 Project CHIP Authors
+ *    Copyright (c) 2020-2023 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/examples/tv-casting-app/darwin/args.gni
+++ b/examples/tv-casting-app/darwin/args.gni
@@ -26,6 +26,9 @@ chip_project_config_include_dirs += [ "${chip_root}/config/ios" ]
 
 chip_build_libshell = true
 
+# Example Credentials like ExampleDAC.h/cpp are not required for the tv-casting-app
+chip_build_example_creds = false
+
 chip_enable_additional_data_advertising = true
 
 chip_enable_rotating_device_id = true


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/25989
 
### Change summary
So far, the DAC Provider/Holder had to be set in the calls to init the tv-casting libraries on Android/iOS. This change decouples setting the DAC Provider/Holder so that it can be set lazily by a client app.

### Testing
Built and Tested the Android/iOS tv-casting-app with the Linux tv-app

