### PR TITLE
[Silabs] Adds fix for SPI corruption when SPI was multiplexed

### DIFF
--- a/examples/platform/silabs/efr32/display/lcd.cpp
+++ b/examples/platform/silabs/efr32/display/lcd.cpp
@@ -71,12 +71,6 @@ CHIP_ERROR SilabsLCD::Init(uint8_t * name, bool initialState)
         err = CHIP_ERROR_INTERNAL;
     }
 
-#if (defined(EFR32MG24) && defined(WF200_WIFI))
-    if (pr_type != LCD)
-    {
-        pr_type = LCD;
-    }
-#endif
     /* Initialize the DMD module for the DISPLAY device driver. */
     status = DMD_init(0);
     if (DMD_OK != status)

--- a/examples/platform/silabs/efr32/spi_multiplex.c
+++ b/examples/platform/silabs/efr32/spi_multiplex.c
@@ -131,7 +131,6 @@ void pre_lcd_spi_transfer(void)
     {
         return;
     }
-    sl_wfx_host_spi_cs_deassert();
     spi_drv_reinit(SL_BIT_RATE_LCD);
     /*LCD CS is handled as part of LCD gsdk*/
     SILABS_LOG("%s: completed", __func__);

--- a/examples/platform/silabs/efr32/spi_multiplex.c
+++ b/examples/platform/silabs/efr32/spi_multiplex.c
@@ -114,8 +114,6 @@ void post_bootloader_spi_transfer(void)
      * De-Assert CS pin for EXT SPI Flash
      */
     spiflash_cs_deassert();
-    spi_drv_reinit(SL_BIT_RATE_EXP_HDR);
-    sl_wfx_host_spi_cs_assert();
     xSemaphoreGive(spi_sem_sync_hdl);
 }
 
@@ -149,8 +147,6 @@ void pre_lcd_spi_transfer(void)
 void post_lcd_spi_transfer(void)
 {
     SILABS_LOG("%s: started", __func__);
-    spi_drv_reinit(SL_BIT_RATE_EXP_HDR);
-    sl_wfx_host_spi_cs_assert();
     xSemaphoreGive(spi_sem_sync_hdl);
     SILABS_LOG("%s: completed", __func__);
 }
@@ -196,7 +192,6 @@ void post_uart_transfer(void)
         return;
     }
     GPIO_PinModeSet(gpioPortA, 8, gpioModeInputPull, 1);
-    spi_drv_reinit(SL_BIT_RATE_EXP_HDR);
     xSemaphoreGive(spi_sem_sync_hdl);
     sl_wfx_host_enable_platform_interrupt();
     sl_wfx_enable_irq();

--- a/examples/platform/silabs/efr32/spi_multiplex.c
+++ b/examples/platform/silabs/efr32/spi_multiplex.c
@@ -144,8 +144,8 @@ void pre_lcd_spi_transfer(void)
  *****************************************************************************/
 void post_lcd_spi_transfer(void)
 {
-    sl_wfx_host_spi_cs_assert();
     spi_drv_reinit(SL_BIT_RATE_EXP_HDR);
+    sl_wfx_host_spi_cs_assert();
     xSemaphoreGive(spi_sem_sync_hdl);
 }
 #if (defined(EFR32MG24) && defined(WF200_WIFI))

--- a/examples/platform/silabs/efr32/spi_multiplex.c
+++ b/examples/platform/silabs/efr32/spi_multiplex.c
@@ -29,6 +29,8 @@
 #include "spi_multiplex.h"
 #endif /* SL_WIFI */
 
+#include "efr32_utils.h"
+
 /****************************************************************************
  * @fn  void spi_drv_reinit()
  * @brief
@@ -126,6 +128,7 @@ void post_bootloader_spi_transfer(void)
  *****************************************************************************/
 void pre_lcd_spi_transfer(void)
 {
+    SILABS_LOG("%s: started", __func__);
     if (xSemaphoreTake(spi_sem_sync_hdl, portMAX_DELAY) != pdTRUE)
     {
         return;
@@ -133,6 +136,7 @@ void pre_lcd_spi_transfer(void)
     sl_wfx_host_spi_cs_deassert();
     spi_drv_reinit(SL_BIT_RATE_LCD);
     /*LCD CS is handled as part of LCD gsdk*/
+    SILABS_LOG("%s: completed", __func__);
 }
 
 /****************************************************************************
@@ -144,9 +148,11 @@ void pre_lcd_spi_transfer(void)
  *****************************************************************************/
 void post_lcd_spi_transfer(void)
 {
+    SILABS_LOG("%s: started", __func__);
     spi_drv_reinit(SL_BIT_RATE_EXP_HDR);
     sl_wfx_host_spi_cs_assert();
     xSemaphoreGive(spi_sem_sync_hdl);
+    SILABS_LOG("%s: completed", __func__);
 }
 #if (defined(EFR32MG24) && defined(WF200_WIFI))
 /****************************************************************************
@@ -158,11 +164,13 @@ void post_lcd_spi_transfer(void)
  *****************************************************************************/
 void pre_uart_transfer(void)
 {
+    SILABS_LOG("%s: started", __func__);
     if (spi_sem_sync_hdl == NULL)
     {
         // UART is initialized before host SPI interface
         // spi_sem_sync_hdl will not be initalized during execution
         GPIO_PinModeSet(gpioPortA, 8, gpioModePushPull, 1);
+        SILABS_LOG("%s: completed", __func__);
         return;
     }
     sl_wfx_disable_irq();
@@ -182,6 +190,7 @@ void pre_uart_transfer(void)
  *****************************************************************************/
 void post_uart_transfer(void)
 {
+    SILABS_LOG("%s: started", __func__);
     if (spi_sem_sync_hdl == NULL)
     {
         return;
@@ -191,5 +200,6 @@ void post_uart_transfer(void)
     xSemaphoreGive(spi_sem_sync_hdl);
     sl_wfx_host_enable_platform_interrupt();
     sl_wfx_enable_irq();
+    SILABS_LOG("%s: completed", __func__);
 }
 #endif /* EFR32MG24 && WF200_WIFI */

--- a/examples/platform/silabs/efr32/spi_multiplex.c
+++ b/examples/platform/silabs/efr32/spi_multiplex.c
@@ -47,7 +47,7 @@ void spi_drv_reinit(uint32_t baudrate)
     usartInit.databits               = (USART_Databits_TypeDef) databits;
     usartInit.autoCsEnable           = true;
 
-    USART_InitSync(USART0, &usartInit);
+    USART_InitSync(MY_USART, &usartInit);
 }
 
 /****************************************************************************

--- a/examples/platform/silabs/efr32/spi_multiplex.c
+++ b/examples/platform/silabs/efr32/spi_multiplex.c
@@ -29,8 +29,6 @@
 #include "spi_multiplex.h"
 #endif /* SL_WIFI */
 
-#include "efr32_utils.h"
-
 /****************************************************************************
  * @fn  void spi_drv_reinit()
  * @brief
@@ -40,7 +38,6 @@
  *****************************************************************************/
 void spi_drv_reinit(uint32_t baudrate)
 {
-    SILABS_LOG("%s: started", __func__);
     // USART is used in MG24 + WF200 combination
     USART_InitSync_TypeDef usartInit = USART_INITSYNC_DEFAULT;
     usartInit.msbf                   = true;
@@ -51,9 +48,6 @@ void spi_drv_reinit(uint32_t baudrate)
     usartInit.autoCsEnable           = true;
 
     USART_InitSync(USART0, &usartInit);
-
-    vTaskDelay(100);
-    SILABS_LOG("%s: completed", __func__);
 }
 
 /****************************************************************************
@@ -130,16 +124,12 @@ void post_bootloader_spi_transfer(void)
  *****************************************************************************/
 void pre_lcd_spi_transfer(void)
 {
-    SILABS_LOG("%s: started", __func__);
     if (xSemaphoreTake(spi_sem_sync_hdl, portMAX_DELAY) != pdTRUE)
     {
         return;
     }
     spi_drv_reinit(SL_BIT_RATE_LCD);
-    // TODO: Remove spi_drv_reinit once SPI issue is resolved.
-    // SPIDRV_DeInit(SL_SPIDRV_HANDLE);
     /*LCD CS is handled as part of LCD gsdk*/
-    SILABS_LOG("%s: completed", __func__);
 }
 
 /****************************************************************************
@@ -151,10 +141,7 @@ void pre_lcd_spi_transfer(void)
  *****************************************************************************/
 void post_lcd_spi_transfer(void)
 {
-    SILABS_LOG("%s: started", __func__);
-    // spi_drv_reinit(SL_SPIDRV_EXP_BITRATE);
     xSemaphoreGive(spi_sem_sync_hdl);
-    SILABS_LOG("%s: completed", __func__);
 }
 #if (defined(EFR32MG24) && defined(WF200_WIFI))
 /****************************************************************************
@@ -166,13 +153,11 @@ void post_lcd_spi_transfer(void)
  *****************************************************************************/
 void pre_uart_transfer(void)
 {
-    SILABS_LOG("%s: started", __func__);
     if (spi_sem_sync_hdl == NULL)
     {
         // UART is initialized before host SPI interface
         // spi_sem_sync_hdl will not be initalized during execution
         GPIO_PinModeSet(gpioPortA, 8, gpioModePushPull, 1);
-        SILABS_LOG("%s: completed", __func__);
         return;
     }
     sl_wfx_disable_irq();
@@ -192,7 +177,6 @@ void pre_uart_transfer(void)
  *****************************************************************************/
 void post_uart_transfer(void)
 {
-    SILABS_LOG("%s: started", __func__);
     if (spi_sem_sync_hdl == NULL)
     {
         return;
@@ -201,6 +185,5 @@ void post_uart_transfer(void)
     xSemaphoreGive(spi_sem_sync_hdl);
     sl_wfx_host_enable_platform_interrupt();
     sl_wfx_enable_irq();
-    SILABS_LOG("%s: completed", __func__);
 }
 #endif /* EFR32MG24 && WF200_WIFI */

--- a/examples/platform/silabs/efr32/spi_multiplex.c
+++ b/examples/platform/silabs/efr32/spi_multiplex.c
@@ -88,11 +88,6 @@ void pre_bootloader_spi_transfer(void)
         return;
     }
     /*
-     * CS for Expansion header controlled within GSDK,
-     * however we need to ensure CS for Expansion header is High/disabled before use of EXT SPI Flash
-     */
-    sl_wfx_host_spi_cs_deassert();
-    /*
      * Assert CS pin for EXT SPI Flash
      */
     spi_drv_reinit(SL_BIT_RATE_SPI_FLASH);

--- a/examples/platform/silabs/efr32/spi_multiplex.c
+++ b/examples/platform/silabs/efr32/spi_multiplex.c
@@ -47,9 +47,10 @@ void spi_drv_reinit(uint32_t baudrate)
     usartInit.baudrate               = baudrate;
     uint32_t databits                = SL_SPIDRV_EXP_FRAME_LENGTH - 4U + _USART_FRAME_DATABITS_FOUR;
     usartInit.databits               = (USART_Databits_TypeDef) databits;
-    usartInit.autoCsEnable           = true;
+    // usartInit.autoCsEnable           = true;
 
     USART_InitSync(USART0, &usartInit);
+    vTaskDelay(100);
 }
 
 /****************************************************************************

--- a/examples/platform/silabs/efr32/spi_multiplex.c
+++ b/examples/platform/silabs/efr32/spi_multiplex.c
@@ -40,6 +40,7 @@
  *****************************************************************************/
 void spi_drv_reinit(uint32_t baudrate)
 {
+    SILABS_LOG("%s: started", __func__);
     // USART is used in MG24 + WF200 combination
     USART_InitSync_TypeDef usartInit = USART_INITSYNC_DEFAULT;
     usartInit.msbf                   = true;
@@ -50,6 +51,9 @@ void spi_drv_reinit(uint32_t baudrate)
     usartInit.autoCsEnable           = true;
 
     USART_InitSync(USART0, &usartInit);
+
+    vTaskDelay(100);
+    SILABS_LOG("%s: completed", __func__);
 }
 
 /****************************************************************************
@@ -132,6 +136,8 @@ void pre_lcd_spi_transfer(void)
         return;
     }
     spi_drv_reinit(SL_BIT_RATE_LCD);
+    // TODO: Remove spi_drv_reinit once SPI issue is resolved.
+    // SPIDRV_DeInit(SL_SPIDRV_HANDLE);
     /*LCD CS is handled as part of LCD gsdk*/
     SILABS_LOG("%s: completed", __func__);
 }
@@ -146,6 +152,7 @@ void pre_lcd_spi_transfer(void)
 void post_lcd_spi_transfer(void)
 {
     SILABS_LOG("%s: started", __func__);
+    // spi_drv_reinit(SL_SPIDRV_EXP_BITRATE);
     xSemaphoreGive(spi_sem_sync_hdl);
     SILABS_LOG("%s: completed", __func__);
 }

--- a/examples/platform/silabs/efr32/spi_multiplex.c
+++ b/examples/platform/silabs/efr32/spi_multiplex.c
@@ -40,7 +40,7 @@ void spi_drv_reinit(uint32_t baudrate)
 {
     if (USART_BaudrateGet(USART0) == baudrate)
     {
-        // USART synced to buadrate already
+        // USART synced to baudrate already
         return;
     }
     // USART is used in MG24 + WF200 combination

--- a/examples/platform/silabs/efr32/spi_multiplex.c
+++ b/examples/platform/silabs/efr32/spi_multiplex.c
@@ -38,6 +38,11 @@
  *****************************************************************************/
 void spi_drv_reinit(uint32_t baudrate)
 {
+    if (USART_BaudrateGet(MY_USART) == baudrate)
+    {
+        // USART synced to buadrate already
+        return;
+    }
     // USART is used in MG24 + WF200 combination
     USART_InitSync_TypeDef usartInit = USART_INITSYNC_DEFAULT;
     usartInit.msbf                   = true;

--- a/examples/platform/silabs/efr32/spi_multiplex.c
+++ b/examples/platform/silabs/efr32/spi_multiplex.c
@@ -47,10 +47,9 @@ void spi_drv_reinit(uint32_t baudrate)
     usartInit.baudrate               = baudrate;
     uint32_t databits                = SL_SPIDRV_EXP_FRAME_LENGTH - 4U + _USART_FRAME_DATABITS_FOUR;
     usartInit.databits               = (USART_Databits_TypeDef) databits;
-    // usartInit.autoCsEnable           = true;
+    usartInit.autoCsEnable           = true;
 
     USART_InitSync(USART0, &usartInit);
-    vTaskDelay(100);
 }
 
 /****************************************************************************

--- a/examples/platform/silabs/efr32/spi_multiplex.c
+++ b/examples/platform/silabs/efr32/spi_multiplex.c
@@ -38,7 +38,7 @@
  *****************************************************************************/
 void spi_drv_reinit(uint32_t baudrate)
 {
-    if (USART_BaudrateGet(MY_USART) == baudrate)
+    if (USART_BaudrateGet(USART0) == baudrate)
     {
         // USART synced to buadrate already
         return;
@@ -52,7 +52,7 @@ void spi_drv_reinit(uint32_t baudrate)
     usartInit.databits               = (USART_Databits_TypeDef) databits;
     usartInit.autoCsEnable           = true;
 
-    USART_InitSync(MY_USART, &usartInit);
+    USART_InitSync(USART0, &usartInit);
 }
 
 /****************************************************************************

--- a/examples/platform/silabs/efr32/spi_multiplex.h
+++ b/examples/platform/silabs/efr32/spi_multiplex.h
@@ -25,6 +25,7 @@ extern "C" {
 #include "sl_mx25_flash_shutdown_usart_config.h"
 #include "sl_spidrv_exp_config.h"
 #include "sl_wfx_host_api.h"
+#include "spidrv.h"
 
 #define SL_BIT_RATE_LCD 1100000
 #define SL_BIT_RATE_EXP_HDR 16000000
@@ -32,6 +33,16 @@ extern "C" {
 #define SL_BIT_RATE_UART_CONSOLE 16000000
 
 extern SemaphoreHandle_t spi_sem_sync_hdl;
+
+#ifdef RS911X_WIFI
+extern SPIDRV_Handle_t sl_spidrv_eusart_exp_handle;
+#define SL_SPIDRV_HANDLE sl_spidrv_eusart_exp_handle
+#endif
+
+#ifdef WF200_WIFI
+extern SPIDRV_Handle_t sl_spidrv_exp_handle;
+#define SL_SPIDRV_HANDLE sl_spidrv_exp_handle
+#endif
 
 void spi_drv_reinit(uint32_t);
 

--- a/examples/platform/silabs/efr32/spi_multiplex.h
+++ b/examples/platform/silabs/efr32/spi_multiplex.h
@@ -26,22 +26,14 @@ extern "C" {
 #include "sl_spidrv_exp_config.h"
 #include "sl_wfx_host_api.h"
 
-#define LCD_BIT_RATE 1100000
-#define EXP_HDR_BIT_RATE 16000000
-#define SPI_FLASH_BIT_RATE 16000000
-
-typedef enum PERIPHERAL_TYPE
-{
-    EXP_HDR = 0,
-    LCD,
-    EXT_SPIFLASH,
-} peripheraltype_t;
+#define SL_BIT_RATE_LCD 1100000
+#define SL_BIT_RATE_EXP_HDR 16000000
+#define SL_BIT_RATE_SPI_FLASH 16000000
+#define SL_BIT_RATE_UART_CONSOLE 16000000
 
 extern SemaphoreHandle_t spi_sem_sync_hdl;
-extern peripheraltype_t pr_type;
 
 void spi_drv_reinit(uint32_t);
-void set_spi_baudrate(peripheraltype_t);
 
 void spiflash_cs_assert(void);
 void spiflash_cs_deassert(void);

--- a/examples/platform/silabs/efr32/wf200/efr_spi.c
+++ b/examples/platform/silabs/efr32/wf200/efr_spi.c
@@ -153,7 +153,7 @@ sl_status_t sl_wfx_host_spi_cs_assert()
     {
         return SL_STATUS_TIMEOUT;
     }
-    spi_drv_reinit(SL_BIT_RATE_EXP_HDR);
+    spi_drv_reinit(SL_SPIDRV_EXP_BITRATE);
     GPIO_PinOutClear(SL_SPIDRV_EXP_CS_PORT, SL_SPIDRV_EXP_CS_PIN);
     return SL_STATUS_OK;
 }

--- a/examples/platform/silabs/efr32/wf200/efr_spi.c
+++ b/examples/platform/silabs/efr32/wf200/efr_spi.c
@@ -153,7 +153,7 @@ sl_status_t sl_wfx_host_spi_cs_assert()
     {
         return SL_STATUS_TIMEOUT;
     }
-    spi_drv_reinit(SL_SPIDRV_EXP_BITRATE);
+    spi_drv_reinit(SL_BIT_RATE_EXP_HDR);
     GPIO_PinOutClear(SL_SPIDRV_EXP_CS_PORT, SL_SPIDRV_EXP_CS_PIN);
     return SL_STATUS_OK;
 }

--- a/examples/platform/silabs/efr32/wf200/efr_spi.c
+++ b/examples/platform/silabs/efr32/wf200/efr_spi.c
@@ -153,6 +153,7 @@ sl_status_t sl_wfx_host_spi_cs_assert()
     {
         return SL_STATUS_TIMEOUT;
     }
+    spi_drv_reinit(SL_BIT_RATE_EXP_HDR);
     GPIO_PinOutClear(SL_SPIDRV_EXP_CS_PORT, SL_SPIDRV_EXP_CS_PIN);
     return SL_STATUS_OK;
 }

--- a/examples/platform/silabs/efr32/wf200/efr_spi.c
+++ b/examples/platform/silabs/efr32/wf200/efr_spi.c
@@ -54,15 +54,6 @@
 StaticSemaphore_t spi_sem_peripharal;
 SemaphoreHandle_t spi_sem_sync_hdl;
 #endif
-#ifdef RS911X_WIFI
-extern SPIDRV_Handle_t sl_spidrv_eusart_exp_handle;
-#define SL_SPIDRV_HANDLE sl_spidrv_eusart_exp_handle
-#endif
-
-#ifdef WF200_WIFI
-extern SPIDRV_Handle_t sl_spidrv_exp_handle;
-#define SL_SPIDRV_HANDLE sl_spidrv_exp_handle
-#endif
 
 #define USART SL_WFX_HOST_PINOUT_SPI_PERIPHERAL
 

--- a/examples/platform/silabs/efr32/wf200/efr_spi.c
+++ b/examples/platform/silabs/efr32/wf200/efr_spi.c
@@ -49,7 +49,7 @@
 #include "sl_power_manager.h"
 #endif
 
-#if defined(EFR32MG24)
+#if SL_WIFI
 #include "spi_multiplex.h"
 StaticSemaphore_t spi_sem_peripharal;
 SemaphoreHandle_t spi_sem_sync_hdl;

--- a/examples/platform/silabs/efr32/wf200/efr_spi.c
+++ b/examples/platform/silabs/efr32/wf200/efr_spi.c
@@ -112,8 +112,10 @@ sl_status_t sl_wfx_host_init_bus(void)
     spi_sem = xSemaphoreCreateBinaryStatic(&xEfrSpiSemaBuffer);
     xSemaphoreGive(spi_sem);
 
+#if defined(EFR32MG24)
     spi_sem_sync_hdl = xSemaphoreCreateBinaryStatic(&spi_sem_peripharal);
     xSemaphoreGive(spi_sem_sync_hdl);
+#endif /* EFR32MG24 */
     return SL_STATUS_OK;
 }
 


### PR DESCRIPTION
Adds fix for the SPI communication getting corrupted due to race conditions in the multiplexing logic.

Symptoms are:
`Receive frame error`
`Firmware error`

Currently seen in EFR32MG24 + WF200 combination