### PR TITLE
[vscode] Disable search.followSymlinks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -168,5 +168,6 @@
     "files.trimFinalNewlines": true,
     "C_Cpp.default.cppStandard": "gnu++14",
     "C_Cpp.default.cStandard": "gnu11",
-    "cmake.configureOnOpen": false
+    "cmake.configureOnOpen": false,
+    "search.followSymlinks": false
 }


### PR DESCRIPTION
This avoids search results being duplicated due to symlinks between different sub-directories
