### PR TITLE
Make Group Id follow the SPEC

### DIFF
--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -75,7 +75,7 @@ static bool KeyExists(FabricIndex fabricIndex, GroupId groupId)
 
 static Status GroupAdd(FabricIndex fabricIndex, EndpointId endpointId, GroupId groupId, const CharSpan & groupName)
 {
-    VerifyOrReturnError(IsFabricGroupId(groupId), Status::ConstraintError);
+    VerifyOrReturnError(IsValidGroupId(groupId), Status::ConstraintError);
 
     GroupDataProvider * provider = GetGroupDataProvider();
     VerifyOrReturnError(nullptr != provider, Status::NotFound);
@@ -99,7 +99,7 @@ static Status GroupAdd(FabricIndex fabricIndex, EndpointId endpointId, GroupId g
 
 static EmberAfStatus GroupRemove(FabricIndex fabricIndex, EndpointId endpointId, GroupId groupId)
 {
-    VerifyOrReturnError(IsFabricGroupId(groupId), EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+    VerifyOrReturnError(IsValidGroupId(groupId), EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     VerifyOrReturnError(GroupExists(fabricIndex, endpointId, groupId), EMBER_ZCL_STATUS_NOT_FOUND);
 
     GroupDataProvider * provider = GetGroupDataProvider();
@@ -159,7 +159,7 @@ bool emberAfGroupsClusterViewGroupCallback(app::CommandHandler * commandObj, con
     CHIP_ERROR err       = CHIP_NO_ERROR;
     EmberAfStatus status = EMBER_ZCL_STATUS_NOT_FOUND;
 
-    VerifyOrExit(IsFabricGroupId(groupId), status = EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+    VerifyOrExit(IsValidGroupId(groupId), status = EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     VerifyOrExit(nullptr != provider, status = EMBER_ZCL_STATUS_FAILURE);
     VerifyOrExit(provider->HasEndpoint(fabricIndex, groupId, commandPath.mEndpointId), status = EMBER_ZCL_STATUS_NOT_FOUND);
 

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -78,9 +78,9 @@ constexpr ByteSpan kCompressedFabricId1(kCompressedFabricIdBuffer1);
 static const uint8_t kCompressedFabricIdBuffer2[] = { 0x3f, 0xaa, 0xe2, 0x90, 0x93, 0xd5, 0xaf, 0x45 };
 constexpr ByteSpan kCompressedFabricId2(kCompressedFabricIdBuffer2);
 
-constexpr chip::GroupId kGroup1 = kMinFabricGroupId;
+constexpr chip::GroupId kGroup1 = kMinApplicationGroupId;
 constexpr chip::GroupId kGroup2 = 0x2222;
-constexpr chip::GroupId kGroup3 = kMaxFabricGroupId;
+constexpr chip::GroupId kGroup3 = kMaxApplicationGroupId;
 constexpr chip::GroupId kGroup4 = 0x4444;
 constexpr chip::GroupId kGroup5 = 0x5555;
 

--- a/src/lib/core/GroupId.h
+++ b/src/lib/core/GroupId.h
@@ -25,17 +25,17 @@ using GroupId = uint16_t;
 
 constexpr GroupId kUndefinedGroupId = 0;
 
-constexpr GroupId kMinUniversalGroupId = 0x8000;
+constexpr GroupId kMinUniversalGroupId = 0xFF00;
 constexpr GroupId kMaxUniversalGroupId = 0xFFFF;
 
-constexpr GroupId kMinFabricGroupId = 0x0001;
-constexpr GroupId kMaxFabricGroupId = 0x7FFF;
+constexpr GroupId kMinApplicationGroupId = 0x0001;
+constexpr GroupId kMaxApplicationGroupId = 0xFEFF;
 
 constexpr GroupId kAllNodes     = 0xFFFF;
 constexpr GroupId kAllNonSleepy = 0xFFFE;
 constexpr GroupId kAllProxies   = 0xFFFD;
 
-constexpr GroupId kMinUniversalGroupIdReserved = 0x8000;
+constexpr GroupId kMinUniversalGroupIdReserved = 0xFF00;
 constexpr GroupId kMaxUniversalGroupIdReserved = 0xFFFC;
 
 constexpr bool IsOperationalGroupId(GroupId aGroupId)
@@ -44,9 +44,9 @@ constexpr bool IsOperationalGroupId(GroupId aGroupId)
         ((aGroupId < kMinUniversalGroupIdReserved) || (aGroupId > kMaxUniversalGroupIdReserved));
 }
 
-constexpr bool IsFabricGroupId(GroupId aGroupId)
+constexpr bool IsApplicationGroupId(GroupId aGroupId)
 {
-    return (aGroupId >= kMinFabricGroupId) && (aGroupId <= kMaxFabricGroupId);
+    return (aGroupId >= kMinApplicationGroupId) && (aGroupId <= kMaxApplicationGroupId);
 }
 
 constexpr bool IsUniversalGroupId(GroupId aGroupId)


### PR DESCRIPTION
Change `FabricGroupID` to `ApplicationGroupID` and change the range of `UniversalGroupID` and `ApplicationGroupID` according to the SPEC.

