### PR TITLE
[dnssd] Fixed OT DNS API usage for Thread platform

### DIFF
--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -172,7 +172,9 @@ static void HandleNodeBrowse(void * context, DnssdService * services, size_t ser
     {
         proxy->Retain();
         // For some platforms browsed services are already resolved, so verify if resolve is really needed or call resolve callback
-        if (!services[i].mAddress.HasValue())
+
+        // Check if SRV, TXT and AAAA records were received in DNS responses
+        if (strlen(services[i].mHostName) == 0 || services[i].mTextEntrySize == 0 || !services[i].mAddress.HasValue())
         {
             ChipDnssdResolve(&services[i], services[i].mInterface, HandleNodeResolve, context);
         }

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -136,8 +136,12 @@ protected:
     CHIP_ERROR _DnsBrowse(const char * aServiceName, DnsBrowseCallback aCallback, void * aContext);
     CHIP_ERROR _DnsResolve(const char * aServiceName, const char * aInstanceName, DnsResolveCallback aCallback, void * aContext);
     static void DispatchResolve(intptr_t context);
+    static void DispatchResolveNoMemory(intptr_t context);
+    static void DispatchAddressResolve(intptr_t context);
+    static void DispatchBrowseInvokedAddressResolve(intptr_t context);
     static void DispatchBrowseEmpty(intptr_t context);
     static void DispatchBrowse(intptr_t context);
+    static void DispatchBrowseNoMemory(intptr_t context);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
@@ -261,6 +265,16 @@ private:
 
     static void OnDnsBrowseResult(otError aError, const otDnsBrowseResponse * aResponse, void * aContext);
     static void OnDnsResolveResult(otError aError, const otDnsServiceResponse * aResponse, void * aContext);
+    static void OnDnsAddressResolveResult(otError aError, const otDnsAddressResponse * aResponse, void * aContext);
+    static void OnDnsBrowseInvokedResolveResult(otError aError, const otDnsServiceResponse * aResponse, void * aContext);
+    static void OnDnsBrowseInvokedAddressResolveResult(otError aError, const otDnsAddressResponse * aResponse, void * aContext);
+
+    static void ResolveAddress(intptr_t context, otDnsAddressCallback callback);
+    static void ResolveResult(otError aError, const otDnsServiceResponse * aResponse, void * aContext,
+                              AsyncWorkFunct dispatchMdnsCallback, AsyncWorkFunct dispatchAddressResolve);
+    static void AddressResolveResult(otError aError, const otDnsAddressResponse * aResponse, void * aContext,
+                                     AsyncWorkFunct dispatchAddressResolve);
+
     static CHIP_ERROR FromOtDnsResponseToMdnsData(otDnsServiceInfo & serviceInfo, const char * serviceType,
                                                   chip::Dnssd::DnssdService & mdnsService,
                                                   DnsServiceTxtEntries & serviceTxtEntries);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -138,7 +138,6 @@ protected:
     static void DispatchResolve(intptr_t context);
     static void DispatchResolveNoMemory(intptr_t context);
     static void DispatchAddressResolve(intptr_t context);
-    static void DispatchBrowseInvokedAddressResolve(intptr_t context);
     static void DispatchBrowseEmpty(intptr_t context);
     static void DispatchBrowse(intptr_t context);
     static void DispatchBrowseNoMemory(intptr_t context);
@@ -266,18 +265,12 @@ private:
     static void OnDnsBrowseResult(otError aError, const otDnsBrowseResponse * aResponse, void * aContext);
     static void OnDnsResolveResult(otError aError, const otDnsServiceResponse * aResponse, void * aContext);
     static void OnDnsAddressResolveResult(otError aError, const otDnsAddressResponse * aResponse, void * aContext);
-    static void OnDnsBrowseInvokedResolveResult(otError aError, const otDnsServiceResponse * aResponse, void * aContext);
-    static void OnDnsBrowseInvokedAddressResolveResult(otError aError, const otDnsAddressResponse * aResponse, void * aContext);
 
-    static void ResolveAddress(intptr_t context, otDnsAddressCallback callback);
-    static void ResolveResult(otError aError, const otDnsServiceResponse * aResponse, void * aContext,
-                              AsyncWorkFunct dispatchMdnsCallback, AsyncWorkFunct dispatchAddressResolve);
-    static void AddressResolveResult(otError aError, const otDnsAddressResponse * aResponse, void * aContext,
-                                     AsyncWorkFunct dispatchAddressResolve);
+    static CHIP_ERROR ResolveAddress(intptr_t context, otDnsAddressCallback callback);
 
     static CHIP_ERROR FromOtDnsResponseToMdnsData(otDnsServiceInfo & serviceInfo, const char * serviceType,
-                                                  chip::Dnssd::DnssdService & mdnsService,
-                                                  DnsServiceTxtEntries & serviceTxtEntries);
+                                                  chip::Dnssd::DnssdService & mdnsService, DnsServiceTxtEntries & serviceTxtEntries,
+                                                  otError error);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 


### PR DESCRIPTION
Introduced several fixes to the Thread platform DNS implementation:
* Added checking if memory allocation for DnsResult was successful and dispatching dedicated methods to inform upper layer in case of memory allocation failure
* Added checking if DNS response for DNS resolve includes AAAA record. In case it doesn't the additional DNS query to obtain IPv6 address will be sent.
* Added checking if DNS response for DNS browse includes SRV, TXT and AAAA records. In case it doesn't the additional DNS queries to obtain SRV + TXT, and AAAA records will be sent.

Fixes: https://github.com/project-chip/connectedhomeip/issues/26101

