### PR TITLE
[Silabs] Remove groups cluster from endpoint 0 on our lighting-app zap configs

### DIFF
--- a/examples/lighting-app/silabs/SiWx917/data_model/lighting-wifi-app.matter
+++ b/examples/lighting-app/silabs/SiWx917/data_model/lighting-wifi-app.matter
@@ -1622,12 +1622,6 @@ endpoint 0 {
   device type rootdevice = 22, version 1;
   binding cluster OtaSoftwareUpdateProvider;
 
-  server cluster Groups {
-    ram      attribute nameSupport;
-    ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 4;
-  }
-
   server cluster Descriptor {
     callback attribute deviceTypeList;
     callback attribute serverList;

--- a/examples/lighting-app/silabs/SiWx917/data_model/lighting-wifi-app.zap
+++ b/examples/lighting-app/silabs/SiWx917/data_model/lighting-wifi-app.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 92,
+  "featureLevel": 95,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -198,7 +198,7 @@
           "mfgCode": null,
           "define": "GROUPS_CLUSTER",
           "side": "server",
-          "enabled": 1,
+          "enabled": 0,
           "commands": [
             {
               "name": "AddGroupResponse",
@@ -8194,5 +8194,6 @@
       "endpointVersion": 1,
       "deviceIdentifier": 257
     }
-  ]
+  ],
+  "log": []
 }

--- a/examples/lighting-app/silabs/efr32/data_model/lighting-thread-app.matter
+++ b/examples/lighting-app/silabs/efr32/data_model/lighting-thread-app.matter
@@ -1712,12 +1712,6 @@ endpoint 0 {
   device type rootdevice = 22, version 1;
   binding cluster OtaSoftwareUpdateProvider;
 
-  server cluster Groups {
-    ram      attribute nameSupport;
-    ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 4;
-  }
-
   server cluster Descriptor {
     callback attribute deviceTypeList;
     callback attribute serverList;

--- a/examples/lighting-app/silabs/efr32/data_model/lighting-thread-app.zap
+++ b/examples/lighting-app/silabs/efr32/data_model/lighting-thread-app.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 92,
+  "featureLevel": 95,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -198,7 +198,7 @@
           "mfgCode": null,
           "define": "GROUPS_CLUSTER",
           "side": "server",
-          "enabled": 1,
+          "enabled": 0,
           "commands": [
             {
               "name": "AddGroupResponse",
@@ -7796,5 +7796,6 @@
       "endpointVersion": 1,
       "deviceIdentifier": 257
     }
-  ]
+  ],
+  "log": []
 }

--- a/examples/lighting-app/silabs/efr32/data_model/lighting-wifi-app.matter
+++ b/examples/lighting-app/silabs/efr32/data_model/lighting-wifi-app.matter
@@ -1622,12 +1622,6 @@ endpoint 0 {
   device type rootdevice = 22, version 1;
   binding cluster OtaSoftwareUpdateProvider;
 
-  server cluster Groups {
-    ram      attribute nameSupport;
-    ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 4;
-  }
-
   server cluster Descriptor {
     callback attribute deviceTypeList;
     callback attribute serverList;

--- a/examples/lighting-app/silabs/efr32/data_model/lighting-wifi-app.zap
+++ b/examples/lighting-app/silabs/efr32/data_model/lighting-wifi-app.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 92,
+  "featureLevel": 95,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -198,7 +198,7 @@
           "mfgCode": null,
           "define": "GROUPS_CLUSTER",
           "side": "server",
-          "enabled": 1,
+          "enabled": 0,
           "commands": [
             {
               "name": "AddGroupResponse",
@@ -8194,5 +8194,6 @@
       "endpointVersion": 1,
       "deviceIdentifier": 257
     }
-  ]
+  ],
+  "log": []
 }


### PR DESCRIPTION
fixes #26065

TC_RR_1.1 was failing on the silabs lighting app. `CHIP_CONFIG_MAX_GROUP_ENDPOINTS_PER_FABRIC` is set to 1 by default and our lighting app had the groups cluster on endpoint 0 and endpoint 1. 
You can define `CHIP_CONFIG_MAX_GROUP_ENDPOINTS_PER_FABRIC` to what your app needs, but more importantly, groups shouldn't be on endpoint 0. I believe it was used for some tests at the time.

This PR removes the groups cluster from endpoint 0.
