### PR TITLE
[nrfconnect] Repair Rotating Device ID UID parsing

### DIFF
--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -190,6 +190,7 @@ CHIP_ERROR AppTask::Init()
         memset(sTestEventTriggerEnableKey, 0, sizeof(sTestEventTriggerEnableKey));
     }
 #else
+    SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 #endif
 

--- a/examples/all-clusters-app/nrfconnect/main/include/AppTask.h
+++ b/examples/all-clusters-app/nrfconnect/main/include/AppTask.h
@@ -24,6 +24,8 @@
 
 #if CONFIG_CHIP_FACTORY_DATA
 #include <platform/nrfconnect/FactoryDataProvider.h>
+#else
+#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_BT

--- a/examples/all-clusters-minimal-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/nrfconnect/main/AppTask.cpp
@@ -144,6 +144,7 @@ CHIP_ERROR AppTask::Init()
     SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
     SetCommissionableDataProvider(&mFactoryDataProvider);
 #else
+    SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 #endif
 

--- a/examples/all-clusters-minimal-app/nrfconnect/main/include/AppTask.h
+++ b/examples/all-clusters-minimal-app/nrfconnect/main/include/AppTask.h
@@ -24,6 +24,8 @@
 
 #if CONFIG_CHIP_FACTORY_DATA
 #include <platform/nrfconnect/FactoryDataProvider.h>
+#else
+#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_BT

--- a/examples/light-switch-app/nrfconnect/main/AppTask.cpp
+++ b/examples/light-switch-app/nrfconnect/main/AppTask.cpp
@@ -208,6 +208,7 @@ CHIP_ERROR AppTask::Init()
         memset(sTestEventTriggerEnableKey, 0, sizeof(sTestEventTriggerEnableKey));
     }
 #else
+    SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 #endif
 

--- a/examples/light-switch-app/nrfconnect/main/include/AppTask.h
+++ b/examples/light-switch-app/nrfconnect/main/include/AppTask.h
@@ -25,6 +25,8 @@
 
 #if CONFIG_CHIP_FACTORY_DATA
 #include <platform/nrfconnect/FactoryDataProvider.h>
+#else
+#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_BT

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -232,6 +232,7 @@ CHIP_ERROR AppTask::Init()
         memset(sTestEventTriggerEnableKey, 0, sizeof(sTestEventTriggerEnableKey));
     }
 #else
+    SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 #endif
 

--- a/examples/lighting-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppTask.h
@@ -26,6 +26,8 @@
 
 #if CONFIG_CHIP_FACTORY_DATA
 #include <platform/nrfconnect/FactoryDataProvider.h>
+#else
+#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
 #endif
 
 #ifdef CONFIG_CHIP_PW_RPC

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -202,6 +202,7 @@ CHIP_ERROR AppTask::Init()
         memset(sTestEventTriggerEnableKey, 0, sizeof(sTestEventTriggerEnableKey));
     }
 #else
+    SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 #endif
 

--- a/examples/lock-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lock-app/nrfconnect/main/include/AppTask.h
@@ -27,6 +27,8 @@
 
 #if CONFIG_CHIP_FACTORY_DATA
 #include <platform/nrfconnect/FactoryDataProvider.h>
+#else
+#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_BT

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -175,6 +175,7 @@ CHIP_ERROR AppTask::Init()
         memset(sTestEventTriggerEnableKey, 0, sizeof(sTestEventTriggerEnableKey));
     }
 #else
+    SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 #endif
 

--- a/examples/pump-app/nrfconnect/main/include/AppTask.h
+++ b/examples/pump-app/nrfconnect/main/include/AppTask.h
@@ -27,6 +27,8 @@
 
 #if CONFIG_CHIP_FACTORY_DATA
 #include <platform/nrfconnect/FactoryDataProvider.h>
+#else
+#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_BT

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -173,6 +173,7 @@ CHIP_ERROR AppTask::Init()
         memset(sTestEventTriggerEnableKey, 0, sizeof(sTestEventTriggerEnableKey));
     }
 #else
+    SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 #endif
 

--- a/examples/pump-controller-app/nrfconnect/main/include/AppTask.h
+++ b/examples/pump-controller-app/nrfconnect/main/include/AppTask.h
@@ -27,6 +27,8 @@
 
 #if CONFIG_CHIP_FACTORY_DATA
 #include <platform/nrfconnect/FactoryDataProvider.h>
+#else
+#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_BT

--- a/examples/window-app/nrfconnect/main/AppTask.cpp
+++ b/examples/window-app/nrfconnect/main/AppTask.cpp
@@ -179,6 +179,7 @@ CHIP_ERROR AppTask::Init()
         memset(sTestEventTriggerEnableKey, 0, sizeof(sTestEventTriggerEnableKey));
     }
 #else
+    SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 
 #endif

--- a/examples/window-app/nrfconnect/main/include/AppTask.h
+++ b/examples/window-app/nrfconnect/main/include/AppTask.h
@@ -24,6 +24,8 @@
 
 #if CONFIG_CHIP_FACTORY_DATA
 #include <platform/nrfconnect/FactoryDataProvider.h>
+#else
+#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_BT

--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -69,6 +69,11 @@ static_library("nrfconnect") {
       "FactoryDataProvider.cpp",
       "FactoryDataProvider.h",
     ]
+  } else {
+    sources += [
+      "DeviceInstanceInfoProviderImpl.cpp",
+      "DeviceInstanceInfoProviderImpl.h",
+    ]
   }
 
   if (chip_enable_openthread) {

--- a/src/platform/nrfconnect/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/nrfconnect/DeviceInstanceInfoProviderImpl.cpp
@@ -1,0 +1,47 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "DeviceInstanceInfoProviderImpl.h"
+#include <lib/support/BytesToHex.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+CHIP_ERROR DeviceInstanceInfoProviderImpl::GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan)
+{
+#if CHIP_ENABLE_ROTATING_DEVICE_ID && defined(CONFIG_CHIP_DEVICE_ROTATING_DEVICE_UID)
+    static_assert(ConfigurationManager::kRotatingDeviceIDUniqueIDLength >= ConfigurationManager::kMinRotatingDeviceIDUniqueIDLength,
+                  "Length of unique ID for rotating device ID is smaller than minimum.");
+
+    ReturnErrorCodeIf(ConfigurationManager::kRotatingDeviceIDUniqueIDLength > uniqueIdSpan.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    size_t bytesLen = chip::Encoding::HexToBytes(CONFIG_CHIP_DEVICE_ROTATING_DEVICE_UID,
+                                                 ConfigurationManager::kRotatingDeviceIDUniqueIDLength * 2, uniqueIdSpan.data(),
+                                                 uniqueIdSpan.size());
+
+    ReturnErrorCodeIf(bytesLen != ConfigurationManager::kRotatingDeviceIDUniqueIDLength, CHIP_ERROR_INVALID_STRING_LENGTH);
+    uniqueIdSpan.reduce_size(bytesLen);
+
+    return CHIP_NO_ERROR;
+#endif // CHIP_ENABLE_ROTATING_DEVICE_ID
+
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nrfconnect/DeviceInstanceInfoProviderImpl.h
+++ b/src/platform/nrfconnect/DeviceInstanceInfoProviderImpl.h
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <platform/Zephyr/ConfigurationManagerImpl.h>
+#include <platform/internal/GenericDeviceInstanceInfoProvider.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+class DeviceInstanceInfoProviderImpl : public Internal::GenericDeviceInstanceInfoProvider<Internal::ZephyrConfig>
+{
+public:
+    CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override;
+
+    DeviceInstanceInfoProviderImpl(ConfigurationManagerImpl & configManager) :
+        Internal::GenericDeviceInstanceInfoProvider<Internal::ZephyrConfig>(configManager)
+    {}
+};
+
+inline DeviceInstanceInfoProviderImpl & DeviceInstanceInfoProviderMgrImpl()
+{
+    static DeviceInstanceInfoProviderImpl sInstance(ConfigurationManagerImpl::GetDefaultInstance());
+    return sInstance;
+}
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nrfconnect/FactoryDataParser.c
+++ b/src/platform/nrfconnect/FactoryDataParser.c
@@ -18,14 +18,11 @@
 #include "FactoryDataParser.h"
 
 #include <zcbor_decode.h>
-#include <zephyr/logging/log.h>
 
 #include <ctype.h>
 #include <string.h>
 
 #define MAX_FACTORY_DATA_NESTING_LEVEL 3
-
-LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 
 static inline bool uint16_decode(zcbor_state_t * states, uint16_t * value)
 {
@@ -174,14 +171,14 @@ bool ParseFactoryData(uint8_t * buffer, uint16_t bufferSize, struct FactoryData 
                 isdigit(date.value[3]) && date.value[4] == '-' && isdigit(date.value[5]) && isdigit(date.value[6]) &&
                 date.value[7] == '-' && isdigit(date.value[8]) && isdigit(date.value[9]))
             {
-                factoryData->date_year =
-                    1000 * (date.value[0] - '0') + 100 * (date.value[1] - '0') + 10 * (date.value[2] - '0') + date.value[3] - '0';
-                factoryData->date_month = 10 * (date.value[5] - '0') + date.value[6] - '0';
-                factoryData->date_day   = 10 * (date.value[8] - '0') + date.value[9] - '0';
+                factoryData->date_year = (uint16_t)(1000 * (uint16_t)(date.value[0] - '0') + 100 * (uint16_t)(date.value[1] - '0') +
+                                                    10 * (uint16_t)(date.value[2] - '0') + (uint16_t)(date.value[3] - '0'));
+                factoryData->date_month = (uint8_t)(10 * (uint16_t)(date.value[5] - '0') + (uint16_t)(date.value[6] - '0'));
+                factoryData->date_day   = (uint8_t)(10 * (uint16_t)(date.value[8] - '0') + (uint16_t)(date.value[9] - '0'));
             }
             else
             {
-                LOG_ERR("Parsing error - wrong date format");
+                res = false;
             }
         }
         else if (strncmp("hw_ver_str", (const char *) currentString.value, currentString.len) == 0)
@@ -240,7 +237,7 @@ bool ParseFactoryData(uint8_t * buffer, uint16_t bufferSize, struct FactoryData 
         {
             factoryData->user.data = (void *) states->payload;
             res                    = res && zcbor_any_skip(states, NULL);
-            factoryData->user.len  = (void *) states->payload - factoryData->user.data;
+            factoryData->user.len  = (size_t)((void *) states->payload - factoryData->user.data);
         }
         else
         {

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -81,7 +81,7 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::Init()
         return error;
     }
 
-    if (!ParseFactoryData(factoryData, factoryDataSize, &mFactoryData))
+    if (!ParseFactoryData(factoryData, static_cast<uint16_t>(factoryDataSize), &mFactoryData))
     {
         ChipLogError(DeviceLayer, "Failed to parse factory data");
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;


### PR DESCRIPTION
Rotating Device Id Unique Id was parsing wrongly in nrfconnect's factory data provider implementation.
There was also a problem, that testing Rotating Device Id UID was not being provided by Zephyr's Kconfig.
Repaired the factory_data build for nRFconnect devices.
