### PR TITLE
[Tizen] Allow to build examples without Thread

### DIFF
--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -135,6 +135,6 @@ jobs:
               run: |
                 ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py \
-                        --target tizen-arm-tests-no-ble \
+                        --target tizen-arm-tests-no-ble-no-thread \
                         build
                     "

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -477,10 +477,11 @@ def BuildTizenTarget():
         TargetPart('tests', app=TizenApp.TESTS),
     ])
 
-    target.AppendModifier(name="no-ble", enable_ble=False)
-    target.AppendModifier(name="no-wifi", enable_wifi=False)
-    target.AppendModifier(name="asan", use_asan=True)
-    target.AppendModifier(name="ubsan", use_ubsan=True)
+    target.AppendModifier("no-ble", enable_ble=False)
+    target.AppendModifier("no-thread", enable_thread=False)
+    target.AppendModifier("no-wifi", enable_wifi=False)
+    target.AppendModifier("asan", use_asan=True)
+    target.AppendModifier("ubsan", use_ubsan=True)
 
     return target
 

--- a/scripts/build/builders/tizen.py
+++ b/scripts/build/builders/tizen.py
@@ -88,6 +88,7 @@ class TizenBuilder(GnBuilder):
                  app: TizenApp = TizenApp.LIGHT,
                  board: TizenBoard = TizenBoard.ARM,
                  enable_ble: bool = True,
+                 enable_thread: bool = True,
                  enable_wifi: bool = True,
                  use_asan: bool = False,
                  use_tsan: bool = False,
@@ -114,6 +115,8 @@ class TizenBuilder(GnBuilder):
 
         if not enable_ble:
             self.extra_gn_options.append('chip_config_network_layer_ble=false')
+        if not enable_thread:
+            self.extra_gn_options.append('chip_enable_openthread=false')
         if not enable_wifi:
             self.extra_gn_options.append('chip_enable_wifi=false')
         if use_asan:

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -18,6 +18,6 @@ mw320-all-clusters-app
 nrf-{nrf5340dk,nrf52840dk,nrf52840dongle}-{all-clusters,all-clusters-minimal,lock,light,light-switch,shell,pump,pump-controller,window-covering}[-rpc]
 nrf-native-posix-64-tests
 qpg-qpg6105-{lock,light,shell,persistent-storage}
-tizen-arm-{all-clusters,all-clusters-minimal,chip-tool,light,tests}[-no-ble][-no-wifi][-asan][-ubsan]
+tizen-arm-{all-clusters,all-clusters-minimal,chip-tool,light,tests}[-no-ble][-no-thread][-no-wifi][-asan][-ubsan]
 telink-tlsr9518adk80d-{all-clusters,all-clusters-minimal,bridge,contact-sensor,light,light-switch,lock,ota-requestor,pump,pump-controller,temperature-measurement,thermostat,window-covering}[-rpc][-factory-data]
 openiotsdk-{shell,lock}


### PR DESCRIPTION
### Problem

Currently, all examples for Tizen platform are built with Thread enabled. Our QEMU-based CI test does not support Thread, though.
```
...
INFO    D/CHIP    (  875): DMG: Endpoint 1, Cluster 0x0000_0406 update version to c605d1e2
INFO    E/CHIP    (  875): DL: Thread stack not initialized
INFO    E/CHIP    (  875): DL: FAIL: get thread device type
INFO    D/CHIP    (  875): IN: SecureSession[0x1233c0]: Allocated Type:1 LSID:55725
...
```

### Changes

- allow to disable Thread support 

### Testing

CI will verify.