### PR TITLE
[Bouffalolab] Disable strict_warnings for pigweed enabled and fix to get Wi-Fi BSSID

### DIFF
--- a/examples/lighting-app/bouffalolab/bl602/with_pw_rpc.gni
+++ b/examples/lighting-app/bouffalolab/bl602/with_pw_rpc.gni
@@ -24,4 +24,9 @@ chip_enable_pw_rpc = true
 chip_build_pw_trace_lib = false
 
 cpp_standard = "gnu++17"
-#pw_trace_BACKEND = "$dir_pw_trace_tokenized"
+
+# pigweed updated to a1bd248 makes compile conversion errors;
+# it seems riscv gcc (version > 10) can fixes this issue.
+# let's disable strict warnings for RPC enabled for now.
+remove_default_configs = [ "$dir_pw_build:strict_warnings" ]
+treat_warnings_as_errors=false

--- a/examples/lighting-app/bouffalolab/bl602/with_pw_rpc.gni
+++ b/examples/lighting-app/bouffalolab/bl602/with_pw_rpc.gni
@@ -29,4 +29,4 @@ cpp_standard = "gnu++17"
 # it seems riscv gcc (version > 10) can fixes this issue.
 # let's disable strict warnings for RPC enabled for now.
 remove_default_configs = [ "$dir_pw_build:strict_warnings" ]
-treat_warnings_as_errors=false
+treat_warnings_as_errors = false

--- a/examples/lighting-app/bouffalolab/bl702/with_pw_rpc.gni
+++ b/examples/lighting-app/bouffalolab/bl702/with_pw_rpc.gni
@@ -24,4 +24,9 @@ chip_enable_pw_rpc = true
 chip_build_pw_trace_lib = false
 
 cpp_standard = "gnu++17"
-#pw_trace_BACKEND = "$dir_pw_trace_tokenized"
+
+# pigweed updated to a1bd248 makes compile conversion errors;
+# it seems riscv gcc (version > 10) can fixes this issue.
+# let's disable strict warnings for RPC enabled for now.
+remove_default_configs = [ "$dir_pw_build:strict_warnings" ]
+treat_warnings_as_errors=false

--- a/examples/lighting-app/bouffalolab/bl702/with_pw_rpc.gni
+++ b/examples/lighting-app/bouffalolab/bl702/with_pw_rpc.gni
@@ -29,4 +29,4 @@ cpp_standard = "gnu++17"
 # it seems riscv gcc (version > 10) can fixes this issue.
 # let's disable strict warnings for RPC enabled for now.
 remove_default_configs = [ "$dir_pw_build:strict_warnings" ]
-treat_warnings_as_errors=false
+treat_warnings_as_errors = false

--- a/src/platform/bouffalolab/BL602/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/bouffalolab/BL602/DiagnosticDataProviderImpl.cpp
@@ -221,9 +221,7 @@ DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(ByteSpan & BssId)
 {
-    static uint8_t macAddress[kMaxHardwareAddrSize];
-
-    memcpy(macAddress, wifiMgmr.wifi_mgmr_stat_info.bssid, kMaxHardwareAddrSize);
+    BssId = ByteSpan(wifiMgmr.wifi_mgmr_stat_info.bssid, sizeof(wifiMgmr.wifi_mgmr_stat_info.bssid));
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
- pigweed updated to a1bd248 makes compile conversion errors.
    - it seems riscv gcc (version > 10) can fixes this issue; disable strict_warnings for now, and try when new version of riscv gcc is available for our chipset
- Fix to get Wi-Fi BSSID in DiagnosticDataProviderImpl::GetWiFiBssId

