### PR TITLE
Fix space characters in commands listed in README.md files that were a problem for Linux users

### DIFF
--- a/examples/light-switch-app/silabs/SiWx917/README.md
+++ b/examples/light-switch-app/silabs/SiWx917/README.md
@@ -79,7 +79,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/light-switch-app/silabs/SiWx917/ ./out/light-switch-app BRD4325B
+          ./scripts/examples/gn_efr32_example.sh ./examples/light-switch-app/silabs/SiWx917/ ./out/light-switch-app BRD4325B
 
 -   To delete generated executable, libraries and object files use:
 

--- a/examples/light-switch-app/silabs/efr32/README.md
+++ b/examples/light-switch-app/silabs/efr32/README.md
@@ -106,7 +106,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/light-switch-app/silabs/efr32/ ./out/light-switch-app BRD4161A
+          ./scripts/examples/gn_efr32_example.sh ./examples/light-switch-app/silabs/efr32/ ./out/light-switch-app BRD4161A
 
 -   To delete generated executable, libraries and object files use:
 

--- a/examples/lighting-app/silabs/SiWx917/README.md
+++ b/examples/lighting-app/silabs/SiWx917/README.md
@@ -77,7 +77,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh examples/lighting-app/silabs SiWx917/ out/lighting-app BRD4325B
+          ./scripts/examples/gn_efr32_example.sh examples/lighting-app/silabs/SiWx917/ out/lighting-app BRD4325B
 
 -   To delete generated executable, libraries and object files use:
 

--- a/examples/lighting-app/silabs/SiWx917/README.md
+++ b/examples/lighting-app/silabs/SiWx917/README.md
@@ -10,7 +10,7 @@ An example showing the use of CHIP on the Silicon Labs SiWx917.
     -   [Flashing the Application](#flashing-the-application)
     -   [Viewing Logging Output](#viewing-logging-output)
     -   [Running the Complete Example](#running-the-complete-example)
-    -   [Notes](#notes)
+        -   [Notes](#notes)
     -   [Memory settings](#memory-settings)
     -   [Group Communication (Multicast)](#group-communication-multicast)
     -   [Building options](#building-options)
@@ -77,7 +77,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh examples/lighting-app/silabs/SiWx917/ out/lighting-app BRD4325B
+          ./scripts/examples/gn_efr32_example.sh examples/lighting-app/silabs SiWx917/ out/lighting-app BRD4325B
 
 -   To delete generated executable, libraries and object files use:
 

--- a/examples/lighting-app/silabs/efr32/README.md
+++ b/examples/lighting-app/silabs/efr32/README.md
@@ -100,7 +100,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/silabs/efr32/ ./out/lighting-app BRD4161A
+          ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/silabs/efr32/ ./out/lighting-app BRD4161A
 
 -   To delete generated executable, libraries and object files use:
 

--- a/examples/lock-app/silabs/SiWx917/README.md
+++ b/examples/lock-app/silabs/SiWx917/README.md
@@ -77,7 +77,7 @@ Mac OS X
 
           ```
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/lock-app/silabs SiWx917/ ./out/lock_app BRD4325B
+          ./scripts/examples/gn_efr32_example.sh ./examples/lock-app/silabs/SiWx917/ ./out/lock_app BRD4325B
           ```
 
 -   To delete generated executable, libraries and object files use:

--- a/examples/lock-app/silabs/SiWx917/README.md
+++ b/examples/lock-app/silabs/SiWx917/README.md
@@ -77,7 +77,7 @@ Mac OS X
 
           ```
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/lock-app/silabs/SiWx917/ ./out/lock_app BRD4325B
+          ./scripts/examples/gn_efr32_example.sh ./examples/lock-app/silabs SiWx917/ ./out/lock_app BRD4325B
           ```
 
 -   To delete generated executable, libraries and object files use:

--- a/examples/lock-app/silabs/efr32/README.md
+++ b/examples/lock-app/silabs/efr32/README.md
@@ -102,7 +102,7 @@ Mac OS X
 
           ```
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/lock-app/silabs efr32/ ./out/lock_app BRD4161A
+          ./scripts/examples/gn_efr32_example.sh ./examples/lock-app/silabs/efr32/ ./out/lock_app BRD4161A
           ```
 
 -   To delete generated executable, libraries and object files use:

--- a/examples/lock-app/silabs/efr32/README.md
+++ b/examples/lock-app/silabs/efr32/README.md
@@ -102,7 +102,7 @@ Mac OS X
 
           ```
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/lock-app/silabs/efr32/ ./out/lock_app BRD4161A
+          ./scripts/examples/gn_efr32_example.sh ./examples/lock-app/silabs efr32/ ./out/lock_app BRD4161A
           ```
 
 -   To delete generated executable, libraries and object files use:

--- a/examples/thermostat/silabs/efr32/README.md
+++ b/examples/thermostat/silabs/efr32/README.md
@@ -106,7 +106,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/thermostat/silabs/efr32/ ./out/thermostat-app BRD4161A
+          ./scripts/examples/gn_efr32_example.sh ./examples/thermostat/silabs efr32/ ./out/thermostat-app BRD4161A
 
 -   To delete generated executable, libraries and object files use:
 

--- a/examples/thermostat/silabs/efr32/README.md
+++ b/examples/thermostat/silabs/efr32/README.md
@@ -106,7 +106,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/thermostat/silabs efr32/ ./out/thermostat-app BRD4161A
+          ./scripts/examples/gn_efr32_example.sh ./examples/thermostat/silabs/efr32/ ./out/thermostat-app BRD4161A
 
 -   To delete generated executable, libraries and object files use:
 

--- a/examples/window-app/silabs/SiWx917/README.md
+++ b/examples/window-app/silabs/SiWx917/README.md
@@ -74,7 +74,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/window-app/silabs/SiWx917/ ./out/window-app BRD4325B
+          ./scripts/examples/gn_efr32_example.sh ./examples/window-app/silabs SiWx917/ ./out/window-app BRD4325B
 
 -   To delete generated executable, libraries and object files use:
 

--- a/examples/window-app/silabs/SiWx917/README.md
+++ b/examples/window-app/silabs/SiWx917/README.md
@@ -74,7 +74,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/window-app/silabs SiWx917/ ./out/window-app BRD4325B
+          ./scripts/examples/gn_efr32_example.sh ./examples/window-app/silabs/SiWx917/ ./out/window-app BRD4325B
 
 -   To delete generated executable, libraries and object files use:
 


### PR DESCRIPTION
Fixed some bogus space characters that got into our paths in the README.md files, this was a problem for Linux users who c/p the paths into their terminal, should be all weeded out now.
