### PR TITLE
[Ameba] fix ota init bug

### DIFF
--- a/examples/all-clusters-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/ameba/main/DeviceCallbacks.cpp
@@ -142,8 +142,9 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
         chip::app::DnssdServer::Instance().StartServer();
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
         // Init OTA requestor only when we have gotten IPv6 address
-        if (OTAInitializer::Instance().CheckInit())
+        if (!OTAInitializer::Instance().CheckInit())
         {
+            ChipLogProgress(DeviceLayer, "Initializing OTA");
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);
         }

--- a/examples/light-switch-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/light-switch-app/ameba/main/DeviceCallbacks.cpp
@@ -142,8 +142,9 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
         chip::app::DnssdServer::Instance().StartServer();
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
         // Init OTA requestor only when we have gotten IPv6 address
-        if (OTAInitializer::Instance().CheckInit())
+        if (!OTAInitializer::Instance().CheckInit())
         {
+            ChipLogProgress(DeviceLayer, "Initializing OTA");
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);
         }

--- a/examples/lighting-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/lighting-app/ameba/main/DeviceCallbacks.cpp
@@ -122,8 +122,9 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
         chip::app::DnssdServer::Instance().StartServer();
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
         // Init OTA requestor only when we have gotten IPv6 address
-        if (OTAInitializer::Instance().CheckInit())
+        if (!OTAInitializer::Instance().CheckInit())
         {
+            ChipLogProgress(DeviceLayer, "Initializing OTA");
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);
         }

--- a/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
@@ -142,8 +142,9 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
         chip::app::DnssdServer::Instance().StartServer();
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
         // Init OTA requestor only when we have gotten IPv6 address
-        if (OTAInitializer::Instance().CheckInit())
+        if (!OTAInitializer::Instance().CheckInit())
         {
+            ChipLogProgress(DeviceLayer, "Initializing OTA");
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);
         }


### PR DESCRIPTION
- Bug, ota should initialized if `CheckInit()` return false
