### PR TITLE
Fix build of darwin-framework-tool with progress logging disabled.

### DIFF
--- a/examples/darwin-framework-tool/commands/pairing/GetCommissionerNodeIdCommand.mm
+++ b/examples/darwin-framework-tool/commands/pairing/GetCommissionerNodeIdCommand.mm
@@ -25,8 +25,8 @@ CHIP_ERROR GetCommissionerNodeIdCommand::RunCommand()
     auto * controller = CurrentCommissioner();
     VerifyOrReturnError(nil != controller, CHIP_ERROR_INCORRECT_STATE);
 
-    auto id = [controller.controllerNodeId unsignedLongLongValue];
-    ChipLogProgress(chipTool, "Commissioner Node Id 0x" ChipLogFormatX64, ChipLogValueX64(id));
+    ChipLogProgress(
+        chipTool, "Commissioner Node Id 0x" ChipLogFormatX64, ChipLogValueX64(controller.controllerNodeId.unsignedLongLongValue));
 
     SetCommandExitStatus(CHIP_NO_ERROR);
     return CHIP_NO_ERROR;

--- a/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
+++ b/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
@@ -24,8 +24,6 @@ using namespace ::chip;
 
 namespace {
 
-#if CHIP_PROGRESS_LOGGING
-
 NSString * CustomFlowString(MTRCommissioningFlow flow)
 {
     switch (flow) {
@@ -41,8 +39,6 @@ NSString * CustomFlowString(MTRCommissioningFlow flow)
 
     return @"???";
 }
-
-#endif // CHIP_PROGRESS_LOGGING
 
 } // namespace
 


### PR DESCRIPTION
* CustomFlowString is used even if progress logging is disabled.
* The id variable in GetCommissionerNodeIdCommand was unused when progress logging was disabled.


