### PR TITLE
[chip-tool] Update chip-tool such that the device scanner is able to directly gives the discovered CommissionNodeData to the SetUpCodePairer

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -61,7 +61,6 @@ static_library("chip-tool-utils") {
     "commands/common/Commands.cpp",
     "commands/common/Commands.h",
     "commands/common/CredentialIssuerCommands.h",
-    "commands/common/DeviceScanner.cpp",
     "commands/common/HexConversion.h",
     "commands/common/RemoteDataModelLogger.cpp",
     "commands/common/RemoteDataModelLogger.h",
@@ -95,6 +94,10 @@ static_library("chip-tool-utils") {
 
   if (config_enable_yaml_tests) {
     sources += [ "commands/tests/TestCommand.cpp" ]
+  }
+
+  if (chip_device_platform == "darwin") {
+    sources += [ "commands/common/DeviceScanner.cpp" ]
   }
 
   public_deps = [

--- a/examples/chip-tool/commands/common/DeviceScanner.cpp
+++ b/examples/chip-tool/commands/common/DeviceScanner.cpp
@@ -19,34 +19,38 @@
 #include "DeviceScanner.h"
 
 using namespace chip;
-using namespace chip::Ble;
 using namespace chip::Dnssd;
+
+#if CONFIG_NETWORK_LAYER_BLE
+using namespace chip::Ble;
+constexpr const char * kBleKey = "BLE";
+#endif // CONFIG_NETWORK_LAYER_BLE
 
 CHIP_ERROR DeviceScanner::Start()
 {
     mDiscoveredResults.clear();
 
-#if CHIP_TOOL_DEVICE_SCANNER_USE_BLE
+#if CONFIG_NETWORK_LAYER_BLE
     ReturnErrorOnFailure(DeviceLayer::PlatformMgrImpl().StartBleScan(this));
-#endif // CHIP_TOOL_DEVICE_SCANNER_USE_BLE
+#endif // CONFIG_NETWORK_LAYER_BLE
 
-    ReturnErrorOnFailure(mDNSResolver.Init(DeviceLayer::UDPEndPointManager()));
-    mDNSResolver.SetCommissioningDelegate(this);
+    ReturnErrorOnFailure(chip::Dnssd::Resolver::Instance().Init(DeviceLayer::UDPEndPointManager()));
 
-    DiscoveryFilter filter(DiscoveryFilterType::kNone, (uint64_t) 0);
-    return mDNSResolver.DiscoverCommissionableNodes(filter);
+    char serviceName[kMaxCommissionableServiceNameSize];
+    auto filter = DiscoveryFilterType::kNone;
+    ReturnErrorOnFailure(MakeServiceTypeName(serviceName, sizeof(serviceName), filter, DiscoveryType::kCommissionableNode));
+
+    return ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::IPAddressType::kAny,
+                           Inet::InterfaceId::Null(), this);
 }
 
 CHIP_ERROR DeviceScanner::Stop()
 {
-#if CHIP_TOOL_DEVICE_SCANNER_USE_BLE
+#if CONFIG_NETWORK_LAYER_BLE
     ReturnErrorOnFailure(DeviceLayer::PlatformMgrImpl().StopBleScan());
-#endif // CHIP_TOOL_DEVICE_SCANNER_USE_BLE
+#endif // CONFIG_NETWORK_LAYER_BLE
 
-    mDNSResolver.SetCommissioningDelegate(nullptr);
-    ReturnErrorOnFailure(mDNSResolver.StopDiscovery());
-    mDNSResolver.Shutdown();
-    return CHIP_NO_ERROR;
+    return ChipDnssdStopBrowse(this);
 }
 
 void DeviceScanner::OnNodeDiscovered(const DiscoveredNodeData & nodeData)
@@ -61,41 +65,152 @@ void DeviceScanner::OnNodeDiscovered(const DiscoveredNodeData & nodeData)
                     productId);
 
     auto & resolutionData = nodeData.resolutionData;
+
+    auto & instanceData  = mDiscoveredResults[commissionData.instanceName];
+    auto & interfaceData = instanceData[resolutionData.interfaceId.GetPlatformInterface()];
+
     for (size_t i = 0; i < resolutionData.numIPs; i++)
     {
         auto params                = Controller::SetUpCodePairerParameters(resolutionData, i);
-        DeviceScannerResult result = { params, vendorId, productId, discriminator };
-        mDiscoveredResults.push_back(result);
+        DeviceScannerResult result = { params, vendorId, productId, discriminator, chip::MakeOptional(resolutionData) };
+        interfaceData.push_back(result);
     }
 
     nodeData.LogDetail();
 }
 
-#if CHIP_TOOL_DEVICE_SCANNER_USE_BLE
+void DeviceScanner::OnBrowseAdd(chip::Dnssd::DnssdService service)
+{
+    ChipLogProgress(chipTool, "OnBrowseAdd: %s", service.mName);
+    LogErrorOnFailure(ChipDnssdResolve(&service, service.mInterface, this));
+
+    auto & instanceData  = mDiscoveredResults[service.mName];
+    auto & interfaceData = instanceData[service.mInterface.GetPlatformInterface()];
+    (void) interfaceData;
+}
+
+void DeviceScanner::OnBrowseRemove(chip::Dnssd::DnssdService service)
+{
+    ChipLogProgress(chipTool, "OnBrowseRemove: %s", service.mName);
+    auto & instanceData  = mDiscoveredResults[service.mName];
+    auto & interfaceData = instanceData[service.mInterface.GetPlatformInterface()];
+
+    // Check if the interface data has been resolved already, otherwise, just inform the
+    // back end that we may not need it anymore.
+    if (interfaceData.size() == 0)
+    {
+        ChipDnssdResolveNoLongerNeeded(service.mName);
+    }
+
+    // Delete the interface placeholder.
+    instanceData.erase(service.mInterface.GetPlatformInterface());
+
+    // If there is nothing else to resolve for the given instance name, just remove it
+    // too.
+    if (instanceData.size() == 0)
+    {
+        mDiscoveredResults.erase(service.mName);
+    }
+}
+
+void DeviceScanner::OnBrowseStop(CHIP_ERROR error)
+{
+    ChipLogProgress(chipTool, "OnBrowseStop: %" CHIP_ERROR_FORMAT, error.Format());
+
+    for (auto & instance : mDiscoveredResults)
+    {
+        for (auto & interface : instance.second)
+        {
+            if (interface.second.size() == 0)
+            {
+                ChipDnssdResolveNoLongerNeeded(instance.first.c_str());
+            }
+        }
+    }
+}
+
+#if CONFIG_NETWORK_LAYER_BLE
 void DeviceScanner::OnBleScanAdd(BLE_CONNECTION_OBJECT connObj, const ChipBLEDeviceIdentificationInfo & info)
 {
     auto discriminator = info.GetDeviceDiscriminator();
     auto vendorId      = static_cast<VendorId>(info.GetVendorId());
     auto productId     = info.GetProductId();
 
-    ChipLogProgress(chipTool, "OnNodeDiscovered (BLE): discriminator: %u, vendorId: %u, productId: %u", discriminator, vendorId,
-                    productId);
+    ChipLogProgress(chipTool, "OnBleScanAdd (BLE): %p, discriminator: %u, vendorId: %u, productId: %u", connObj, discriminator,
+                    vendorId, productId);
 
     auto params                = Controller::SetUpCodePairerParameters(connObj, false /* connected */);
     DeviceScannerResult result = { params, vendorId, productId, discriminator };
-    mDiscoveredResults.push_back(result);
+
+    auto & instanceData  = mDiscoveredResults[kBleKey];
+    auto & interfaceData = instanceData[chip::Inet::InterfaceId::Null().GetPlatformInterface()];
+    interfaceData.push_back(result);
 }
 
-void DeviceScanner::OnBleScanRemove(BLE_CONNECTION_OBJECT connObj) {}
-#endif // CHIP_TOOL_DEVICE_SCANNER_USE_BLE
+void DeviceScanner::OnBleScanRemove(BLE_CONNECTION_OBJECT connObj)
+{
+    ChipLogProgress(chipTool, "OnBleScanRemove: %p", connObj);
+
+    auto & instanceData  = mDiscoveredResults[kBleKey];
+    auto & interfaceData = instanceData[chip::Inet::InterfaceId::Null().GetPlatformInterface()];
+
+    interfaceData.erase(std::remove_if(interfaceData.begin(), interfaceData.end(),
+                                       [connObj](const DeviceScannerResult & result) {
+                                           return result.mParams.HasDiscoveredObject() &&
+                                               result.mParams.GetDiscoveredObject() == connObj;
+                                       }),
+                        interfaceData.end());
+
+    if (interfaceData.size() == 0)
+    {
+        instanceData.clear();
+        mDiscoveredResults.erase(kBleKey);
+    }
+}
+#endif // CONFIG_NETWORK_LAYER_BLE
 
 CHIP_ERROR DeviceScanner::Get(uint16_t index, RendezvousParameters & params)
 {
-    VerifyOrReturnError(index < mDiscoveredResults.size(), CHIP_ERROR_NOT_FOUND);
+    uint16_t currentIndex = 0;
+    for (auto & instance : mDiscoveredResults)
+    {
+        for (auto & interface : instance.second)
+        {
+            for (auto & result : interface.second)
+            {
+                if (currentIndex == index)
+                {
+                    params = result.mParams;
+                    return CHIP_NO_ERROR;
+                }
+                currentIndex++;
+            }
+        }
+    }
 
-    auto & result = mDiscoveredResults.at(index);
-    params        = result.mParams;
-    return CHIP_NO_ERROR;
+    return CHIP_ERROR_NOT_FOUND;
+}
+
+CHIP_ERROR DeviceScanner::Get(uint16_t index, Dnssd::CommonResolutionData & resolutionData)
+{
+    uint16_t currentIndex = 0;
+    for (auto & instance : mDiscoveredResults)
+    {
+        for (auto & interface : instance.second)
+        {
+            for (auto & result : interface.second)
+            {
+                if (currentIndex == index && result.mResolutionData.HasValue())
+                {
+                    resolutionData = result.mResolutionData.Value();
+                    return CHIP_NO_ERROR;
+                }
+                currentIndex++;
+            }
+        }
+    }
+
+    return CHIP_ERROR_NOT_FOUND;
 }
 
 void DeviceScanner::Log() const
@@ -104,14 +219,21 @@ void DeviceScanner::Log() const
     VerifyOrReturn(resultsCount > 0, ChipLogProgress(chipTool, "No device discovered."));
 
     uint16_t index = 0;
-    for (auto & result : mDiscoveredResults)
+    for (auto & instance : mDiscoveredResults)
     {
-        char addr[Transport::PeerAddress::kMaxToStringSize];
-        result.mParams.GetPeerAddress().ToString(addr);
+        ChipLogProgress(chipTool, "Instance Name: %s ", instance.first.c_str());
+        for (auto & interface : instance.second)
+        {
+            for (auto & result : interface.second)
+            {
+                char addr[Transport::PeerAddress::kMaxToStringSize];
+                result.mParams.GetPeerAddress().ToString(addr);
 
-        ChipLogProgress(chipTool, "\t %u - Discriminator: %u - Vendor: %u - Product: %u - %s", index, result.mDiscriminator,
-                        result.mVendorId, result.mProductId, addr);
-        index++;
+                ChipLogProgress(chipTool, "\t %u - Discriminator: %u - Vendor: %u - Product: %u - %s", index, result.mDiscriminator,
+                                result.mVendorId, result.mProductId, addr);
+                index++;
+            }
+        }
     }
 }
 

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
@@ -38,29 +38,41 @@ void DiscoverCommissionablesCommandBase::OnDiscoveredDevice(const chip::Dnssd::D
 
 CHIP_ERROR DiscoverCommissionablesStartCommand::RunCommand()
 {
+#if CHIP_DEVICE_LAYER_TARGET_DARWIN
     VerifyOrReturnError(IsInteractive(), CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(GetDeviceScanner().Start());
 
     SetCommandExitStatus(CHIP_NO_ERROR);
     return CHIP_NO_ERROR;
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
 }
 
 CHIP_ERROR DiscoverCommissionablesStopCommand::RunCommand()
 {
+#if CHIP_DEVICE_LAYER_TARGET_DARWIN
     VerifyOrReturnError(IsInteractive(), CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(GetDeviceScanner().Stop());
 
     SetCommandExitStatus(CHIP_NO_ERROR);
     return CHIP_NO_ERROR;
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
 }
 
 CHIP_ERROR DiscoverCommissionablesListCommand::RunCommand()
 {
+#if CHIP_DEVICE_LAYER_TARGET_DARWIN
     VerifyOrReturnError(IsInteractive(), CHIP_ERROR_INCORRECT_STATE);
     GetDeviceScanner().Log();
 
     SetCommandExitStatus(CHIP_NO_ERROR);
     return CHIP_NO_ERROR;
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
 }
 
 CHIP_ERROR DiscoverCommissionablesCommand::RunCommand()

--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -199,6 +199,15 @@ public:
     {}
 };
 
+class PairAlreadyDiscoveredByIndexWithCode : public PairingCommand
+{
+public:
+    PairAlreadyDiscoveredByIndexWithCode(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("already-discovered-by-index-with-code", PairingMode::AlreadyDiscoveredByIndexWithCode,
+                       PairingNetworkType::None, credsIssuerConfig)
+    {}
+};
+
 class StartUdcServerCommand : public CHIPCommand
 {
 public:
@@ -228,6 +237,7 @@ void registerCommandsPairing(Commands & commands, CredentialIssuerCommands * cre
         make_unique<PairAlreadyDiscovered>(credsIssuerConfig),
         make_unique<PairAlreadyDiscoveredByIndex>(credsIssuerConfig),
         make_unique<PairAlreadyDiscoveredByIndexWithWiFi>(credsIssuerConfig),
+        make_unique<PairAlreadyDiscoveredByIndexWithCode>(credsIssuerConfig),
         make_unique<PairOnNetwork>(credsIssuerConfig),
         make_unique<PairOnNetworkShort>(credsIssuerConfig),
         make_unique<PairOnNetworkLong>(credsIssuerConfig),

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -36,6 +36,7 @@ enum class PairingMode
     SoftAP,
     AlreadyDiscovered,
     AlreadyDiscoveredByIndex,
+    AlreadyDiscoveredByIndexWithCode,
     OnNetwork,
 };
 
@@ -122,6 +123,12 @@ public:
             AddArgument("index", 0, UINT16_MAX, &mIndex);
             AddArgument("pase-only", 0, 1, &mPaseOnly);
             break;
+        case PairingMode::AlreadyDiscoveredByIndexWithCode:
+            AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
+            AddArgument("payload", &mOnboardingPayload);
+            AddArgument("index", 0, UINT16_MAX, &mIndex);
+            AddArgument("pase-only", 0, 1, &mPaseOnly);
+            break;
         }
 
         switch (filterType)
@@ -180,6 +187,7 @@ private:
     CHIP_ERROR PairWithCode(NodeId remoteId);
     CHIP_ERROR PaseWithCode(NodeId remoteId);
     CHIP_ERROR PairWithMdnsOrBleByIndex(NodeId remoteId, uint16_t index);
+    CHIP_ERROR PairWithMdnsOrBleByIndexWithCode(NodeId remoteId, uint16_t index);
     CHIP_ERROR Unpair(NodeId remoteId);
     chip::Controller::CommissioningParameters GetCommissioningParameters();
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -587,7 +587,7 @@ CHIP_ERROR DeviceCommissioner::GetDeviceBeingCommissioned(NodeId deviceId, Commi
 }
 
 CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * setUpCode, const CommissioningParameters & params,
-                                          DiscoveryType discoveryType)
+                                          DiscoveryType discoveryType, Optional<Dnssd::CommonResolutionData> resolutionData)
 {
     MATTER_TRACE_EVENT_SCOPE("PairDevice", "DeviceCommissioner");
     if (mDefaultCommissioner == nullptr)
@@ -597,13 +597,16 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * se
     }
     ReturnErrorOnFailure(mDefaultCommissioner->SetCommissioningParameters(params));
 
-    return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kCommission, discoveryType);
+    return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kCommission, discoveryType,
+                                       resolutionData);
 }
 
-CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType)
+CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType,
+                                          Optional<Dnssd::CommonResolutionData> resolutionData)
 {
     MATTER_TRACE_EVENT_SCOPE("PairDevice", "DeviceCommissioner");
-    return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kCommission, discoveryType);
+    return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kCommission, discoveryType,
+                                       resolutionData);
 }
 
 CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParameters & params)
@@ -621,10 +624,12 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
     return Commission(remoteDeviceId, commissioningParams);
 }
 
-CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType)
+CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType,
+                                                       Optional<Dnssd::CommonResolutionData> resolutionData)
 {
     MATTER_TRACE_EVENT_SCOPE("EstablishPASEConnection", "DeviceCommissioner");
-    return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kPaseOnly, discoveryType);
+    return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kPaseOnly, discoveryType,
+                                       resolutionData);
 }
 
 CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, RendezvousParameters & params)

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -425,10 +425,13 @@ public:
      * @param[in] remoteDeviceId        The remote device Id.
      * @param[in] setUpCode             The setup code for connecting to the device
      * @param[in] discoveryType         The network discovery type, defaults to DiscoveryType::kAll.
+     * @param[in] resolutionData        Optional resolution data previously discovered on the network for the target device.
      */
-    CHIP_ERROR PairDevice(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType = DiscoveryType::kAll);
+    CHIP_ERROR PairDevice(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType = DiscoveryType::kAll,
+                          Optional<Dnssd::CommonResolutionData> resolutionData = NullOptional);
     CHIP_ERROR PairDevice(NodeId remoteDeviceId, const char * setUpCode, const CommissioningParameters & CommissioningParameters,
-                          DiscoveryType discoveryType = DiscoveryType::kAll);
+                          DiscoveryType discoveryType                          = DiscoveryType::kAll,
+                          Optional<Dnssd::CommonResolutionData> resolutionData = NullOptional);
 
     /**
      * @brief
@@ -490,9 +493,11 @@ public:
      * @param[in] remoteDeviceId        The remote device Id.
      * @param[in] setUpCode             The setup code for connecting to the device
      * @param[in] discoveryType         The network discovery type, defaults to DiscoveryType::kAll.
+     * @param[in] resolutionData        Optional resolution data previously discovered on the network for the target device.
      */
     CHIP_ERROR EstablishPASEConnection(NodeId remoteDeviceId, const char * setUpCode,
-                                       DiscoveryType discoveryType = DiscoveryType::kAll);
+                                       DiscoveryType discoveryType                          = DiscoveryType::kAll,
+                                       Optional<Dnssd::CommonResolutionData> resolutionData = NullOptional);
 
     /**
      * @brief

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -37,9 +37,13 @@ namespace chip {
 namespace Controller {
 
 CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, SetupCodePairerBehaviour commission,
-                                       DiscoveryType discoveryType)
+                                       DiscoveryType discoveryType, Optional<Dnssd::CommonResolutionData> resolutionData)
 {
     VerifyOrReturnError(mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    if (resolutionData.HasValue())
+    {
+        VerifyOrReturnError(discoveryType != DiscoveryType::kAll, CHIP_ERROR_INVALID_ARGUMENT);
+    }
 
     SetupPayload payload;
     mConnectionType = commission;
@@ -62,12 +66,16 @@ CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, 
 
     ResetDiscoveryState();
 
-    ReturnErrorOnFailure(Connect(payload));
+    if (resolutionData.HasValue())
+    {
+        NotifyCommissionableDeviceDiscovered(resolutionData.Value());
+        return CHIP_NO_ERROR;
+    }
 
+    ReturnErrorOnFailure(Connect(payload));
     return mSystemLayer->StartTimer(System::Clock::Milliseconds32(kDeviceDiscoveredTimeout), OnDeviceDiscoveredTimeoutCallback,
                                     this);
 }
-
 CHIP_ERROR SetUpCodePairer::Connect(SetupPayload & payload)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -347,20 +355,23 @@ void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::Discover
 
     ChipLogProgress(Controller, "Discovered device to be commissioned over DNS-SD");
 
-    auto & resolutionData = nodeData.resolutionData;
+    NotifyCommissionableDeviceDiscovered(nodeData.resolutionData);
+}
 
+void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::CommonResolutionData & resolutionData)
+{
     if (mDiscoveryType == DiscoveryType::kDiscoveryNetworkOnlyWithoutPASEAutoRetry)
     {
         // If the discovery type does not want the PASE auto retry mechanism, we will just store
         // a single IP. So the discovery process is stopped as it won't be of any help anymore.
         StopConnectOverIP();
-        mDiscoveredParameters.emplace_back(nodeData.resolutionData, 0);
+        mDiscoveredParameters.emplace_back(resolutionData, 0);
     }
     else
     {
         for (size_t i = 0; i < resolutionData.numIPs; i++)
         {
-            mDiscoveredParameters.emplace_back(nodeData.resolutionData, i);
+            mDiscoveredParameters.emplace_back(resolutionData, i);
         }
     }
 

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -79,8 +79,9 @@ public:
     virtual ~SetUpCodePairer() {}
 
     CHIP_ERROR PairDevice(chip::NodeId remoteId, const char * setUpCode,
-                          SetupCodePairerBehaviour connectionType = SetupCodePairerBehaviour::kCommission,
-                          DiscoveryType discoveryType             = DiscoveryType::kAll);
+                          SetupCodePairerBehaviour connectionType              = SetupCodePairerBehaviour::kCommission,
+                          DiscoveryType discoveryType                          = DiscoveryType::kAll,
+                          Optional<Dnssd::CommonResolutionData> resolutionData = NullOptional);
 
     // Called by the DeviceCommissioner to notify that we have discovered a new device.
     void NotifyCommissionableDeviceDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData);
@@ -150,6 +151,8 @@ private:
         kSoftAPTransport,
         kTransportTypeCount,
     };
+
+    void NotifyCommissionableDeviceDiscovered(const chip::Dnssd::CommonResolutionData & resolutionData);
 
     static void OnDeviceDiscoveredTimeoutCallback(System::Layer * layer, void * context);
 

--- a/src/lib/dnssd/platform/Dnssd.h
+++ b/src/lib/dnssd/platform/Dnssd.h
@@ -80,6 +80,8 @@ struct DnssdService
     Optional<chip::Inet::IPAddress> mAddress;
     // Time to live in seconds. Per rfc6762 section 10, because we have a hostname, our default TTL is 120 seconds
     uint32_t mTtlSeconds = 120;
+
+    void ToDiscoveredNodeData(const Span<Inet::IPAddress> & addresses, DiscoveredNodeData & nodeData);
 };
 
 /**
@@ -272,6 +274,23 @@ CHIP_ERROR ChipDnssdStopBrowse(DnssdBrowseDelegate * delegate);
  */
 CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId interface, DnssdResolveCallback callback,
                             void * context);
+
+#if CHIP_DEVICE_LAYER_TARGET_DARWIN
+/**
+ * This function resolves the services published by mDNS
+ *
+ * @param[in] browseResult  The service entry returned by @ref ChipDnssdBrowse
+ * @param[in] interface     The interface to send queries.
+ * @param[in] delegate      The delegate to notify when a service is resolved.
+ *
+ * @retval CHIP_NO_ERROR                The resolve succeeds.
+ * @retval CHIP_ERROR_INVALID_ARGUMENT  The name, type or delegate is nullptr.
+ * @retval Error code                   The resolve fails.
+ *
+ */
+CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId interface,
+                            CommissioningResolveDelegate * delegate);
+#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
 
 /**
  * This function notifies the implementation that a resolve result is no longer

--- a/src/lib/dnssd/platform/Dnssd.h
+++ b/src/lib/dnssd/platform/Dnssd.h
@@ -36,6 +36,8 @@
 #include <lib/dnssd/ServiceNaming.h>
 #include <system/TimeSource.h>
 
+#include "DnssdBrowseDelegate.h"
+
 namespace chip {
 namespace Dnssd {
 
@@ -228,6 +230,32 @@ CHIP_ERROR ChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, chi
  *                         ChipDnssdBrowse.
  */
 CHIP_ERROR ChipDnssdStopBrowse(intptr_t browseIdentifier);
+
+#if CHIP_DEVICE_LAYER_TARGET_DARWIN
+/**
+ * This function continuously browses the services published by mDNS
+ * and reports any addition/removal of services.
+ *
+ * @param[in] type        The service type.
+ * @param[in] protocol    The service protocol.
+ * @param[in] addressType The protocol version of the IP address.
+ * @param[in] interface   The interface to send queries.
+ * @param[in] delegate    The delegate to notify when a service is found/removed.
+ *
+ * @retval CHIP_NO_ERROR                The browse succeeds.
+ * @retval CHIP_ERROR_INVALID_ARGUMENT  The type or the delegate is nullptr.
+ * @retval Error code                   The browse fails.
+ *
+ */
+CHIP_ERROR ChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, chip::Inet::IPAddressType addressType,
+                           chip::Inet::InterfaceId interface, DnssdBrowseDelegate * delegate);
+
+/**
+ * Stop an ongoing browse, if supported by this backend.  If successful, this
+ * will call the OnBrowseStop method of the delegate.
+ */
+CHIP_ERROR ChipDnssdStopBrowse(DnssdBrowseDelegate * delegate);
+#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
 
 /**
  * This function resolves the services published by mDNS

--- a/src/lib/dnssd/platform/DnssdBrowseDelegate.h
+++ b/src/lib/dnssd/platform/DnssdBrowseDelegate.h
@@ -1,0 +1,59 @@
+/*
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+namespace chip {
+namespace Dnssd {
+
+struct DnssdService;
+
+/**
+ * A delegate that can be notified of service additions/removals as a mdns browse proceeds.
+ */
+class DLL_EXPORT DnssdBrowseDelegate
+{
+public:
+    virtual ~DnssdBrowseDelegate() {}
+
+    /**
+     * @brief
+     *   Called when a service is added.
+     *
+     * @param[in] service The service.
+     */
+    virtual void OnBrowseAdd(DnssdService service) = 0;
+
+    /**
+     * @brief
+     *   Called when a service is removed.
+     *
+     * @param[in] service The service.
+     */
+    virtual void OnBrowseRemove(DnssdService service) = 0;
+
+    /**
+     * @brief
+     *   Called when the browse stops.
+     *
+     * @param error Error cause, if any
+     */
+    virtual void OnBrowseStop(CHIP_ERROR error) = 0;
+};
+
+} // namespace Dnssd
+} // namespace chip

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -63,6 +63,7 @@ static_library("Darwin") {
     "DnssdHostNameRegistrar.cpp",
     "DnssdImpl.cpp",
     "DnssdImpl.h",
+    "DnssdType.cpp",
     "InetPlatformConfig.h",
     "LoggingImpl.cpp",
     "MdnsError.cpp",

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -15,17 +15,25 @@
  *    limitations under the License.
  */
 #include "DnssdImpl.h"
+#include "DnssdType.h"
 #include "MdnsError.h"
 
 #include <lib/support/CHIPMemString.h>
 #include <platform/CHIPDeviceLayer.h>
 
 using namespace chip::Dnssd;
+using namespace chip::Dnssd::Internal;
 
 namespace {
 
 constexpr uint8_t kDnssdKeyMaxSize          = 32;
 constexpr uint8_t kDnssdTxtRecordMaxEntries = 20;
+constexpr const char * kLocalDot            = "local.";
+
+bool IsLocalDomain(const char * domain)
+{
+    return strcmp(kLocalDot, domain) == 0;
+}
 
 std::string GetHostNameWithoutDomain(const char * hostnameWithDomain)
 {
@@ -37,17 +45,6 @@ std::string GetHostNameWithoutDomain(const char * hostnameWithDomain)
     }
 
     return hostname;
-}
-
-std::string GetFullTypeWithoutSubTypes(std::string fullType)
-{
-    size_t position = fullType.find(",");
-    if (position != std::string::npos)
-    {
-        fullType.erase(position);
-    }
-
-    return fullType;
 }
 
 void GetTextEntries(DnssdService & service, const unsigned char * data, uint16_t len)
@@ -105,6 +102,19 @@ DNSServiceProtocol GetProtocol(const chip::Inet::IPAddressType & addressType)
     // without IPv4, IPv6 is the only option
     return kDNSServiceProtocol_IPv6;
 #endif
+}
+
+DnssdService GetService(const char * name, const char * type, DnssdServiceProtocol protocol, uint32_t interfaceId)
+{
+    DnssdService service = {};
+    service.mInterface   = chip::Inet::InterfaceId(interfaceId);
+    service.mProtocol    = protocol;
+
+    auto baseType = GetBaseType(type);
+    chip::Platform::CopyString(service.mType, baseType.c_str());
+    chip::Platform::CopyString(service.mName, name);
+
+    return service;
 }
 
 } // namespace
@@ -289,6 +299,19 @@ ResolveContext * MdnsContexts::GetExistingResolveForInstanceName(const char * in
     return nullptr;
 }
 
+BrowseWithDelegateContext * MdnsContexts::GetExistingBrowseForDelegate(DnssdBrowseDelegate * delegate)
+{
+    for (auto & ctx : mContexts)
+    {
+        if (ctx->type == ContextType::BrowseWithDelegate && (static_cast<BrowseWithDelegateContext *>(ctx))->Matches(delegate))
+        {
+            return static_cast<BrowseWithDelegateContext *>(ctx);
+        }
+    }
+
+    return nullptr;
+}
+
 RegisterContext::RegisterContext(const char * sType, const char * instanceName, DnssdPublishCallback cb, void * cbContext)
 {
     type     = ContextType::Register;
@@ -346,6 +369,96 @@ void BrowseContext::DispatchPartialSuccess()
     callback(context, services.data(), services.size(), false, CHIP_NO_ERROR);
     sContextDispatchingSuccess = nullptr;
     services.clear();
+}
+
+void BrowseContext::OnBrowse(DNSServiceFlags flags, const char * name, const char * type, const char * domain, uint32_t interfaceId)
+{
+    (flags & kDNSServiceFlagsAdd) ? OnBrowseAdd(name, type, domain, interfaceId) : OnBrowseRemove(name, type, domain, interfaceId);
+
+    if (!(flags & kDNSServiceFlagsMoreComing))
+    {
+        DispatchPartialSuccess();
+    }
+}
+
+void BrowseContext::OnBrowseAdd(const char * name, const char * type, const char * domain, uint32_t interfaceId)
+{
+    ChipLogProgress(Discovery, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %" PRIu32, __func__, StringOrNullMarker(name),
+                    StringOrNullMarker(type), StringOrNullMarker(domain), interfaceId);
+
+    VerifyOrReturn(IsLocalDomain(domain));
+    auto service = GetService(name, type, protocol, interfaceId);
+    services.push_back(service);
+}
+
+void BrowseContext::OnBrowseRemove(const char * name, const char * type, const char * domain, uint32_t interfaceId)
+{
+    ChipLogProgress(Discovery, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %" PRIu32, __func__, StringOrNullMarker(name),
+                    StringOrNullMarker(type), StringOrNullMarker(domain), interfaceId);
+
+    VerifyOrReturn(name != nullptr);
+    VerifyOrReturn(IsLocalDomain(domain));
+
+    services.erase(std::remove_if(services.begin(), services.end(),
+                                  [name, type, interfaceId](const DnssdService & service) {
+                                      return strcmp(name, service.mName) == 0 && type == GetFullType(&service) &&
+                                          service.mInterface == chip::Inet::InterfaceId(interfaceId);
+                                  }),
+                   services.end());
+}
+
+BrowseWithDelegateContext::BrowseWithDelegateContext(DnssdBrowseDelegate * delegate, DnssdServiceProtocol cbContextProtocol)
+{
+    type     = ContextType::BrowseWithDelegate;
+    context  = static_cast<void *>(delegate);
+    protocol = cbContextProtocol;
+}
+
+void BrowseWithDelegateContext::DispatchFailure(const char * errorStr, CHIP_ERROR err)
+{
+    ChipLogError(Discovery, "Mdns: Browse failure (%s)", errorStr);
+
+    auto delegate = static_cast<DnssdBrowseDelegate *>(context);
+    delegate->OnBrowseStop(err);
+    MdnsContexts::GetInstance().Remove(this);
+}
+
+void BrowseWithDelegateContext::DispatchSuccess()
+{
+    auto delegate = static_cast<DnssdBrowseDelegate *>(context);
+    delegate->OnBrowseStop(CHIP_NO_ERROR);
+    MdnsContexts::GetInstance().Remove(this);
+}
+
+void BrowseWithDelegateContext::OnBrowse(DNSServiceFlags flags, const char * name, const char * type, const char * domain,
+                                         uint32_t interfaceId)
+{
+    (flags & kDNSServiceFlagsAdd) ? OnBrowseAdd(name, type, domain, interfaceId) : OnBrowseRemove(name, type, domain, interfaceId);
+}
+
+void BrowseWithDelegateContext::OnBrowseAdd(const char * name, const char * type, const char * domain, uint32_t interfaceId)
+{
+    ChipLogProgress(Discovery, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %" PRIu32, __func__, StringOrNullMarker(name),
+                    StringOrNullMarker(type), StringOrNullMarker(domain), interfaceId);
+
+    VerifyOrReturn(IsLocalDomain(domain));
+
+    auto delegate = static_cast<DnssdBrowseDelegate *>(context);
+    auto service  = GetService(name, type, protocol, interfaceId);
+    delegate->OnBrowseAdd(service);
+}
+
+void BrowseWithDelegateContext::OnBrowseRemove(const char * name, const char * type, const char * domain, uint32_t interfaceId)
+{
+    ChipLogProgress(Discovery, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %" PRIu32, __func__, StringOrNullMarker(name),
+                    StringOrNullMarker(type), StringOrNullMarker(domain), interfaceId);
+
+    VerifyOrReturn(name != nullptr);
+    VerifyOrReturn(IsLocalDomain(domain));
+
+    auto delegate = static_cast<DnssdBrowseDelegate *>(context);
+    auto service  = GetService(name, type, protocol, interfaceId);
+    delegate->OnBrowseRemove(service);
 }
 
 ResolveContext::ResolveContext(void * cbContext, DnssdResolveCallback cb, chip::Inet::IPAddressType cbAddressType,

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -33,6 +33,7 @@ enum class ContextType
 {
     Register,
     Browse,
+    BrowseWithDelegate,
     Resolve,
 };
 
@@ -54,6 +55,7 @@ private:
     CHIP_ERROR FinalizeInternal(const char * errorStr, CHIP_ERROR err);
 };
 
+struct BrowseWithDelegateContext;
 struct RegisterContext;
 struct ResolveContext;
 
@@ -92,6 +94,12 @@ public:
      * instanceName, if any.  Returns nullptr if there are none.
      */
     ResolveContext * GetExistingResolveForInstanceName(const char * instanceName);
+
+    /**
+     * Return a pointer to an existing BrowserWithDelegateContext for the given
+     * delegate, if any.  Returns nullptr if there are none.
+     */
+    BrowseWithDelegateContext * GetExistingBrowseForDelegate(DnssdBrowseDelegate * delegate);
 
     /**
      * Remove context from the list, if it's present in the list.  Return
@@ -141,20 +149,34 @@ struct RegisterContext : public GenericContext
     bool matches(const char * sType) { return mType.compare(sType) == 0; }
 };
 
-struct BrowseContext : public GenericContext
+struct BrowseHandler : public GenericContext
+{
+    virtual ~BrowseHandler() {}
+
+    DnssdServiceProtocol protocol;
+
+    virtual void OnBrowse(DNSServiceFlags flags, const char * name, const char * type, const char * domain,
+                          uint32_t interfaceId)                                                                  = 0;
+    virtual void OnBrowseAdd(const char * name, const char * type, const char * domain, uint32_t interfaceId)    = 0;
+    virtual void OnBrowseRemove(const char * name, const char * type, const char * domain, uint32_t interfaceId) = 0;
+};
+
+struct BrowseContext : public BrowseHandler
 {
     DnssdBrowseCallback callback;
     std::vector<DnssdService> services;
-    DnssdServiceProtocol protocol;
 
     BrowseContext(void * cbContext, DnssdBrowseCallback cb, DnssdServiceProtocol cbContextProtocol);
-    virtual ~BrowseContext() {}
 
     void DispatchFailure(const char * errorStr, CHIP_ERROR err) override;
     void DispatchSuccess() override;
 
     // Dispatch what we have found so far, but don't stop browsing.
     void DispatchPartialSuccess();
+
+    void OnBrowse(DNSServiceFlags flags, const char * name, const char * type, const char * domain, uint32_t interfaceId) override;
+    void OnBrowseAdd(const char * name, const char * type, const char * domain, uint32_t interfaceId) override;
+    void OnBrowseRemove(const char * name, const char * type, const char * domain, uint32_t interfaceId) override;
 
     // While we are dispatching partial success, sContextDispatchingSuccess will
     // be set to the BrowseContext doing the dispatch.  This allows resolves
@@ -169,6 +191,20 @@ struct BrowseContext : public GenericContext
     // TODO: Consider fixing the higher-level APIs to make it possible to pass
     // in multiple IPs for a successful browse result.
     static BrowseContext * sContextDispatchingSuccess;
+};
+
+struct BrowseWithDelegateContext : public BrowseHandler
+{
+    BrowseWithDelegateContext(DnssdBrowseDelegate * delegate, DnssdServiceProtocol cbContextProtocol);
+
+    void DispatchFailure(const char * errorStr, CHIP_ERROR err) override;
+    void DispatchSuccess() override;
+
+    void OnBrowse(DNSServiceFlags flags, const char * name, const char * type, const char * domain, uint32_t interfaceId) override;
+    void OnBrowseAdd(const char * name, const char * type, const char * domain, uint32_t interfaceId) override;
+    void OnBrowseRemove(const char * name, const char * type, const char * domain, uint32_t interfaceId) override;
+
+    bool Matches(DnssdBrowseDelegate * otherDelegate) const { return context == otherDelegate; }
 };
 
 struct InterfaceInfo

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -234,6 +234,8 @@ struct ResolveContext : public GenericContext
     ResolveContext(void * cbContext, DnssdResolveCallback cb, chip::Inet::IPAddressType cbAddressType,
                    const char * instanceNameToResolve, BrowseContext * browseCausingResolve,
                    std::shared_ptr<uint32_t> && consumerCounterToUse);
+    ResolveContext(CommissioningResolveDelegate * delegate, chip::Inet::IPAddressType cbAddressType,
+                   const char * instanceNameToResolve, std::shared_ptr<uint32_t> && consumerCounterToUse);
     virtual ~ResolveContext();
 
     void DispatchFailure(const char * errorStr, CHIP_ERROR err) override;

--- a/src/platform/Darwin/DnssdType.cpp
+++ b/src/platform/Darwin/DnssdType.cpp
@@ -1,0 +1,99 @@
+/*
+ *
+ *    Copyright (c) 2021-2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "DnssdType.h"
+
+#include <sstream>
+
+constexpr const char * kProtocolTcp = "._tcp";
+constexpr const char * kProtocolUdp = "._udp";
+
+namespace chip {
+namespace Dnssd {
+namespace Internal {
+
+std::string GetFullType(const char * type, DnssdServiceProtocol protocol)
+{
+    std::ostringstream typeBuilder;
+    typeBuilder << type;
+    typeBuilder << (protocol == DnssdServiceProtocol::kDnssdProtocolUdp ? kProtocolUdp : kProtocolTcp);
+    return typeBuilder.str();
+}
+
+std::string GetFullType(const DnssdService * service)
+{
+    return GetFullType(service->mType, service->mProtocol);
+}
+
+std::string GetFullTypeWithSubTypes(const char * type, DnssdServiceProtocol protocol)
+{
+    auto fullType = GetFullType(type, protocol);
+
+    std::string subtypeDelimiter = "._sub.";
+    size_t position              = fullType.find(subtypeDelimiter);
+    if (position != std::string::npos)
+    {
+        fullType = fullType.substr(position + subtypeDelimiter.size()) + "," + fullType.substr(0, position);
+    }
+
+    return fullType;
+}
+
+std::string GetFullTypeWithSubTypes(const char * type, DnssdServiceProtocol protocol, const char * subTypes[], size_t subTypeSize)
+{
+    std::ostringstream typeBuilder;
+    typeBuilder << type;
+    typeBuilder << (protocol == DnssdServiceProtocol::kDnssdProtocolUdp ? kProtocolUdp : kProtocolTcp);
+    for (int i = 0; i < (int) subTypeSize; i++)
+    {
+        typeBuilder << ",";
+        typeBuilder << subTypes[i];
+    }
+    return typeBuilder.str();
+}
+
+std::string GetFullTypeWithSubTypes(const DnssdService * service)
+{
+    return GetFullTypeWithSubTypes(service->mType, service->mProtocol, service->mSubTypes, service->mSubTypeSize);
+}
+
+std::string GetFullTypeWithoutSubTypes(std::string fullType)
+{
+    size_t position = fullType.find(",");
+    if (position != std::string::npos)
+    {
+        fullType.erase(position);
+    }
+
+    return fullType;
+}
+
+std::string GetBaseType(const char * fulltype)
+{
+    std::string type(fulltype);
+    size_t position = type.find(".");
+    if (position != std::string::npos)
+    {
+        type.erase(position);
+    }
+
+    return type;
+}
+
+} // namespace Internal
+} // namespace Dnssd
+} // namespace chip

--- a/src/platform/Darwin/DnssdType.h
+++ b/src/platform/Darwin/DnssdType.h
@@ -1,0 +1,40 @@
+/*
+ *
+ *    Copyright (c) 2021-2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/dnssd/platform/Dnssd.h>
+#include <string.h>
+
+namespace chip {
+namespace Dnssd {
+namespace Internal {
+
+std::string GetFullType(const char * type, DnssdServiceProtocol protocol);
+std::string GetFullType(const DnssdService * service);
+
+std::string GetFullTypeWithSubTypes(const DnssdService * service);
+std::string GetFullTypeWithSubTypes(const char * type, DnssdServiceProtocol protocol);
+std::string GetFullTypeWithSubTypes(const char * type, DnssdServiceProtocol protocol, const char * subTypes[], size_t subTypeSize);
+
+std::string GetFullTypeWithoutSubTypes(std::string fullType);
+
+std::string GetBaseType(const char * fulltype);
+
+} // namespace Internal
+} // namespace Dnssd
+} // namespace chip


### PR DESCRIPTION
#### Problem

This PR adds methods such that the `SetUpCodePairer` can consume a `CommissionNodeData`thas has been previously discovered.

In order to discover the commissioning info over mdns, this PR also adds 2 new method for mdns resolver platform implementations. Those methods are `ChipDnssdBrowse` and `ChipDnssdResolve`but instead of taking a callback they takes a delegate.

I have added the darwin implementation for those, and I have updated `chip-tool- to use them directly.
