### PR TITLE
[Android] Fix EventLoop issue when commissioner restart

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -59,6 +59,8 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_InitChipStack()
     // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
     ReturnErrorOnFailure(GenericPlatformManagerImpl<ImplClass>::_InitChipStack());
 
+    mShouldRunEventLoop.store(true, std::memory_order_relaxed);
+
     int ret = pthread_cond_init(&mEventQueueStoppedCond, nullptr);
     VerifyOrReturnError(ret == 0, CHIP_ERROR_POSIX(ret));
 


### PR DESCRIPTION
### Problem

There is a problem that the EventLoop terminates as soon as it starts when the Android platform-based commissioner is restarted. Restarting commissioner means calling the following methods in order.

- ChipDeviceController.loadJni()
- androidPlatform = new AndroidPlatform()
- chipDeviceController = new ChipDeviceController()
- ChipDeviceController.shutdownCommissioning()
- androidPlatform = new AndroidPlatform()
- chipDeviceController = new ChipDeviceController()

For reference, this commissioner is not implemented as a singleton.

### Change overview

`mShouldRunEventLoop` is set to `false` by calling "shutdownCommissioning()" method. In this state, to reinitialize the commissioner and restart the EventLoop, call the "new ChipDeviceController()" constructor. The EventLoop then terminates as soon as it starts.
This change sets `mShouldRunEventLoop` to `true` when initializing the EventLoop, fixing an issue where the EventLoop terminates as soon as it starts when the commissioner restarts.

### Testing

Restart the Android platform-based commissioner.