### PR TITLE
[Silabs] [WiFi] Adding the lock and unlock chip stack and some build fixes for 917 SoC

### DIFF
--- a/examples/platform/silabs/SiWx917/BaseApplication.cpp
+++ b/examples/platform/silabs/SiWx917/BaseApplication.cpp
@@ -166,7 +166,10 @@ CHIP_ERROR BaseApplication::Init(Identify * identifyObj)
     SILABS_LOG("APP: Done WiFi Init");
     /* We will init server when we get IP */
 
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
     sWiFiNetworkCommissioningInstance.Init();
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+
 #endif
 
     // Create FreeRTOS sw timer for Function Selection.

--- a/examples/platform/silabs/efr32/BaseApplication.cpp
+++ b/examples/platform/silabs/efr32/BaseApplication.cpp
@@ -178,7 +178,10 @@ CHIP_ERROR BaseApplication::Init(Identify * identifyObj)
     SILABS_LOG("APP: Done WiFi Init");
     /* We will init server when we get IP */
 
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
     sWiFiNetworkCommissioningInstance.Init();
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+
 #endif
 
     // Create FreeRTOS sw timer for Function Selection.

--- a/src/platform/silabs/platformAbstraction/WiseMCU_SPAM.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMCU_SPAM.cpp
@@ -41,7 +41,7 @@ void SilabsPlatform::InitLed(void)
     SilabsPlatformAbstractionBase::InitLed();
 }
 
-CHIP_ERROR SilabsPlatform::SetLed(bool state, uint8_t led) override
+CHIP_ERROR SilabsPlatform::SetLed(bool state, uint8_t led)
 {
     // TODO add range check
     RSI_Board_LED_Set(led, state);
@@ -54,7 +54,7 @@ bool SilabsPlatform::GetLedState(uint8_t led)
     return SilabsPlatformAbstractionBase::GetLedState(led);
 }
 
-CHIP_ERROR SilabsPlatform::ToggleLed(uint8_t led) override
+CHIP_ERROR SilabsPlatform::ToggleLed(uint8_t led)
 {
     // TODO add range check
     RSI_Board_LED_Toggle(led);


### PR DESCRIPTION
PR https://github.com/project-chip/connectedhomeip/pull/26180 added assert on the task ownership of the chip Stack lock on some SystemLayer timer calls.
On power cycle when the device try to connect to the older network the device is failing with this error. Adding lock and unlock chip stack for the init of networkcommissioningwifidriver.cpp

```
[00:00:00.977][error ][DL] Chip stack locking error at 'src/system/SystemLayerImplFreeRTOS.cpp:94'. Code is unsafe/racy
[00:00:00.977][error ][-] chipDie chipDie chipDie
```

Small fix for 917 SoC, build failure
