### PR TITLE
Add a lint for SuccessOrExit(CHIP_ERROR_*).

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -221,3 +221,12 @@ jobs:
               if: always()
               run: |
                   flake8 --extend-ignore=E501,W391
+
+            # git grep exits with 0 if it finds a match, but we want
+            # to fail (exit nonzero) on match.  And we want to exclude this file,
+            # to avoid our grep regexp matching itself.
+            - name: Check for use of "SuccessOrExit(CHIP_ERROR_*)", which should probably be "SuccessOrExit(err = CHIP_ERROR_*)"
+              if: always()
+              run: |
+                  git grep -n 'SuccessOrExit(CHIP_ERROR' -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
+


### PR DESCRIPTION
Since it's not changing state, it's identical to ExitNow(), but it _looks_ like it's going to somehow return the provided error code.
