### PR TITLE
Fix TestDnssd exit after last HandleResolved call

### DIFF
--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -499,7 +499,7 @@ int TestConfigurationMgr()
 {
     nlTestSuite theSuite = { "ConfigurationMgr tests", &sTests[0], TestConfigurationMgr_Setup, TestConfigurationMgr_Teardown };
 
-    // Run test suit against one context.
+    // Run test suite against one context.
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -499,7 +499,7 @@ int TestConfigurationMgr()
 {
     nlTestSuite theSuite = { "ConfigurationMgr tests", &sTests[0], TestConfigurationMgr_Setup, TestConfigurationMgr_Teardown };
 
-    // Run test suit againt one context.
+    // Run test suit against one context.
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/platform/tests/TestConnectivityMgr.cpp
+++ b/src/platform/tests/TestConnectivityMgr.cpp
@@ -99,7 +99,7 @@ int TestConnectivityMgr()
 {
     nlTestSuite theSuite = { "ConfigurationMgr tests", &sTests[0], TestConnectivityMgr_Setup, TestConnectivityMgr_Teardown };
 
-    // Run test suit againt one context.
+    // Run test suit against one context.
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/platform/tests/TestConnectivityMgr.cpp
+++ b/src/platform/tests/TestConnectivityMgr.cpp
@@ -99,7 +99,7 @@ int TestConnectivityMgr()
 {
     nlTestSuite theSuite = { "ConfigurationMgr tests", &sTests[0], TestConnectivityMgr_Setup, TestConnectivityMgr_Teardown };
 
-    // Run test suit against one context.
+    // Run test suite against one context.
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -15,12 +15,6 @@
  *    limitations under the License.
  */
 
-/**
- *    @file
- *      This file implements a unit test suite for the mDNS code functionality.
- *
- */
-
 #include <atomic>
 
 #include <nlunit-test.h>

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -83,6 +83,11 @@ static void HandleResolve(void * context, DnssdService * result, const chip::Spa
     if (ctx->mBrowsedServicesCount == ++ctx->mResolvedServicesCount)
     {
         chip::DeviceLayer::SystemLayer().CancelTimer(Timeout, context);
+        // StopEventLoopTask can be called from any thread, but when called from
+        // non-Matter one it will lock the Matter stack. The same locking rules
+        // are required when the resolve callback (this one) is called. In order
+        // to avoid deadlocks, we need to call the StopEventLoopTask from inside
+        // the Matter event loop by scheduling a lambda.
         chip::DeviceLayer::SystemLayer().ScheduleLambda([]() {
             // After last service is resolved, stop the event loop,
             // so the test case can gracefully exit.

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -39,9 +39,9 @@ static void HandleResolve(void * context, DnssdService * result, const chip::Spa
 
     if (gBrowsedServicesCount == ++gResolvedServicesCount)
     {
+        // After last service is resolved, stop the event loop,
+        // so the test case can gracefully exit.
         chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
-        chip::DeviceLayer::PlatformMgr().Shutdown();
-        exit(0);
     }
 }
 

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -198,7 +198,7 @@ int TestDnssd()
 {
     nlTestSuite theSuite = { "CHIP DeviceLayer mDNS tests", &sTests[0], TestDnssd_Setup, TestDnssd_Teardown };
 
-    // Run test suit against one context.
+    // Run test suite against one context.
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -1,3 +1,26 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a unit test suite for the mDNS code functionality.
+ *
+ */
+
 #include <condition_variable>
 #include <mutex>
 #include <thread>

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -83,9 +83,11 @@ static void HandleResolve(void * context, DnssdService * result, const chip::Spa
     if (ctx->mBrowsedServicesCount == ++ctx->mResolvedServicesCount)
     {
         chip::DeviceLayer::SystemLayer().CancelTimer(Timeout, context);
-        // After last service is resolved, stop the event loop,
-        // so the test case can gracefully exit.
-        chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
+        chip::DeviceLayer::SystemLayer().ScheduleLambda([]() {
+            // After last service is resolved, stop the event loop,
+            // so the test case can gracefully exit.
+            chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
+        });
     }
 }
 

--- a/src/platform/tests/TestKeyValueStoreMgr.cpp
+++ b/src/platform/tests/TestKeyValueStoreMgr.cpp
@@ -353,7 +353,7 @@ int TestKeyValueStoreMgr()
 {
     nlTestSuite theSuite = { "KeyValueStoreMgr tests", &sTests[0], TestKeyValueStoreMgr_Setup, TestKeyValueStoreMgr_Teardown };
 
-    // Run test suit against one context.
+    // Run test suite against one context.
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/platform/tests/TestKeyValueStoreMgr.cpp
+++ b/src/platform/tests/TestKeyValueStoreMgr.cpp
@@ -353,7 +353,7 @@ int TestKeyValueStoreMgr()
 {
     nlTestSuite theSuite = { "KeyValueStoreMgr tests", &sTests[0], TestKeyValueStoreMgr_Setup, TestKeyValueStoreMgr_Teardown };
 
-    // Run test suit againt one context.
+    // Run test suit against one context.
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -247,7 +247,7 @@ int TestPlatformMgr()
 {
     nlTestSuite theSuite = { "PlatformMgr tests", &sTests[0], TestPlatformMgr_Setup, TestPlatformMgr_Teardown };
 
-    // Run test suit againt one context.
+    // Run test suit against one context.
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -247,7 +247,7 @@ int TestPlatformMgr()
 {
     nlTestSuite theSuite = { "PlatformMgr tests", &sTests[0], TestPlatformMgr_Setup, TestPlatformMgr_Teardown };
 
-    // Run test suit against one context.
+    // Run test suite against one context.
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -125,7 +125,7 @@ int TestPlatformTime()
 {
     nlTestSuite theSuite = { "PlatformTime tests", &sTests[0], nullptr, nullptr };
 
-    // Run test suit against one context.
+    // Run test suite against one context.
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -125,7 +125,7 @@ int TestPlatformTime()
 {
     nlTestSuite theSuite = { "PlatformTime tests", &sTests[0], nullptr, nullptr };
 
-    // Run test suit againt one context.
+    // Run test suit against one context.
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }


### PR DESCRIPTION
### Problem

After last service has been resolved the test case calls `chip::DeviceLayer::PlatformMgr().Shutdown()` without waiting for event loop termination. So, from time to time we've got race condition with abort:
```
[1681807067.000859][1049843:1049844] CHIP:DL: Avahi resolve found
Service[8] at [127.0.0.1]:80
[1681807067.002774][1049843:1049844] CHIP:DL: writing settings to file (/tmp/chip_counters.ini-vRqojS)
[1681807067.002981][1049843:1049844] CHIP:DL: renamed tmp file to file (/tmp/chip_counters.ini)
[1681807067.003022][1049843:1049844] CHIP:DL: NVS set: chip-counters/total-operational-hours = 0 (0x0)
[1681807067.003045][1049843:1049844] CHIP:SPT: VerifyOrDie failure at src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp:312: mState.load(std::memory_order_relaxed) == State::kStopped
Aborted (core dumped)
```

It happens because the `chip::DeviceLayer::PlatformMgr().StopEventLoopTask()` is called on the Matter thread, so this call can not wait for "self-thread join".

### Changes

- add `Setup` and `Teardown` for test runner (share matter stack between test cases added in the future)
- do not call `Shutdown()` and `exit()` on the Matter thread
- use dedicated browse context instead of global variables

### Testing

Tested on Linux with avahi:

```
[1681807644.570791][1065218:1065219] CHIP:DL: Avahi resolve found                                                                                                                                                    
Service[8] at [127.0.0.1]:80                                                                                                                                                                                         
[1681807644.571849][1065218:1065219] CHIP:DL: End EventLoop                                                                                                                                                          
'#3:','Test Dnssd::PubSub','PASSED'                                                                                                                                                                                  
'#6:','0','1'                                                                                                                                                                                                        
'#7:','0','59'                                                                                                                                                                                                       
[1681807644.573872][1065218:1065218] CHIP:DL: writing settings to file (/tmp/chip_counters.ini-733Ciz)                                                                                                               
[1681807644.574124][1065218:1065218] CHIP:DL: renamed tmp file to file (/tmp/chip_counters.ini)                                                                                                                      
[1681807644.574194][1065218:1065218] CHIP:DL: NVS set: chip-counters/total-operational-hours = 0 (0x0)                                                                                                               
[1681807644.574221][1065218:1065218] CHIP:DL: Inet Layer shutdown                                                                                                                                                    
[1681807644.574241][1065218:1065218] CHIP:DL: BLE shutdown                                                                                                                                                           
[1681807644.574314][1065218:1065218] CHIP:DL: System Layer shutdown
'#4:','Teardown          ','PASSED'
'#6:','0','1'
'#7:','0','61'
```
