### PR TITLE
[Silabs] WiFi - fix for 917SoC commissionable data provider

### DIFF
--- a/examples/platform/silabs/SiWx917/BUILD.gn
+++ b/examples/platform/silabs/SiWx917/BUILD.gn
@@ -148,10 +148,6 @@ source_set("siwx917-attestation-credentials") {
 }
 
 source_set("silabs-factory-data-provider") {
-  if (siwx917_commissionable_data) {
-    defines = [ "SIWX917_USE_COMISSIONABLE_DATA=1" ]
-  }
-
   sources = [
     "${silabs_common_plat_dir}/SilabsDeviceDataProvider.cpp",
     "${silabs_common_plat_dir}/SilabsDeviceDataProvider.h",
@@ -162,6 +158,8 @@ source_set("silabs-factory-data-provider") {
     "${chip_root}/src/platform:platform_base",
     "${chip_root}/src/setup_payload",
   ]
+
+  public_configs = [ ":siwx917-common-config" ]
 }
 
 config("siwx917-common-config") {
@@ -183,6 +181,10 @@ config("siwx917-common-config") {
 
   if (enable_heap_monitoring) {
     defines += [ "HEAP_MONITORING" ]
+  }
+
+  if (siwx917_commissionable_data) {
+    defines += [ "SIWX917_USE_COMISSIONABLE_DATA=1" ]
   }
 }
 

--- a/examples/platform/silabs/SilabsDeviceDataProvider.cpp
+++ b/examples/platform/silabs/SilabsDeviceDataProvider.cpp
@@ -161,6 +161,7 @@ CHIP_ERROR SIWx917DeviceDataProvider::FlashFactoryData()
             return err;
         }
     }
+    return CHIP_NO_ERROR;
 }
 #endif
 

--- a/examples/platform/silabs/SilabsDeviceDataProvider.cpp
+++ b/examples/platform/silabs/SilabsDeviceDataProvider.cpp
@@ -22,6 +22,13 @@
 #include <setup_payload/Base38Encode.h>
 #include <setup_payload/SetupPayload.h>
 
+#ifdef SIWX917_USE_COMISSIONABLE_DATA
+#include "DeviceConfig.h"
+#include "siwx917_utils.h"
+#include <setup_payload/Base38Decode.h>
+#include <setup_payload/QRCodeSetupPayloadGenerator.h>
+#endif // SIWX917_USE_COMISSIONABLE_DATA
+
 namespace chip {
 namespace DeviceLayer {
 namespace Silabs {
@@ -31,7 +38,7 @@ using namespace chip::DeviceLayer::Internal;
 
 // TODO Remove once Commander supports (doesn't erase) NVM3 for 917
 #ifdef SIWX917_USE_COMISSIONABLE_DATA
-void SIWx917DeviceDataProvider::setupPayload(uint8_t * outBuf)
+void SilabsDeviceDataProvider::setupPayload(uint8_t * outBuf)
 {
     SetupPayload payload;
     std::string result;
@@ -64,7 +71,7 @@ void SIWx917DeviceDataProvider::setupPayload(uint8_t * outBuf)
 }
 
 // writing to the flash based on the value given in the DeviceConfig.h
-CHIP_ERROR SIWx917DeviceDataProvider::FlashFactoryData()
+CHIP_ERROR SilabsDeviceDataProvider::FlashFactoryData()
 {
     // flashing the value to the nvm3 section of the flash
     // TODO: remove this once it is removed SiWx917 have the nvm3 simiplicity commander support


### PR DESCRIPTION
#### Fix for the commissionable data provider
> The macro needed for the commissionable data provider is not in common location in .gn file, this causing the issue
> Moved the macro to a common location in .gn file
#### Resolved build failure issue for 917SoC commissionable data provider caused by https://github.com/project-chip/connectedhomeip/pull/26107