### PR TITLE
Chip-tool hits the Code is unsafe/racy assert when BLE commissioning is started.

### DIFF
--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -796,7 +796,11 @@ void BLEManagerImpl::OnDeviceScanned(BluezDevice1 * device, const chip::Ble::Chi
     }
 
     mBLEScanConfig.mBleScanState = BleScanState::kConnecting;
+
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
     DeviceLayer::SystemLayer().StartTimer(kConnectTimeout, HandleConnectTimeout, mpEndpoint);
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+
     mDeviceScanner->StopScan();
 
     ConnectDevice(device, mpEndpoint);


### PR DESCRIPTION
PR [#26180](https://github.com/project-chip/connectedhomeip/pull/26180) added assert on the task ownership of the chip Stack lock on some SystemLayer timer calls. 

The Linux bleManagerImpl starts a SystemLayer timer on the BLE connection which now asserts.

This pr fix the assert on SystemLayer().StartTimer call by acquiring the chipStack Lock before the call (and releasing it after)

Tested the fix by successfully completing the commissioning with chip-tool on a raspi.

