### PR TITLE
Allowing for CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES to be set in build args

### DIFF
--- a/examples/tv-casting-app/android/args.gni
+++ b/examples/tv-casting-app/android/args.gni
@@ -31,3 +31,5 @@ chip_enable_additional_data_advertising = true
 chip_enable_rotating_device_id = true
 
 chip_config_network_layer_ble = false
+
+chip_max_discovered_ip_addresses = 20

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/ConversionUtils.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/ConversionUtils.mm
@@ -137,7 +137,7 @@
     }
     for (size_t i = 0; i < cppDiscoveredNodedata->resolutionData.numIPs; i++) {
         char addrCString[chip::Inet::IPAddress::kMaxStringLength];
-        cppDiscoveredNodedata->resolutionData.ipAddress->ToString(addrCString, chip::Inet::IPAddress::kMaxStringLength);
+        cppDiscoveredNodedata->resolutionData.ipAddress[i].ToString(addrCString, chip::Inet::IPAddress::kMaxStringLength);
         objCDiscoveredNodeData.ipAddresses[i] = [NSString stringWithCString:addrCString encoding:NSASCIIStringEncoding];
     }
     return objCDiscoveredNodeData;

--- a/examples/tv-casting-app/darwin/args.gni
+++ b/examples/tv-casting-app/darwin/args.gni
@@ -31,3 +31,5 @@ chip_enable_additional_data_advertising = true
 chip_enable_rotating_device_id = true
 
 chip_config_network_layer_ble = false
+
+chip_max_discovered_ip_addresses = 20

--- a/examples/tv-casting-app/linux/args.gni
+++ b/examples/tv-casting-app/linux/args.gni
@@ -29,3 +29,5 @@ chip_build_libshell = true
 chip_enable_additional_data_advertising = true
 
 chip_enable_rotating_device_id = true
+
+chip_max_discovered_ip_addresses = 20

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -38,8 +38,7 @@ namespace Dnssd {
 /// Node resolution data common to both operational and commissionable discovery
 struct CommonResolutionData
 {
-    // TODO: is this count OK? Sufficient space for IPv6 LL, GUA, ULA (and maybe IPv4 if enabled)
-    static constexpr unsigned kMaxIPAddresses = 5;
+    static constexpr unsigned kMaxIPAddresses = CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES;
 
     Inet::InterfaceId interfaceId;
 

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -65,6 +65,9 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
 
     # The string of device software version was built.
     chip_device_config_device_software_version_string = ""
+
+    # Define the default number of ip addresses to discover
+    chip_max_discovered_ip_addresses = 5
   }
 
   if (chip_stack_lock_tracking == "auto") {
@@ -291,6 +294,8 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     if (chip_device_config_device_software_version_string != "") {
       defines += [ "CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING=\"${chip_device_config_device_software_version_string}\"" ]
     }
+
+    defines += [ "CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES=${chip_max_discovered_ip_addresses}" ]
   }
 } else if (chip_device_platform == "none") {
   buildconfig_header("platform_buildconfig") {


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/25993

### Change summary
The CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES should be configurable per app, add a configuration that allows for this to be specified.

### Testing
Tested by verifying the ninja file was filled in with the right arguments when building both chip tool as well as the tv-casting-app