### PR TITLE
Fix template argument naming for value assign

### DIFF
--- a/src/lib/assign/ValueAssign.h
+++ b/src/lib/assign/ValueAssign.h
@@ -22,7 +22,7 @@ namespace chip {
 namespace Value {
 
 template <class DEST, class SRC>
-SRC & Assign(DEST & dest, const SRC & src)
+DEST & Assign(DEST & dest, const SRC & src)
 {
     return dest = src;
 }

--- a/src/lib/assign/ValueAssign.h
+++ b/src/lib/assign/ValueAssign.h
@@ -21,8 +21,8 @@
 namespace chip {
 namespace Value {
 
-template <class DEST, class SRC>
-SRC & Assign(DEST & dest, const SRC & src)
+template <class SRC, class DEST>
+SRC & Assign(SRC & dest, const DEST & src)
 {
     return dest = src;
 }

--- a/src/lib/assign/ValueAssign.h
+++ b/src/lib/assign/ValueAssign.h
@@ -21,8 +21,8 @@
 namespace chip {
 namespace Value {
 
-template <class SRC, class DEST>
-SRC & Assign(SRC & dest, const DEST & src)
+template <class DEST, class SRC>
+SRC & Assign(DEST & dest, const SRC & src)
 {
     return dest = src;
 }


### PR DESCRIPTION
The SRC/DEST names were odd ... still correct, but saying `DEST src` sounds odd.