### PR TITLE
[darwin-framework-tool] Add is_asan proper supports

### DIFF
--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/build/chip/tools.gni")
+import("${chip_root}/build/config/compiler/compiler.gni")
 import("${chip_root}/build/config/mac/mac_sdk.gni")
 import("${chip_root}/examples//chip-tool/chip-tool.gni")
 
@@ -31,6 +32,8 @@ declare_args() {
   # When config_enable_yaml_tests is false, the Matter SDK options are not available.
   if (!config_enable_yaml_tests) {
     chip_inet_config_enable_ipv4 = true
+    chip_config_network_layer_ble = true
+    is_clang = false
   }
 }
 
@@ -73,8 +76,28 @@ action("build-darwin-framework") {
     ]
   }
 
-  if (defined(chip_inet_config_enable_ipv4) && !chip_inet_config_enable_ipv4) {
+  if (defined(chip_inet_config_enable_ipv4) && chip_inet_config_enable_ipv4) {
+    args += [ "--ipv4" ]
+  } else {
     args += [ "--no-ipv4" ]
+  }
+
+  if (defined(is_asan) && is_asan) {
+    args += [ "--asan" ]
+  } else {
+    args += [ "--no-asan" ]
+  }
+
+  if (defined(chip_config_network_layer_ble) && chip_config_network_layer_ble) {
+    args += [ "--ble" ]
+  } else {
+    args += [ "--no-ble" ]
+  }
+
+  if (defined(is_clang) && is_clang) {
+    args += [ "--clang" ]
+  } else {
+    args += [ "--no-clang" ]
   }
 
   output_name = "Matter.framework"

--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -95,6 +95,7 @@ declare -a args=(
     'chip_enable_wifi=false'
     'chip_log_message_max_size=4096' # might as well allow nice long log messages
     'chip_disable_platform_kvs=true'
+    'enable_fuzz_test_targets=false'
     "target_cpu=\"$target_cpu\""
     "target_defines=$target_defines"
     "target_cflags=[$target_cflags]"
@@ -120,6 +121,24 @@ declare -a args=(
 [[ $CHIP_INET_CONFIG_ENABLE_IPV4 == NO ]] && {
     args+=(
         'chip_inet_config_enable_ipv4=false'
+    )
+}
+
+[[ $CHIP_IS_ASAN == YES ]] && {
+    args+=(
+        'is_asan=true'
+    )
+}
+
+[[ $CHIP_IS_CLANG == YES ]] && {
+    args+=(
+        'is_clang=true'
+    )
+}
+
+[[ $CHIP_IS_BLE == NO ]] && {
+    args+=(
+        'chip_config_network_layer_ble=false'
     )
 }
 


### PR DESCRIPTION
#### Problem

When `darwin-framework-tool` is built with `is_asan=true` or `is_tsan=true` those are not properly carried over to the framework build.
