### PR TITLE
openiotsdk: Enable build with GCC 12

### DIFF
--- a/config/openiotsdk/cmake/sdk.cmake
+++ b/config/openiotsdk/cmake/sdk.cmake
@@ -42,6 +42,22 @@ FetchContent_Declare(
     GIT_PROGRESS   ON
 )
 
+# Apply a patch to TF-M to support GCC 12
+FetchContent_Declare(
+    trusted-firmware-m
+    GIT_REPOSITORY  https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git
+    GIT_TAG         d0c0a67f1b412e89d09b0987091c12998c4e4660
+    GIT_SHALLOW     OFF
+    GIT_PROGRESS    ON
+    # Note: This prevents FetchContent_MakeAvailable() from calling
+    # add_subdirectory() on the fetched repository. TF-M needs a
+    # standalone build because it relies on functions defined in its
+    # own toolchain files and contains paths that reference the
+    # top-level project instead of its own project.
+    SOURCE_SUBDIR   NONE
+    PATCH_COMMAND   git reset --hard --quiet && git clean --force -dx --quiet && git apply ${CMAKE_CURRENT_LIST_DIR}/tf-m.patch
+)
+
 # Open IoT SDK configuration
 set(IOTSDK_FETCH_LIST
     mcu-driver-reference-platforms-for-arm

--- a/config/openiotsdk/cmake/tf-m.patch
+++ b/config/openiotsdk/cmake/tf-m.patch
@@ -1,0 +1,12 @@
+diff --git a/toolchain_GNUARM.cmake b/toolchain_GNUARM.cmake
+index d044ed4a5..3d8f64d17 100644
+--- a/toolchain_GNUARM.cmake
++++ b/toolchain_GNUARM.cmake
+@@ -71,7 +71,6 @@ macro(tfm_toolchain_reset_linker_flags)
+         --entry=Reset_Handler
+         --specs=nano.specs
+         LINKER:-check-sections
+-        LINKER:-fatal-warnings
+         LINKER:--gc-sections
+         LINKER:--no-wchar-size-warning
+         ${MEMORY_USAGE_FLAG}


### PR DESCRIPTION
TF-M fails to link with GCC 11.3 and onward as new warning are raised at link time and the linking step disallow warning. 
To workaround the issue we disable link warnings for TF-M by patching it.

This PR is required by https://github.com/project-chip/connectedhomeip/pull/26133 . 

