### PR TITLE
Fix IDL parser for older lark

### DIFF
--- a/scripts/py_matter_idl/matter_idl/matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter_idl/matter_idl_parser.py
@@ -287,6 +287,7 @@ class MatterIdlTransformer(Transformer):
     def command(self, meta, *args):
         # The command takes 4 arguments if no input argument, 5 if input
         # argument is provided
+        args = list(args) # convert from tuple
         if len(args) != 5:
             args.insert(2, None)
 

--- a/scripts/py_matter_idl/matter_idl/matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter_idl/matter_idl_parser.py
@@ -257,12 +257,12 @@ class MatterIdlTransformer(Transformer):
         return field
 
     @v_args(meta=True)
-    def server_cluster(self, meta, _):
+    def server_cluster(self, meta, unused_args):
         self._cluster_start_pos = meta and meta.start_pos
         return ClusterSide.SERVER
 
     @v_args(meta=True, inline=True)
-    def client_cluster(self, meta, *_):
+    def client_cluster(self, meta, *unused_args):
         self._cluster_start_pos = meta and meta.start_pos
         return ClusterSide.CLIENT
 
@@ -287,7 +287,7 @@ class MatterIdlTransformer(Transformer):
     def command(self, meta, *args):
         # The command takes 4 arguments if no input argument, 5 if input
         # argument is provided
-        args = list(args) # convert from tuple
+        args = list(args)  # convert from tuple
         if len(args) != 5:
             args.insert(2, None)
 

--- a/scripts/py_matter_idl/matter_idl/matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter_idl/matter_idl_parser.py
@@ -2,6 +2,7 @@
 
 import functools
 import logging
+from typing import Optional
 
 from lark import Lark
 from lark.lexer import Token
@@ -260,8 +261,8 @@ class MatterIdlTransformer(Transformer):
         self._cluster_start_pos = meta and meta.start_pos
         return ClusterSide.SERVER
 
-    @v_args(meta=True)
-    def client_cluster(self, meta, _):
+    @v_args(meta=True, inline=True)
+    def client_cluster(self, meta, *_):
         self._cluster_start_pos = meta and meta.start_pos
         return ClusterSide.CLIENT
 
@@ -280,8 +281,10 @@ class MatterIdlTransformer(Transformer):
 
         return init_args
 
-    @v_args(meta=True)
-    def command(self, meta, args):
+    # NOTE: awkward inline because the order of 'meta, children' vs 'children, meta' was flipped
+    #       between lark versions in https://github.com/lark-parser/lark/pull/993
+    @v_args(meta=True, inline=True)
+    def command(self, meta, *args):
         # The command takes 4 arguments if no input argument, 5 if input
         # argument is provided
         if len(args) != 5:
@@ -513,7 +516,7 @@ class ParserWithLines:
             }
         )
 
-    def parse(self, file: str, file_name: str = None):
+    def parse(self, file: str, file_name: Optional[str] = None):
         idl = self.transformer.transform(self.parser.parse(file))
         idl.parse_file_name = file_name
 

--- a/scripts/py_matter_idl/matter_idl/matter_idl_types.py
+++ b/scripts/py_matter_idl/matter_idl/matter_idl_types.py
@@ -1,6 +1,6 @@
 import enum
 from dataclasses import dataclass, field
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Set
 
 from lark.tree import Meta
 
@@ -13,7 +13,7 @@ class ParseMetaData:
     column: Optional[int]
     start_pos: Optional[int]
 
-    def __init__(self, meta: Meta = None, line: int = None, column: int = None, start_pos: int = None):
+    def __init__(self, meta: Optional[Meta] = None, line: Optional[int] = None, column: Optional[int] = None, start_pos: Optional[int] = None):
         if meta:
             self.line = meta.line
             self.column = meta.column
@@ -236,7 +236,7 @@ class AttributeInstantiation:
 class ServerClusterInstantiation:
     name: str
     attributes: List[AttributeInstantiation] = field(default_factory=list)
-    events_emitted: List[str] = field(default_factory=set)
+    events_emitted: Set[str] = field(default_factory=set)
 
     # Parsing meta data missing only when skip meta data is requested
     parse_meta: Optional[ParseMetaData] = field(default=None)

--- a/scripts/py_matter_idl/matter_idl/matter_idl_types.py
+++ b/scripts/py_matter_idl/matter_idl/matter_idl_types.py
@@ -1,6 +1,6 @@
 import enum
 from dataclasses import dataclass, field
-from typing import List, Optional, Union, Set
+from typing import List, Optional, Set, Union
 
 from lark.tree import Meta
 


### PR DESCRIPTION
It turns out lark had some backwards incompatible changes in meta placement first vs last argument when only `@v_args(meta=True)` is used.

Switch code to use inline as well, which seems consistent across versions.

While checking this, also fixed some mypy checks for static typing.