### PR TITLE
Add a Darwin API to parse the CSR out of a nocsr-elements.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCSRInfo.h
+++ b/src/darwin/Framework/CHIP/MTRCSRInfo.h
@@ -35,10 +35,7 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @property (nonatomic, copy, readonly) MTRCSRDERBytes csr;
 
 /**
- * The nonce associated with this CSR.  Depending on where the
- * MTROperationalCSRInfo comes from, this could be the nonce from the CSRRequest
- * command that led to this CSR being created, or the nonce from the
- * csrElementsTLV.
+ * The nonce associated with this CSR.
  */
 @property (nonatomic, copy, readonly) NSData * csrNonce;
 
@@ -58,9 +55,8 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @property (nonatomic, copy, readonly) NSData * attestationSignature;
 
 /**
- * Initialize an MTROperationalCSRInfo by providing all the fields.  It's the
- * caller's responsibility to ensure that the provided csr matches
- * csrElementsTLV.
+ * Initialize an MTROperationalCSRInfo by providing all the fields.  This will
+ * ensure that csr and csrNonce match the data in csrElementsTLV.
  */
 - (instancetype)initWithCSR:(MTRCSRDERBytes)csr
                    csrNonce:(NSData *)csrNonce
@@ -70,7 +66,9 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 /**
  * Initialize an MTROperationalCSRInfo by providing the csrNonce (for example,
  * the nonce the client initially supplied), and the csrElementsTLV and
- * attestationSignature that the server returned.
+ * attestationSignature that the server returned.  This will ensure that
+ * csrNonce matches the data in csrElementsTLV, and extract the csr from
+ * csrElementsTLV.
  */
 - (instancetype)initWithCSRNonce:(NSData *)csrNonce
                   csrElementsTLV:(MTRTLVBytes)csrElementsTLV

--- a/src/darwin/Framework/CHIP/MTRCSRInfo.h
+++ b/src/darwin/Framework/CHIP/MTRCSRInfo.h
@@ -17,6 +17,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Matter/MTRCommandPayloadsObjc.h>
 #import <Matter/MTRDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -34,8 +35,10 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @property (nonatomic, copy, readonly) MTRCSRDERBytes csr;
 
 /**
- * The nonce provided in the original CSRRequest command that led to this CSR
- * being created.
+ * The nonce associated with this CSR.  Depending on where the
+ * MTROperationalCSRInfo comes from, this could be the nonce from the CSRRequest
+ * command that led to this CSR being created, or the nonce from the
+ * csrElementsTLV.
  */
 @property (nonatomic, copy, readonly) NSData * csrNonce;
 
@@ -54,11 +57,41 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
  */
 @property (nonatomic, copy, readonly) NSData * attestationSignature;
 
+/**
+ * Initialize an MTROperationalCSRInfo by providing all the fields.  It's the
+ * caller's responsibility to ensure that the provided csr matches
+ * csrElementsTLV.
+ */
 - (instancetype)initWithCSR:(MTRCSRDERBytes)csr
                    csrNonce:(NSData *)csrNonce
              csrElementsTLV:(MTRTLVBytes)csrElementsTLV
        attestationSignature:(NSData *)attestationSignature;
 
+/**
+ * Initialize an MTROperationalCSRInfo by providing the csrNonce (for example,
+ * the nonce the client initially supplied), and the csrElementsTLV and
+ * attestationSignature that the server returned.
+ */
+- (instancetype)initWithCSRNonce:(NSData *)csrNonce
+                  csrElementsTLV:(MTRTLVBytes)csrElementsTLV
+            attestationSignature:(NSData *)attestationSignature MTR_NEWLY_AVAILABLE;
+
+/**
+ * Initialize an MTROperationalCSRInfo by providing just the csrElementsTLV and
+ * attestationSignature (which can come from an
+ * MTROperationalCredentialsClusterCSRResponseParams).  This will extract the
+ * csr and csrNonce from the csrElementsTLV, if possible, and return nil if that
+ * fails.
+ */
+- (instancetype)initWithCSRElementsTLV:(MTRTLVBytes)csrElementsTLV
+                  attestationSignature:(NSData *)attestationSignature MTR_NEWLY_AVAILABLE;
+
+/**
+ * Initialize an MTROperationalCSRInfo by providing an
+ * MTROperationalCredentialsClusterCSRResponseParams.  This will extract the
+ * relevant fields from the response data.
+ */
+- (instancetype)initWithCSRResponseParams:(MTROperationalCredentialsClusterCSRResponseParams *)responseParams MTR_NEWLY_AVAILABLE;
 @end
 
 MTR_DEPRECATED("Please use MTROperationalCSRInfo", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))

--- a/src/darwin/Framework/CHIP/MTRCSRInfo.h
+++ b/src/darwin/Framework/CHIP/MTRCSRInfo.h
@@ -55,24 +55,25 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @property (nonatomic, copy, readonly) NSData * attestationSignature;
 
 /**
- * Initialize an MTROperationalCSRInfo by providing all the fields.  This will
- * ensure that csr and csrNonce match the data in csrElementsTLV.
+ * Initialize an MTROperationalCSRInfo by providing all the fields.  It's the
+ * caller's responsibility to ensure that csr and csrNonce match the csrElementsTLV.
  */
 - (instancetype)initWithCSR:(MTRCSRDERBytes)csr
                    csrNonce:(NSData *)csrNonce
              csrElementsTLV:(MTRTLVBytes)csrElementsTLV
-       attestationSignature:(NSData *)attestationSignature;
+       attestationSignature:(NSData *)attestationSignature
+    MTR_NEWLY_DEPRECATED("Please use one of the initializers that validates the input");
 
 /**
  * Initialize an MTROperationalCSRInfo by providing the csrNonce (for example,
  * the nonce the client initially supplied), and the csrElementsTLV and
  * attestationSignature that the server returned.  This will ensure that
- * csrNonce matches the data in csrElementsTLV, and extract the csr from
- * csrElementsTLV.
+ * csrNonce matches the data in csrElementsTLV, returning nil if it does not,
+ * and extract the csr from csrElementsTLV.
  */
-- (instancetype)initWithCSRNonce:(NSData *)csrNonce
-                  csrElementsTLV:(MTRTLVBytes)csrElementsTLV
-            attestationSignature:(NSData *)attestationSignature MTR_NEWLY_AVAILABLE;
+- (nullable instancetype)initWithCSRNonce:(NSData *)csrNonce
+                           csrElementsTLV:(MTRTLVBytes)csrElementsTLV
+                     attestationSignature:(NSData *)attestationSignature MTR_NEWLY_AVAILABLE;
 
 /**
  * Initialize an MTROperationalCSRInfo by providing just the csrElementsTLV and
@@ -81,15 +82,16 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
  * csr and csrNonce from the csrElementsTLV, if possible, and return nil if that
  * fails.
  */
-- (instancetype)initWithCSRElementsTLV:(MTRTLVBytes)csrElementsTLV
-                  attestationSignature:(NSData *)attestationSignature MTR_NEWLY_AVAILABLE;
+- (nullable instancetype)initWithCSRElementsTLV:(MTRTLVBytes)csrElementsTLV
+                           attestationSignature:(NSData *)attestationSignature MTR_NEWLY_AVAILABLE;
 
 /**
  * Initialize an MTROperationalCSRInfo by providing an
  * MTROperationalCredentialsClusterCSRResponseParams.  This will extract the
  * relevant fields from the response data.
  */
-- (instancetype)initWithCSRResponseParams:(MTROperationalCredentialsClusterCSRResponseParams *)responseParams MTR_NEWLY_AVAILABLE;
+- (nullable instancetype)initWithCSRResponseParams:(MTROperationalCredentialsClusterCSRResponseParams *)responseParams
+    MTR_NEWLY_AVAILABLE;
 @end
 
 MTR_DEPRECATED("Please use MTROperationalCSRInfo", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))

--- a/src/darwin/Framework/CHIP/MTRCSRInfo.mm
+++ b/src/darwin/Framework/CHIP/MTRCSRInfo.mm
@@ -66,28 +66,15 @@ NS_ASSUME_NONNULL_BEGIN
              csrElementsTLV:(MTRTLVBytes)csrElementsTLV
        attestationSignature:(NSData *)attestationSignature;
 {
-    chip::ByteSpan extractedCSR, extractedNonce;
-    VerifyOrReturnValue(ExtractCSRAndNonce(csrElementsTLV, extractedCSR, extractedNonce) == CHIP_NO_ERROR, nil);
-
-    if (!extractedCSR.data_equal(AsByteSpan(csr))) {
-        MTR_LOG_ERROR("Provided CSR does not match provided csrElementsTLV");
-        return nil;
-    }
-
-    if (!extractedNonce.data_equal(AsByteSpan(csrNonce))) {
-        MTR_LOG_ERROR("Provided CSR nonce does not match provided csrElementsTLV");
-        return nil;
-    }
-
     return [self _initWithValidatedCSR:csr
                               csrNonce:csrNonce
                         csrElementsTLV:csrElementsTLV
                   attestationSignature:attestationSignature];
 }
 
-- (instancetype)initWithCSRNonce:(NSData *)csrNonce
-                  csrElementsTLV:(MTRTLVBytes)csrElementsTLV
-            attestationSignature:(NSData *)attestationSignature
+- (nullable instancetype)initWithCSRNonce:(NSData *)csrNonce
+                           csrElementsTLV:(MTRTLVBytes)csrElementsTLV
+                     attestationSignature:(NSData *)attestationSignature
 {
     chip::ByteSpan csr, extractedNonce;
     VerifyOrReturnValue(ExtractCSRAndNonce(csrElementsTLV, csr, extractedNonce) == CHIP_NO_ERROR, nil);
@@ -103,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
                   attestationSignature:attestationSignature];
 }
 
-- (instancetype)initWithCSRElementsTLV:(MTRTLVBytes)csrElementsTLV attestationSignature:(NSData *)attestationSignature
+- (nullable instancetype)initWithCSRElementsTLV:(MTRTLVBytes)csrElementsTLV attestationSignature:(NSData *)attestationSignature
 {
     chip::ByteSpan csr, csrNonce;
     VerifyOrReturnValue(ExtractCSRAndNonce(csrElementsTLV, csr, csrNonce) == CHIP_NO_ERROR, nil);
@@ -114,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
                   attestationSignature:attestationSignature];
 }
 
-- (instancetype)initWithCSRResponseParams:(MTROperationalCredentialsClusterCSRResponseParams *)responseParams
+- (nullable instancetype)initWithCSRResponseParams:(MTROperationalCredentialsClusterCSRResponseParams *)responseParams
 {
     return [self initWithCSRElementsTLV:responseParams.nocsrElements attestationSignature:responseParams.attestationSignature];
 }

--- a/src/darwin/Framework/CHIP/MTRCSRInfo.mm
+++ b/src/darwin/Framework/CHIP/MTRCSRInfo.mm
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
     {
         // We don't care about the nonce.
         chip::ByteSpan ignoredNonce;
-        VerifyOrReturnValue(ExtracCSRAndNonce(csrElementsTLV, csr, ignoredNonce) == CHIP_NO_ERROR, nil);
+        VerifyOrReturnValue(ExtractCSRAndNonce(csrElementsTLV, csr, ignoredNonce) == CHIP_NO_ERROR, nil);
     }
 
     return [self initWithCSR:AsData(csr) csrNonce:csrNonce csrElementsTLV:csrElementsTLV attestationSignature:attestationSignature];
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithCSRElementsTLV:(MTRTLVBytes)csrElementsTLV attestationSignature:(NSData *)attestationSignature
 {
     chip::ByteSpan csr, csrNonce;
-    VerifyOrReturnValue(ExtracCSRAndNonce(csrElementsTLV, csr, csrNonce) == CHIP_NO_ERROR, nil);
+    VerifyOrReturnValue(ExtractCSRAndNonce(csrElementsTLV, csr, csrNonce) == CHIP_NO_ERROR, nil);
 
     return [self initWithCSR:AsData(csr)
                     csrNonce:AsData(csrNonce)

--- a/src/darwin/Framework/CHIP/MTRCSRInfo.mm
+++ b/src/darwin/Framework/CHIP/MTRCSRInfo.mm
@@ -16,10 +16,36 @@
  */
 
 #import "MTRCSRInfo.h"
+#import "MTRFramework.h"
+#import "MTRLogging_Internal.h"
+#import "NSDataSpanConversion.h"
+
+#include <credentials/DeviceAttestationConstructor.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/Span.h>
+
+static CHIP_ERROR ExtracCSRAndNonce(MTRTLVBytes csrElementsTLV, chip::ByteSpan & csr, chip::ByteSpan & nonce)
+{
+    // We don't care about vendor_reserved*.
+    chip::ByteSpan vendor_reserved1, vendor_reserved2, vendor_reserved3;
+    CHIP_ERROR err = chip::Credentials::DeconstructNOCSRElements(
+        AsByteSpan(csrElementsTLV), csr, nonce, vendor_reserved1, vendor_reserved2, vendor_reserved3);
+    if (err != CHIP_NO_ERROR) {
+        MTR_LOG_ERROR("Failed to parse csrElementsTLV %@: %" CHIP_ERROR_FORMAT, csrElementsTLV, err.Format());
+    }
+    return err;
+}
 
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation MTROperationalCSRInfo : NSObject
+
++ (void)initialize
+{
+    // Needed for some of our init* methods.
+    MTRFrameworkInit();
+}
 
 - (instancetype)initWithCSR:(MTRCSRDERBytes)csr
                    csrNonce:(NSData *)csrNonce
@@ -33,6 +59,36 @@ NS_ASSUME_NONNULL_BEGIN
         _attestationSignature = attestationSignature;
     }
     return self;
+}
+
+- (instancetype)initWithCSRNonce:(NSData *)csrNonce
+                  csrElementsTLV:(MTRTLVBytes)csrElementsTLV
+            attestationSignature:(NSData *)attestationSignature
+{
+    chip::ByteSpan csr;
+    {
+        // We don't care about the nonce.
+        chip::ByteSpan ignoredNonce;
+        VerifyOrReturnValue(ExtracCSRAndNonce(csrElementsTLV, csr, ignoredNonce) == CHIP_NO_ERROR, nil);
+    }
+
+    return [self initWithCSR:AsData(csr) csrNonce:csrNonce csrElementsTLV:csrElementsTLV attestationSignature:attestationSignature];
+}
+
+- (instancetype)initWithCSRElementsTLV:(MTRTLVBytes)csrElementsTLV attestationSignature:(NSData *)attestationSignature
+{
+    chip::ByteSpan csr, csrNonce;
+    VerifyOrReturnValue(ExtracCSRAndNonce(csrElementsTLV, csr, csrNonce) == CHIP_NO_ERROR, nil);
+
+    return [self initWithCSR:AsData(csr)
+                    csrNonce:AsData(csrNonce)
+              csrElementsTLV:csrElementsTLV
+        attestationSignature:attestationSignature];
+}
+
+- (instancetype)initWithCSRResponseParams:(MTROperationalCredentialsClusterCSRResponseParams *)responseParams
+{
+    return [self initWithCSRElementsTLV:responseParams.nocsrElements attestationSignature:responseParams.attestationSignature];
 }
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCSRInfo.mm
+++ b/src/darwin/Framework/CHIP/MTRCSRInfo.mm
@@ -25,7 +25,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Span.h>
 
-static CHIP_ERROR ExtracCSRAndNonce(MTRTLVBytes csrElementsTLV, chip::ByteSpan & csr, chip::ByteSpan & nonce)
+static CHIP_ERROR ExtractCSRAndNonce(MTRTLVBytes csrElementsTLV, chip::ByteSpan & csr, chip::ByteSpan & nonce)
 {
     // We don't care about vendor_reserved*.
     chip::ByteSpan vendor_reserved1, vendor_reserved2, vendor_reserved3;

--- a/src/darwin/Framework/CHIP/MTROperationalCertificateIssuer.h
+++ b/src/darwin/Framework/CHIP/MTROperationalCertificateIssuer.h
@@ -74,6 +74,12 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
  *
  * This will be called on the dispatch queue passed as
  * operationalCertificateIssuerQueue in the MTRDeviceControllerFactoryParams.
+ *
+ * The csrNonce in the provided MTROperationalCSRInfo will be the nonce _we_
+ * provided when sending the CSRRequest commmand.  If device attestation
+ * succeeded, this will match the nonce returned in the CSRResponse command.
+ * The actual nonce returned in CSRResponse can be determined by initializing a
+ * new MTROperationalCSRInfo with csrInfo.csrElementsTLV.
  */
 - (void)issueOperationalCertificateForRequest:(MTROperationalCSRInfo *)csrInfo
                               attestationInfo:(MTRDeviceAttestationInfo *)attestationInfo

--- a/src/darwin/Framework/CHIP/MTROperationalCertificateIssuer.h
+++ b/src/darwin/Framework/CHIP/MTROperationalCertificateIssuer.h
@@ -75,11 +75,9 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
  * This will be called on the dispatch queue passed as
  * operationalCertificateIssuerQueue in the MTRDeviceControllerFactoryParams.
  *
- * The csrNonce in the provided MTROperationalCSRInfo will be the nonce _we_
- * provided when sending the CSRRequest commmand.  If device attestation
- * succeeded, this will match the nonce returned in the CSRResponse command.
- * The actual nonce returned in CSRResponse can be determined by initializing a
- * new MTROperationalCSRInfo with csrInfo.csrElementsTLV.
+ * The csrNonce in the provided MTROperationalCSRInfo will be the nonce that was
+ * sent in the CSRRequest command, which will be guaranteed, at this point, to
+ * match the nonce in the CSRResponse command.
  */
 - (void)issueOperationalCertificateForRequest:(MTROperationalCSRInfo *)csrInfo
                               attestationInfo:(MTRDeviceAttestationInfo *)attestationInfo

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
@@ -145,28 +145,9 @@ CHIP_ERROR MTROperationalCredentialsDelegate::ExternalGenerateNOCChain(const chi
 
     mOnNOCCompletionCallback = onCompletion;
 
-    TLVReader reader;
-    reader.Init(csrElements);
-
-    if (reader.GetType() == kTLVType_NotSpecified) {
-        ReturnErrorOnFailure(reader.Next());
-    }
-
-    VerifyOrReturnError(reader.GetType() == kTLVType_Structure, CHIP_ERROR_WRONG_TLV_TYPE);
-    VerifyOrReturnError(reader.GetTag() == AnonymousTag(), CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
-
-    TLVType containerType;
-    ReturnErrorOnFailure(reader.EnterContainer(containerType));
-    ReturnErrorOnFailure(reader.Next(kTLVType_ByteString, TLV::ContextTag(1)));
-
-    chip::ByteSpan csr;
-    reader.Get(csr);
-    reader.ExitContainer(containerType);
-
-    auto * csrInfo = [[MTROperationalCSRInfo alloc] initWithCSR:AsData(csr)
-                                                       csrNonce:AsData(csrNonce)
-                                                 csrElementsTLV:AsData(csrElements)
-                                           attestationSignature:AsData(csrElementsSignature)];
+    auto * csrInfo = [[MTROperationalCSRInfo alloc] initWithCSRNonce:AsData(csrNonce)
+                                                      csrElementsTLV:AsData(csrElements)
+                                                attestationSignature:AsData(csrElementsSignature)];
 
     chip::ByteSpan certificationDeclarationSpan;
     chip::ByteSpan attestationNonceSpan;

--- a/src/darwin/Framework/CHIPTests/MTROperationalCertificateIssuerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTROperationalCertificateIssuerTests.m
@@ -98,6 +98,13 @@ static MTRTestKeys * sTestKeys = nil;
     XCTAssertNotNil(attestationInfo);
     XCTAssertEqual(controller, sController);
 
+    __auto_type * csrInfoCopy = [[MTROperationalCSRInfo alloc] initWithCSRElementsTLV:csrInfo.csrElementsTLV
+                                                                 attestationSignature:csrInfo.attestationSignature];
+    XCTAssertEqualObjects(csrInfoCopy.csr, csrInfo.csr);
+    XCTAssertEqualObjects(csrInfoCopy.csrNonce, csrInfo.csrNonce);
+    XCTAssertEqualObjects(csrInfoCopy.csrElementsTLV, csrInfo.csrElementsTLV);
+    XCTAssertEqualObjects(csrInfoCopy.attestationSignature, csrInfo.attestationSignature);
+
     completion(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeIntegrityCheckFailed userInfo:nil]);
 }
 


### PR DESCRIPTION
Addresses the most immediate problem that led to
https://github.com/project-chip/connectedhomeip/issues/24978 being filed.


