### PR TITLE
Make the GetWiFiBssId signature safer.

### DIFF
--- a/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
+++ b/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
@@ -79,15 +79,16 @@ CHIP_ERROR WiFiDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (DiagnosticDataP
 CHIP_ERROR WiFiDiagosticsAttrAccess::ReadWiFiBssId(AttributeValueEncoder & aEncoder)
 {
     Attributes::Bssid::TypeInfo::Type bssid;
-    ByteSpan value;
 
-    if (DeviceLayer::GetDiagnosticDataProvider().GetWiFiBssId(value) == CHIP_NO_ERROR)
+    uint8_t bssidBytes[chip::DeviceLayer::kMaxHardwareAddrSize];
+    MutableByteSpan bssidSpan(bssidBytes);
+    if (DeviceLayer::GetDiagnosticDataProvider().GetWiFiBssId(bssidSpan) == CHIP_NO_ERROR)
     {
-        if (!value.empty())
+        if (!bssidSpan.empty())
         {
-            bssid.SetNonNull(value);
+            bssid.SetNonNull(bssidSpan);
             ChipLogProgress(Zcl, "Node is currently connected to Wi-Fi network with BSSID:");
-            ChipLogByteSpan(Zcl, value);
+            ChipLogByteSpan(Zcl, bssidSpan);
         }
     }
     else

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -156,7 +156,13 @@ public:
     /**
      * WiFi network diagnostics methods
      */
-    virtual CHIP_ERROR GetWiFiBssId(ByteSpan & value);
+
+    /**
+     * The MutableByteSpan provided to GetWiFiBssId must have size at least
+     * kMaxHardwareAddrSize. Its size will be set to the actual size of the
+     * BSSID.
+     */
+    virtual CHIP_ERROR GetWiFiBssId(MutableByteSpan & value);
     virtual CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType);
     virtual CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wiFiVersion);
     virtual CHIP_ERROR GetWiFiChannelNumber(uint16_t & channelNumber);
@@ -328,7 +334,7 @@ inline CHIP_ERROR DiagnosticDataProvider::ResetEthNetworkDiagnosticsCounts()
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-inline CHIP_ERROR DiagnosticDataProvider::GetWiFiBssId(ByteSpan & value)
+inline CHIP_ERROR DiagnosticDataProvider::GetWiFiBssId(MutableByteSpan & value)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
@@ -253,19 +253,19 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(ByteSpan & BssId)
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(MutableByteSpan & BssId)
 {
-    CHIP_ERROR err = CHIP_ERROR_READ_FAILED;
-    static uint8_t ameba_bssid[6];
+    constexpr size_t bssIdSize = 6;
+    VerifyOrReturnError(BssId.size() >= bssIdSize, CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    if (wifi_get_ap_bssid(ameba_bssid) == 0)
+    if (wifi_get_ap_bssid(BssId.data()) != 0)
     {
-        err = CHIP_NO_ERROR;
-        ChipLogProgress(DeviceLayer, "%02x,%02x,%02x,%02x,%02x,%02x\n", ameba_bssid[0], ameba_bssid[1], ameba_bssid[2],
-                        ameba_bssid[3], ameba_bssid[4], ameba_bssid[5]);
+        return CHIP_ERROR_READ_FAILED;
     }
 
-    BssId = ameba_bssid;
+    BssId.reduce_size(bssIdSize);
+    ChipLogProgress(DeviceLayer, "%02x,%02x,%02x,%02x,%02x,%02x\n", BssId.data()[0], BssId.data()[1], BssId.data()[2],
+                    BssId.data()[3], BssId.data()[4], BssId.data()[5]);
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.h
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.h
@@ -54,7 +54,7 @@ public:
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    CHIP_ERROR GetWiFiBssId(ByteSpan & BssId) override;
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & BssId) override;
     CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType) override;
     CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wifiVersion) override;
     CHIP_ERROR GetWiFiChannelNumber(uint16_t & channelNumber) override;

--- a/src/platform/Beken/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Beken/DiagnosticDataProviderImpl.cpp
@@ -153,14 +153,18 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(ByteSpan & BssId)
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(MutableByteSpan & BssId)
 {
     LinkStatusTypeDef linkStatus;
+
+    constexpr size_t bssIdSize = 6;
+    VerifyOrReturnError(BssId.size() >= bssIdSize, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     memset(&linkStatus, 0x0, sizeof(LinkStatusTypeDef));
     if (0 == bk_wlan_get_link_status(&linkStatus))
     {
-        BssId = ByteSpan(linkStatus.bssid, 6);
+        memcpy(BssId.data(), linkStatus.bssid, bssIdSize);
+        BssId.reduce_size(bssIdSize);
     }
     else
     {

--- a/src/platform/Beken/DiagnosticDataProviderImpl.h
+++ b/src/platform/Beken/DiagnosticDataProviderImpl.h
@@ -50,7 +50,7 @@ public:
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    CHIP_ERROR GetWiFiBssId(ByteSpan & BssId) override;
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & BssId) override;
     CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType) override;
     CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wifiVersion) override;
     CHIP_ERROR GetWiFiChannelNumber(uint16_t & channelNumber) override;

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -275,18 +275,22 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(ByteSpan & BssId)
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(MutableByteSpan & BssId)
 {
+    constexpr size_t bssIdSize = 6;
+    VerifyOrReturnError(BssId.size() >= bssIdSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+
     wifi_ap_record_t ap_info;
     esp_err_t err;
-    static uint8_t macAddress[kMaxHardwareAddrSize];
 
     err = esp_wifi_sta_get_ap_info(&ap_info);
-    if (err == ESP_OK)
+    if (err != ESP_OK)
     {
-        memcpy(macAddress, ap_info.bssid, 6);
+        return CHIP_ERROR_READ_FAILED;
     }
-    BssId = ByteSpan(macAddress, 6);
+
+    memcpy(BssId.data(), ap_info.bssid, bssIdSize);
+    BssId.reduce_size(bssIdSize);
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.h
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.h
@@ -52,7 +52,7 @@ public:
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    CHIP_ERROR GetWiFiBssId(ByteSpan & BssId) override;
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & BssId) override;
     CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType) override;
     CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wifiVersion) override;
     CHIP_ERROR GetWiFiChannelNumber(uint16_t & channelNumber) override;

--- a/src/platform/Infineon/PSOC6/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Infineon/PSOC6/DiagnosticDataProviderImpl.cpp
@@ -183,8 +183,10 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
 
 /* Wi-Fi Diagnostics Cluster Support */
 
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(ByteSpan & value)
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(MutableByteSpan & value)
 {
+    VerifyOrReturnError(BssId.size() >= CY_WCM_MAC_ADDR_LEN, CHIP_ERROR_BUFFER_TOO_SMALL);
+
     cy_wcm_associated_ap_info_t ap_info;
     cy_rslt_t result = CY_RSLT_SUCCESS;
     CHIP_ERROR err   = CHIP_NO_ERROR;
@@ -195,8 +197,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(ByteSpan & value)
         ChipLogError(DeviceLayer, "cy_wcm_get_associated_ap_info failed: %d", (int) result);
         SuccessOrExit(err = CHIP_ERROR_INTERNAL);
     }
-    memcpy(mWiFiMacAddress, ap_info.BSSID, CY_WCM_MAC_ADDR_LEN);
-    value = ByteSpan(mWiFiMacAddress, CY_WCM_MAC_ADDR_LEN);
+    memcpy(value.data(), ap_info.BSSID, CY_WCM_MAC_ADDR_LEN);
+    value.reduce_size(CY_WCM_MAC_ADDR_LEN);
 
 exit:
     return err;

--- a/src/platform/Infineon/PSOC6/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Infineon/PSOC6/DiagnosticDataProviderImpl.cpp
@@ -185,7 +185,7 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(MutableByteSpan & value)
 {
-    VerifyOrReturnError(BssId.size() >= CY_WCM_MAC_ADDR_LEN, CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError(value.size() >= CY_WCM_MAC_ADDR_LEN, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     cy_wcm_associated_ap_info_t ap_info;
     cy_rslt_t result = CY_RSLT_SUCCESS;

--- a/src/platform/Infineon/PSOC6/DiagnosticDataProviderImpl.h
+++ b/src/platform/Infineon/PSOC6/DiagnosticDataProviderImpl.h
@@ -75,7 +75,7 @@ public:
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 
-    CHIP_ERROR GetWiFiBssId(ByteSpan & BssId) override;
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & BssId) override;
     CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType) override;
     CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wifiVersion) override;
     CHIP_ERROR GetWiFiChannelNumber(uint16_t & channelNumber) override;

--- a/src/platform/Infineon/PSOC6/DiagnosticDataProviderImpl.h
+++ b/src/platform/Infineon/PSOC6/DiagnosticDataProviderImpl.h
@@ -110,7 +110,6 @@ public:
     uint32_t mPacketUnicastRxCount   = 0;
     uint32_t mPacketUnicastTxCount   = 0;
     uint64_t mOverrunCount           = 0;
-    uint8_t mWiFiMacAddress[CY_WCM_MAC_ADDR_LEN];
     app::DataModel::Nullable<bool> mipv4_offpremise;
     app::DataModel::Nullable<bool> mipv6_offpremise;
 };

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1163,8 +1163,12 @@ CHIP_ERROR ConnectivityManagerImpl::CommitConfig()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConnectivityManagerImpl::GetWiFiBssId(ByteSpan & value)
+CHIP_ERROR ConnectivityManagerImpl::GetWiFiBssId(MutableByteSpan & value)
 {
+    constexpr size_t bssIdSize = 6;
+    static_assert(kMaxHardwareAddrSize >= bssIdSize, "We are assuming we can fit a BSSID in a buffer of size kMaxHardwareAddrSize");
+    VerifyOrReturnError(value.size() >= bssIdSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+
     CHIP_ERROR err          = CHIP_ERROR_READ_FAILED;
     struct ifaddrs * ifaddr = nullptr;
 
@@ -1176,23 +1180,22 @@ CHIP_ERROR ConnectivityManagerImpl::GetWiFiBssId(ByteSpan & value)
     }
     else
     {
-        uint8_t macAddress[kMaxHardwareAddrSize];
-
         // Walk through linked list, maintaining head pointer so we can free list later.
         for (struct ifaddrs * ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
             if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
                 InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI)
             {
-                if (ConnectivityUtils::GetInterfaceHardwareAddrs(ifa->ifa_name, macAddress, kMaxHardwareAddrSize) != CHIP_NO_ERROR)
+                if (ConnectivityUtils::GetInterfaceHardwareAddrs(ifa->ifa_name, value.data(), kMaxHardwareAddrSize) !=
+                    CHIP_NO_ERROR)
                 {
                     ChipLogError(DeviceLayer, "Failed to get WiFi network hardware address");
                 }
                 else
                 {
                     // Set 48-bit IEEE MAC Address
-                    value = ByteSpan(macAddress, 6);
-                    err   = CHIP_NO_ERROR;
+                    value.reduce_size(bssIdSize);
+                    err = CHIP_NO_ERROR;
                     break;
                 }
             }

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -137,7 +137,7 @@ public:
     void StartWiFiManagement();
     bool IsWiFiManagementStarted();
     int32_t GetDisconnectReason();
-    CHIP_ERROR GetWiFiBssId(ByteSpan & value);
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & value);
     CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType);
     CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wiFiVersion);
     CHIP_ERROR GetConfiguredNetwork(NetworkCommissioning::Network & network);

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -818,7 +818,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiVersion(app::Clusters::WiFiNetwork
     return ConnectivityMgrImpl().GetWiFiVersion(wiFiVersion);
 }
 
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(ByteSpan & value)
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(MutableByteSpan & value)
 {
     return ConnectivityMgrImpl().GetWiFiBssId(value);
 }

--- a/src/platform/Linux/DiagnosticDataProviderImpl.h
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.h
@@ -84,7 +84,7 @@ public:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wiFiVersion) override;
-    CHIP_ERROR GetWiFiBssId(ByteSpan & value) override;
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & value) override;
     CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType) override;
 #endif
 

--- a/src/platform/bouffalolab/BL602/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/bouffalolab/BL602/DiagnosticDataProviderImpl.cpp
@@ -219,13 +219,14 @@ DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
     return DiagnosticDataProviderImpl::GetDefaultInstance();
 }
 
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(ByteSpan & BssId)
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(MutableByteSpan & BssId)
 {
     static uint8_t macAddress[kMaxHardwareAddrSize];
 
     memcpy(macAddress, wifiMgmr.wifi_mgmr_stat_info.bssid, kMaxHardwareAddrSize);
 
-    return CHIP_NO_ERROR;
+    // TODO: This does not actually put the data in the out param.
+    return CHIP_ERROR_READ_FAILED;
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType)

--- a/src/platform/bouffalolab/BL602/DiagnosticDataProviderImpl.h
+++ b/src/platform/bouffalolab/BL602/DiagnosticDataProviderImpl.h
@@ -50,7 +50,7 @@ public:
 
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
-    CHIP_ERROR GetWiFiBssId(ByteSpan & BssId) override;
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & BssId) override;
     CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType) override;
     CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wifiVersion) override;
     CHIP_ERROR GetWiFiChannelNumber(uint16_t & channelNumber) override;

--- a/src/platform/nrfconnect/DiagnosticDataProviderImplNrf.cpp
+++ b/src/platform/nrfconnect/DiagnosticDataProviderImplNrf.cpp
@@ -42,12 +42,12 @@ DiagnosticDataProviderImplNrf & DiagnosticDataProviderImplNrf::GetDefaultInstanc
 }
 
 #ifdef CONFIG_WIFI_NRF700X
-CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiBssId(ByteSpan & value)
+CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiBssId(MutableByteSpan & value)
 {
     WiFiManager::WiFiInfo info;
-    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
-    value          = info.mBssId;
-    return err;
+    ReturnErrorOnFailure(WiFiManager::Instance().GetWiFiInfo(info));
+
+    return CopySpanToMutableSpan(info.mBssId, value);
 }
 
 CHIP_ERROR

--- a/src/platform/nrfconnect/DiagnosticDataProviderImplNrf.h
+++ b/src/platform/nrfconnect/DiagnosticDataProviderImplNrf.h
@@ -32,7 +32,7 @@ class DiagnosticDataProviderImplNrf : public DiagnosticDataProviderImpl
 {
 public:
 #ifdef CONFIG_WIFI_NRF700X
-    CHIP_ERROR GetWiFiBssId(ByteSpan & value) override;
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & value) override;
     CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType) override;
     CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wiFiVersion) override;
     CHIP_ERROR GetWiFiChannelNumber(uint16_t & channelNumber) override;

--- a/src/platform/nxp/mw320/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/mw320/ConnectivityManagerImpl.cpp
@@ -190,22 +190,24 @@ CHIP_ERROR ConnectivityManagerImpl::CommitConfig()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConnectivityManagerImpl::GetWiFiBssId(ByteSpan & value)
+CHIP_ERROR ConnectivityManagerImpl::GetWiFiBssId(MutableByteSpan & value)
 {
-    int ret = wlan_get_current_network(&sta_network);
-    uint8_t macAddress[6];
+    constexpr size_t bssIdSize = 6;
+    VerifyOrReturnError(BssId.size() >= bssIdSize, CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    if (ret == WM_SUCCESS)
+    int ret = wlan_get_current_network(&sta_network);
+
+    if (ret != WM_SUCCESS)
     {
-        memcpy(macAddress, sta_network.bssid, 6);
+        ChipLogProgress(DeviceLayer, "GetWiFiBssId failed: %d", ret);
+        return CHIP_ERROR_READ_FAILED;
     }
-    else
-    {
-        memset(macAddress, 0, 6);
-    }
-    ChipLogProgress(DeviceLayer, "GetWiFiBssId: %02x:%02x:%02x:%02x:%02x:%02x", macAddress[0], macAddress[1], macAddress[2],
-                    macAddress[3], macAddress[4], macAddress[5]);
-    value = ByteSpan(macAddress, 6);
+
+    memcpy(value.data(), sta_network.bssid, bssIdSize);
+    value.reduce_size(bssIdSize);
+
+    ChipLogProgress(DeviceLayer, "GetWiFiBssId: %02x:%02x:%02x:%02x:%02x:%02x", value.data()[0], value.data()[1], value.data()[2],
+                    value.data()[3], value.data()[4], value.data()[5]);
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/nxp/mw320/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/mw320/ConnectivityManagerImpl.cpp
@@ -193,7 +193,7 @@ CHIP_ERROR ConnectivityManagerImpl::CommitConfig()
 CHIP_ERROR ConnectivityManagerImpl::GetWiFiBssId(MutableByteSpan & value)
 {
     constexpr size_t bssIdSize = 6;
-    VerifyOrReturnError(BssId.size() >= bssIdSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError(value.size() >= bssIdSize, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     int ret = wlan_get_current_network(&sta_network);
 

--- a/src/platform/nxp/mw320/ConnectivityManagerImpl.h
+++ b/src/platform/nxp/mw320/ConnectivityManagerImpl.h
@@ -84,7 +84,7 @@ public:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     void StartWiFiManagement();
-    CHIP_ERROR GetWiFiBssId(ByteSpan & value);
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & value);
     CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType);
     CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wiFiVersion);
 #endif

--- a/src/platform/nxp/mw320/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/mw320/DiagnosticDataProviderImpl.cpp
@@ -294,7 +294,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiVersion(app::Clusters::WiFiNetwork
     return ConnectivityMgrImpl().GetWiFiVersion(wiFiVersion);
 }
 
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(ByteSpan & value)
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(MutableByteSpan & value)
 {
     return ConnectivityMgrImpl().GetWiFiBssId(value);
 }

--- a/src/platform/nxp/mw320/DiagnosticDataProviderImpl.h
+++ b/src/platform/nxp/mw320/DiagnosticDataProviderImpl.h
@@ -70,7 +70,7 @@ public:
     CHIP_ERROR ResetWiFiNetworkDiagnosticsCounts() override;
 
     CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wiFiVersion) override;
-    CHIP_ERROR GetWiFiBssId(ByteSpan & value) override;
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & value) override;
     CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType) override;
 };
 

--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -346,15 +346,17 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
 }
 
 #if SL_WIFI
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(ByteSpan & BssId)
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(MutableByteSpan & BssId)
 {
+    constexpr size_t bssIdSize = 6;
+    VerifyOrReturnError(BssId.size() >= bssIdSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+
     wfx_wifi_scan_result_t ap;
     int32_t err = wfx_get_ap_info(&ap);
-    static uint8_t bssid[6];
     if (err == 0)
     {
-        memcpy(bssid, ap.bssid, 6);
-        BssId = ByteSpan(bssid, 6);
+        memcpy(BssId.data(), ap.bssid, bssIdSize);
+        BssId.reduce_size(bssIdSize);
         return CHIP_NO_ERROR;
     }
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;

--- a/src/platform/silabs/DiagnosticDataProviderImpl.h
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.h
@@ -57,7 +57,7 @@ public:
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 
 #if SL_WIFI
-    CHIP_ERROR GetWiFiBssId(ByteSpan & BssId) override;
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & BssId) override;
     CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType) override;
     CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wifiVersion) override;
     CHIP_ERROR GetWiFiChannelNumber(uint16_t & channelNumber) override;

--- a/src/platform/webos/ConnectivityManagerImpl.h
+++ b/src/platform/webos/ConnectivityManagerImpl.h
@@ -137,7 +137,7 @@ public:
     void StartWiFiManagement();
     bool IsWiFiManagementStarted();
     int32_t GetDisconnectReason();
-    CHIP_ERROR GetWiFiBssId(ByteSpan & value);
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & value);
     CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType);
     CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wiFiVersion);
     CHIP_ERROR GetConfiguredNetwork(NetworkCommissioning::Network & network);

--- a/src/platform/webos/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/webos/DiagnosticDataProviderImpl.cpp
@@ -787,7 +787,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiVersion(app::Clusters::WiFiNetwork
     return ConnectivityMgrImpl().GetWiFiVersion(wiFiVersion);
 }
 
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(ByteSpan & value)
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(MutableByteSpan & value)
 {
     return ConnectivityMgrImpl().GetWiFiBssId(value);
 }

--- a/src/platform/webos/DiagnosticDataProviderImpl.h
+++ b/src/platform/webos/DiagnosticDataProviderImpl.h
@@ -82,7 +82,7 @@ public:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wiFiVersion) override;
-    CHIP_ERROR GetWiFiBssId(ByteSpan & value) override;
+    CHIP_ERROR GetWiFiBssId(MutableByteSpan & value) override;
     CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType) override;
 #endif
 


### PR DESCRIPTION
The existing signature relied on the implementation keeping around a static-lifetime buffer holding the data.  Some implementations did this right, some did not.

The fix is to just have the caller provide the buffer.
