### PR TITLE
Fix shutdown ordering in TestDnssd.

### DIFF
--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -164,8 +164,8 @@ int TestDnssd()
             // This will stop the event loop above, and wait till it has actually stopped
             // (i.e exited RunEventLoop()).
             //
-            chip::Dnssd::ChipDnssdShutdown();
             chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
+            chip::Dnssd::ChipDnssdShutdown();
             chip::DeviceLayer::PlatformMgr().Shutdown();
             shutdown = true;
 
@@ -181,8 +181,8 @@ int TestDnssd()
 
     if (!shutdown)
     {
-        chip::Dnssd::ChipDnssdShutdown();
         chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
+        chip::Dnssd::ChipDnssdShutdown();
         chip::DeviceLayer::PlatformMgr().Shutdown();
     }
     chip::Platform::MemoryShutdown();


### PR DESCRIPTION
For init it does, in order: PlatformMgr().InitChipStack(), ChipDnssdInit, RunEventLoop.

For shutdown it should do them in exactly the opposite order.

Fixes https://github.com/project-chip/connectedhomeip/issues/26023
