### PR TITLE
Fix Dynamic Bridge example compilation

### DIFF
--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -179,6 +179,17 @@ jobs:
                     linux debug bridge-app \
                     out/linux-x64-bridge/chip-bridge-app \
                     /tmp/bloat_reports/
+            - name: Build example Dynamic Bridge
+              timeout-minutes: 10
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target linux-x64-dynamic-bridge-ipv6only \
+                        build"
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                    linux debug dynamic-bridge-app-ipv6only \
+                    out/linux-x64-dynamic-bridge-ipv6only/chip-bridge-app \
+                    /tmp/bloat_reports/
             - name: Build example OTA Provider
               timeout-minutes: 10
               run: |

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -188,7 +188,7 @@ jobs:
                         build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     linux debug dynamic-bridge-app-ipv6only \
-                    out/linux-x64-dynamic-bridge-ipv6only/chip-bridge-app \
+                    out/linux-x64-dynamic-bridge-ipv6only/dynamic-chip-bridge-app \
                     /tmp/bloat_reports/
             - name: Build example OTA Provider
               timeout-minutes: 10

--- a/examples/dynamic-bridge-app/linux/BUILD.gn
+++ b/examples/dynamic-bridge-app/linux/BUILD.gn
@@ -61,6 +61,7 @@ executable("dynamic-chip-bridge-app") {
     "${chip_root}/examples/platform/linux:app-main",
     "${chip_root}/src/app/tests/suites/credentials:dac_provider",
     "${chip_root}/src/lib",
+    "${chip_root}/src/lib/assign",
   ]
 
   include_dirs = [
@@ -116,7 +117,7 @@ executable("dynamic-chip-bridge-app") {
 
   output_dir = root_out_dir
 
-  configs += ["${chip_root}/src:includes"]
+  configs += [ "${chip_root}/src:includes" ]
 }
 
 group("linux") {

--- a/examples/dynamic-bridge-app/linux/main.cpp
+++ b/examples/dynamic-bridge-app/linux/main.cpp
@@ -184,12 +184,6 @@ chip::Optional<chip::ClusterId> LookupClusterByName(const char * name)
     return chip::Optional<chip::ClusterId>();
 }
 
-std::unique_ptr<GeneratedCluster> CreateCluster(const char * name)
-{
-    auto id = LookupClusterByName(name);
-    return id.HasValue() ? CreateCluster(id.Value()) : nullptr;
-}
-
 std::unique_ptr<GeneratedCluster> CreateCluster(chip::ClusterId id)
 {
     for (const auto & cluster : clusters::kKnownClusters)
@@ -200,6 +194,12 @@ std::unique_ptr<GeneratedCluster> CreateCluster(chip::ClusterId id)
         }
     }
     return nullptr;
+}
+
+std::unique_ptr<GeneratedCluster> CreateCluster(const char * name)
+{
+    auto id = LookupClusterByName(name);
+    return id.HasValue() ? CreateCluster(id.Value()) : nullptr;
 }
 
 CHIP_ERROR TLVWriteValue(chip::TLV::TLVWriter & wr, const Span<const char> & v)

--- a/scripts/py_matter_idl/matter_idl/generators/bridge/BridgeClustersGlobalStructs.jinja
+++ b/scripts/py_matter_idl/matter_idl/generators/bridge/BridgeClustersGlobalStructs.jinja
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <app/data-model/Nullable.h>
+#include <lib/assign/ValueAssign.h>
 
 #include <string>
 #include <vector>
@@ -15,9 +16,9 @@ struct {{struct.name}}
     chip::app::Clusters::detail::Structs::{{struct.name}}::DecodableType t;
     CHIP_ERROR err = t.Decode(reader);
     if(err == CHIP_NO_ERROR) {
-      {%-      for field in struct.fields %}
-      {{field.name}} = t.{{field.name}};
-      {%-      endfor  %}
+      {%- for field in struct.fields %}
+      chip::Value::Assign({{field.name}},  t.{{field.name}});
+      {%- endfor  %}
     }
     return err;
   }
@@ -25,9 +26,9 @@ struct {{struct.name}}
   CHIP_ERROR Encode(chip::TLV::TLVWriter & writer, chip::TLV::Tag tag) const
   {
     chip::app::Clusters::detail::Structs::{{struct.name}}::Type t;
-    {%-      for field in struct.fields %}
-    t.{{field.name}} = {{field.name}};
-    {%-      endfor  %}
+      {%- for field in struct.fields %}
+      chip::Value::Assign(t.{{field.name}},  {{field.name}});
+      {%- endfor  %}
     return t.Encode(writer, tag);
   }
 

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/cluster_struct_attribute/bridge/BridgeGlobalStructs.h
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/cluster_struct_attribute/bridge/BridgeGlobalStructs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <app/data-model/Nullable.h>
+#include <lib/assign/ValueAssign.h>
 
 #include <string>
 #include <vector>

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/cluster_with_commands/bridge/BridgeGlobalStructs.h
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/cluster_with_commands/bridge/BridgeGlobalStructs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <app/data-model/Nullable.h>
+#include <lib/assign/ValueAssign.h>
 
 #include <string>
 #include <vector>

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/global_struct_attribute/bridge/BridgeGlobalStructs.h
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/global_struct_attribute/bridge/BridgeGlobalStructs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <app/data-model/Nullable.h>
+#include <lib/assign/ValueAssign.h>
 
 #include <string>
 #include <vector>
@@ -15,8 +16,8 @@ struct LabelStruct
     chip::app::Clusters::detail::Structs::LabelStruct::DecodableType t;
     CHIP_ERROR err = t.Decode(reader);
     if(err == CHIP_NO_ERROR) {
-      label = t.label;
-      value = t.value;
+      chip::Value::Assign(label,  t.label);
+      chip::Value::Assign(value,  t.value);
     }
     return err;
   }
@@ -24,8 +25,8 @@ struct LabelStruct
   CHIP_ERROR Encode(chip::TLV::TLVWriter & writer, chip::TLV::Tag tag) const
   {
     chip::app::Clusters::detail::Structs::LabelStruct::Type t;
-    t.label = label;
-    t.value = value;
+      chip::Value::Assign(t.label,  label);
+      chip::Value::Assign(t.value,  value);
     return t.Encode(writer, tag);
   }
   std::string label;

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/bridge/BridgeGlobalStructs.h
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/bridge/BridgeGlobalStructs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <app/data-model/Nullable.h>
+#include <lib/assign/ValueAssign.h>
 
 #include <string>
 #include <vector>

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/simple_attribute/bridge/BridgeGlobalStructs.h
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/simple_attribute/bridge/BridgeGlobalStructs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <app/data-model/Nullable.h>
+#include <lib/assign/ValueAssign.h>
 
 #include <string>
 #include <vector>

--- a/scripts/tools/check_includes_config.py
+++ b/scripts/tools/check_includes_config.py
@@ -33,6 +33,7 @@ IGNORE: Set[str] = {
     '/Test',
     '/tests/',
     '/tools/',
+    '/lib/assign/ValueAssign.h',
 
     # Platforms can opt in or out.
     '/darwin/',

--- a/scripts/tools/check_includes_config.py
+++ b/scripts/tools/check_includes_config.py
@@ -33,7 +33,7 @@ IGNORE: Set[str] = {
     '/Test',
     '/tests/',
     '/tools/',
-    '/lib/assign/ValueAssign.h',
+    r'/lib/assign/ValueAssign\.h',
 
     # Platforms can opt in or out.
     '/darwin/',

--- a/src/lib/assign/BUILD.gn
+++ b/src/lib/assign/BUILD.gn
@@ -1,0 +1,26 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+static_library("assign") {
+  sources = [
+    "ValueAssign.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/lib/support",
+  ]
+}

--- a/src/lib/assign/BUILD.gn
+++ b/src/lib/assign/BUILD.gn
@@ -16,11 +16,7 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 static_library("assign") {
-  sources = [
-    "ValueAssign.h",
-  ]
+  sources = [ "ValueAssign.h" ]
 
-  public_deps = [
-    "${chip_root}/src/lib/support",
-  ]
+  public_deps = [ "${chip_root}/src/lib/support" ]
 }

--- a/src/lib/assign/ValueAssign.h
+++ b/src/lib/assign/ValueAssign.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+#include <lib/support/Span.h>
+
+namespace chip {
+namespace Value {
+
+template<class SRC, class DEST>
+SRC & Assign(SRC &dest, const DEST &src) {
+    return dest=src;
+}
+
+template<>
+std::string& Assign(std::string &dest, const chip::CharSpan &src) {
+   dest = std::string(src.begin(), src.end());
+   return dest;
+}
+
+template <>
+chip::CharSpan & Assign(chip::CharSpan &dest, const std::string & src) {
+   dest = chip::CharSpan(src.c_str(), src.size());
+   return dest;
+}
+
+} // namespace Value
+} // namespace chip

--- a/src/lib/assign/ValueAssign.h
+++ b/src/lib/assign/ValueAssign.h
@@ -1,3 +1,18 @@
+/*
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 #pragma once
 
 #include <string>

--- a/src/lib/assign/ValueAssign.h
+++ b/src/lib/assign/ValueAssign.h
@@ -28,16 +28,16 @@ SRC & Assign(SRC & dest, const DEST & src)
 }
 
 template <>
-std::string & Assign(std::string & dest, const chip::CharSpan & src)
+std::string & Assign(std::string & dest, const CharSpan & src)
 {
     dest = std::string(src.begin(), src.end());
     return dest;
 }
 
 template <>
-chip::CharSpan & Assign(chip::CharSpan & dest, const std::string & src)
+CharSpan & Assign(CharSpan & dest, const std::string & src)
 {
-    dest = chip::CharSpan(src.c_str(), src.size());
+    dest = CharSpan(src.c_str(), src.size());
     return dest;
 }
 

--- a/src/lib/assign/ValueAssign.h
+++ b/src/lib/assign/ValueAssign.h
@@ -15,27 +15,30 @@
  */
 #pragma once
 
-#include <string>
 #include <lib/support/Span.h>
+#include <string>
 
 namespace chip {
 namespace Value {
 
-template<class SRC, class DEST>
-SRC & Assign(SRC &dest, const DEST &src) {
-    return dest=src;
-}
-
-template<>
-std::string& Assign(std::string &dest, const chip::CharSpan &src) {
-   dest = std::string(src.begin(), src.end());
-   return dest;
+template <class SRC, class DEST>
+SRC & Assign(SRC & dest, const DEST & src)
+{
+    return dest = src;
 }
 
 template <>
-chip::CharSpan & Assign(chip::CharSpan &dest, const std::string & src) {
-   dest = chip::CharSpan(src.c_str(), src.size());
-   return dest;
+std::string & Assign(std::string & dest, const chip::CharSpan & src)
+{
+    dest = std::string(src.begin(), src.end());
+    return dest;
+}
+
+template <>
+chip::CharSpan & Assign(chip::CharSpan & dest, const std::string & src)
+{
+    dest = chip::CharSpan(src.c_str(), src.size());
+    return dest;
 }
 
 } // namespace Value


### PR DESCRIPTION
#26016 pulled in some std::string-backed global structs into the bridge app, which made it fail to compile since it was relying that `operator=` is defined for underlying data types and they are not (for std::string and chip::CharSpan).

I switched things to a separate Assign operation that I overloaded for std::string/char-span compatibility.
I also added dynamic bridge to CI tests so that this app does not fail again.