### PR TITLE
Improve the logging for MTRDevice.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
@@ -28,15 +28,18 @@ using chip::System::Clock::Timeout;
 using chip::System::Clock::Seconds16;
 
 static void MTRClustersLogEnqueue(NSString *logPrefix, MTRAsyncCallbackWorkQueue *workQueue) {
-    MTR_LOG_INFO("%@ enqueueWorkItem %@", logPrefix, workQueue);
+    MTR_LOG_DEFAULT("%@ enqueueWorkItem %@", logPrefix, workQueue);
 }
 
 static void MTRClustersLogDequeue(NSString *logPrefix, MTRAsyncCallbackWorkQueue *workQueue) {
-    MTR_LOG_INFO("%@ dequeueWorkItem %@", logPrefix, workQueue);
+    MTR_LOG_DEFAULT("%@ dequeueWorkItem %@", logPrefix, workQueue);
 }
 
 static void MTRClustersLogCompletion(NSString *logPrefix, id value, NSError *error) {
-    MTR_LOG_INFO("%@ completion value %@ error %@ endWork", logPrefix, value, error);
+    // Log the data at the INFO level (not usually persisted permanently),
+    // but make sure we log the work completion at the DEFAULT level.
+    MTR_LOG_INFO("%@ received response: %@ error: %@", logPrefix, value, error);
+    MTR_LOG_DEFAULT("%@ endWork", logPrefix);
 }
 
 // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks): Linter is unable to locate the delete on these objects.

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
@@ -44,17 +44,20 @@ using chip::System::Clock::Timeout;
 
 static void MTRClustersLogEnqueue(NSString * logPrefix, MTRAsyncCallbackWorkQueue * workQueue)
 {
-    MTR_LOG_INFO("%@ enqueueWorkItem %@", logPrefix, workQueue);
+    MTR_LOG_DEFAULT("%@ enqueueWorkItem %@", logPrefix, workQueue);
 }
 
 static void MTRClustersLogDequeue(NSString * logPrefix, MTRAsyncCallbackWorkQueue * workQueue)
 {
-    MTR_LOG_INFO("%@ dequeueWorkItem %@", logPrefix, workQueue);
+    MTR_LOG_DEFAULT("%@ dequeueWorkItem %@", logPrefix, workQueue);
 }
 
 static void MTRClustersLogCompletion(NSString * logPrefix, id value, NSError * error)
 {
-    MTR_LOG_INFO("%@ completion value %@ error %@ endWork", logPrefix, value, error);
+    // Log the data at the INFO level (not usually persisted permanently),
+    // but make sure we log the work completion at the DEFAULT level.
+    MTR_LOG_INFO("%@ received response: %@ error: %@", logPrefix, value, error);
+    MTR_LOG_DEFAULT("%@ endWork", logPrefix);
 }
 
 // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks): Linter is unable to locate the delete on these objects.


### PR DESCRIPTION
MTR_LOG_INFO does not get persisted by default.  Move logging involving errors or the operation queue lifetime to MTR_LOG_ERROR/MTR_LOG_DEFAULT.
