### PR TITLE
Add a way for auto-commissioner to skip network setup.

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -418,9 +418,9 @@ CHIP_ERROR AutoCommissioner::StartCommissioning(DeviceCommissioner * commissione
     mStopCommissioning       = false;
     mCommissioner            = commissioner;
     mCommissioneeDeviceProxy = proxy;
-    mNeedsNetworkSetup =
+    mNeedsNetworkSetup       = mParams.GetDoNetworkSetup().ValueOr(
         mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType() ==
-        Transport::Type::kBle;
+        Transport::Type::kBle);
     CHIP_ERROR err               = CHIP_NO_ERROR;
     CommissioningStage nextStage = GetNextCommissioningStage(CommissioningStage::kSecurePairing, err);
     mCommissioner->PerformCommissioningStep(mCommissioneeDeviceProxy, nextStage, mParams, this, GetEndpoint(nextStage),

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -103,6 +103,19 @@ public:
     static constexpr size_t kMaxCredentialsLen   = 64;
     static constexpr size_t kMaxCountryCodeLen   = 2;
 
+    enum class NetworkSetupMode : uint8_t
+    {
+        // Automatically decide, based on whether we established a PASE session
+        // on-network or not, whether network setup needs to be done.
+        kAutomatic,
+        // Skip network setup.  Can be used when the commissioner determines
+        // that the commissionee is already on the right network.
+        kSkip,
+        // Perform network setup, even if PASE was on-network.  Can be used
+        // when trying to commission onto a different network.
+        kForce,
+    };
+
     // Value to use when setting the commissioning failsafe timer on the node being commissioned.
     // If the failsafe timer value is passed in as part of the commissioning parameters, that value will be used. If not supplied,
     // the AutoCommissioner will set this to the recommended value read from the node. If that is not set, it will fall back to the
@@ -427,18 +440,12 @@ public:
         return *this;
     }
 
-    // Whether network setup should be performed.  If not set, the need for
-    // network setup will be auto-detected based on whether we established a
-    // PASE session on-network or not.
-    Optional<bool> GetDoNetworkSetup() const { return mDoNetworkSetup; }
-    CommissioningParameters & SetDoNetworkSetup(bool doNetworkSetup)
+    // The network setup mode; see documentation for NetworkSetupMode.
+    // Defaults to NetworkSetupMode::kAutomatic.
+    NetworkSetupMode GetNetworkSetupMode() const { return mNetworkSetupMode; }
+    CommissioningParameters & SetNetworkSetupMode(NetworkSetupMode networkSetupMode)
     {
-        mDoNetworkSetup = MakeOptional(doNetworkSetup);
-        return *this;
-    }
-    CommissioningParameters & ResetDoNetworkSetup()
-    {
-        mDoNetworkSetup.ClearValue();
+        mNetworkSetupMode = networkSetupMode;
         return *this;
     }
 
@@ -494,8 +501,8 @@ private:
     Optional<bool> mAttemptWiFiNetworkScan;
     Optional<bool> mAttemptThreadNetworkScan; // This automatically gets set to false when a ThreadOperationalDataset is set
     Optional<bool> mSkipCommissioningComplete;
-    Optional<bool> mDoNetworkSetup;
-    bool mCheckForMatchingFabric = false;
+    NetworkSetupMode mNetworkSetupMode = NetworkSetupMode::kAutomatic;
+    bool mCheckForMatchingFabric       = false;
 };
 
 struct RequestedCertificate

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -427,6 +427,21 @@ public:
         return *this;
     }
 
+    // Whether network setup should be performed.  If not set, the need for
+    // network setup will be auto-detected based on whether we established a
+    // PASE session on-network or not.
+    Optional<bool> GetDoNetworkSetup() const { return mDoNetworkSetup; }
+    CommissioningParameters & SetDoNetworkSetup(bool doNetworkSetup)
+    {
+        mDoNetworkSetup = MakeOptional(doNetworkSetup);
+        return *this;
+    }
+    CommissioningParameters & ResetDoNetworkSetup()
+    {
+        mDoNetworkSetup.ClearValue();
+        return *this;
+    }
+
     // Clear all members that depend on some sort of external buffer.  Can be
     // used to make sure that we are not holding any dangling pointers.
     void ClearExternalBufferDependentValues()
@@ -479,6 +494,7 @@ private:
     Optional<bool> mAttemptWiFiNetworkScan;
     Optional<bool> mAttemptThreadNetworkScan; // This automatically gets set to false when a ThreadOperationalDataset is set
     Optional<bool> mSkipCommissioningComplete;
+    Optional<bool> mDoNetworkSetup;
     bool mCheckForMatchingFabric = false;
 };
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
@@ -20,6 +20,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSUInteger, MTRNetworkSetupMode) {
+    MTRNetworkSetupModeAutomatic,
+    MTRNetworkSetupModeSkipped,
+    MTRNetworkSetupModeForced,
+} MTR_NEWLY_AVAILABLE;
+
 @protocol MTRDeviceAttestationDelegate;
 
 /**
@@ -79,6 +85,23 @@ NS_ASSUME_NONNULL_BEGIN
  * deviceAttestationDelegate.
  */
 @property (nonatomic, copy, nullable) NSNumber * failSafeTimeout API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+
+/**
+ * Whether to perform network setup on the device.
+ *
+ * If set to MTRNetworkSetupModeAutomatic (the default), the commissioning process will attempt to
+ * auto-detect whether network setup is needed (e.g. based on whether the PASE session to the
+ * accessory is over the operational network).  Credentials for the desired operational network
+ * should be provided to enable this to happen.
+ *
+ * If set to MTRNetworkSetupModeSkipped, any needed network configuration should have been done on
+ * the device already prior to starting the rest of the commissioning process.  In that case, the
+ * various network identifiers and credentials above can all be nil.
+ *
+ * If set to MTRNetworkSetupModeForced, the commissioning process will attempt to do network setup
+ * using the provided network credentials.
+ */
+@property (nonatomic, assign) MTRNetworkSetupMode networkSetupMode MTR_NEWLY_AVAILABLE;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.mm
@@ -21,6 +21,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation MTRCommissioningParameters : NSObject
 
+- (instancetype)init
+{
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    _csrNonce = nil;
+    _attestationNonce = nil;
+    _wifiSSID = nil;
+    _wifiCredentials = nil;
+    _threadOperationalDataset = nil;
+    _deviceAttestationDelegate = nil;
+    _failSafeTimeout = nil;
+    _networkSetupMode = MTRNetworkSetupModeAutomatic;
+    return self;
+}
+
 @end
 
 @implementation MTRCommissioningParameters (Deprecated)

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -493,10 +493,10 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
         }
         switch (commissioningParams.networkSetupMode) {
         case MTRNetworkSetupModeSkipped:
-            params.SetDoNetworkSetup(false);
+            params.SetNetworkSetupMode(chip::Controller::CommissioningParameters::NetworkSetupMode::kSkip);
             break;
         case MTRNetworkSetupModeForced:
-            params.SetDoNetworkSetup(true);
+            params.SetNetworkSetupMode(chip::Controller::CommissioningParameters::NetworkSetupMode::kForce);
             break;
         default:
             // MTRNetworkSetupModeAutomatic and any unknown value, just do the

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -491,6 +491,18 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
                 self, commissioningParams.deviceAttestationDelegate, timeoutSecs, shouldWaitAfterDeviceAttestation);
             params.SetDeviceAttestationDelegate(self->_deviceAttestationDelegateBridge);
         }
+        switch (commissioningParams.networkSetupMode) {
+        case MTRNetworkSetupModeSkipped:
+            params.SetDoNetworkSetup(false);
+            break;
+        case MTRNetworkSetupModeForced:
+            params.SetDoNetworkSetup(true);
+            break;
+        default:
+            // MTRNetworkSetupModeAutomatic and any unknown value, just do the
+            // auto-detect behavior.
+            break;
+        }
 
         chip::NodeId deviceId = [nodeID unsignedLongLongValue];
         self->_operationalCredentialsDelegate->SetDeviceID(deviceId);


### PR DESCRIPTION
Right now auto-commissioner expects to handle network setup itself if the PASE session is over BLE.  Add a flag to allow the API consumer to skip that logic, if they have already done network setup for some reason before kicking off the rest of the commissioning process, or have out-of-band knowledge that network setup is not actually needed.
