### PR TITLE
[Silabs]Fix pigweedLogger assert

### DIFF
--- a/examples/platform/silabs/PigweedLogger.cpp
+++ b/examples/platform/silabs/PigweedLogger.cpp
@@ -68,9 +68,8 @@ void init(void)
 
 int putString(const char * buffer, size_t size)
 {
-    assert(sWriteBufferPos < kWriteBufferSize);
-
     xSemaphoreTake(sLoggerLock, portMAX_DELAY);
+    assert(sWriteBufferPos < kWriteBufferSize);
 
     for (size_t i = 0; i < size; ++i)
     {


### PR DESCRIPTION
Wait until the previous send has completed/emptied the buffer before verifying if we have enough space in the send buffer

Tested with the efr32 lighting-app pw-rpc.
Commissioned successfully the device with the rpc console attached and validated the pw command sending and responses