### PR TITLE
ESP32: Upgrade to ESP-IDF release v4.4.4

### DIFF
--- a/docs/guides/esp32/setup_idf_chip.md
+++ b/docs/guides/esp32/setup_idf_chip.md
@@ -13,27 +13,27 @@ step.
 
 ### Install Prerequisites
 
--   [Linux](https://docs.espressif.com/projects/esp-idf/en/v4.4.3/esp32/get-started/linux-setup.html)
--   [macOS](https://docs.espressif.com/projects/esp-idf/en/v4.4.3/esp32/get-started/macos-setup.html)
+-   [Linux](https://docs.espressif.com/projects/esp-idf/en/v4.4.4/esp32/get-started/linux-setup.html)
+-   [macOS](https://docs.espressif.com/projects/esp-idf/en/v4.4.4/esp32/get-started/macos-setup.html)
 
-### Get IDF v4.4.3
+### Get IDF v4.4.4
 
 -   Clone ESP-IDF
-    [v4.4.3 release](https://github.com/espressif/esp-idf/releases/tag/v4.4.3)
+    [v4.4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4.4)
 
     ```
-    $ git clone -b v4.4.3 --recursive https://github.com/espressif/esp-idf.git
+    $ git clone -b v4.4.4 --recursive https://github.com/espressif/esp-idf.git
     $ cd esp-idf
     $ ./install.sh
     ```
 
--   To update an existing esp-idf toolchain to v4.4.3:
+-   To update an existing esp-idf toolchain to v4.4.4:
 
     ```
     $ cd path/to/esp-idf
     $ git fetch origin
-    $ git checkout v4.4.3
-    $ git reset --hard origin/v4.4.3
+    $ git checkout v4.4.4
+    $ git reset --hard origin/v4.4.4
     $ git submodule update --recursive --init
     $ git clean -fdx
     $ ./install.sh

--- a/integrations/docker/images/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32/Dockerfile
@@ -10,7 +10,7 @@ RUN set -x \
     && : # last line
 
 RUN set -x \
-    && git clone --recursive -b v4.4.3 --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git /tmp/esp-idf \
+    && git clone --recursive -b v4.4.4 --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git /tmp/esp-idf \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.7.0 Version bump reason: [Android] Use NDK r23c and OpenSSL 1.1.1t
+0.7.1 Version bump reason: [ESP32] Update ESP-IDF to v4.4.4 release


### PR DESCRIPTION
Upgrade to ESP-IDF release v4.4.4

With this, the issue of GDBGUI should get fixed too (as per the comment here https://github.com/espressif/esp-idf/issues/10936#issuecomment-1458268466) cc @andy31415 

Tests:
i. Compilation of all-clusters-app
ii. Commissioning and cluster control using chip-tool