### PR TITLE
Switch from wasRemoved to isSupported for Darwin codegen.

### DIFF
--- a/examples/darwin-framework-tool/templates/commands.zapt
+++ b/examples/darwin-framework-tool/templates/commands.zapt
@@ -18,12 +18,12 @@
 {{> clusters_header}}
 
 {{#all_user_clusters side='client'}}
-{{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
 {{> cluster_header}}
 
 {{#zcl_commands}}
 {{#if (is_str_equal source 'client')}}
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
 /*
  * Command {{asUpperCamelCase name}}
  */
@@ -90,12 +90,12 @@ private:
     {{/zcl_command_arguments}}
 };
 
-{{/unless}}
+{{/if}}
 {{/if}}
 {{/zcl_commands}}
 
 {{#zcl_attributes_server removeKeys='isOptional'}}
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#*inline "cluster"}}Cluster{{asUpperCamelCase parent.name preserveAcronyms=true}}{{/inline}}
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 
@@ -247,16 +247,16 @@ public:
 };
 
 {{/if}}
-{{/unless}}
+{{/if}}
 {{/zcl_attributes_server}}
-{{/unless}}
+{{/if}}
 {{/all_user_clusters}}
 
 /*----------------------------------------------------------------------------*\
 | Register all Clusters commands                                               |
 \*----------------------------------------------------------------------------*/
 {{#all_user_clusters side='client'}}
-{{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
 void registerCluster{{asUpperCamelCase name}}(Commands & commands)
 {
     using namespace chip::app::Clusters::{{asUpperCamelCase name}};
@@ -267,34 +267,34 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands)
         make_unique<ClusterCommand>(Id), //
         {{#zcl_commands}}
         {{#if (is_str_equal source 'client')}}
-        {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
+        {{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
         make_unique<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(), //
-        {{/unless}}
+        {{/if}}
         {{/if}}
         {{/zcl_commands}}
         {{#zcl_attributes_server removeKeys='isOptional'}}
         {{#first}}
          make_unique<ReadAttribute>(Id), //
         {{/first}}
-        {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
+        {{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
         make_unique<Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(), //
-        {{/unless}}
+        {{/if}}
         {{#first}}
         make_unique<WriteAttribute>(Id), //
         {{/first}}
-        {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
+        {{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
         {{#if isWritableAttribute}}
         make_unique<Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(), //
         {{/if}}
-        {{/unless}}
+        {{/if}}
         {{#first}}
         make_unique<SubscribeAttribute>(Id), //
         {{/first}}
-        {{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
+        {{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
         {{#if isReportableAttribute}}
         make_unique<SubscribeAttribute{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(), //
         {{/if}}
-        {{/unless}}
+        {{/if}}
         {{/zcl_attributes_server}}
         {{#zcl_events}}
         {{#first}}
@@ -306,7 +306,7 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands)
 
     commands.Register(clusterName, clusterCommands);
 }
-{{/unless}}
+{{/if}}
 {{/all_user_clusters}}
 
 void registerClusterAny(Commands & commands)
@@ -330,8 +330,8 @@ void registerClusters(Commands & commands)
 {
     registerClusterAny(commands);
 {{#all_user_clusters side='client'}}
-    {{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
+    {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
     registerCluster{{asUpperCamelCase name}}(commands);
-    {{/unless}}
+    {{/if}}
 {{/all_user_clusters}}
 }

--- a/examples/darwin-framework-tool/templates/commands.zapt
+++ b/examples/darwin-framework-tool/templates/commands.zapt
@@ -17,7 +17,7 @@
 
 {{> clusters_header}}
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
 {{> cluster_header}}
 
@@ -250,12 +250,12 @@ public:
 {{/if}}
 {{/zcl_attributes_server}}
 {{/if}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
 /*----------------------------------------------------------------------------*\
 | Register all Clusters commands                                               |
 \*----------------------------------------------------------------------------*/
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
 void registerCluster{{asUpperCamelCase name}}(Commands & commands)
 {
@@ -307,7 +307,7 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands)
     commands.Register(clusterName, clusterCommands);
 }
 {{/if}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
 void registerClusterAny(Commands & commands)
 {
@@ -329,9 +329,9 @@ void registerClusterAny(Commands & commands)
 void registerClusters(Commands & commands)
 {
     registerClusterAny(commands);
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
     {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
     registerCluster{{asUpperCamelCase name}}(commands);
     {{/if}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 }

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -7,7 +7,7 @@ ARG COMMITHASH=7b99e6399c6069037c613782d78132c69b9dcabb
 # ZAP Development install, so that it runs on both x64 and arm64
 # Generally this should match with the ZAP version that is used for codegen within the
 # specified SHA
-ARG ZAP_VERSION=v2023.04.05-nightly
+ARG ZAP_VERSION=v2023.04.18-nightly
 
 # Ensure TARGETPLATFORM is set
 RUN case ${TARGETPLATFORM} in \

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -8,7 +8,7 @@
                 "mac-arm64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2023.04.05-nightly.1"]
+            "tags": ["version:2@v2023.04.18-nightly.1"]
         }
     ]
 }

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2023.4.5'
+MIN_ZAP_VERSION = '2023.4.18'
 
 
 class ZapTool:

--- a/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
@@ -18,7 +18,7 @@ id MTRDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader &
 {
     switch (aPath.mClusterId)
     {
-    {{#all_user_clusters side='client'}}
+    {{#zcl_clusters}}
     {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
     case Clusters::{{asUpperCamelCase name}}::Id: {
         using namespace Clusters::{{asUpperCamelCase name}};
@@ -47,7 +47,7 @@ id MTRDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader &
         break;
     }
     {{/if}}
-    {{/all_user_clusters}}
+    {{/zcl_clusters}}
     default: {
       *aError = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB;
       break;

--- a/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
@@ -19,13 +19,13 @@ id MTRDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader &
     switch (aPath.mClusterId)
     {
     {{#all_user_clusters side='client'}}
-    {{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
+    {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
     case Clusters::{{asUpperCamelCase name}}::Id: {
         using namespace Clusters::{{asUpperCamelCase name}};
         switch (aPath.mAttributeId)
         {
         {{#zcl_attributes_server removeKeys='isOptional'}}
-        {{#unless (wasRemoved (asUpperCamelCase ../name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
+        {{#if (isSupported (asUpperCamelCase ../name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
         case Attributes::{{asUpperCamelCase name}}::Id: {
             using TypeInfo = Attributes::{{asUpperCamelCase name}}::TypeInfo;
             TypeInfo::DecodableType cppValue;
@@ -38,7 +38,7 @@ id MTRDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader &
             {{>decode_value target="value" source="cppValue" cluster=parent.name errorCode="*aError = err; return nil;" depth=0}}
             return value;
         }
-        {{/unless}}
+        {{/if}}
         {{/zcl_attributes_server}}
         default:
           *aError = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB;
@@ -46,7 +46,7 @@ id MTRDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader &
         }
         break;
     }
-    {{/unless}}
+    {{/if}}
     {{/all_user_clusters}}
     default: {
       *aError = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB;

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
@@ -27,7 +27,7 @@ using chip::System::Clock::Seconds16;
 
 // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks): Linter is unable to locate the delete on these objects.
 {{#all_user_clusters side='client'}}
-{{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
 @implementation MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}}
 
 - (instancetype)initWithDevice:(MTRBaseDevice *)device endpointID:(NSNumber *)endpointID queue:(dispatch_queue_t)queue
@@ -50,15 +50,15 @@ using chip::System::Clock::Seconds16;
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandImpl"}}
 {{! This is used as the implementation for both the new-name and old-name bits, so check for both here. }}
-{{#unless (and (wasRemoved cluster command=command)
-               (wasRemoved (compatClusterNameRemapping parent.name) command=(compatCommandNameRemapping parent.name name)))}}
+{{#if (or (isSupported cluster command=command)
+          (isSupported (compatClusterNameRemapping parent.name) command=(compatCommandNameRemapping parent.name name)))}}
 {{#*inline "callbackName"}}{{#if hasSpecificResponse}}{{cluster}}Cluster{{asUpperCamelCase responseName preserveAcronyms=true}}{{else}}CommandSuccess{{/if}}{{/inline}}
 {{#*inline "paramsType"}}
-{{#if (wasRemoved cluster command=command)}}
+{{#unless (isSupported cluster command=command)}}
 MTR{{compatClusterNameRemapping parent.name}}Cluster{{compatCommandNameRemapping parent.name name}}Params
 {{else}}
 MTR{{cluster}}Cluster{{command}}Params
-{{/if}}
+{{/unless}}
 {{/inline}}
 {{#unless hasArguments}}
 - (void){{asLowerCamelCase name}}WithCompletion:({{>command_completion_type command=.}})completion
@@ -124,7 +124,7 @@ MTR{{cluster}}Cluster{{command}}Params
     });
     std::move(*bridge).DispatchAction(self.device);
 }
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{> commandImpl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
@@ -133,9 +133,9 @@ MTR{{cluster}}Cluster{{command}}Params
 
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{! This is used as the implementation for both the new-name and old-name bits, so check for both here. }}
-{{#unless (and (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))
-               (or (wasRemoved (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))
-                   (not wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))))}}
+{{#if (or (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))
+          (and (isSupported (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))
+               (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))))}}
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 - (void)read{{>attribute}}With
 {{~#if_is_fabric_scoped_struct type~}}
@@ -233,28 +233,28 @@ reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value
 }
 
 {{/if}}
-{{/unless}}
+{{/if}}
 {{/zcl_attributes_server}}
 
 @end
-{{/unless}}
+{{/if}}
 {{#unless (isStrEqual (asUpperCamelCase name preserveAcronyms=true) (compatClusterNameRemapping name))}}
-{{#unless (wasRemoved (compatClusterNameRemapping name))}}
+{{#if (isSupported (compatClusterNameRemapping name))}}
 
 @implementation MTRBaseCluster{{compatClusterNameRemapping name}}
 @end
-{{/unless}}
+{{/if}}
 {{/unless}}
 
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping name))
-           (not (wasRemoved (compatClusterNameRemapping name))))}}
+           (isSupported (compatClusterNameRemapping name)))}}
 @implementation MTRBaseCluster{{compatClusterNameRemapping name}} (Deprecated)
 
 {{#zcl_commands}}
 {{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandImpl"}}
-{{#unless (wasRemoved cluster command=command)}}
+{{#if (isSupported cluster command=command)}}
 - (void){{asLowerCamelCase command}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler
 {
   [self {{asLowerCamelCase name}}WithParams:params completion:
@@ -274,7 +274,7 @@ reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value
   [self {{asLowerCamelCase command}}WithParams:nil completionHandler:completionHandler];
 }
 {{/unless}}
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{> commandImpl cluster=(compatClusterNameRemapping parent.name)
                 command=(compatCommandNameRemapping parent.name name)}}
@@ -283,7 +283,7 @@ reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value
 
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))
-           (not (wasRemoved (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))))}}
+           (isSupported (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name)))}}
 {{#*inline "attribute"}}Attribute{{compatAttributeNameRemapping parent.name name}}{{/inline}}
 - (void)read{{>attribute}}With
 {{~#if_is_fabric_scoped_struct type~}}

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
@@ -26,7 +26,7 @@ using chip::System::Clock::Timeout;
 using chip::System::Clock::Seconds16;
 
 // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks): Linter is unable to locate the delete on these objects.
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
 @implementation MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}}
 
@@ -349,6 +349,6 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 @end
 {{/if}}
 
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -7,7 +7,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 
 
 {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
@@ -72,9 +72,9 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 @end
 {{/if}}
 
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 {{#unless (isStrEqual (asUpperCamelCase name preserveAcronyms=true) (compatClusterNameRemapping name))}}
 {{#if (isSupported (compatClusterNameRemapping name))}}
 {{availability (compatClusterNameRemapping name) deprecationMessage=(concat "Please use MTRBaseCluster" (asUpperCamelCase name preserveAcronyms=true))}}
@@ -83,7 +83,7 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 
 {{/if}}
 {{/unless}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
 {{#zcl_clusters}}
 {{#zcl_enums}}
@@ -179,7 +179,7 @@ typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName bitm
 {{/zcl_bitmaps}}
 {{/zcl_clusters}}
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping name))
            (isSupported (compatClusterNameRemapping name)))}}
 @interface MTRBaseCluster{{compatClusterNameRemapping name}} (Deprecated)
@@ -234,6 +234,6 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 @end
 
 {{/if}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{#all_user_clusters side='client'}}
 
 
-{{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
 /**
  * Cluster {{name}}
  *
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandDecl"}}
-{{#unless (wasRemoved cluster command=command)}}
+{{#if (isSupported cluster command=command)}}
 /**
  * Command {{name}}
  *
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{#unless hasArguments}}
 - (void){{asLowerCamelCase name}}WithCompletion:({{>command_completion_type command=.}})completion {{availability cluster command=command minimalRelease="First major API revamp"}};
 {{/unless}}
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{> commandDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{/zcl_commands}}
 
 {{#zcl_attributes_server removeKeys='isOptional'}}
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 - (void)read{{>attribute}}With
 {{~#if_is_fabric_scoped_struct type~}}
@@ -63,25 +63,25 @@ NS_ASSUME_NONNULL_BEGIN
 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))reportHandler {{availability (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true) minimalRelease="First major API revamp"}};
 + (void) read{{>attribute}}WithClusterStateCache:(MTRClusterStateCacheContainer *)clusterStateCacheContainer endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue completion:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))completion {{availability (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true) minimalRelease="First major API revamp"}};
 {{/if}}
-{{/unless}}
+{{/if}}
 {{/zcl_attributes_server}}
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
 @end
-{{/unless}}
+{{/if}}
 
 {{/all_user_clusters}}
 
 {{#all_user_clusters side='client'}}
 {{#unless (isStrEqual (asUpperCamelCase name preserveAcronyms=true) (compatClusterNameRemapping name))}}
-{{#unless (wasRemoved (compatClusterNameRemapping name))}}
+{{#if (isSupported (compatClusterNameRemapping name))}}
 {{availability (compatClusterNameRemapping name) deprecationMessage=(concat "Please use MTRBaseCluster" (asUpperCamelCase name preserveAcronyms=true))}}
 @interface MTRBaseCluster{{compatClusterNameRemapping name}} : MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}}
 @end
 
-{{/unless}}
+{{/if}}
 {{/unless}}
 {{/all_user_clusters}}
 
@@ -90,14 +90,14 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 {{#*inline "enumDef"}}
 typedef NS_ENUM({{asUnderlyingZclType name}}, {{objCEnumName clusterName enumName}}) {
    {{#zcl_enum_items}}
-   {{#unless (wasRemoved ../clusterName enum=../enumName enumValue=(asUpperCamelCase label preserveAcronyms=true))}}
+   {{#if (isSupported ../clusterName enum=../enumName enumValue=(asUpperCamelCase label preserveAcronyms=true))}}
    {{objCEnumName ../clusterName ../enumName}}{{asUpperCamelCase label preserveAcronyms=true}} {{availability ../clusterName enum=../enumName enumValue=(asUpperCamelCase label preserveAcronyms=true) deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../../name preserveAcronyms=true) ../label) (asUpperCamelCase label preserveAcronyms=true))}} = {{asHex value 2}},
-   {{/unless}}
+   {{/if}}
    {{#*inline "oldNameItemDecl"}}
    {{#if oldItemName}}
-   {{#unless (wasRemoved ../clusterName enum=../enumName enumValue=oldItemName)}}
+   {{#if (isSupported ../clusterName enum=../enumName enumValue=oldItemName)}}
    {{objCEnumName ../clusterName ../enumName}}{{objCEnumItemLabel oldItemName}} {{availability ../clusterName enum=../enumName enumValue=oldItemName deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../../name preserveAcronyms=true) ../label) (asUpperCamelCase label preserveAcronyms=true))}} = {{asHex value 2}},
-   {{/unless}}
+   {{/if}}
    {{/if}}
    {{/inline}}
    {{> oldNameItemDecl oldItemName=(oldName ../clusterName enum=../enumName enumValue=(asUpperCamelCase label preserveAcronyms=true))}}
@@ -105,20 +105,20 @@ typedef NS_ENUM({{asUnderlyingZclType name}}, {{objCEnumName clusterName enumNam
    {{!We had extra "Not Supported" values for DoorLockUserStatus/DoorLockUserType that we have to wedge in here manually for now.}}
    {{#if (and (isStrEqual clusterName "DoorLock")
               (or (isStrEqual enumName "UserTypeEnum") (isStrEqual enumName "UserStatusEnum"))
-              (not (wasRemoved clusterName enum=enumName enumValue="NotSupported")))}}
+              (isSupported clusterName enum=enumName enumValue="NotSupported"))}}
    {{objCEnumName clusterName enumName}}{{objCEnumItemLabel "NotSupported"}} {{availability clusterName enum=enumName enumValue="NotSupported" deprecationMessage="This value is not part of the specification and will be removed"}} = 0xFF,
    {{/if}}
 }
 {{/inline}}
-{{#unless (wasRemoved (asUpperCamelCase ../name preserveAcronyms=true) enum=(asUpperCamelCase label preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase ../name preserveAcronyms=true) enum=(asUpperCamelCase label preserveAcronyms=true))}}
 {{> enumDef name=name clusterName=(asUpperCamelCase ../name preserveAcronyms=true) enumName=(asUpperCamelCase label preserveAcronyms=true)}} {{availability (asUpperCamelCase ../name preserveAcronyms=true) enum=(asUpperCamelCase label preserveAcronyms=true) deprecationMessage="This enum is unused and will be removed"}};
-{{/unless}}
+{{/if}}
 {{! Takes the name of the enum to use as enumName. }}
 {{#*inline "oldNameDecl"}}
-{{#unless (wasRemoved (compatClusterNameRemapping ../name) enum=enumName)}}
+{{#if (isSupported (compatClusterNameRemapping ../name) enum=enumName)}}
 
 {{> enumDef name=name clusterName=(compatClusterNameRemapping ../name) enumName=enumName}} {{availability (compatClusterNameRemapping ../name) enum=enumName deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../name preserveAcronyms=true) label))}};
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{! Takes the old name of the enum, if any, as oldEnumName. }}
 {{#*inline "oldNameCheck"}}
@@ -138,29 +138,29 @@ typedef NS_ENUM({{asUnderlyingZclType name}}, {{objCEnumName clusterName enumNam
 {{#*inline "bitmapDef"}}
 typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName bitmapName}}) {
    {{#zcl_bitmap_items}}
-   {{#unless (wasRemoved ../clusterName bitmap=../bitmapName bitmapValue=(asUpperCamelCase label preserveAcronyms=true))}}
+   {{#if (isSupported ../clusterName bitmap=../bitmapName bitmapValue=(asUpperCamelCase label preserveAcronyms=true))}}
    {{objCEnumName ../clusterName ../bitmapName}}{{asUpperCamelCase label preserveAcronyms=true}} {{availability ../clusterName bitmap=../bitmapName bitmapValue=(asUpperCamelCase label preserveAcronyms=true) deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../../name preserveAcronyms=true) ../label) (asUpperCamelCase label preserveAcronyms=true))}} = {{asHex mask}},
-   {{/unless}}
+   {{/if}}
    {{#*inline "oldNameItemDecl"}}
    {{#if oldItemName}}
-   {{#unless (wasRemoved ../clusterName bitmap=../bitmapName bitmapValue=oldItemName)}}
+   {{#if (isSupported ../clusterName bitmap=../bitmapName bitmapValue=oldItemName)}}
    {{objCEnumName ../clusterName ../bitmapName}}{{objCEnumItemLabel oldItemName}} {{availability ../clusterName bitmap=../bitmapName bitmapValue=oldItemName deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../../name preserveAcronyms=true) ../label) (asUpperCamelCase label preserveAcronyms=true))}} = {{asHex mask}},
-   {{/unless}}
+   {{/if}}
    {{/if}}
    {{/inline}}
    {{> oldNameItemDecl oldItemName=(oldName ../clusterName bitmap=../bitmapName bitmapValue=(asUpperCamelCase label preserveAcronyms=true))}}
    {{/zcl_bitmap_items}}
 }
 {{/inline}}
-{{#unless (wasRemoved (asUpperCamelCase ../name preserveAcronyms=true) bitmap=(asUpperCamelCase label preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase ../name preserveAcronyms=true) bitmap=(asUpperCamelCase label preserveAcronyms=true))}}
 {{> bitmapDef name=name clusterName=(asUpperCamelCase ../name preserveAcronyms=true) bitmapName=(asUpperCamelCase label preserveAcronyms=true)}} {{availability (asUpperCamelCase ../name preserveAcronyms=true) bitmap=(asUpperCamelCase label preserveAcronyms=true)}};
-{{/unless}}
+{{/if}}
 {{! Takes the name of the bitmap to use as bitmapName. }}
 {{#*inline "oldNameDecl"}}
-{{#unless (wasRemoved (compatClusterNameRemapping ../name) bitmap=bitmapName)}}
+{{#if (isSupported (compatClusterNameRemapping ../name) bitmap=bitmapName)}}
 
 {{> bitmapDef name=name clusterName=(compatClusterNameRemapping ../name) bitmapName=bitmapName}} {{availability (compatClusterNameRemapping ../name) bitmap=bitmapName deprecationMessage=(concat "Please use " (objCEnumName (asUpperCamelCase ../name preserveAcronyms=true) label))}};
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{! Takes the old name of the bitmap, if any, as oldBitmapName. }}
 {{#*inline "oldNameCheck"}}
@@ -181,7 +181,7 @@ typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName bitm
 
 {{#all_user_clusters side='client'}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping name))
-           (not (wasRemoved (compatClusterNameRemapping name))))}}
+           (isSupported (compatClusterNameRemapping name)))}}
 @interface MTRBaseCluster{{compatClusterNameRemapping name}} (Deprecated)
 
 - (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
@@ -193,7 +193,7 @@ typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName bitm
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandDecl"}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" cluster command=command)
-           (not (wasRemoved cluster command=command)))}}
+           (isSupported cluster command=command))}}
 - (void){{asLowerCamelCase command}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField }}_Nullable{{/unless}})params completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler
     {{availability cluster command=command deprecatedRelease="First major API revamp" deprecationMessage=(concat "Please use " (asLowerCamelCase name) "WithParams:completion:")}};
 {{#unless hasArguments}}
@@ -209,7 +209,7 @@ typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName bitm
 
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))
-           (not (wasRemoved (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))))}}
+           (isSupported (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name)))}}
 {{#*inline "attribute"}}Attribute{{compatAttributeNameRemapping parent.name name}}{{/inline}}
 - (void)read{{>attribute}}With
 {{~#if_is_fabric_scoped_struct type~}}

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Internal.zapt
@@ -7,7 +7,7 @@
 
 #include <zap-generated/CHIPClusters.h>
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 
 {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
 @interface MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}} ()
@@ -16,4 +16,4 @@
 @end
 {{/if}}
 
-{{/all_user_clusters}}
+{{/zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Internal.zapt
@@ -9,11 +9,11 @@
 
 {{#all_user_clusters side='client'}}
 
-{{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
 @interface MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}} ()
 @property (nonatomic, strong, readonly) MTRBaseDevice * device;
 @property (nonatomic, assign, readonly) chip::EndpointId endpoint;
 @end
-{{/unless}}
+{{/if}}
 
 {{/all_user_clusters}}

--- a/src/darwin/Framework/CHIP/templates/MTRCallbackBridge-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCallbackBridge-src.zapt
@@ -39,7 +39,7 @@
 
 {{#all_user_clusters side='client'}}
 {{#zcl_attributes_server removeKeys='isOptional'}}
-{{#unless (wasRemoved (asUpperCamelCase ../name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase ../name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#if isArray}}
 {{#>MTRCallbackBridge ns=parent.name                                }}{{asUpperCamelCase ../../name preserveAcronyms=true}}{{asUpperCamelCase ../name preserveAcronyms=true}}ListAttributeCallback{{/MTRCallbackBridge}}
 {{else}}
@@ -50,23 +50,23 @@
   {{#>MTRCallbackBridge ns=parent.name                              }}{{asUpperCamelCase ../../name preserveAcronyms=true}}{{asUpperCamelCase ../name preserveAcronyms=true}}AttributeCallback{{/MTRCallbackBridge}}
   {{/if_is_strongly_typed_bitmap}}
 {{/if}}
-{{/unless}}
+{{/if}}
 {{/zcl_attributes_server}}
 {{/all_user_clusters}}
 
 {{#all_user_clusters side='client'}}
 {{#zcl_command_responses}}
-{{#unless (wasRemoved (asUpperCamelCase ../name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase ../name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#>MTRCallbackBridge partial-type="Command"                        }}{{asUpperCamelCase ../../name preserveAcronyms=true}}Cluster{{asUpperCamelCase ../name preserveAcronyms=true}}Callback{{/MTRCallbackBridge}}
-{{/unless}}
+{{/if}}
 {{/zcl_command_responses}}
 {{/all_user_clusters}}
 
 {{#zcl_clusters}}
 {{#zcl_enums}}
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) enum=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) enum=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#>MTRCallbackBridge type=(asType label) isNullable=false ns=parent.name}}{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}AttributeCallback{{/MTRCallbackBridge}}
 {{#>MTRCallbackBridge type=(asType label) isNullable=true  ns=parent.name}}Nullable{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}AttributeCallback{{/MTRCallbackBridge}}
-{{/unless}}
+{{/if}}
 {{/zcl_enums}}
 {{/zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/MTRCallbackBridge-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCallbackBridge-src.zapt
@@ -37,7 +37,7 @@
 {{#>MTRCallbackBridge type="vendor_id"    isNullable=false ns="chip"}}VendorIdAttributeCallback{{/MTRCallbackBridge}}
 {{#>MTRCallbackBridge type="vendor_id"    isNullable=true  ns="chip"}}NullableVendorIdAttributeCallback{{/MTRCallbackBridge}}
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{#if (isSupported (asUpperCamelCase ../name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#if isArray}}
@@ -52,15 +52,15 @@
 {{/if}}
 {{/if}}
 {{/zcl_attributes_server}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 {{#zcl_command_responses}}
 {{#if (isSupported (asUpperCamelCase ../name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#>MTRCallbackBridge partial-type="Command"                        }}{{asUpperCamelCase ../../name preserveAcronyms=true}}Cluster{{asUpperCamelCase ../name preserveAcronyms=true}}Callback{{/MTRCallbackBridge}}
 {{/if}}
 {{/zcl_command_responses}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
 {{#zcl_clusters}}
 {{#zcl_enums}}

--- a/src/darwin/Framework/CHIP/templates/MTRCallbackBridge.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCallbackBridge.zapt
@@ -14,13 +14,13 @@ typedef void (*DefaultSuccessCallbackType)(void *);
 typedef void (*VendorIdAttributeCallback)(void *, chip::VendorId);
 typedef void (*NullableVendorIdAttributeCallback)(void *, const chip::app::DataModel::Nullable<chip::VendorId> &);
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 {{#zcl_command_responses}}
 {{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
 typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}CallbackType)(void *, const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType &);
 {{/if}}
 {{/zcl_command_responses}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
 {{#zcl_clusters}}
 {{#zcl_enums}}
@@ -31,7 +31,7 @@ typedef void (*Nullable{{asUpperCamelCase parent.name preserveAcronyms=true}}Clu
 {{/zcl_enums}}
 {{/zcl_clusters}}
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#if isArray}}
@@ -46,7 +46,7 @@ typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCa
 {{/if}}
 {{/if}}
 {{/zcl_attributes_server}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
 {{#>MTRCallbackBridge header="1" partial-type="Status"                         }}DefaultSuccessCallback{{/MTRCallbackBridge}}
 {{#>MTRCallbackBridge header="1" partial-type="CommandStatus"                  }}CommandSuccessCallback{{/MTRCallbackBridge}}
@@ -79,7 +79,7 @@ typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCa
 {{#>MTRCallbackBridge header="1" type="vendor_id"    isNullable=false ns="chip"}}VendorIdAttributeCallback{{/MTRCallbackBridge}}
 {{#>MTRCallbackBridge header="1" type="vendor_id"    isNullable=true  ns="chip"}}NullableVendorIdAttributeCallback{{/MTRCallbackBridge}}
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 {{#zcl_attributes_server removeKeys='isOptional'}}
 {{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#if isArray}}
@@ -94,15 +94,15 @@ typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCa
 {{/if}}
 {{/if}}
 {{/zcl_attributes_server}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 {{#zcl_command_responses}}
 {{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#>MTRCallbackBridge header="1" partial-type="Command"                        }}{{asUpperCamelCase ../../name preserveAcronyms=true}}Cluster{{asUpperCamelCase ../name preserveAcronyms=true}}Callback{{/MTRCallbackBridge}}
 {{/if}}
 {{/zcl_command_responses}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
 {{#zcl_clusters}}
 {{#zcl_enums}}

--- a/src/darwin/Framework/CHIP/templates/MTRCallbackBridge.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCallbackBridge.zapt
@@ -16,24 +16,24 @@ typedef void (*NullableVendorIdAttributeCallback)(void *, const chip::app::DataM
 
 {{#all_user_clusters side='client'}}
 {{#zcl_command_responses}}
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
 typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}CallbackType)(void *, const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType &);
-{{/unless}}
+{{/if}}
 {{/zcl_command_responses}}
 {{/all_user_clusters}}
 
 {{#zcl_clusters}}
 {{#zcl_enums}}
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) enum=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) enum=(asUpperCamelCase name preserveAcronyms=true))}}
 typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}AttributeCallback)(void *, chip::app::Clusters::{{asUpperCamelCase parent.name}}::{{asType label}});
 typedef void (*Nullable{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}AttributeCallback)(void *, const chip::app::DataModel::Nullable<chip::app::Clusters::{{asUpperCamelCase parent.name}}::{{asType label}}> &);
-{{/unless}}
+{{/if}}
 {{/zcl_enums}}
 {{/zcl_clusters}}
 
 {{#all_user_clusters side='client'}}
 {{#zcl_attributes_server removeKeys='isOptional'}}
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#if isArray}}
 typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCamelCase name preserveAcronyms=true}}ListAttributeCallback)(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} data);
 {{else}}
@@ -44,7 +44,7 @@ typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCa
 typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCamelCase name preserveAcronyms=true}}AttributeCallback)(void *, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true forceNotOptional=true}});
 {{/if_is_strongly_typed_bitmap}}
 {{/if}}
-{{/unless}}
+{{/if}}
 {{/zcl_attributes_server}}
 {{/all_user_clusters}}
 
@@ -81,7 +81,7 @@ typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCa
 
 {{#all_user_clusters side='client'}}
 {{#zcl_attributes_server removeKeys='isOptional'}}
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#if isArray}}
 {{#>MTRCallbackBridge header="1" ns=parent.name                                }}{{asUpperCamelCase ../../name preserveAcronyms=true}}{{asUpperCamelCase ../name preserveAcronyms=true}}ListAttributeCallback{{/MTRCallbackBridge}}
 {{else}}
@@ -92,23 +92,23 @@ typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCa
   {{#>MTRCallbackBridge header="1" ns=parent.name                              }}{{asUpperCamelCase ../../name preserveAcronyms=true}}{{asUpperCamelCase ../name preserveAcronyms=true}}AttributeCallback{{/MTRCallbackBridge}}
   {{/if_is_strongly_typed_bitmap}}
 {{/if}}
-{{/unless}}
+{{/if}}
 {{/zcl_attributes_server}}
 {{/all_user_clusters}}
 
 {{#all_user_clusters side='client'}}
 {{#zcl_command_responses}}
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#>MTRCallbackBridge header="1" partial-type="Command"                        }}{{asUpperCamelCase ../../name preserveAcronyms=true}}Cluster{{asUpperCamelCase ../name preserveAcronyms=true}}Callback{{/MTRCallbackBridge}}
-{{/unless}}
+{{/if}}
 {{/zcl_command_responses}}
 {{/all_user_clusters}}
 
 {{#zcl_clusters}}
 {{#zcl_enums}}
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) enum=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) enum=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#>MTRCallbackBridge header="1" type=(asType label) isNullable=false ns=parent.name}}{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}AttributeCallback{{/MTRCallbackBridge}}
 {{#>MTRCallbackBridge header="1" type=(asType label) isNullable=true  ns=parent.name}}Nullable{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}AttributeCallback{{/MTRCallbackBridge}}
-{{/unless}}
+{{/if}}
 {{/zcl_enums}}
 {{/zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusterConstants.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterConstants.zapt
@@ -8,15 +8,15 @@
 typedef NS_ENUM(uint32_t, MTRClusterIDType) {
 {{#zcl_clusters}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping name) isForIds=true)
-           (not (wasRemoved (compatClusterNameRemapping name) isForIds=true)))}}
+           (isSupported (compatClusterNameRemapping name) isForIds=true))}}
 MTRCluster{{compatClusterNameRemapping label}}ID {{availability (compatClusterNameRemapping name) deprecatedRelease="First major API revamp" deprecationMessage=(concat "Please use MTRClusterIDType" (asUpperCamelCase label preserveAcronyms=true) "ID") isForIds=true}} = {{asMEI manufacturerCode code}},
 {{/if}}
 {{/zcl_clusters}}
 {{#zcl_clusters}}
-{{#unless (wasRemoved (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
+{{#if (isSupported (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
 {{~#*inline "cluster"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
 MTRClusterIDType{{>cluster}}ID {{availability (asUpperCamelCase label preserveAcronyms=true) minimalRelease="First major API revamp" isForIds=true}} = {{asMEI manufacturerCode code}},
-{{/unless}}
+{{/if}}
 {{/zcl_clusters}}
 };
 
@@ -38,9 +38,9 @@ MTRClusterGlobalAttribute{{asUpperCamelCase label}}ID
 {{#zcl_attributes_server}}
 {{~#*inline "attribute"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
 {{#unless clusterRef}}
-{{#unless (wasRemoved "" globalAttribute=(asUpperCamelCase label) isForIds=true)}}
+{{#if (isSupported "" globalAttribute=(asUpperCamelCase label) isForIds=true)}}
 MTRAttributeIDTypeGlobalAttribute{{>attribute}}ID {{availability "" globalAttribute=(asUpperCamelCase label) minimalRelease="First major API revamp" isForIds=true}} = {{asMEI manufacturerCode code}},
-{{/unless}}
+{{/if}}
 {{/unless}}
 {{/zcl_attributes_server}}
 
@@ -49,9 +49,9 @@ MTRAttributeIDTypeGlobalAttribute{{>attribute}}ID {{availability "" globalAttrib
 {{#zcl_attributes_server}}
 {{#first}}
 {{#if (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping ../clusterName) isForIds=true)}}
-{{#unless (wasRemoved (compatClusterNameRemapping ../clusterName))}}
+{{#if (isSupported (compatClusterNameRemapping ../clusterName) isForIds=true)}}
 // Cluster {{compatClusterNameRemapping ../clusterName}} deprecated attribute names
-{{/unless}}
+{{/if}}
 {{/if}}
 {{/first}}
 {{! DeviceTypeList is special: we did not call it by that name
@@ -65,7 +65,7 @@ MTRClusterDescriptorAttributeDeviceTypeListID
 {{/if}}
 {{/if}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping ../clusterName) attribute=(compatAttributeNameRemapping ../clusterName label) isForIds=true)
-           (not (wasRemoved (compatClusterNameRemapping ../clusterName) attribute=(compatAttributeNameRemapping ../clusterName label) isForIds=true)))}}
+           (isSupported (compatClusterNameRemapping ../clusterName) attribute=(compatAttributeNameRemapping ../clusterName label) isForIds=true))}}
 MTRCluster{{compatClusterNameRemapping ../clusterName}}Attribute{{compatAttributeNameRemapping ../clusterName label}}ID
 {{availability (compatClusterNameRemapping ../clusterName) attribute=(compatAttributeNameRemapping ../clusterName label) deprecatedRelease="First major API revamp" deprecationMessage=(concat "Please use MTRAttributeIDTypeCluster" (asUpperCamelCase ../clusterName preserveAcronyms=true) "Attribute" (asUpperCamelCase label preserveAcronyms=true) "ID") isForIds=true}} =
 {{#if clusterRef}}
@@ -82,24 +82,24 @@ MTRClusterGlobalAttribute{{asUpperCamelCase label}}ID,
 {{~#*inline "cluster"}}{{asUpperCamelCase ../clusterName preserveAcronyms=true}}{{/inline~}}
 {{~#*inline "attribute"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
 {{#first}}
-{{#unless (wasRemoved (asUpperCamelCase ../clusterName preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) isForIds=true)}}
 // Cluster {{> cluster}} attributes
-{{/unless}}
+{{/if}}
 {{/first}}
-{{#unless (wasRemoved (asUpperCamelCase ../clusterName preserveAcronyms=true) attribute=(asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
+{{#if (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) attribute=(asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
 MTRAttributeIDTypeCluster{{>cluster}}Attribute{{>attribute}}ID {{availability (asUpperCamelCase ../clusterName preserveAcronyms=true) attribute=(asUpperCamelCase label preserveAcronyms=true) minimalRelease="First major API revamp" isForIds=true}} =
 {{#if clusterRef}}
 {{asMEI manufacturerCode code}},
 {{else}}
 MTRAttributeIDTypeGlobalAttribute{{asUpperCamelCase label}}ID,
 {{/if}}
-{{/unless}}
+{{/if}}
 {{! Anything which has an old name, and the new name was introduced in the "First after major API revamp" release or later
     (or just after the "First major API revamp" release, but we don't have a good way to test for that),
     we need to generate the new-form id for the old name too, as long as it was not removed. }}
 {{#if (and (hasOldName (asUpperCamelCase ../clusterName preserveAcronyms=true) attribute=(asUpperCamelCase label preserveAcronyms=true) isForIds=true)
            (not (wasIntroducedBeforeRelease "First after major API revamp" (asUpperCamelCase ../clusterName preserveAcronyms=true) attribute=(asUpperCamelCase label preserveAcronyms=true) isForIds=true))
-           (not (wasRemoved (compatClusterNameRemapping ../clusterName) attribute=(compatAttributeNameRemapping ../clusterName label) isForIds=true)))}}
+           (isSupported (compatClusterNameRemapping ../clusterName) attribute=(compatAttributeNameRemapping ../clusterName label) isForIds=true))}}
 MTRAttributeIDTypeCluster{{compatClusterNameRemapping ../clusterName}}Attribute{{compatAttributeNameRemapping ../clusterName label}}ID {{availability (compatClusterNameRemapping ../clusterName) attribute=(compatAttributeNameRemapping ../clusterName label) isForIds=true minimalRelease="First major API revamp" deprecationMessage=(concat "Please use MTRAttributeIDType" (asUpperCamelCase ../clusterName preserveAcronyms=true) "Attribute" (asUpperCamelCase label preserveAcronyms=true) "ID")}} = MTRAttributeIDTypeCluster{{>cluster}}Attribute{{>attribute}}ID,
 {{/if}}
 {{#last}}
@@ -120,15 +120,15 @@ typedef NS_ENUM(uint32_t, MTRCommandIDType) {
 {{#zcl_commands}}
 {{#first}}
 {{#if (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping ../clusterName) isForIds=true)}}
-{{#unless (wasRemoved (compatClusterNameRemapping ../clusterName))}}
+{{#if (isSupported (compatClusterNameRemapping ../clusterName) isForIds=true)}}
 // Cluster {{compatClusterNameRemapping ../clusterName}} deprecated command id names
-{{/unless}}
+{{/if}}
 {{/if}}
 {{/first}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandIdDecl"}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" cluster command=command isForIds=true)
-           (not (wasRemoved cluster command=command isForIds=true)))}}
+           (isSupported cluster command=command isForIds=true))}}
 MTRCluster{{cluster}}Command{{command}}ID
 {{availability cluster command=command deprecatedRelease="First major API revamp" deprecationMessage=(concat "Please use MTRCommandIDTypeCluster" (asUpperCamelCase ../clusterName preserveAcronyms=true) "Command" (asUpperCamelCase name preserveAcronyms=true) "ID") isForIds=true}}
 = {{asMEI manufacturerCode code}},
@@ -143,15 +143,15 @@ MTRCluster{{cluster}}Command{{command}}ID
 {{#zcl_commands}}
 {{~#*inline "cluster"}}{{asUpperCamelCase ../clusterName preserveAcronyms=true}}{{/inline~}}
 {{#first}}
-{{#unless (wasRemoved (asUpperCamelCase ../clusterName preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) isForIds=true)}}
 // Cluster {{>cluster}} commands
-{{/unless}}
+{{/if}}
 {{/first}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandIdDecl"}}
-{{#unless (wasRemoved cluster command=command isForIds=true)}}
+{{#if (isSupported cluster command=command isForIds=true)}}
 MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID {{availability cluster command=command minimalRelease="First major API revamp" isForIds=true}} = {{asMEI manufacturerCode code}},
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{> commandIdDecl cluster=(asUpperCamelCase ../clusterName preserveAcronyms=true)
                   command=(asUpperCamelCase name preserveAcronyms=true)}}
@@ -173,13 +173,13 @@ typedef NS_ENUM(uint32_t, MTREventIDType) {
 {{#zcl_events}}
 {{#first}}
 {{#if (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping ../clusterName) isForIds=true)}}
-{{#unless (wasRemoved (compatClusterNameRemapping ../clusterName))}}
+{{#if (isSupported (compatClusterNameRemapping ../clusterName))}}
 // Cluster {{compatClusterNameRemapping ../clusterName}} deprecated event names
-{{/unless}}
+{{/if}}
 {{/if}}
 {{/first}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping ../clusterName) event=(asUpperCamelCase name) isForIds=true)
-           (not (wasRemoved (compatClusterNameRemapping ../clusterName) event=(asUpperCamelCase name) isForIds=true)))}}
+           (isSupported (compatClusterNameRemapping ../clusterName) event=(asUpperCamelCase name) isForIds=true))}}
 MTRCluster{{compatClusterNameRemapping ../clusterName}}Event{{asUpperCamelCase name}}ID
 {{availability (compatClusterNameRemapping ../clusterName) event=(asUpperCamelCase name) deprecatedRelease="First major API revamp" deprecationMessage=(concat "Please use MTREventIDTypeCluster" (asUpperCamelCase ../clusterName preserveAcronyms=true) "Event" (asUpperCamelCase name preserveAcronyms=true) "ID") isForIds=true}}
 = {{asMEI manufacturerCode code}},
@@ -192,13 +192,13 @@ MTRCluster{{compatClusterNameRemapping ../clusterName}}Event{{asUpperCamelCase n
 {{~#*inline "cluster"}}{{asUpperCamelCase ../clusterName preserveAcronyms=true}}{{/inline~}}
 {{~#*inline "event"}}{{asUpperCamelCase name preserveAcronyms=true}}{{/inline~}}
 {{#first}}
-{{#unless (wasRemoved (asUpperCamelCase ../clusterName preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true))}}
 // Cluster {{>cluster}} events
-{{/unless}}
+{{/if}}
 {{/first}}
-{{#unless (wasRemoved (asUpperCamelCase ../clusterName preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true) isForIds=true)}}
+{{#if (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true) isForIds=true)}}
 MTREventIDTypeCluster{{>cluster}}Event{{>event}}ID {{availability (asUpperCamelCase ../clusterName preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true) minimalRelease="First major API revamp" isForIds=true}} = {{asMEI manufacturerCode code}},
-{{/unless}}
+{{/if}}
 {{#last}}
 
 {{/last}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
@@ -41,7 +41,7 @@ static void MTRClustersLogCompletion(NSString *logPrefix, id value, NSError *err
 
 // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks): Linter is unable to locate the delete on these objects.
 {{#all_user_clusters side='client'}}
-{{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
 @implementation MTRCluster{{asUpperCamelCase name preserveAcronyms=true}}
 
 - (instancetype)initWithDevice:(MTRDevice *)device endpointID:(NSNumber *)endpointID queue:(dispatch_queue_t)queue
@@ -63,29 +63,29 @@ static void MTRClustersLogCompletion(NSString *logPrefix, id value, NSError *err
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandImpl"}}
 {{! This is used as the implementation for both the new-name and old-name bits, so check for both here. }}
-{{#unless (and (wasRemoved cluster command=command)
-               (wasRemoved (compatClusterNameRemapping parent.name) command=(compatCommandNameRemapping parent.name name)))}}
+{{#if (or (isSupported cluster command=command)
+          (isSupported (compatClusterNameRemapping parent.name) command=(compatCommandNameRemapping parent.name name)))}}
 {{#*inline "callbackName"}}{{#if hasSpecificResponse}}{{cluster}}Cluster{{asUpperCamelCase responseName preserveAcronyms=true}}{{else}}CommandSuccess{{/if}}{{/inline}}
 {{#*inline "paramsType"}}
-{{#if (wasRemoved cluster command=command)}}
+{{#unless (isSupported cluster command=command)}}
 MTR{{compatClusterNameRemapping parent.name}}Cluster{{compatCommandNameRemapping parent.name name}}Params
 {{else}}
 MTR{{cluster}}Cluster{{command}}Params
-{{/if}}
+{{/unless}}
 {{/inline}}
 {{#*inline "clusterId"}}
-{{#if (wasRemoved cluster command=command)}}
+{{#unless (isSupported cluster command=command)}}
 {{asMEI ../manufacturerCode ../code}}
 {{else}}
 MTRClusterIDType{{cluster}}ID
-{{/if}}
+{{/unless}}
 {{/inline}}
 {{#*inline "commandId"}}
-{{#if (wasRemoved cluster command=command)}}
+{{#unless (isSupported cluster command=command)}}
 {{asMEI manufacturerCode code}}
 {{else}}
 MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
-{{/if}}
+{{/unless}}
 {{/inline}}
 {{#unless hasArguments}}
 - (void){{asLowerCamelCase name}}WithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion
@@ -176,7 +176,7 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
       [self.device setExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs];
     }
 }
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{#if (is_str_equal source 'client')}}
 {{> commandImpl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
@@ -186,9 +186,9 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
 
 {{#zcl_attributes_server}}
 {{! This is used as the implementation for both the new-name and old-name bits, so check for both here. }}
-{{#unless (and (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))
-               (or (wasRemoved (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))
-                   (not wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))))}}
+{{#if (or (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))
+          (and (isSupported (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))
+               (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))))}}
 {{#*inline "cluster"}}{{asUpperCamelCase parent.name preserveAcronyms=true}}{{/inline}}
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 - (NSDictionary<NSString *, id> *)read{{>attribute}}WithParams:(MTRReadParams * _Nullable)params {
@@ -215,20 +215,20 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
 
 {{/if}}
 
-{{/unless}}
+{{/if}}
 {{/zcl_attributes_server}}
 
 @end
-{{/unless}}
+{{/if}}
 {{#unless (isStrEqual (asUpperCamelCase name preserveAcronyms=true) (compatClusterNameRemapping name))}}
-{{#unless (wasRemoved (compatClusterNameRemapping name))}}
+{{#if (isSupported (compatClusterNameRemapping name))}}
 @implementation MTRCluster{{compatClusterNameRemapping name}}
 @end
-{{/unless}}
+{{/if}}
 {{/unless}}
 
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping name))
-           (not (wasRemoved (compatClusterNameRemapping name))))}}
+           (isSupported (compatClusterNameRemapping name)))}}
 @implementation MTRCluster{{compatClusterNameRemapping name}} (Deprecated)
 
 - (instancetype)initWithDevice:(MTRDevice *)device endpoint:(uint16_t)endpoint queue:(dispatch_queue_t)queue
@@ -240,7 +240,7 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
 {{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandImpl"}}
-{{#unless (wasRemoved cluster command=command)}}
+{{#if (isSupported cluster command=command)}}
 - (void){{asLowerCamelCase command}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler
 {
   [self {{asLowerCamelCase name}}WithParams:params expectedValues:expectedDataValueDictionaries expectedValueInterval:expectedValueIntervalMs completion:
@@ -260,7 +260,7 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
   [self {{asLowerCamelCase command}}WithParams:nil expectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completionHandler:completionHandler];
 }
 {{/unless}}
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{> commandImpl cluster=(compatClusterNameRemapping parent.name)
                 command=(compatCommandNameRemapping parent.name name)}}
@@ -268,8 +268,8 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
 {{/zcl_commands}}
 {{~#zcl_attributes_server}}
 {{~#*inline "attributeImpls"}}
-{{#unless (or (isStrEqual attribute (asUpperCamelCase name preserveAcronyms=true))
-              (wasRemoved (compatClusterNameRemapping parent.name) attribute=attribute))}}
+{{#if (and (not (isStrEqual attribute (asUpperCamelCase name preserveAcronyms=true)))
+           (isSupported (compatClusterNameRemapping parent.name) attribute=attribute))}}
 - (NSDictionary<NSString *, id> *)readAttribute{{attribute}}WithParams:(MTRReadParams * _Nullable)params
 {
   return [self readAttribute{{asUpperCamelCase name preserveAcronyms=true}}WithParams:params];
@@ -284,7 +284,7 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
   [self writeAttribute{{asUpperCamelCase name preserveAcronyms=true}}WithValue:dataValueDictionary expectedValueInterval:expectedValueIntervalMs params:params];
 }
 {{/if}}
-{{/unless}}
+{{/if}}
 {{/inline~}}
 {{> attributeImpls attribute=(compatAttributeNameRemapping parent.name name)}}
 {{/zcl_attributes_server}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
@@ -40,7 +40,7 @@ static void MTRClustersLogCompletion(NSString *logPrefix, id value, NSError *err
 }
 
 // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks): Linter is unable to locate the delete on these objects.
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
 @implementation MTRCluster{{asUpperCamelCase name preserveAcronyms=true}}
 
@@ -291,6 +291,6 @@ MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID
 @end
 {{/if}}
 
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)

--- a/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
@@ -8,7 +8,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 
 
 {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
@@ -59,9 +59,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 {{/if}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 {{#unless (isStrEqual (asUpperCamelCase name preserveAcronyms=true) (compatClusterNameRemapping name))}}
 {{#if (isSupported (compatClusterNameRemapping name))}}
 {{availability (compatClusterNameRemapping name) deprecationMessage=(concat "Please use MTRCluster" (asUpperCamelCase name preserveAcronyms=true))}}
@@ -70,9 +70,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{/if}}
 {{/unless}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping name))
            (isSupported (compatClusterNameRemapping name)))}}
 @interface MTRCluster{{compatClusterNameRemapping name}} (Deprecated)
@@ -113,6 +113,6 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 {{/if}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{#all_user_clusters side='client'}}
 
 
-{{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
 /**
  * Cluster {{name}}
  *    {{description}}
@@ -27,12 +27,12 @@ NS_ASSUME_NONNULL_BEGIN
 {{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandDecl"}}
-{{#unless (wasRemoved cluster command=command)}}
+{{#if (isSupported cluster command=command)}}
 - (void){{asLowerCamelCase name}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion {{availability cluster command=command minimalRelease="First major API revamp"}};
 {{#unless hasArguments}}
 - (void){{asLowerCamelCase name}}WithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion {{availability cluster command=command minimalRelease="First major API revamp"}};
 {{/unless}}
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{> commandDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{/zcl_commands}}
 
 {{#zcl_attributes_server}}
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 {{#*inline "availability"}}
 {{availability (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true)}}
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs {{> availability}};
 - (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs params:(MTRWriteParams * _Nullable)params {{> availability}};
 {{/if}}
-{{/unless}}
+{{/if}}
 {{/zcl_attributes_server}}
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -58,23 +58,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-{{/unless}}
+{{/if}}
 {{/all_user_clusters}}
 
 {{#all_user_clusters side='client'}}
 {{#unless (isStrEqual (asUpperCamelCase name preserveAcronyms=true) (compatClusterNameRemapping name))}}
-{{#unless (wasRemoved (compatClusterNameRemapping name))}}
+{{#if (isSupported (compatClusterNameRemapping name))}}
 {{availability (compatClusterNameRemapping name) deprecationMessage=(concat "Please use MTRCluster" (asUpperCamelCase name preserveAcronyms=true))}}
 @interface MTRCluster{{compatClusterNameRemapping name}} : MTRCluster{{asUpperCamelCase name preserveAcronyms=true}}
 @end
 
-{{/unless}}
+{{/if}}
 {{/unless}}
 {{/all_user_clusters}}
 
 {{#all_user_clusters side='client'}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" (compatClusterNameRemapping name))
-           (not (wasRemoved (compatClusterNameRemapping name))))}}
+           (isSupported (compatClusterNameRemapping name)))}}
 @interface MTRCluster{{compatClusterNameRemapping name}} (Deprecated)
 
 - (nullable instancetype)initWithDevice:(MTRDevice *)device
@@ -86,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandDecl"}}
 {{#if (and (wasIntroducedBeforeRelease "First major API revamp" cluster command=command)
-           (not (wasRemoved cluster command=command)))}}
+           (isSupported cluster command=command))}}
 - (void){{asLowerCamelCase command}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler {{availability cluster command=command deprecatedRelease="First major API revamp" deprecationMessage=(concat "Please use " (asLowerCamelCase name) "WithParams:expectedValues:expectedValueInterval:completion:")}};
 {{#unless hasArguments}}
 - (void){{asLowerCamelCase command}}WithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completionHandler:({{>command_completion_type command=. compatRemapNames=true}})completionHandler {{availability cluster command=command deprecatedRelease="First major API revamp" deprecationMessage=(concat "Please use " (asLowerCamelCase name) "WithExpectedValues:expectedValueInterval:completion:")}};

--- a/src/darwin/Framework/CHIP/templates/MTRClusters_Internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters_Internal.zapt
@@ -8,7 +8,7 @@
 
 #include <zap-generated/CHIPClusters.h>
 
-{{#all_user_clusters side='client'}}
+{{#zcl_clusters}}
 
 {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
 @interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} ()
@@ -17,4 +17,4 @@
 @end
 {{/if}}
 
-{{/all_user_clusters}}
+{{/zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusters_Internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters_Internal.zapt
@@ -10,11 +10,11 @@
 
 {{#all_user_clusters side='client'}}
 
-{{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
 @interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} ()
 @property (nonatomic, readonly) uint16_t endpoint;
 @property (nonatomic, readonly) MTRDevice *device;
 @end
-{{/unless}}
+{{/if}}
 
 {{/all_user_clusters}}

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{#zcl_clusters}}
 {{#zcl_commands}}
 {{#*inline "completeImpl"}}
-{{#unless (wasRemoved cluster command=command)}}
+{{#if (isSupported cluster command=command isForCommandPayload=true)}}
 @implementation MTR{{cluster}}Cluster{{command}}Params
 - (instancetype)init
 {
@@ -59,14 +59,14 @@ NS_ASSUME_NONNULL_BEGIN
 {{/zcl_command_arguments}}
 
 @end
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{#*inline "oldNameImpl"}}
 
 @implementation MTR{{cluster}}Cluster{{command}}Params
 @end
 {{/inline}}
-{{#if (not (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true)))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
 {{> completeImpl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                  command=(asUpperCamelCase name preserveAcronyms=true)
                  includeRenamedProperties=false}}

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{#zcl_clusters}}
 {{#zcl_commands}}
 {{#*inline "completeDecl"}}
-{{#unless (wasRemoved cluster command=command)}}
+{{#if (isSupported cluster command=command isForCommandPayload=true)}}
 
 {{availability cluster command=command isForCommandPayload=true deprecationMessage="This command has been removed"}}
 @interface MTR{{cluster}}Cluster{{command}}Params : NSObject <NSCopying>
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs {{availability "" api="Timed Invoke for server to client commands" deprecationMessage="Timed invoke does not make sense for server to client commands"}};
 {{/if}}
 @end
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{#*inline "oldNameDecl"}}
 
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 {{/inline}}
-{{#if (not (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true)))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
 {{> completeDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                  command=(asUpperCamelCase name preserveAcronyms=true)
                  includeRenamedProperties=false}}

--- a/src/darwin/Framework/CHIP/templates/MTREventTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTREventTLVValueDecoder-src.zapt
@@ -21,7 +21,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
 {
     switch (aPath.mClusterId)
     {
-    {{#all_user_clusters side='client'}}
+    {{#zcl_clusters}}
     {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
     case Clusters::{{asUpperCamelCase name}}::Id: {
         using namespace Clusters::{{asUpperCamelCase name}};
@@ -63,7 +63,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
         break;
     }
     {{/if}}
-    {{/all_user_clusters}}
+    {{/zcl_clusters}}
     default: {
       *aError = CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB;
       break;

--- a/src/darwin/Framework/CHIP/templates/MTREventTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTREventTLVValueDecoder-src.zapt
@@ -22,13 +22,13 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
     switch (aPath.mClusterId)
     {
     {{#all_user_clusters side='client'}}
-    {{#unless (wasRemoved (asUpperCamelCase name preserveAcronyms=true))}}
+    {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
     case Clusters::{{asUpperCamelCase name}}::Id: {
         using namespace Clusters::{{asUpperCamelCase name}};
         switch (aPath.mEventId)
         {
         {{#zcl_events}}
-        {{#unless (wasRemoved (asUpperCamelCase ../name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true))}}
+        {{#if (isSupported (asUpperCamelCase ../name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true))}}
 
         case Events::{{asUpperCamelCase name}}::Id: {
             Events::{{asUpperCamelCase name}}::DecodableType cppValue;
@@ -41,19 +41,19 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
             __auto_type *value = [MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event new];
 
             {{#zcl_event_fields}}
-            {{#unless (wasRemoved (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
+            {{#if (isSupported (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
             do {
                 {{asObjectiveCType type parent.parent.name}} memberValue;
                 {{>decode_value target="memberValue" source=(concat "cppValue." (asLowerCamelCase name)) cluster=parent.parent.name errorCode="*aError = err; return nil;" depth=0}}
                 value.{{asStructPropertyName name}} = memberValue;
             } while(0);
-            {{/unless}}
+            {{/if}}
             {{/zcl_event_fields}}
 
             return value;
         }
 
-        {{/unless}}
+        {{/if}}
         {{/zcl_events}}
 
         default:
@@ -62,7 +62,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
         }
         break;
     }
-    {{/unless}}
+    {{/if}}
     {{/all_user_clusters}}
     default: {
       *aError = CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB;

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
@@ -12,9 +12,9 @@ NS_ASSUME_NONNULL_BEGIN
 {
   if (self = [super init]) {
     {{#zcl_struct_items}}
-    {{#unless (wasRemoved (asUpperCamelCase parent.parent.name preserveAcronyms=true) struct=(asUpperCamelCase parent.name preserveAcronyms=true) structField=(asStructPropertyName label))}}
+    {{#if (isSupported (asUpperCamelCase parent.parent.name preserveAcronyms=true) struct=(asUpperCamelCase parent.name preserveAcronyms=true) structField=(asStructPropertyName label))}}
     {{>init_struct_member label=label type=type cluster=parent.parent.name}}
-    {{/unless}}
+    {{/if}}
     {{/zcl_struct_items}}
   }
   return self;
@@ -25,9 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
   auto other = [[{{interfaceName}} alloc] init];
 
   {{#zcl_struct_items}}
-  {{#unless (wasRemoved (asUpperCamelCase parent.parent.name preserveAcronyms=true) struct=(asUpperCamelCase parent.name preserveAcronyms=true) structField=(asStructPropertyName label))}}
+  {{#if (isSupported (asUpperCamelCase parent.parent.name preserveAcronyms=true) struct=(asUpperCamelCase parent.name preserveAcronyms=true) structField=(asStructPropertyName label))}}
   other.{{asStructPropertyName label}} = self.{{asStructPropertyName label}};
-  {{/unless}}
+  {{/if}}
   {{/zcl_struct_items}}
 
   return other;
@@ -36,19 +36,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)description
 {
   NSString *descriptionString = [NSString stringWithFormat:@"<%@: {{#zcl_struct_items~}}
-  {{~#unless (wasRemoved (asUpperCamelCase parent.parent.name preserveAcronyms=true) struct=(asUpperCamelCase parent.name preserveAcronyms=true) structField=(asStructPropertyName label))~}}
+  {{~#if (isSupported (asUpperCamelCase parent.parent.name preserveAcronyms=true) struct=(asUpperCamelCase parent.name preserveAcronyms=true) structField=(asStructPropertyName label))~}}
   {{~asStructPropertyName label}}:%@; {{!Just here to keep the preceding space}}
-  {{~/unless~}}
+  {{~/if~}}
   {{~/zcl_struct_items}}>", NSStringFromClass([self class]){{#zcl_struct_items~}}
-  {{~#unless (wasRemoved (asUpperCamelCase parent.parent.name preserveAcronyms=true) struct=(asUpperCamelCase parent.name preserveAcronyms=true) structField=(asStructPropertyName label))~}}
+  {{~#if (isSupported (asUpperCamelCase parent.parent.name preserveAcronyms=true) struct=(asUpperCamelCase parent.name preserveAcronyms=true) structField=(asStructPropertyName label))~}}
   ,{{#if isArray}}_{{asStructPropertyName label}}{{else if (isOctetString type)}}[_{{asStructPropertyName label}} base64EncodedStringWithOptions:0]{{else}}_{{asStructPropertyName label}}{{/if}}
-  {{~/unless~}}
+  {{~/if~}}
   {{~/zcl_struct_items}}];
   return descriptionString;
 }
 {{#zcl_struct_items}}
 {{#if (and (hasOldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label))
-           (not (wasRemoved (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(oldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label)))))}}
+           (isSupported (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(oldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label))))}}
 
 {{> renamed_struct_field_impl cluster=../../name type=type newName=label oldName=(oldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label))}}
 {{/if}}
@@ -57,16 +57,16 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 {{/inline}}
 
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) struct=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) struct=(asUpperCamelCase name preserveAcronyms=true))}}
 {{> interfaceImpl interfaceName=(concat "MTR" (asUpperCamelCase parent.name preserveAcronyms=true) "Cluster" (asUpperCamelCase name preserveAcronyms=true))}}
-{{/unless}}
+{{/if}}
 
 {{! Takes the name of the struct to use as structName. }}
 {{#*inline "oldNameImpl"}}
-{{#unless (wasRemoved (compatClusterNameRemapping parent.name) struct=structName)}}
+{{#if (isSupported (compatClusterNameRemapping parent.name) struct=structName)}}
 @implementation MTR{{compatClusterNameRemapping parent.name}}Cluster{{structName}} : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}
 @end
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{! Takes the old name of the struct, if any, as oldStructName. }}
 {{#*inline "oldNameCheck"}}
@@ -84,15 +84,15 @@ NS_ASSUME_NONNULL_BEGIN
 {{/zcl_structs}}
 
 {{#zcl_events}}
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true))}}
 @implementation MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event
 - (instancetype)init
 {
   if (self = [super init]) {
     {{#zcl_event_fields}}
-    {{#unless (wasRemoved (asUpperCamelCase parent.parent.name preserveAcronyms=true) event=(asUpperCamelCase parent.name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
+    {{#if (isSupported (asUpperCamelCase parent.parent.name preserveAcronyms=true) event=(asUpperCamelCase parent.name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
     {{>init_struct_member label=name type=type cluster=parent.parent.name}}
-    {{/unless}}
+    {{/if}}
     {{/zcl_event_fields}}
   }
   return self;
@@ -103,9 +103,9 @@ NS_ASSUME_NONNULL_BEGIN
   auto other = [[MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event alloc] init];
 
   {{#zcl_event_fields}}
-  {{#unless (wasRemoved (asUpperCamelCase parent.parent.name preserveAcronyms=true) event=(asUpperCamelCase parent.name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
+  {{#if (isSupported (asUpperCamelCase parent.parent.name preserveAcronyms=true) event=(asUpperCamelCase parent.name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
   other.{{asStructPropertyName name}} = self.{{asStructPropertyName name}};
-  {{/unless}}
+  {{/if}}
   {{/zcl_event_fields}}
 
   return other;
@@ -114,33 +114,33 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)description
 {
   NSString *descriptionString = [NSString stringWithFormat:@"<%@: {{#zcl_event_fields~}}
-  {{~#unless (wasRemoved (asUpperCamelCase parent.parent.name preserveAcronyms=true) event=(asUpperCamelCase parent.name preserveAcronyms=true) eventField=(asStructPropertyName name))~}}
+  {{~#if (isSupported (asUpperCamelCase parent.parent.name preserveAcronyms=true) event=(asUpperCamelCase parent.name preserveAcronyms=true) eventField=(asStructPropertyName name))~}}
   {{asStructPropertyName name}}:%@; {{!Just here to keep the preceding space}}
-  {{~/unless~}}
+  {{~/if~}}
   {{~/zcl_event_fields}}>", NSStringFromClass([self class]){{#zcl_event_fields~}}
-  {{~#unless (wasRemoved (asUpperCamelCase parent.parent.name preserveAcronyms=true) event=(asUpperCamelCase parent.name preserveAcronyms=true) eventField=(asStructPropertyName name))~}}
+  {{~#if (isSupported (asUpperCamelCase parent.parent.name preserveAcronyms=true) event=(asUpperCamelCase parent.name preserveAcronyms=true) eventField=(asStructPropertyName name))~}}
   ,{{#if isArray}}_{{asStructPropertyName name}}{{else if (isOctetString type)}}[_{{asStructPropertyName name}} base64EncodedStringWithOptions:0]{{else}}_{{asStructPropertyName name}}{{/if}}
-  {{~/unless~}}
+  {{~/if~}}
   {{~/zcl_event_fields}}];
   return descriptionString;
 }
 
 {{#zcl_event_fields}}
 {{#if (and (hasOldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))
-           (not (wasRemoved (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(oldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name)))))}}
+           (isSupported (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(oldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))))}}
 
 {{> renamed_struct_field_impl cluster=../parent.name type=type newName=name oldName=(oldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
 {{/if}}
 {{/zcl_event_fields}}
 @end
-{{/unless}}
+{{/if}}
 {{! Takes the name of the event to use as eventName. }}
 {{#*inline "oldNameImpl"}}
-{{#unless (wasRemoved (compatClusterNameRemapping parent.name) event=eventName)}}
+{{#if (isSupported (compatClusterNameRemapping parent.name) event=eventName)}}
 
 @implementation MTR{{compatClusterNameRemapping parent.name}}Cluster{{eventName}}Event : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event
 @end
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{! Takes the old name of the event, if any, as oldEventName. }}
 {{#*inline "oldNameCheck"}}

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
@@ -8,30 +8,30 @@ NS_ASSUME_NONNULL_BEGIN
 {{#zcl_structs}}
 {{#*inline "interfaceDecl"}}
 {{#zcl_struct_items}}
-{{#unless (wasRemoved (asUpperCamelCase ../../name preserveAcronyms=true) struct=../struct structField=(asStructPropertyName label))}}
+{{#if (isSupported (asUpperCamelCase ../../name preserveAcronyms=true) struct=../struct structField=(asStructPropertyName label))}}
 {{> struct_field_decl cluster=parent.parent.name type=type label=label}} {{availability (asUpperCamelCase ../../name preserveAcronyms=true) struct=../struct structField=(asStructPropertyName label) deprecationMessage=(concat "Please use MTR" (asUpperCamelCase ../../name preserveAcronyms=true) "Cluster" (asUpperCamelCase ../name preserveAcronyms=true))}};
-{{/unless}}
+{{/if}}
 {{#if (hasOldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label))}}
-{{#unless (wasRemoved (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(oldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label)))}}
+{{#if (isSupported (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(oldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label)))}}
 {{> struct_field_decl cluster=../../name type=type label=(oldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label))}} {{availability (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(oldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label)) deprecationMessage=(concat "Please use " (asStructPropertyName label))}};
-{{/unless}}
+{{/if}}
 {{/if}}
 {{/zcl_struct_items}}
 {{/inline}}
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) struct=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) struct=(asUpperCamelCase name preserveAcronyms=true))}}
 {{availability (asUpperCamelCase parent.name preserveAcronyms=true) struct=(asUpperCamelCase name preserveAcronyms=true) deprecationMessage="This struct is unused and will be removed"}}
 @interface MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}} : NSObject <NSCopying>
 {{> interfaceDecl struct=(asUpperCamelCase name preserveAcronyms=true)}}
 @end
 
-{{/unless}}
+{{/if}}
 {{! Takes the name of the struct to use as structName. }}
 {{#*inline "oldNameDecl"}}
-{{#unless (wasRemoved (compatClusterNameRemapping parent.name) struct=structName)}}
+{{#if (isSupported (compatClusterNameRemapping parent.name) struct=structName)}}
 {{availability (compatClusterNameRemapping parent.name) struct=structName deprecationMessage=(concat "Please use MTR" (asUpperCamelCase parent.name preserveAcronyms=true) "Cluster" (asUpperCamelCase name preserveAcronyms=true))}}
 @interface MTR{{compatClusterNameRemapping parent.name}}Cluster{{structName}} : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}
 @end
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{! Takes the old name of the struct, if any, as oldStructName. }}
 {{#*inline "oldNameCheck"}}
@@ -48,29 +48,29 @@ NS_ASSUME_NONNULL_BEGIN
 {{/zcl_structs}}
 
 {{#zcl_events}}
-{{#unless (wasRemoved (asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true))}}
 {{availability (asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true)}}
 @interface MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event : NSObject <NSCopying>
 {{#zcl_event_fields}}
-{{#unless (wasRemoved (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
+{{#if (isSupported (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
 {{> struct_field_decl cluster=parent.parent.name type=type label=name}} {{availability (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name)}};
-{{/unless}}
+{{/if}}
 {{#if (hasOldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
-{{#unless (wasRemoved (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(oldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name)))}}
+{{#if (isSupported (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(oldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name)))}}
 {{> struct_field_decl cluster=parent.parent.name type=type label=(oldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))}} {{availability (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(oldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name)) deprecationMessage=(concat "Please use " (asStructPropertyName name))}};
-{{/unless}}
+{{/if}}
 {{/if}}
 {{/zcl_event_fields}}
 @end
-{{/unless}}
+{{/if}}
 {{! Takes the name of the event to use as eventName. }}
 {{#*inline "oldNameDecl"}}
-{{#unless (wasRemoved (compatClusterNameRemapping parent.name) event=eventName)}}
+{{#if (isSupported (compatClusterNameRemapping parent.name) event=eventName)}}
 
 {{availability (compatClusterNameRemapping parent.name) event=eventName deprecationMessage=(concat "Please use MTR" (asUpperCamelCase parent.name preserveAcronyms=true) "Cluster" (asUpperCamelCase name preserveAcronyms=true) "Event")}}
 @interface MTR{{compatClusterNameRemapping parent.name}}Cluster{{eventName}}Event : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event
 @end
-{{/unless}}
+{{/if}}
 {{/inline}}
 {{! Takes the old name of the event, if any, as oldEventName. }}
 {{#*inline "oldNameCheck"}}

--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -6566,9 +6566,10 @@
       watchos: "9.5"
       tvos: "16.5"
   introduced:
-      attributes:
-          TimeSynchronization:
-              - DSTOffset
+      ids:
+          attributes:
+              TimeSynchronization:
+                  - DSTOffset
       command fields:
           DiagnosticLogs:
               RetrieveLogsRequest:

--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -53,6 +53,17 @@
 #              NOTE: support for "removed" may not be complete in the templates.
 #              Please examine codegen carefully when using "removed" to make
 #              sure all the things that should have been removed have been.
+#
+# * "provisional": Can contain clusters, commands, attributes, etc as described
+#                  above for "introduced" and "deprecated".  Items can be
+#                  defined as provisional to prevent code generation for them.
+#                  If they are then listed as introduced in a release that is
+#                  later than the one where they were marked provisional,
+#                  they will start being code-generated.
+#                  NOTE: support for "provisional" may not be complete in the
+#                  templates. Please examine codegen carefully when using
+#                  "provisional" to make sure all the things that should have
+#                  been omitted have been.
 
 - release: "Initial release"
   versions:
@@ -4577,6 +4588,14 @@
       apis:
           - Timed Invoke for server to client commands
           - Deprecated global attribute names
+  provisional:
+      clusters:
+          - PulseWidthModulation
+          - TimeSynchronization
+          - ProxyConfiguration
+          - ProxyDiscovery
+          - ProxyValid
+          - FaultInjection
 
 - release: "First dot-release"
   versions:
@@ -6142,9 +6161,6 @@
           - Timed Invoke for server to client commands
           - Deprecated global attribute names
   removed:
-      clusters:
-          # Not ready to be public API yet.
-          - ClientMonitoring
       commands:
           BasicInformation:
               - MfgSpecificPing
@@ -6198,6 +6214,10 @@
                   - Dual
               CredentialRuleEnum:
                   - Double
+  provisional:
+      clusters:
+          # Not ready to be public API yet.
+          - ClientMonitoring
   renames:
       clusters:
           UnitTesting: TestCluster
@@ -6813,12 +6833,10 @@
           PumpConfigurationAndControl:
               PumpFeature:
                   - Local
-  removed:
+  provisional:
       global attributes:
-          # EventList is provisional for now.
           - EventList
       attributes:
-          # EventList is provisional for now.
           Scenes:
               - EventList
           OnOff:
@@ -6961,6 +6979,7 @@
               - EventList
           FaultInjection:
               - EventList
+  removed:
       enum values:
           DoorLock:
               DlLockDataType:


### PR DESCRIPTION
isSupported allows things to be marked as "provisional", which unlike "removed" can be overridden by a later "introduced" annotation.


