### PR TITLE
Fix #26115: Setup discriminator parameter corruption

### DIFF
--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -91,9 +91,11 @@ namespace DeviceLayer {
         dispatch_queue_t bleWorkQueue;
 
         void BleConnectionDelegateImpl::NewConnection(
-            Ble::BleLayer * bleLayer, void * appState, const SetupDiscriminator & deviceDiscriminator)
+            Ble::BleLayer * bleLayer, void * appState, const SetupDiscriminator & inDeviceDiscriminator)
         {
             assertChipStackLockedByCurrentThread();
+
+            SetupDiscriminator deviceDiscriminator = inDeviceDiscriminator;
 
             ChipLogProgress(Ble, "%s", __FUNCTION__);
             if (!bleWorkQueue) {

--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -95,6 +95,7 @@ namespace DeviceLayer {
         {
             assertChipStackLockedByCurrentThread();
 
+            // Make a copy of the device discriminator for the block to capture.
             SetupDiscriminator deviceDiscriminator = inDeviceDiscriminator;
 
             ChipLogProgress(Ble, "%s", __FUNCTION__);


### PR DESCRIPTION
The setup discriminator parameter is being passed by reference, but by the time the block is run by dispatch, that reference points to stack contents that have been changed.  Making a local copy of the discriminator fixes the problem.
