### PR TITLE
[ESP32] Simplifies SimpleNamespace creation for generating factory partition with and without encryption

### DIFF
--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -400,22 +400,17 @@ def generate_nvs_csv(out_csv_filename):
 
 
 def generate_nvs_bin(encrypt, size, csv_filename, bin_filename):
+    nvs_args = SimpleNamespace(version = 2,
+                               outdir = os.getcwd(),
+                               input = csv_filename,
+                               output = bin_filename,
+                               size = hex(size))    
     if encrypt:
-        nvs_args = SimpleNamespace(version=2,
-                                   keygen=True,
-                                   keyfile=NVS_KEY_PARTITION_BIN,
-                                   inputkey=None,
-                                   outdir=os.getcwd(),
-                                   input=csv_filename,
-                                   output=bin_filename,
-                                   size=hex(size))
+        nvs_args.keygen = True
+        nvs_args.keyfile = NVS_KEY_PARTITION_BIN
+        nvs_args.inputkey = None,
         nvs_partition_gen.encrypt(nvs_args)
     else:
-        nvs_args = SimpleNamespace(input=csv_filename,
-                                   output=bin_filename,
-                                   size=hex(size),
-                                   outdir=os.getcwd(),
-                                   version=2)
         nvs_partition_gen.generate(nvs_args)
 
 

--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -400,11 +400,11 @@ def generate_nvs_csv(out_csv_filename):
 
 
 def generate_nvs_bin(encrypt, size, csv_filename, bin_filename):
-    nvs_args = SimpleNamespace(version = 2,
-                               outdir = os.getcwd(),
-                               input = csv_filename,
-                               output = bin_filename,
-                               size = hex(size))    
+    nvs_args = SimpleNamespace(version=2,
+                               outdir=os.getcwd(),
+                               input=csv_filename,
+                               output=bin_filename,
+                               size=hex(size))
     if encrypt:
         nvs_args.keygen = True
         nvs_args.keyfile = NVS_KEY_PARTITION_BIN


### PR DESCRIPTION
Aim - To simplify `SimpleNamespace` creation logic and arguments required to generate `nvs factory partition binary` for `esp32` with and without encryption in [`scripts/tools/generate_esp32_chip_factory_bin.py`](https://github.com/project-chip/connectedhomeip/blob/master/scripts/tools/generate_esp32_chip_factory_bin.py#L402-L419).

Change Overview - 
- A common, single NameSpace created in the `generate_nvs_bin` function instead of different ones.
- Specific arguments added for factory partition generation with and without `nvs encryption`.

