### PR TITLE
Fix leak when shutting down a controller with pending session setups.

### DIFF
--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -262,7 +262,7 @@ void OperationalSessionSetup::EnqueueConnectionCallbacks(Callback::Callback<OnDe
     }
 }
 
-void OperationalSessionSetup::DequeueConnectionCallbacks(CHIP_ERROR error)
+void OperationalSessionSetup::DequeueConnectionCallbacksWithoutReleasing(CHIP_ERROR error)
 {
     Cancelable failureReady, successReady;
 
@@ -318,6 +318,11 @@ void OperationalSessionSetup::DequeueConnectionCallbacks(CHIP_ERROR error)
             cb->mCall(cb->mContext, *exchangeMgr, optionalSessionHandle.Value());
         }
     }
+}
+
+void OperationalSessionSetup::DequeueConnectionCallbacks(CHIP_ERROR error)
+{
+    DequeueConnectionCallbacksWithoutReleasing(error);
     VerifyOrDie(mReleaseDelegate != nullptr);
     mReleaseDelegate->ReleaseSession(this);
 }
@@ -429,6 +434,8 @@ OperationalSessionSetup::~OperationalSessionSetup()
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
     CancelSessionSetupReattempt();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+
+    DequeueConnectionCallbacksWithoutReleasing(CHIP_ERROR_CANCELLED);
 }
 
 CHIP_ERROR OperationalSessionSetup::LookupPeerAddress()

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -322,6 +322,12 @@ private:
      */
     void DequeueConnectionCallbacks(CHIP_ERROR error);
 
+    /*
+     * Like DequeueConnectionCallbacks but does not release ourselves.  For use
+     * from our destructor.
+     */
+    void DequeueConnectionCallbacksWithoutReleasing(CHIP_ERROR error);
+
     /**
      * Triggers a DNSSD lookup to find a usable peer address.
      */


### PR DESCRIPTION
When shutting down a controller, we just destroyed its pending session setups without notifying their consumers.  This leaks, becase those consumers never get a "setup has failed" notification and hence can't clean up properly.

A simple way to reproduce is to build darwin-framework-tool without ASAN enabled, then run:

    MallocStackLogging=YES leaks --atExit -- darwin-framework-tool onoff toggle 0xDEADBEEF 1

when no node with id 0xDEADBEEF is commissioned.

The fix is to send notifications when tearing down the OperationalSessionSetup, if we have not notified yet.
