### PR TITLE
[darwin-framework-tool] heap-use-after-free when calling chip::app::D…

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -343,6 +343,30 @@ void DnssdServer::StartServer()
     return StartServer(mode);
 }
 
+void DnssdServer::StopServer()
+{
+    DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventWrapper, 0);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
+    if (mExtendedDiscoveryExpiration != kTimeoutCleared)
+    {
+        DeviceLayer::SystemLayer().CancelTimer(HandleExtendedDiscoveryExpiration, nullptr);
+        mExtendedDiscoveryExpiration = kTimeoutCleared;
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
+
+    if (Dnssd::ServiceAdvertiser::Instance().IsInitialized())
+    {
+        auto err = Dnssd::ServiceAdvertiser::Instance().RemoveServices();
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Discovery, "Failed to remove advertised services: %" CHIP_ERROR_FORMAT, err.Format());
+        }
+
+        Dnssd::ServiceAdvertiser::Instance().Shutdown();
+    }
+}
+
 void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
 {
     ChipLogProgress(Discovery, "Updating services using commissioning mode %d", static_cast<int>(mode));

--- a/src/app/server/Dnssd.h
+++ b/src/app/server/Dnssd.h
@@ -94,6 +94,9 @@ public:
     /// (Re-)starts the Dnssd server, using the provided commissioning mode.
     void StartServer(Dnssd::CommissioningMode mode);
 
+    //// Stop the Dnssd server.
+    void StopServer();
+
     CHIP_ERROR GenerateRotatingDeviceId(char rotatingDeviceIdHexBuffer[], size_t rotatingDeviceIdHexBufferSize);
 
     /// Generates the (random) instance name that a CHIP device is to use for pre-commissioning DNS-SD

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -340,6 +340,21 @@ CHIP_ERROR DeviceControllerFactory::ServiceEvents()
     return CHIP_NO_ERROR;
 }
 
+void DeviceControllerFactory::RetainSystemState()
+{
+    (void) mSystemState->Retain();
+}
+
+void DeviceControllerFactory::ReleaseSystemState()
+{
+    mSystemState->Release();
+
+    if (!mSystemState->IsInitialized() && mEnableServerInteractions)
+    {
+        app::DnssdServer::Instance().StopServer();
+    }
+}
+
 DeviceControllerFactory::~DeviceControllerFactory()
 {
     Shutdown();

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -174,7 +174,7 @@ public:
     // created to permit retention of the underlying system state.
     //
     // NB: The system state will still be freed in Shutdown() regardless of this call.
-    void RetainSystemState() { (void) mSystemState->Retain(); }
+    void RetainSystemState();
 
     //
     // To initiate shutdown of the stack upon termination of all resident controllers in the
@@ -183,7 +183,7 @@ public:
     //
     // This should only be invoked if a matching call to RetainSystemState() was called prior.
     //
-    void ReleaseSystemState() { mSystemState->Release(); }
+    void ReleaseSystemState();
 
     //
     // Retrieve a read-only pointer to the system state object that contains pointers to key stack

--- a/src/lib/dnssd/Advertiser.h
+++ b/src/lib/dnssd/Advertiser.h
@@ -300,6 +300,13 @@ public:
     virtual CHIP_ERROR Init(chip::Inet::EndPointManager<chip::Inet::UDPEndPoint> * udpEndPointManager) = 0;
 
     /**
+     * Returns whether the advertiser has completed the initialization.
+     *
+     * Returns true if the advertiser is ready to advertise services.
+     */
+    virtual bool IsInitialized() = 0;
+
+    /**
      * Shuts down the advertiser.
      */
     virtual void Shutdown() = 0;

--- a/src/lib/dnssd/Advertiser_ImplNone.cpp
+++ b/src/lib/dnssd/Advertiser_ImplNone.cpp
@@ -32,6 +32,8 @@ public:
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
+    bool IsInitialized() override { return false; }
+
     void Shutdown() override {}
 
     CHIP_ERROR RemoveServices() override

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -486,8 +486,6 @@ CHIP_ERROR DiscoveryImplPlatform::PublishService(const char * serviceType, TextE
                                                  Inet::InterfaceId interfaceId, const chip::ByteSpan & mac,
                                                  DnssdServiceProtocol protocol, PeerId peerId)
 {
-    VerifyOrReturnError(mState == State::kInitialized, CHIP_ERROR_INCORRECT_STATE);
-
     DnssdService service;
     ReturnErrorOnFailure(MakeHostName(service.mHostName, sizeof(service.mHostName), mac));
     ReturnErrorOnFailure(protocol == DnssdServiceProtocol::kDnssdProtocolTcp
@@ -525,6 +523,7 @@ CHIP_ERROR DiscoveryImplPlatform::PublishService(const char * serviceType, TextE
 }
 
 #define PREPARE_RECORDS(Type)                                                                                                      \
+    VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);                                                              \
     TextEntry textEntries[Type##AdvertisingParameters::kTxtMaxNumber];                                                             \
     size_t textEntrySize = 0;                                                                                                      \
     const char * subTypes[Type::kSubTypeMaxNumber];                                                                                \
@@ -593,6 +592,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const CommissionAdvertisingParameter
 
 CHIP_ERROR DiscoveryImplPlatform::RemoveServices()
 {
+    VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(ChipDnssdRemoveServices());
 
     return CHIP_NO_ERROR;
@@ -600,6 +600,7 @@ CHIP_ERROR DiscoveryImplPlatform::RemoveServices()
 
 CHIP_ERROR DiscoveryImplPlatform::FinalizeServiceUpdate()
 {
+    VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
     return ChipDnssdFinalizeServiceUpdate();
 }
 

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -38,6 +38,7 @@ class DiscoveryImplPlatform : public ServiceAdvertiser, public Resolver
 public:
     // Members that implement both ServiceAdveriser and Resolver interfaces.
     CHIP_ERROR Init(Inet::EndPointManager<Inet::UDPEndPoint> *) override { return InitImpl(); }
+    bool IsInitialized() override;
     void Shutdown() override;
 
     // Members that implement ServiceAdvertiser interface.
@@ -49,7 +50,6 @@ public:
     CHIP_ERROR UpdateCommissionableInstanceName() override;
 
     // Members that implement Resolver interface.
-    bool IsInitialized() override;
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override { mResolverProxy.SetOperationalDelegate(delegate); }
     void SetCommissioningDelegate(CommissioningResolveDelegate * delegate) override
     {


### PR DESCRIPTION
…nssdServer::StartServer at startup

#### Problem

when `darwin-framework-tool` starts there is a use after-free:
```
==14751==ERROR: AddressSanitizer: heap-use-after-free on address 0x61e000047f10 at pc 0x0001101fe7b6 bp 0x70000b858c90 sp 0x70000b858c88
READ of size 1 at 0x61e000047f10 thread T1
    #0 0x1101fe7b5 in chip::FabricInfo::IsInitialized() const FabricTable.h:111
    #1 0x1101fe5b8 in chip::FabricTable::HasPendingFabricUpdate() const FabricTable.h:1096
    #2 0x1101fe458 in chip::FabricTable::GetShadowPendingFabricEntry() const FabricTable.h:1091
    #3 0x1101fe410 in chip::FabricTable::cbegin() const FabricTable.h:545
    #4 0x1101c4e3b in chip::FabricTable::begin() const FabricTable.h:552
    #5 0x114ab3a1b in chip::app::DnssdServer::AdvertiseOperational() Dnssd.cpp:153
    #6 0x114ab9796 in chip::app::DnssdServer::StartServer(chip::Dnssd::CommissioningMode) Dnssd.cpp:364
    #7 0x114ab8f33 in chip::app::DnssdServer::StartServer() Dnssd.cpp:343
    #8 0x114aba74a in chip::app::(anonymous namespace)::OnPlatformEvent(chip::DeviceLayer::ChipDeviceEvent const*) Dnssd.cpp:56
    #9 0x114ab9df8 in chip::app::(anonymous namespace)::OnPlatformEventWrapper(chip::DeviceLayer::ChipDeviceEvent const*, long) Dnssd.cpp:66
    #10 0x1149191d5 in chip::DeviceLayer::Internal::GenericPlatformManagerImpl<chip::DeviceLayer::PlatformManagerImpl>::DispatchEventToApplication(chip::DeviceLayer::ChipDeviceEvent const*) GenericPlatformManagerImpl.ipp:336
    #11 0x114918c52 in chip::DeviceLayer::Internal::GenericPlatformManagerImpl<chip::DeviceLayer::PlatformManagerImpl>::_DispatchEvent(chip::DeviceLayer::ChipDeviceEvent const*) GenericPlatformManagerImpl.ipp:301
    #12 0x11491ae40 in chip::DeviceLayer::PlatformManager::DispatchEvent(chip::DeviceLayer::ChipDeviceEvent const*) PlatformManager.h:505
    #13 0x11491adff in invocation function for block in chip::DeviceLayer::PlatformManagerImpl::_PostEvent(chip::DeviceLayer::ChipDeviceEvent const*) PlatformManagerImpl.cpp:150
    #14 0x1070201aa in __wrap_dispatch_async_block_invoke+0xca (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x4a1aa)
    #15 0x7ff80efd27fa in _dispatch_call_block_and_release+0xb (libdispatch.dylib:x86_64+0x17fa)
    #16 0x7ff80efd3a43 in _dispatch_client_callout+0x7 (libdispatch.dylib:x86_64+0x2a43)
    #17 0x7ff80efd9ac3 in _dispatch_lane_serial_drain+0x2b5 (libdispatch.dylib:x86_64+0x8ac3)
    #18 0x7ff80efda5e6 in _dispatch_lane_invoke+0x1a0 (libdispatch.dylib:x86_64+0x95e6)
    #19 0x7ff80efe4ad6 in _dispatch_workloop_worker_thread+0x2f9 (libdispatch.dylib:x86_64+0x13ad6)
    #20 0x7ff80f14fce2 in _pthread_wqthread+0x145 (libsystem_pthread.dylib:x86_64+0x2ce2)
    #21 0x7ff80f14ec66 in start_wqthread+0xe (libsystem_pthread.dylib:x86_64+0x1c66)

0x61e000047f10 is located 2704 bytes inside of 2920-byte region [0x61e000047480,0x61e000047fe8)
freed by thread T0 here:
    #0 0x1070210b9 in wrap_free+0xa9 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x4b0b9)
    #1 0x1145a6459 in chip::Platform::MemoryFree(void*) CHIPMem-Malloc.cpp:111
    #2 0x11444758d in void chip::Platform::Delete<chip::FabricTable>(chip::FabricTable*) CHIPMem.h:169
    #3 0x114446b43 in chip::Controller::DeviceControllerSystemState::Shutdown() CHIPDeviceControllerFactory.cpp:470
    #4 0x1102010c0 in chip::Controller::DeviceControllerSystemState::Release() CHIPDeviceControllerSystemState.h:163
    #5 0x1101cd7b8 in chip::Controller::DeviceControllerFactory::ReleaseSystemState() CHIPDeviceControllerFactory.h:175
    #6 0x1101ccd40 in __59-[MTRDeviceControllerFactory startControllerFactory:error:]_block_invoke MTRDeviceControllerFactory.mm:471
    #7 0x7ff80efd3a43 in _dispatch_client_callout+0x7 (libdispatch.dylib:x86_64+0x2a43)
    #8 0x7ff80efe136a in _dispatch_lane_barrier_sync_invoke_and_complete+0x3b (libdispatch.dylib:x86_64+0x1036a)
    #9 0x1101c5f0e in -[MTRDeviceControllerFactory startControllerFactory:error:] MTRDeviceControllerFactory.mm:301
    #10 0x1031096d9 in CHIPCommandBridge::MaybeSetUpStack() CHIPCommandBridge.mm:130
    #11 0x103107899 in CHIPCommandBridge::Run() CHIPCommandBridge.mm:41
    #12 0x1030b03f5 in Commands::RunCommand(int, char**, bool) Commands.cpp:271
    #13 0x1030adf87 in Commands::Run(int, char**) Commands.cpp:144
    #14 0x1032678a2 in main main.mm:48
    #15 0x7ff80ee2030f  (<unknown module>)

previously allocated by thread T0 here:
    #0 0x107020f70 in wrap_malloc+0xa0 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x4af70)
    #1 0x1145a5d20 in chip::Platform::MemoryAlloc(unsigned long) CHIPMem-Malloc.cpp:91
    #2 0x11444b391 in chip::FabricTable* chip::Platform::New<chip::FabricTable>() CHIPMem.h:145
    #3 0x1144432bb in std::__1::unique_ptr<chip::FabricTable, chip::Platform::Deleter<chip::FabricTable> > chip::Platform::MakeUnique<chip::FabricTable>() CHIPMem.h:184
    #4 0x11443f2d6 in chip::Controller::DeviceControllerFactory::InitSystemState(chip::Controller::FactoryInitParams) CHIPDeviceControllerFactory.cpp:180
    #5 0x11443df04 in chip::Controller::DeviceControllerFactory::Init(chip::Controller::FactoryInitParams) CHIPDeviceControllerFactory.cpp:67
    #6 0x1101cc6c0 in __59-[MTRDeviceControllerFactory startControllerFactory:error:]_block_invoke MTRDeviceControllerFactory.mm:447
    #7 0x7ff80efd3a43 in _dispatch_client_callout+0x7 (libdispatch.dylib:x86_64+0x2a43)
    #8 0x7ff80efe136a in _dispatch_lane_barrier_sync_invoke_and_complete+0x3b (libdispatch.dylib:x86_64+0x1036a)
    #9 0x1101c5f0e in -[MTRDeviceControllerFactory startControllerFactory:error:] MTRDeviceControllerFactory.mm:301
    #10 0x1031096d9 in CHIPCommandBridge::MaybeSetUpStack() CHIPCommandBridge.mm:130
    #11 0x103107899 in CHIPCommandBridge::Run() CHIPCommandBridge.mm:41
    #12 0x1030b03f5 in Commands::RunCommand(int, char**, bool) Commands.cpp:271
    #13 0x1030adf87 in Commands::Run(int, char**) Commands.cpp:144
    #14 0x1032678a2 in main main.mm:48
    #15 0x7ff80ee2030f  (<unknown module>)

Thread T1 created by T0 here:
    <empty stack>

```
