### PR TITLE
Better logging when converting unknown NSError to CHIP_ERROR.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRError.mm
+++ b/src/darwin/Framework/CHIP/MTRError.mm
@@ -238,6 +238,7 @@ NSString * const MTRInteractionErrorDomain = @"MTRInteractionErrorDomain";
     }
 
     if (error.domain != MTRErrorDomain) {
+        ChipLogError(Controller, "Trying to convert non-Matter error %@ to a Matter error code", error);
         return CHIP_ERROR_INTERNAL;
     }
 


### PR DESCRIPTION
Otherwise we don't know what error we really had.
