### PR TITLE
Fix Darwin framework operational advertising for new fabrics.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -335,6 +335,7 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
             commissionerParams.controllerNOC = noc;
         }
         commissionerParams.controllerVendorId = static_cast<chip::VendorId>([startupParams.vendorID unsignedShortValue]);
+        commissionerParams.enableServerInteractions = startupParams.advertiseOperational;
         commissionerParams.deviceAttestationVerifier = _factory.deviceAttestationVerifier;
 
         auto & factory = chip::Controller::DeviceControllerFactory::GetInstance();

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -85,6 +85,7 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
 @property (readonly) Credentials::PersistentStorageOpCertStore * opCertStore;
 @property (readonly) MTROperationalBrowser * operationalBrowser;
 @property () chip::Credentials::DeviceAttestationVerifier * deviceAttestationVerifier;
+@property (readonly) BOOL advertiseOperational;
 
 - (BOOL)findMatchingFabric:(FabricTable &)fabricTable
                     params:(MTRDeviceControllerStartupParams *)params
@@ -435,9 +436,7 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
         if (startupParams.port != nil) {
             params.listenPort = [startupParams.port unsignedShortValue];
         }
-        if (startupParams.shouldStartServer == YES) {
-            params.enableServerInteractions = true;
-        }
+        params.enableServerInteractions = startupParams.shouldStartServer;
 
         params.groupDataProvider = _groupDataProvider;
         params.sessionKeystore = _sessionKeystore;
@@ -470,6 +469,7 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
         _controllerFactory->RetainSystemState();
         _controllerFactory->ReleaseSystemState();
 
+        self->_advertiseOperational = startupParams.shouldStartServer;
         self->_running = YES;
     });
 
@@ -566,6 +566,7 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
         params = [[MTRDeviceControllerStartupParamsInternal alloc] initForExistingFabric:fabricTable
                                                                              fabricIndex:fabric->GetFabricIndex()
                                                                                 keystore:_keystore
+                                                                    advertiseOperational:self.advertiseOperational
                                                                                   params:startupParams];
         if (params == nil) {
             fabricError = CHIP_ERROR_NO_MEMORY;
@@ -649,6 +650,7 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
 
         params = [[MTRDeviceControllerStartupParamsInternal alloc] initForNewFabric:fabricTable
                                                                            keystore:_keystore
+                                                               advertiseOperational:self.advertiseOperational
                                                                              params:startupParams];
         if (params == nil) {
             fabricError = CHIP_ERROR_NO_MEMORY;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -207,6 +207,7 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
 
 - (instancetype)initForNewFabric:(chip::FabricTable *)fabricTable
                         keystore:(chip::Crypto::OperationalKeystore *)keystore
+            advertiseOperational:(BOOL)advertiseOperational
                           params:(MTRDeviceControllerStartupParams *)params
 {
     if (!(self = [self initWithParams:params])) {
@@ -240,6 +241,7 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
 
     _fabricTable = fabricTable;
     _keystore = keystore;
+    _advertiseOperational = advertiseOperational;
 
     return self;
 }
@@ -247,6 +249,7 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
 - (instancetype)initForExistingFabric:(FabricTable *)fabricTable
                           fabricIndex:(FabricIndex)fabricIndex
                              keystore:(chip::Crypto::OperationalKeystore *)keystore
+                 advertiseOperational:(BOOL)advertiseOperational
                                params:(MTRDeviceControllerStartupParams *)params
 {
     if (!(self = [self initWithParams:params])) {
@@ -352,6 +355,7 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
     _fabricTable = fabricTable;
     _fabricIndex.Emplace(fabricIndex);
     _keystore = keystore;
+    _advertiseOperational = advertiseOperational;
 
     return self;
 }

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
@@ -54,6 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
 // Key store we're using with our fabric table, for sanity checks.
 @property (nonatomic, assign, readonly) chip::Crypto::OperationalKeystore * keystore;
 
+@property (nonatomic, assign, readonly) BOOL advertiseOperational;
+
 /**
  * Helper method that checks that our keypairs match our certificates.
  * Specifically:
@@ -73,6 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initForNewFabric:(chip::FabricTable *)fabricTable
                         keystore:(chip::Crypto::OperationalKeystore *)keystore
+            advertiseOperational:(BOOL)advertiseOperational
                           params:(MTRDeviceControllerStartupParams *)params;
 
 /**
@@ -81,6 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initForExistingFabric:(chip::FabricTable *)fabricTable
                           fabricIndex:(chip::FabricIndex)fabricIndex
                              keystore:(chip::Crypto::OperationalKeystore *)keystore
+                 advertiseOperational:(BOOL)advertiseOperational
                                params:(MTRDeviceControllerStartupParams *)params;
 
 /**


### PR DESCRIPTION
Bringing up a new fabric for the very first time was not correctly starting operational advertising for that fabric, because we were not propagating that state to the actual CHIPDeviceController.  It happened to work for existing fabrics, because bringing up the controller factory starts operational advertising for fabrics that are already known at that point.
