### PR TITLE
[Linux] Fix event loop task consecutive start/stop

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -59,6 +59,8 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_InitChipStack()
     // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
     ReturnErrorOnFailure(GenericPlatformManagerImpl<ImplClass>::_InitChipStack());
 
+    mShouldRunEventLoop.store(true, std::memory_order_relaxed);
+
     int ret = pthread_cond_init(&mEventQueueStoppedCond, nullptr);
     VerifyOrReturnError(ret == 0, CHIP_ERROR_POSIX(ret));
 
@@ -224,6 +226,8 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StartEventLoopTask()
     err = pthread_attr_setschedpolicy(&mChipTaskAttr, SCHED_RR);
     VerifyOrReturnError(err == 0, CHIP_ERROR_POSIX(err));
 #endif
+
+    mShouldRunEventLoop.store(true, std::memory_order_relaxed);
 
     //
     // We need to grab the lock here since we have to protect setting

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -77,7 +77,15 @@ static void TestPlatformMgr_BasicEventLoopTask(nlTestSuite * inSuite, void * inC
             counterRun++;
             counterSync--;
         });
+
+        // Sleep for a short time to allow the event loop to process the
+        // scheduled event and go to idle state. Without this sleep, the
+        // event loop may process both scheduled lambdas during single
+        // iteration of the event loop which would defeat the purpose of
+        // this test on POSIX platforms where the event loop is implemented
+        // using a "do { ... } while (shouldRun)" construct.
         chip::test_utils::SleepMillis(10);
+
         DeviceLayer::SystemLayer().ScheduleLambda([&]() {
             counterRun++;
             counterSync--;


### PR DESCRIPTION
### Problem

On Linux (POSIX implementation) it's not possible to start matter event loop task after calling `PlatformMgr().StopEventLoopTask()`. Also, it's not possible to reinitialize matter stack, because in that case event loop will not run as well.

### Changes

- reset `mShouldRunEventLoop` flag on `_InitChipStack()` and `_StartEventLoopTask()`
- modified TestPlatformMgr to properly cover that use case scenario

### Testing

CI will verify.