### PR TITLE
[Darwin] MTRDevice can be sluggish with slow devices when multiple interactions are issued consecutively

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -1438,6 +1438,10 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Check that device resets start time on subscription drop
     XCTAssertNil(device.estimatedStartTime);
+
+    // Issue a read and expect no actual read from device - verified in logs during run
+    NSDictionary * knownExistingAttribute = [device readAttributeWithEndpointID:@0 clusterID:@3 attributeID:@0 params:nil];
+    XCTAssertNotNil(knownExistingAttribute);
 }
 
 - (void)test018_SubscriptionErrorWhenNotResubscribing


### PR DESCRIPTION
Fixes #26020 

Copying description of solution from the issue, which was exactly what was implemented here:

> The problem here is that MTRDevice currently always issues a read-through even if there is an entry in the read cache. This results in redundant reads that just wastes traffic, and because MTRDevice serializes interactions, this delays writes.

> The fix is to "only read-through when needed". And it's needed when:
> 1. There is no active subscription
> 2. There is no value in the read cache
> 3. The attribute being read is not reported through a subscription
>    - This is a little bit more complex this is a solution: whenever a read interaction returns a result, if there is no read cache entry, then it'll add the path to a set that means "not reported through subscription"
>    - Any subscription report will clear the path in the set, if exists
>    - When client calls read, check if the path is in the set, and read-through if true
