### PR TITLE
[Silabs] Wifi bug fixes which were causing hardfault

### DIFF
--- a/examples/platform/silabs/SiWx917/SiWx917/rsi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/rsi_if.c
@@ -357,7 +357,7 @@ static void wfx_rsi_save_ap_info()
 #else  /* !WIFI_ENABLE_SECURITY_WPA3 */
         wfx_rsi.sec.security = WFX_SEC_WPA2;
 #endif /* WIFI_ENABLE_SECURITY_WPA3 */
-        SILABS_LOG("%s: warn: failed with status: %02x", status);
+        SILABS_LOG("%s: warn: failed with status: %02x",__func__, status);
         return;
     }
     else
@@ -429,7 +429,7 @@ static void wfx_rsi_do_join(void)
             connect_security_mode = RSI_OPEN;
             break;
         default:
-            SILABS_LOG("%s: error: unknown security type.");
+            SILABS_LOG("%s: error: unknown security type.", __func__);
             return;
         }
 

--- a/examples/platform/silabs/SiWx917/SiWx917/rsi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/rsi_if.c
@@ -357,7 +357,7 @@ static void wfx_rsi_save_ap_info()
 #else  /* !WIFI_ENABLE_SECURITY_WPA3 */
         wfx_rsi.sec.security = WFX_SEC_WPA2;
 #endif /* WIFI_ENABLE_SECURITY_WPA3 */
-        SILABS_LOG("%s: warn: failed with status: %02x",__func__, status);
+        SILABS_LOG("%s: warn: failed with status: %02x", __func__, status);
         return;
     }
     else

--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -408,7 +408,7 @@ static void wfx_rsi_save_ap_info() // translation
 #else  /* !WIFI_ENABLE_SECURITY_WPA3 */
         wfx_rsi.sec.security = WFX_SEC_WPA2;
 #endif /* WIFI_ENABLE_SECURITY_WPA3 */
-        SILABS_LOG("%s: warn: failed with status: %02x", status);
+        SILABS_LOG("%s: warn: failed with status: %02x", __func__, status);
         return;
     }
     else
@@ -482,7 +482,7 @@ static void wfx_rsi_do_join(void)
             connect_security_mode = RSI_OPEN;
             break;
         default:
-            SILABS_LOG("%s: error: unknown security type.");
+            SILABS_LOG("%s: error: unknown security type.", __func__);
             return;
         }
 

--- a/examples/platform/silabs/efr32/wf200/efr_spi.c
+++ b/examples/platform/silabs/efr32/wf200/efr_spi.c
@@ -381,10 +381,6 @@ sl_status_t sl_wfx_host_enable_spi(void)
 {
     if (spi_enabled == false)
     {
-#ifdef SLEEP_ENABLED
-        // Prevent the host to use lower EM than EM1
-        sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM1);
-#endif
         spi_enabled = true;
     }
     return SL_STATUS_OK;
@@ -403,10 +399,6 @@ sl_status_t sl_wfx_host_disable_spi(void)
     if (spi_enabled == true)
     {
         spi_enabled = false;
-#ifdef SLEEP_ENABLED
-        // Allow the host to use the lowest allowed EM
-        sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
-#endif
     }
     return SL_STATUS_OK;
 }

--- a/examples/platform/silabs/efr32/wf200/host_if.cpp
+++ b/examples/platform/silabs/efr32/wf200/host_if.cpp
@@ -606,6 +606,7 @@ static void wfx_events_task(void * p_arg)
             if (!(wfx_get_wifi_state() & SL_WFX_AP_INTERFACE_UP))
             {
                 // Enable the power save
+                SILABS_LOG("WF200 going to DTIM based sleep");
                 sl_wfx_set_power_mode(WFM_PM_MODE_DTIM, WFM_PM_POLL_FAST_PS, BEACON_1);
                 sl_wfx_enable_device_power_save();
             }


### PR DESCRIPTION
function string was missed to print causing hardfault
and for Wf200 sleepy EM1 add and remove requirement was called twice, so removing one of them since it is already handled during transmit and receive.

