### PR TITLE
[Telink] Fix SensorManager simulatedIndex max number calculation

### DIFF
--- a/examples/temperature-measurement-app/telink/src/SensorManager.cpp
+++ b/examples/temperature-measurement-app/telink/src/SensorManager.cpp
@@ -50,7 +50,7 @@ int16_t SensorManager::SensorEventHandler()
 #ifdef TEMPERATURE_SIMULATION_IS_USED
     static uint8_t nbOfRepetition = 0;
     static uint8_t simulatedIndex = 0;
-    if (simulatedIndex >= sizeof(mSimulatedTemp)/sizeof(mSimulatedTemp[0]))
+    if (simulatedIndex >= sizeof(mSimulatedTemp) / sizeof(mSimulatedTemp[0]))
     {
         simulatedIndex = 0;
     }

--- a/examples/temperature-measurement-app/telink/src/SensorManager.cpp
+++ b/examples/temperature-measurement-app/telink/src/SensorManager.cpp
@@ -50,7 +50,7 @@ int16_t SensorManager::SensorEventHandler()
 #ifdef TEMPERATURE_SIMULATION_IS_USED
     static uint8_t nbOfRepetition = 0;
     static uint8_t simulatedIndex = 0;
-    if (simulatedIndex >= sizeof(mSimulatedTemp) - 1)
+    if (simulatedIndex >= sizeof(mSimulatedTemp)/sizeof(mSimulatedTemp[0]))
     {
         simulatedIndex = 0;
     }

--- a/examples/thermostat/silabs/efr32/src/SensorManager.cpp
+++ b/examples/thermostat/silabs/efr32/src/SensorManager.cpp
@@ -104,7 +104,7 @@ void SensorManager::SensorTimerEventHandler(TimerHandle_t xTimer)
 #else
     static uint8_t nbOfRepetition = 0;
     static uint8_t simulatedIndex = 0;
-    if (simulatedIndex >= sizeof(mSimulatedTemp))
+    if (simulatedIndex >= sizeof(mSimulatedTemp)/sizeof(mSimulatedTemp[0]))
     {
         simulatedIndex = 0;
     }

--- a/examples/thermostat/silabs/efr32/src/SensorManager.cpp
+++ b/examples/thermostat/silabs/efr32/src/SensorManager.cpp
@@ -104,7 +104,7 @@ void SensorManager::SensorTimerEventHandler(TimerHandle_t xTimer)
 #else
     static uint8_t nbOfRepetition = 0;
     static uint8_t simulatedIndex = 0;
-    if (simulatedIndex >= sizeof(mSimulatedTemp)/sizeof(mSimulatedTemp[0]))
+    if (simulatedIndex >= sizeof(mSimulatedTemp) / sizeof(mSimulatedTemp[0]))
     {
         simulatedIndex = 0;
     }

--- a/examples/thermostat/telink/src/SensorManager.cpp
+++ b/examples/thermostat/telink/src/SensorManager.cpp
@@ -63,7 +63,7 @@ void SensorManager::SensorTimerEventHandler(AppEvent * aEvent)
 
     static uint8_t nbOfRepetition = 0;
     static uint8_t simulatedIndex = 0;
-    if (simulatedIndex >= sizeof(mSimulatedTemp))
+    if (simulatedIndex >= sizeof(mSimulatedTemp)/sizeof(mSimulatedTemp[0]))
     {
         simulatedIndex = 0;
     }

--- a/examples/thermostat/telink/src/SensorManager.cpp
+++ b/examples/thermostat/telink/src/SensorManager.cpp
@@ -63,7 +63,7 @@ void SensorManager::SensorTimerEventHandler(AppEvent * aEvent)
 
     static uint8_t nbOfRepetition = 0;
     static uint8_t simulatedIndex = 0;
-    if (simulatedIndex >= sizeof(mSimulatedTemp)/sizeof(mSimulatedTemp[0]))
+    if (simulatedIndex >= sizeof(mSimulatedTemp) / sizeof(mSimulatedTemp[0]))
     {
         simulatedIndex = 0;
     }


### PR DESCRIPTION
**Problem**

- Wrong number of array elements (simulatedIndex max number) calculation

**Change overview**

- Fix SensorManager simulatedIndex max number calculation

**Testing**

- Tested manually with chip-tool.

**Steps:**

- Run: $ chip-tool pairing ble-thread <...>
- Wait till success