### PR TITLE
[Silabs] WiFi- Addressed build failures with wiseMCU package v1.0.1.4 

### DIFF
--- a/examples/platform/silabs/SiWx917/LEDWidget.h
+++ b/examples/platform/silabs/SiWx917/LEDWidget.h
@@ -19,8 +19,10 @@
 
 #pragma once
 
-#include "rsi_board.h"
 #include <stdint.h>
+
+extern "C" void RSI_Board_LED_Set(int, int);
+extern "C" void RSI_Board_LED_Toggle(int);
 
 class LEDWidget
 {

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -180,7 +180,14 @@ template("siwx917_sdk") {
     cflags += [
       "-Wno-maybe-uninitialized",
       "-Wno-shadow",
+      "-Wno-empty-body",
+      "-Wno-cpp",
+      "-Wno-missing-braces",
+      "-Wno-sign-compare",
       "-Wno-error",
+      "-Wno-unknown-warning-option",
+      "-Wno-unused-variable",
+      "-Wno-unused-function",
     ]
 
     if (defined(invoker.defines)) {

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -128,7 +128,6 @@ template("siwx917_sdk") {
         "LWIP_ICMP=1",
         "LWIP_IGMP=1",
         "LWIP_DHCP=1",
-        "LWIP_DNS=0",
       ]
     } else {
       defines += [ "LWIP_IPV4=0" ]


### PR DESCRIPTION
#### changes needed for 917SoC with Wisemcu package v1.0.1.4
> Commissioning is failing with some 917NCP boards using latest(1.0.1.8) wisemcu package.
> Rolling back to the Wisemcu package  v1.0.1.4
> These declarations are in LEDWidget.h will resolve the build failure issue with 1.0.1.4 package.