### PR TITLE
[OTA][Silabs] Reset the OTARequestor state if the downloaded image is invalid

### DIFF
--- a/src/platform/silabs/SiWx917/OTAImageProcessorImpl.cpp
+++ b/src/platform/silabs/SiWx917/OTAImageProcessorImpl.cpp
@@ -190,6 +190,8 @@ void OTAImageProcessorImpl::HandleApply(intptr_t context)
     if (err != SL_BOOTLOADER_OK)
     {
         ChipLogError(SoftwareUpdate, "ERROR: bootloader_verifyImage() error %ld", err);
+        // Call the OTARequestor API to reset the state
+        GetRequestorInstance()->CancelImageUpdate();
 
         return;
     }
@@ -198,6 +200,8 @@ void OTAImageProcessorImpl::HandleApply(intptr_t context)
     if (err != SL_BOOTLOADER_OK)
     {
         ChipLogError(SoftwareUpdate, "ERROR: bootloader_setImageToBootload() error %ld", err);
+        // Call the OTARequestor API to reset the state
+        GetRequestorInstance()->CancelImageUpdate();
 
         return;
     }

--- a/src/platform/silabs/efr32/OTAImageProcessorImpl.cpp
+++ b/src/platform/silabs/efr32/OTAImageProcessorImpl.cpp
@@ -201,6 +201,8 @@ void OTAImageProcessorImpl::HandleApply(intptr_t context)
     if (err != SL_BOOTLOADER_OK)
     {
         ChipLogError(SoftwareUpdate, "ERROR: bootloader_verifyImage() error %ld", err);
+        // Call the OTARequestor API to reset the state
+        GetRequestorInstance()->CancelImageUpdate();
 
         return;
     }
@@ -209,6 +211,8 @@ void OTAImageProcessorImpl::HandleApply(intptr_t context)
     if (err != SL_BOOTLOADER_OK)
     {
         ChipLogError(SoftwareUpdate, "ERROR: bootloader_setImageToBootload() error %ld", err);
+        // Call the OTARequestor API to reset the state
+        GetRequestorInstance()->CancelImageUpdate();
 
         return;
     }


### PR DESCRIPTION
Fixes  https://github.com/project-chip/connectedhomeip/issues/26063

If the downloaded OTA Update image is found to be invalid call the OTA Requestor CancelImageUpdate() API to reset its state, otherwise the Requestor remains in the kApplying state.

All platforms should add similar or equivalent logic to their OTAImageProcessorImpl::Apply() implementations if it's not there already. 

Tested on Silabs EFR32 platform. 
