### PR TITLE
[nrfconnect] Implemented OnSubscriptionRequested callback in examples

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -171,4 +171,27 @@ config CHIP_WIFI_CONNECTION_RECOVERY_JITTER
 	  a random jitter interval is added to it to avoid periodicity. The random jitter is selected
 	  within range [-JITTER; +JITTER].
 
+config CHIP_ICD_SUBSCRIPTION_HANDLING
+	bool "Enables platform specific handling of ICD subscriptions"
+	help
+	  Enables platform specific implementation that handles ICD subscription requests
+	  and selects subscription report interval value considering maximum interval preferred
+	  by the publisher.
+
+if CHIP_ICD_SUBSCRIPTION_HANDLING
+
+config CHIP_MAX_PREFERRED_SUBSCRIPTION_REPORT_INTERVAL
+	int "Maximum preferred interval of sending subscription reports (s)"
+	default 60
+	help
+	  Provides maximum preferred interval to be used by a publisher for negotiation
+	  of the final maximum subscription report interval, after receiving a subscription
+	  request from the initiator. This value should be selected as a compromise between
+	  keeping the power consumption low due to not sending reports too often, and allowing
+	  the initiator device to detect the publisher absence reasonably fast due to not sending
+	  the reports too rarely. The current algorithm is to select bigger value from the one
+	  requested by the initiator and the one preferred by the publisher.
+
+endif # CHIP_ICD_SUBSCRIPTION_HANDLING
+
 endif # CHIP

--- a/examples/light-switch-app/nrfconnect/CMakeLists.txt
+++ b/examples/light-switch-app/nrfconnect/CMakeLists.txt
@@ -70,6 +70,10 @@ if(CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/DFUOverSMP.cpp)
 endif()
 
+if(CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING)
+    target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/ICDUtil.cpp)
+endif()
+
 chip_configure_data_model(app
     INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../light-switch-common/light-switch-app.zap

--- a/examples/light-switch-app/nrfconnect/Kconfig
+++ b/examples/light-switch-app/nrfconnect/Kconfig
@@ -47,6 +47,9 @@ config NRF_WIFI_LOW_POWER
 
 endif # CHIP_WIFI
 
+config CHIP_ICD_SUBSCRIPTION_HANDLING
+	default y
+
 rsource "../../../config/nrfconnect/chip-module/Kconfig.features"
 rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/examples/light-switch-app/nrfconnect/main/AppTask.cpp
+++ b/examples/light-switch-app/nrfconnect/main/AppTask.cpp
@@ -44,6 +44,10 @@
 #include "OTAUtil.h"
 #endif
 
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+#include <app/InteractionModelEngine.h>
+#endif
+
 #include <dk_buttons_and_leds.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -218,6 +222,10 @@ CHIP_ERROR AppTask::Init()
 
     ConfigurationMgr().LogDeviceConfig();
     PrintOnboardingCodes(RendezvousInformationFlags(RendezvousInformationFlag::kBLE));
+
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+    chip::app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(&GetICDUtil());
+#endif
 
     // Add CHIP event handler and start CHIP thread.
     // Note that all the initialization code should happen prior to this point

--- a/examples/light-switch-app/nrfconnect/main/include/AppTask.h
+++ b/examples/light-switch-app/nrfconnect/main/include/AppTask.h
@@ -31,6 +31,10 @@
 #include "DFUOverSMP.h"
 #endif
 
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+#include "ICDUtil.h"
+#endif
+
 #include <cstdint>
 
 struct k_timer;

--- a/examples/lock-app/nrfconnect/CMakeLists.txt
+++ b/examples/lock-app/nrfconnect/CMakeLists.txt
@@ -71,3 +71,7 @@ endif()
 if(CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/DFUOverSMP.cpp)
 endif()
+
+if(CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING)
+    target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/ICDUtil.cpp)
+endif()

--- a/examples/lock-app/nrfconnect/Kconfig
+++ b/examples/lock-app/nrfconnect/Kconfig
@@ -59,6 +59,9 @@ config NRF_WIFI_LOW_POWER
 
 endif # CHIP_WIFI
 
+config CHIP_ICD_SUBSCRIPTION_HANDLING
+	default y
+
 rsource "../../../config/nrfconnect/chip-module/Kconfig.features"
 rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -45,6 +45,10 @@
 #include "OTAUtil.h"
 #endif
 
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+#include <app/InteractionModelEngine.h>
+#endif
+
 #include <dk_buttons_and_leds.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -211,6 +215,10 @@ CHIP_ERROR AppTask::Init()
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
     ConfigurationMgr().LogDeviceConfig();
     PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+    chip::app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(&GetICDUtil());
+#endif
 
     // Add CHIP event handler and start CHIP thread.
     // Note that all the initialization code should happen prior to this point to avoid data races

--- a/examples/lock-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lock-app/nrfconnect/main/include/AppTask.h
@@ -33,6 +33,10 @@
 #include "DFUOverSMP.h"
 #endif
 
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+#include "ICDUtil.h"
+#endif
+
 struct k_timer;
 struct Identify;
 

--- a/examples/platform/nrfconnect/util/ICDUtil.cpp
+++ b/examples/platform/nrfconnect/util/ICDUtil.cpp
@@ -1,0 +1,40 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "ICDUtil.h"
+
+ICDUtil ICDUtil::sICDUtil;
+
+CHIP_ERROR ICDUtil::OnSubscriptionRequested(chip::app::ReadHandler & aReadHandler, chip::Transport::SecureSession & aSecureSession)
+{
+    uint16_t agreedMaxInterval    = CONFIG_CHIP_MAX_PREFERRED_SUBSCRIPTION_REPORT_INTERVAL;
+    uint16_t requestedMinInterval = 0;
+    uint16_t requestedMaxInterval = 0;
+    aReadHandler.GetReportingIntervals(requestedMinInterval, requestedMaxInterval);
+
+    if (requestedMaxInterval > agreedMaxInterval)
+    {
+        agreedMaxInterval = requestedMaxInterval;
+    }
+    else if (agreedMaxInterval > kSubscriptionMaxIntervalPublisherLimit)
+    {
+        agreedMaxInterval = kSubscriptionMaxIntervalPublisherLimit;
+    }
+
+    return aReadHandler.SetReportingIntervals(agreedMaxInterval);
+}

--- a/examples/platform/nrfconnect/util/include/ICDUtil.h
+++ b/examples/platform/nrfconnect/util/include/ICDUtil.h
@@ -1,0 +1,33 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/ReadHandler.h>
+
+class ICDUtil : public chip::app::ReadHandler::ApplicationCallback
+{
+    CHIP_ERROR OnSubscriptionRequested(chip::app::ReadHandler & aReadHandler,
+                                       chip::Transport::SecureSession & aSecureSession) override;
+    friend ICDUtil & GetICDUtil();
+    static ICDUtil sICDUtil;
+};
+
+inline ICDUtil & GetICDUtil()
+{
+    return ICDUtil::sICDUtil;
+}

--- a/examples/window-app/nrfconnect/CMakeLists.txt
+++ b/examples/window-app/nrfconnect/CMakeLists.txt
@@ -73,3 +73,7 @@ endif()
 if(CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/DFUOverSMP.cpp)
 endif()
+
+if(CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING)
+    target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/ICDUtil.cpp)
+endif()

--- a/examples/window-app/nrfconnect/main/AppTask.cpp
+++ b/examples/window-app/nrfconnect/main/AppTask.cpp
@@ -35,6 +35,10 @@
 #include "OTAUtil.h"
 #endif
 
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+#include <app/InteractionModelEngine.h>
+#endif
+
 #include <dk_buttons_and_leds.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -190,6 +194,10 @@ CHIP_ERROR AppTask::Init()
 
     ConfigurationMgr().LogDeviceConfig();
     PrintOnboardingCodes(chip::RendezvousInformationFlag(chip::RendezvousInformationFlag::kBLE));
+
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+    chip::app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(&GetICDUtil());
+#endif
 
     // Add CHIP event handler and start CHIP thread.
     // Note that all the initialization code should happen prior to this point to avoid data races

--- a/examples/window-app/nrfconnect/main/include/AppTask.h
+++ b/examples/window-app/nrfconnect/main/include/AppTask.h
@@ -30,6 +30,10 @@
 #include "DFUOverSMP.h"
 #endif
 
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+#include "ICDUtil.h"
+#endif
+
 struct k_timer;
 struct Identify;
 

--- a/examples/window-app/nrfconnect/prj.conf
+++ b/examples/window-app/nrfconnect/prj.conf
@@ -36,6 +36,9 @@ CONFIG_CHIP_THREAD_SSED=y
 CONFIG_CHIP_SED_IDLE_INTERVAL=500
 CONFIG_CHIP_SED_ACTIVE_INTERVAL=500
 
+# Enable ICD subscription platform specific handling
+CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING=y
+
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterWinCov"
 

--- a/examples/window-app/nrfconnect/prj_no_dfu.conf
+++ b/examples/window-app/nrfconnect/prj_no_dfu.conf
@@ -41,6 +41,9 @@ CONFIG_CHIP_THREAD_SSED=y
 CONFIG_CHIP_SED_IDLE_INTERVAL=500
 CONFIG_CHIP_SED_ACTIVE_INTERVAL=500
 
+# Enable ICD subscription platform specific handling
+CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING=y
+
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterWinCov"
 

--- a/examples/window-app/nrfconnect/prj_release.conf
+++ b/examples/window-app/nrfconnect/prj_release.conf
@@ -41,6 +41,9 @@ CONFIG_CHIP_THREAD_SSED=y
 CONFIG_CHIP_SED_IDLE_INTERVAL=500
 CONFIG_CHIP_SED_ACTIVE_INTERVAL=500
 
+# Enable ICD subscription platform specific handling
+CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING=y
+
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterWinCov"
 


### PR DESCRIPTION
Added OnSubscriptionRequested callback example implementation to make the Matter accessory device negotiate subscription report interval instead of always accepting the requested value.
