### PR TITLE
[Silabs] Adds fix for LastNetworkID & LastConnectErrorValue have null value after device reset

### DIFF
--- a/examples/platform/silabs/efr32/BaseApplication.cpp
+++ b/examples/platform/silabs/efr32/BaseApplication.cpp
@@ -173,7 +173,7 @@ CHIP_ERROR BaseApplication::Init(Identify * identifyObj)
     SILABS_LOG("APP: Wait WiFi Init");
     while (!wfx_hw_ready())
     {
-        vTaskDelay(10);
+        vTaskDelay(pdMS_TO_TICKS(10));
     }
     SILABS_LOG("APP: Done WiFi Init");
     /* We will init server when we get IP */

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -123,7 +123,6 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
             {
             case IP_EVENT_STA_GOT_IP:
                 ChipLogProgress(DeviceLayer, "IP_EVENT_STA_GOT_IP");
-                NetworkCommissioning::SlWiFiDriver::GetInstance().UpdateNetworkingStatus();
                 UpdateInternetConnectivityState();
                 break;
             case IP_EVENT_STA_LOST_IP:
@@ -132,7 +131,6 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
                 break;
             case IP_EVENT_GOT_IP6:
                 ChipLogProgress(DeviceLayer, "IP_EVENT_GOT_IP6");
-                NetworkCommissioning::SlWiFiDriver::GetInstance().UpdateNetworkingStatus();
                 UpdateInternetConnectivityState();
                 break;
             default:
@@ -411,6 +409,7 @@ void ConnectivityManagerImpl::ChangeWiFiStationState(WiFiStationState newState)
         ChipLogProgress(DeviceLayer, "WiFi station state change: %s -> %s", WiFiStationStateToStr(mWiFiStationState),
                         WiFiStationStateToStr(newState));
         mWiFiStationState = newState;
+        NetworkCommissioning::SlWiFiDriver::GetInstance().UpdateNetworkingStatus();
     }
 }
 

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -123,6 +123,7 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
             {
             case IP_EVENT_STA_GOT_IP:
                 ChipLogProgress(DeviceLayer, "IP_EVENT_STA_GOT_IP");
+                NetworkCommissioning::SlWiFiDriver::GetInstance().UpdateNetworkingStatus();
                 UpdateInternetConnectivityState();
                 break;
             case IP_EVENT_STA_LOST_IP:
@@ -131,6 +132,7 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
                 break;
             case IP_EVENT_GOT_IP6:
                 ChipLogProgress(DeviceLayer, "IP_EVENT_GOT_IP6");
+                NetworkCommissioning::SlWiFiDriver::GetInstance().UpdateNetworkingStatus();
                 UpdateInternetConnectivityState();
                 break;
             default:
@@ -386,7 +388,7 @@ void ConnectivityManagerImpl::OnStationConnected()
 
 void ConnectivityManagerImpl::OnStationDisconnected()
 {
-    // TODO Invoke WARM to perform actions that occur when the WiFi station interface goes down.
+    // TODO: Invoke WARM to perform actions that occur when the WiFi station interface goes down.
 
     // Alert other components of the new state.
     ChipDeviceEvent event;

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -145,8 +145,14 @@ CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, 
         {
             // TODO: Re-write implementation with proper driver based callback
             if (mpStatusChangeCallback != nullptr)
+            {
                 mpStatusChangeCallback->OnNetworkingStatusChange(Status::kUnknownError, MakeOptional(networkId),
                                                                  MakeOptional(status));
+            }
+            else
+            {
+                ChipLogError(NetworkProvisioning, "mpStatusChangeCallback is nil");
+            }
             return CHIP_ERROR_INTERNAL;
         }
     }
@@ -164,7 +170,13 @@ CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, 
     ReturnErrorOnFailure(ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Enabled));
     // TODO: Re-write implementation with proper driver based callback
     if (mpStatusChangeCallback != nullptr)
+    {
         mpStatusChangeCallback->OnNetworkingStatusChange(Status::kSuccess, MakeOptional(networkId), NullOptional);
+    }
+    else
+    {
+        ChipLogError(NetworkProvisioning, "mpStatusChangeCallback is nil");
+    }
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -197,7 +197,7 @@ exit:
         callback->OnResult(networkingStatus, CharSpan(), 0);
         // TODO: Re-write implementation with proper driver based callback
         if (mpStatusChangeCallback != nullptr)
-            mpStatusChangeCallback->OnNetworkingStatusChange(Status::kUnknownError, MakeOptional(networkId), MakeOptional(err));
+            mpStatusChangeCallback->OnNetworkingStatusChange(Status::kUnknownError, MakeOptional(networkId), NullOptional);
     }
 }
 

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -42,6 +42,7 @@ CHIP_ERROR SlWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChangeC
     size_t credentialsLen = 0;
     mpScanCallback        = nullptr;
     mpConnectCallback     = nullptr;
+    mpStatusChangeCallback = networkStatusChangeCallback;
 
 #ifdef SL_ONNETWORK_PAIRING
     memcpy(&mSavedNetwork.ssid[0], SL_WIFI_SSID, sizeof(SL_WIFI_SSID));
@@ -183,6 +184,9 @@ void SlWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callback
     {
         mpConnectCallback = callback;
         networkingStatus  = Status::kSuccess;
+        // TODO: Re-write implementation with proper driver based callback
+        if (mpStatusChangeCallback != nullptr)
+            mpStatusChangeCallback->OnNetworkingStatusChange(Status::kSuccess, MakeOptional(networkId), NullOptional);
     }
 
 exit:
@@ -191,6 +195,9 @@ exit:
         ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network:%s", chip::ErrorStr(err));
         mpConnectCallback = nullptr;
         callback->OnResult(networkingStatus, CharSpan(), 0);
+        // TODO: Re-write implementation with proper driver based callback
+        if (mpStatusChangeCallback != nullptr)
+            mpStatusChangeCallback->OnNetworkingStatusChange(Status::kUnknownError, MakeOptional(networkId), MakeOptional(err));
     }
 }
 

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -166,7 +166,13 @@ void SlWiFiDriver::UpdateNetworkingStatus()
 {
     if (mpStatusChangeCallback == nullptr)
     {
-        ChipLogError(NetworkProvisioning, "mpStatusChangeCallback is nil");
+        ChipLogError(NetworkProvisioning, "networkStatusChangeCallback is nil");
+        return;
+    }
+
+    if (mStagingNetwork.ssidLen == 0)
+    {
+        ChipLogError(NetworkProvisioning, "ssidLen is 0");
         return;
     }
 

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -38,10 +38,10 @@ SlScanResponseIterator<NetworkCommissioning::WiFiScanResponse> mScanResponseIter
 CHIP_ERROR SlWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChangeCallback)
 {
     CHIP_ERROR err;
-    size_t ssidLen        = 0;
-    size_t credentialsLen = 0;
-    mpScanCallback        = nullptr;
-    mpConnectCallback     = nullptr;
+    size_t ssidLen         = 0;
+    size_t credentialsLen  = 0;
+    mpScanCallback         = nullptr;
+    mpConnectCallback      = nullptr;
     mpStatusChangeCallback = networkStatusChangeCallback;
 
 #ifdef SL_ONNETWORK_PAIRING

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.h
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.h
@@ -138,6 +138,7 @@ private:
     WiFiNetwork mStagingNetwork = {};
     ScanCallback * mpScanCallback;
     ConnectCallback * mpConnectCallback;
+    NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
 };
 
 } // namespace NetworkCommissioning

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.h
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.h
@@ -123,6 +123,7 @@ public:
     chip::BitFlags<WiFiSecurity> ConvertSecuritytype(wfx_sec_t security);
 
     void OnConnectWiFiNetwork();
+    void UpdateNetworkingStatus();
     static SlWiFiDriver & GetInstance()
     {
         static SlWiFiDriver instance;


### PR DESCRIPTION
The LastNetworkID & LastConnectErrorValue attributes have null value after device reset.
I tested it manually.