### PR TITLE
[Telink] Update Telink Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/chip-build-telink/Dockerfile
@@ -23,7 +23,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=79e02527e04b369180ceef7c4cd682b24889801e
+ARG ZEPHYR_REVISION=abb88b989a7ee31c04d99615cd91c946c81c0aa5
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.7.1 Version bump reason: [ESP32] Update ESP-IDF to v4.4.4 release
+0.7.2 Version bump reason: [Telink] Update Telink Docker image (Zephyr update)


### PR DESCRIPTION
**Change overview**

- Telink driver updates
- Disable SHELL_BACKENDS if PM
- Updated PLL clocks sources

**Testing**
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully