### PR TITLE
[Darwin] Fix #26240: MTRDeviceControllerStartupParams nocSigner empty issue

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -82,6 +82,7 @@ using namespace chip;
     _operationalCertificate = [operationalCertificate copy];
     _intermediateCertificate = [intermediateCertificate copy];
     _rootCertificate = [rootCertificate copy];
+    _nocSigner = operationalKeypair;
     _ipk = [ipk copy];
 
     return self;


### PR DESCRIPTION
Fix #26240 

