### PR TITLE
Remove the temp state generation since we no longer have stateful helpers in the application templates

### DIFF
--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -494,8 +494,6 @@ def main():
 
     timings = []
     if args.parallel:
-        # Ensure each zap run is independent
-        os.environ['ZAP_TEMPSTATE'] = '1'
         with multiprocessing.Pool() as pool:
             for timing in pool.imap_unordered(_ParallelGenerateOne, targets):
                 timings.append(timing)


### PR DESCRIPTION
Remove the temp state generation from the regen all python script since none of the application templates have stateful helpers anymore