### PR TITLE
Fix Disconnect RPC for ESP 32

### DIFF
--- a/examples/platform/esp32/Rpc.cpp
+++ b/examples/platform/esp32/Rpc.cpp
@@ -204,8 +204,11 @@ public:
         size_t password_size = std::min(sizeof(password) - 1, static_cast<size_t>(request.secret.size));
         memcpy(password, request.secret.bytes, password_size);
         password[password_size] = '\0';
-        if (chip::DeviceLayer::NetworkCommissioning::ESPWiFiDriver::GetInstance().ConnectWiFiNetwork(
-                ssid, strlen(ssid), password, strlen(password)) != CHIP_NO_ERROR)
+        chip::DeviceLayer::PlatformMgr().LockChipStack();
+        CHIP_ERROR error = chip::DeviceLayer::NetworkCommissioning::ESPWiFiDriver::GetInstance().ConnectWiFiNetwork(
+                ssid, strlen(ssid), password, strlen(password));
+        chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+        if (error != CHIP_NO_ERROR)
         {
             return pw::Status::Internal();
         }
@@ -214,8 +217,9 @@ public:
 
     pw::Status Disconnect(const pw_protobuf_Empty & request, pw_protobuf_Empty & response) override
     {
+        chip::DeviceLayer::PlatformMgr().LockChipStack();
         chip::DeviceLayer::ConnectivityMgr().ClearWiFiStationProvision();
-        chip::DeviceLayer::ConnectivityMgr().SetWiFiStationMode(chip::DeviceLayer::ConnectivityManager::kWiFiStationMode_Disabled);
+        chip::DeviceLayer::PlatformMgr().UnlockChipStack();
         return pw::OkStatus();
     }
 

--- a/examples/platform/esp32/Rpc.cpp
+++ b/examples/platform/esp32/Rpc.cpp
@@ -206,7 +206,7 @@ public:
         password[password_size] = '\0';
         chip::DeviceLayer::PlatformMgr().LockChipStack();
         CHIP_ERROR error = chip::DeviceLayer::NetworkCommissioning::ESPWiFiDriver::GetInstance().ConnectWiFiNetwork(
-                ssid, strlen(ssid), password, strlen(password));
+            ssid, strlen(ssid), password, strlen(password));
         chip::DeviceLayer::PlatformMgr().UnlockChipStack();
         if (error != CHIP_NO_ERROR)
         {

--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -105,6 +105,12 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision(void)
 {
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
+        CHIP_ERROR error = chip::DeviceLayer::Internal::ESP32Utils::ClearWiFiStationProvision();
+        if (error != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "ClearWiFiStationProvision failed: %s", chip::ErrorStr(error));
+            return;
+        }
         DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL);
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP
         DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);


### PR DESCRIPTION
This fixes Disconnect RPC, by actually clearing the wifi station provision. Without this the device simply reconnects to wifi after disconnection.

Additionally PR https://github.com/project-chip/connectedhomeip/pull/26180 added assert on the task ownership of the chip Stack lock on some SystemLayer timer calls. This PR fix the assert on SystemLayer().ScheduleWork call by acquiring the chipStack Lock before the call

Test:
* `rpcs.chip.rpc.WiFi.Connect(ssid=b'<omitted>', security_type=0, secret=b'<omitted>'` // Confirmed we connected to specified AP
* `rpcs.chip.rpc.WiFi.Disconnect()` //  Confirmed that this disconnected properly from the AP
