### PR TITLE
Add new configs for OSS-Fuzz build

### DIFF
--- a/build/chip/fuzz_test.gni
+++ b/build/chip/fuzz_test.gni
@@ -45,16 +45,20 @@ template("chip_fuzz_target") {
     executable(target_name) {
       forward_variables_from(invoker, "*")
 
-      if (defined(public_configs)) {
-        public_configs += [
-          "//build/config/compiler:libfuzzer_fuzzing",
-          "//build/config/compiler:sanitize_address",
-        ]
+      fuzz_configs = []
+      if (oss_fuzz) {
+        fuzz_configs += [ "//build/config/compiler:oss_fuzz" ]
       } else {
-        public_configs = [
+        fuzz_configs += [
           "//build/config/compiler:libfuzzer_fuzzing",
           "//build/config/compiler:sanitize_address",
         ]
+      }
+
+      if (defined(public_configs)) {
+        public_configs += fuzz_configs
+      } else {
+        public_configs = fuzz_configs
       }
       if (!defined(oubput_dir)) {
         output_dir = "${root_out_dir}/tests"

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -453,10 +453,19 @@ config("libfuzzer_fuzzing") {
   ldflags = cflags
 }
 
+config("oss_fuzz") {
+  cflags = string_split(getenv("CFLAGS"))
+  ldflags = string_split(getenv("CXXFLAGS"))
+  ldflags += [ getenv("LIB_FUZZING_ENGINE") ]
+}
+
 config("fuzzing_default") {
   configs = []
   if (is_libfuzzer) {
     configs += [ ":libfuzzer_fuzzing" ]
+  }
+  if (oss_fuzz) {
+    configs += [ ":oss_fuzz" ]
   }
 }
 

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -56,4 +56,7 @@ declare_args() {
 
   # Debug prefix mapping (values for -fdebug-prefix-map=).
   prefix_mappings = []
+
+  # Enable fuzzer build for OSS-Fuzz
+  oss_fuzz = false
 }

--- a/build/config/linux/pkg_config.gni
+++ b/build/config/linux/pkg_config.gni
@@ -125,6 +125,17 @@ template("pkg_config") {
       lib_dirs = pkgresult[3]
     }
 
+    # Link libraries statically for OSS-Fuzz fuzzer build
+    if (oss_fuzz) {
+      libs = []
+      ldflags = [ "-Wl,-Bstatic" ]
+      foreach(lib, pkgresult[2]) {
+        ldflags += [ "-l$lib" ]
+      }
+      ldflags += [ "-Wl,-Bdynamic" ]
+      lib_dirs = pkgresult[3]
+    }
+
     forward_variables_from(invoker,
                            [
                              "defines",


### PR DESCRIPTION
This PR integrates existing fuzzers to [OSS-Fuzz](https://google.github.io/oss-fuzz/) infrastructure for continuous fuzzing.

I made changes to the GN configs to allow the fuzzers build to easily use compiler and linker flags provided by the OSS-Fuzz. Therefore, to build fuzzers for OSS-Fuzz, we only have to enable the the `oss_fuzz` global config.

For testing, we can build all targets defined by the `chip_fuzz_target` rule for OSS-Fuzz with the following commands:
```bash
gn gen out/fuzz_targets --args="is_clang=true oss_fuzz=true"
ninja -C out/fuzz_targets fuzz_tests
```