### PR TITLE
Add API on Darwin to open commissioning windows without explicitly providing a setup code.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -338,6 +338,22 @@ typedef NS_ENUM(uint8_t, MTRTransportType) {
     API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2));
 
 /**
+ * Open a commissioning window on the device, using a random setup passcode.
+ *
+ * On success, completion will be called on queue with the MTRSetupPayload that
+ * can be used to commission the device.
+ *
+ * @param discriminator The discriminator to use for the commissionable
+ *                      advertisement.
+ * @param duration      Duration, in seconds, during which the commissioning
+ *                      window will be open.
+ */
+- (void)openCommissioningWindowWithDiscriminator:(NSNumber *)discriminator
+                                        duration:(NSNumber *)duration
+                                           queue:(dispatch_queue_t)queue
+                                      completion:(MTRDeviceOpenCommissioningWindowHandler)completion MTR_NEWLY_AVAILABLE;
+
+/**
  * Reads events from the device.
  *
  * Nil values for endpointID, clusterID, eventID indicate wildcards

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -1280,7 +1280,7 @@ class OpenCommissioningWindowHelper {
 
 public:
     static CHIP_ERROR OpenCommissioningWindow(Controller::DeviceController * controller, NodeId nodeID,
-        System::Clock::Seconds16 timeout, uint16_t discriminator, uint32_t setupPIN, ResultCallback callback);
+        System::Clock::Seconds16 timeout, uint16_t discriminator, const Optional<uint32_t> & setupPIN, ResultCallback callback);
 
 private:
     OpenCommissioningWindowHelper(Controller::DeviceController * controller, ResultCallback callback);
@@ -1300,7 +1300,7 @@ OpenCommissioningWindowHelper::OpenCommissioningWindowHelper(Controller::DeviceC
 }
 
 CHIP_ERROR OpenCommissioningWindowHelper::OpenCommissioningWindow(Controller::DeviceController * controller, NodeId nodeID,
-    System::Clock::Seconds16 timeout, uint16_t discriminator, uint32_t setupPIN, ResultCallback callback)
+    System::Clock::Seconds16 timeout, uint16_t discriminator, const Optional<uint32_t> & setupPIN, ResultCallback callback)
 {
     auto * self = new (std::nothrow) OpenCommissioningWindowHelper(controller, callback);
     if (self == nullptr) {
@@ -1309,7 +1309,7 @@ CHIP_ERROR OpenCommissioningWindowHelper::OpenCommissioningWindow(Controller::De
 
     SetupPayload unused;
     CHIP_ERROR err = self->mOpener.OpenCommissioningWindow(nodeID, timeout, Crypto::kSpake2p_Min_PBKDF_Iterations, discriminator,
-        MakeOptional(setupPIN), NullOptional, &self->mOnOpenCommissioningWindowCallback, unused);
+        setupPIN, NullOptional, &self->mOnOpenCommissioningWindowCallback, unused);
     if (err != CHIP_NO_ERROR) {
         delete self;
     }
@@ -1327,11 +1327,11 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
 
 } // anonymous namespace
 
-- (void)openCommissioningWindowWithSetupPasscode:(NSNumber *)setupPasscode
-                                   discriminator:(NSNumber *)discriminator
-                                        duration:(NSNumber *)duration
-                                           queue:(dispatch_queue_t)queue
-                                      completion:(MTRDeviceOpenCommissioningWindowHandler)completion
+- (void)_openCommissioningWindowWithSetupPasscode:(nullable NSNumber *)setupPasscode
+                                    discriminator:(NSNumber *)discriminator
+                                         duration:(NSNumber *)duration
+                                            queue:(dispatch_queue_t)queue
+                                       completion:(MTRDeviceOpenCommissioningWindowHandler)completion
 {
     if (self.isPASEDevice) {
         MTR_LOG_ERROR("Can't open a commissioning window over PASE");
@@ -1360,13 +1360,17 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
         return;
     }
 
-    unsigned long long passcodeVal = [setupPasscode unsignedLongLongValue];
-    if (!CanCastTo<uint32_t>(passcodeVal) || !SetupPayload::IsValidSetupPIN(static_cast<uint32_t>(passcodeVal))) {
-        MTR_LOG_ERROR("Error: Setup passcode %llu is not valid", passcodeVal);
-        dispatch_async(queue, ^{
-            completion(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_INTEGER_VALUE]);
-        });
-        return;
+    Optional<uint32_t> passcode;
+    if (setupPasscode != nil) {
+        unsigned long long passcodeVal = [setupPasscode unsignedLongLongValue];
+        if (!CanCastTo<uint32_t>(passcodeVal) || !SetupPayload::IsValidSetupPIN(static_cast<uint32_t>(passcodeVal))) {
+            MTR_LOG_ERROR("Error: Setup passcode %llu is not valid", passcodeVal);
+            dispatch_async(queue, ^{
+                completion(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_INTEGER_VALUE]);
+            });
+            return;
+        }
+        passcode.Emplace(static_cast<uint32_t>(passcodeVal));
     }
 
     [self.deviceController
@@ -1394,7 +1398,7 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
             SetupPayload setupPayload;
             auto errorCode = OpenCommissioningWindowHelper::OpenCommissioningWindow(commissioner, self.nodeID,
                 chip::System::Clock::Seconds16(static_cast<uint16_t>(durationVal)), static_cast<uint16_t>(discriminatorVal),
-                static_cast<uint32_t>(passcodeVal), resultCallback);
+                passcode, resultCallback);
 
             if (errorCode != CHIP_NO_ERROR) {
                 dispatch_async(queue, ^{
@@ -1410,6 +1414,31 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
                 completion(nil, error);
             });
         }];
+}
+
+- (void)openCommissioningWindowWithSetupPasscode:(NSNumber *)setupPasscode
+                                   discriminator:(NSNumber *)discriminator
+                                        duration:(NSNumber *)duration
+                                           queue:(dispatch_queue_t)queue
+                                      completion:(MTRDeviceOpenCommissioningWindowHandler)completion
+{
+    [self _openCommissioningWindowWithSetupPasscode:setupPasscode
+                                      discriminator:discriminator
+                                           duration:duration
+                                              queue:queue
+                                         completion:completion];
+}
+
+- (void)openCommissioningWindowWithDiscriminator:(NSNumber *)discriminator
+                                        duration:(NSNumber *)duration
+                                           queue:(dispatch_queue_t)queue
+                                      completion:(MTRDeviceOpenCommissioningWindowHandler)completion
+{
+    [self _openCommissioningWindowWithSetupPasscode:nil
+                                      discriminator:discriminator
+                                           duration:duration
+                                              queue:queue
+                                         completion:completion];
 }
 
 #ifdef DEBUG

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -184,6 +184,22 @@ typedef NS_ENUM(NSUInteger, MTRDeviceState) {
                                       completion:(MTRDeviceOpenCommissioningWindowHandler)completion
     API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2));
 
+/**
+ * Open a commissioning window on the device, using a random setup passcode.
+ *
+ * On success, completion will be called on queue with the MTRSetupPayload that
+ * can be used to commission the device.
+ *
+ * @param discriminator The discriminator to use for the commissionable
+ *                      advertisement.
+ * @param duration      Duration, in seconds, during which the commissioning
+ *                      window will be open.
+ */
+- (void)openCommissioningWindowWithDiscriminator:(NSNumber *)discriminator
+                                        duration:(NSNumber *)duration
+                                           queue:(dispatch_queue_t)queue
+                                      completion:(MTRDeviceOpenCommissioningWindowHandler)completion MTR_NEWLY_AVAILABLE;
+
 @end
 
 extern NSString * const MTREventNumberKey API_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5));

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -806,6 +806,15 @@ private:
                                               completion:completion];
 }
 
+- (void)openCommissioningWindowWithDiscriminator:(NSNumber *)discriminator
+                                        duration:(NSNumber *)duration
+                                           queue:(dispatch_queue_t)queue
+                                      completion:(MTRDeviceOpenCommissioningWindowHandler)completion
+{
+    auto * baseDevice = [self newBaseDevice];
+    [baseDevice openCommissioningWindowWithDiscriminator:discriminator duration:duration queue:queue completion:completion];
+}
+
 #pragma mark - Cache management
 
 // assume lock is held

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
@@ -327,6 +327,17 @@ typedef void (^MTRFetchProxyHandleCompletion)(MTRDeviceControllerXPCProxyHandle 
     });
 }
 
+- (void)openCommissioningWindowWithDiscriminator:(NSNumber *)discriminator
+                                        duration:(NSNumber *)duration
+                                           queue:(dispatch_queue_t)queue
+                                      completion:(MTRDeviceOpenCommissioningWindowHandler)completion
+{
+    MTR_LOG_ERROR("MTRDevice doesn't support openCommissioningWindowWithDiscriminator over XPC");
+    dispatch_async(queue, ^{
+        completion(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeInvalidState userInfo:nil]);
+    });
+}
+
 - (void)fetchProxyHandleWithQueue:(dispatch_queue_t)queue completion:(MTRFetchProxyHandleCompletion)completion
 {
     if (self.controllerID != nil) {


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/22842
