### PR TITLE
ot cli command is called networkkey now

### DIFF
--- a/docs/guides/nrfconnect_examples_cli.md
+++ b/docs/guides/nrfconnect_examples_cli.md
@@ -83,7 +83,7 @@ available options for the given command.
 are accessible from the shell, but they must preceded by `ot`. For example:
 
 ```shell
-uart:~$ ot masterkey
+uart:~$ ot networkkey
 00112233445566778899aabbccddeeff
 Done
 ```


### PR DESCRIPTION
Outdated documentation.

The OpenThread CLIU command is now called networkkey, see https://github.com/openthread/openthread/blob/main/src/cli/README.md#networkkey.
