### PR TITLE
Log payloads for read/subscribe even if we reject them.

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -441,6 +441,10 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
         SubscribeRequestMessage::Parser subscribeRequestParser;
         VerifyOrReturnError(subscribeRequestParser.Init(reader) == CHIP_NO_ERROR, Status::InvalidAction);
 
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+        subscribeRequestParser.PrettyPrint();
+#endif
+
         VerifyOrReturnError(subscribeRequestParser.GetKeepSubscriptions(&keepExistingSubscriptions) == CHIP_NO_ERROR,
                             Status::InvalidAction);
         if (!keepExistingSubscriptions)
@@ -538,6 +542,9 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
         ReadRequestMessage::Parser readRequestParser;
         VerifyOrReturnError(readRequestParser.Init(reader) == CHIP_NO_ERROR, Status::InvalidAction);
 
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+        readRequestParser.PrettyPrint();
+#endif
         {
             size_t requestedAttributePathCount = 0;
             size_t requestedEventPathCount     = 0;

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -394,9 +394,10 @@ CHIP_ERROR ReadHandler::ProcessReadRequest(System::PacketBufferHandle && aPayloa
     reader.Init(std::move(aPayload));
 
     ReturnErrorOnFailure(readRequestParser.Init(reader));
-#if CHIP_CONFIG_IM_PRETTY_PRINT
-    readRequestParser.PrettyPrint();
-#endif
+
+    // No need to pretty-print here.  We pretty-print read requests in the read
+    // case of InteractionModelEngine::OnReadInitialRequest, so we do it even if
+    // we reject a read request.
 
     err = readRequestParser.GetAttributeRequests(&attributePathListParser);
     if (err == CHIP_END_OF_TLV)
@@ -647,9 +648,10 @@ CHIP_ERROR ReadHandler::ProcessSubscribeRequest(System::PacketBufferHandle && aP
 
     SubscribeRequestMessage::Parser subscribeRequestParser;
     ReturnErrorOnFailure(subscribeRequestParser.Init(reader));
-#if CHIP_CONFIG_IM_PRETTY_PRINT
-    subscribeRequestParser.PrettyPrint();
-#endif
+
+    // No need to pretty-print here.  We pretty-print subscribe requests in the
+    // subscribe case of InteractionModelEngine::OnReadInitialRequest, so we do
+    // it even if we reject a subscribe request.
 
     AttributePathIBs::Parser attributePathListParser;
     CHIP_ERROR err = subscribeRequestParser.GetAttributeRequests(&attributePathListParser);


### PR DESCRIPTION
Right now we only log read/subscribe payloads when we are actaully handling the read/subscribe.  But that means when they are rejected it's hard to tell what might have caused them to get rejected.

This just moves the logging to much earlier in the processing.
