### PR TITLE
[Silabs] RS911x not going into power save upon power cycle

### DIFF
--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -181,6 +181,7 @@ int32_t wfx_rsi_disconnect()
     return status;
 }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_SED
 /******************************************************************
  * @fn   wfx_rsi_power_save()
  * @brief
@@ -190,7 +191,7 @@ int32_t wfx_rsi_disconnect()
  * @return
  *        None
  *********************************************************************/
-void wfx_rsi_power_save()
+int32_t wfx_rsi_power_save()
 {
     int32_t status;
 #ifdef RSI_BLE_ENABLE
@@ -198,7 +199,7 @@ void wfx_rsi_power_save()
     if (status != RSI_SUCCESS)
     {
         SILABS_LOG("BT Powersave Config Failed, Error Code : 0x%lX", status);
-        return;
+        return status;
     }
 #endif /* RSI_BLE_ENABLE */
 
@@ -206,10 +207,13 @@ void wfx_rsi_power_save()
     if (status != RSI_SUCCESS)
     {
         SILABS_LOG("Powersave Config Failed, Error Code : 0x%lX", status);
-        return;
+        return status;
     }
     SILABS_LOG("Powersave Config Success");
+    return status;
 }
+#endif /* CHIP_DEVICE_CONFIG_ENABLE_SED */
+
 /******************************************************************
  * @fn   wfx_rsi_join_cb(uint16_t status, const uint8_t *buf, const uint16_t len)
  * @brief

--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -192,7 +192,17 @@ int32_t wfx_rsi_disconnect()
  *********************************************************************/
 void wfx_rsi_power_save()
 {
-    int32_t status = rsi_wlan_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
+    int32_t status;
+#ifdef RSI_BLE_ENABLE
+    status = rsi_bt_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
+    if (status != RSI_SUCCESS)
+    {
+        SILABS_LOG("BT Powersave Config Failed, Error Code : 0x%lX", status);
+        return;
+    }
+#endif /* RSI_BLE_ENABLE */
+
+    status = rsi_wlan_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
     if (status != RSI_SUCCESS)
     {
         SILABS_LOG("Powersave Config Failed, Error Code : 0x%lX", status);
@@ -596,13 +606,6 @@ void wfx_rsi_task(void * arg)
                 {
                     wfx_dhcp_got_ipv4((uint32_t) sta_netif->ip_addr.u_addr.ip4.addr);
                     hasNotifiedIPV4 = true;
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-#ifndef RSI_BLE_ENABLE
-                    // enabling the power save mode for RS9116 if sleepy device is enabled
-                    // if BLE is used on the rs9116 then powersave config is done after ble disconnect event
-                    wfx_rsi_power_save();
-#endif /* RSI_BLE_ENABLE */
-#endif /* CHIP_DEVICE_CONFIG_ENABLE_SED */
                     if (!hasNotifiedWifiConnectivity)
                     {
                         wfx_connected_notify(CONNECTION_STATUS_SUCCESS, &wfx_rsi.ap_mac);
@@ -622,13 +625,6 @@ void wfx_rsi_task(void * arg)
                 {
                     wfx_ipv6_notify(GET_IPV6_SUCCESS);
                     hasNotifiedIPV6 = true;
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-#ifndef RSI_BLE_ENABLE
-                    // enabling the power save mode for RS9116 if sleepy device is enabled
-                    // if BLE is used on the rs9116 then powersave config is done after ble disconnect event
-                    wfx_rsi_power_save();
-#endif /* RSI_BLE_ENABLE */
-#endif /* CHIP_DEVICE_CONFIG_ENABLE_SED */
                     if (!hasNotifiedWifiConnectivity)
                     {
                         wfx_connected_notify(CONNECTION_STATUS_SUCCESS, &wfx_rsi.ap_mac);

--- a/examples/platform/silabs/efr32/rs911x/wfx_rsi.h
+++ b/examples/platform/silabs/efr32/rs911x/wfx_rsi.h
@@ -91,7 +91,9 @@ int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap);
 int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info);
 int32_t wfx_rsi_reset_count();
 int32_t wfx_rsi_disconnect();
-void wfx_rsi_power_save();
+#if CHIP_DEVICE_CONFIG_ENABLE_SED
+int32_t wfx_rsi_power_save();
+#endif /* CHIP_DEVICE_CONFIG_ENABLE_SED */
 #define SILABS_LOG(...) efr32Log(__VA_ARGS__);
 
 #ifdef __cplusplus

--- a/examples/platform/silabs/efr32/rs911x/wfx_rsi.h
+++ b/examples/platform/silabs/efr32/rs911x/wfx_rsi.h
@@ -91,6 +91,7 @@ int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap);
 int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info);
 int32_t wfx_rsi_reset_count();
 int32_t wfx_rsi_disconnect();
+void wfx_rsi_power_save();
 #define SILABS_LOG(...) efr32Log(__VA_ARGS__);
 
 #ifdef __cplusplus

--- a/examples/platform/silabs/efr32/rs911x/wfx_rsi_host.c
+++ b/examples/platform/silabs/efr32/rs911x/wfx_rsi_host.c
@@ -195,6 +195,10 @@ sl_status_t wfx_connect_to_ap(void)
     return SL_STATUS_OK;
 }
 
+void wfx_power_save(){
+    wfx_rsi_power_save();
+}
+
 /*********************************************************************
  * @fn  void wfx_setup_ip6_link_local(sl_wfx_interface_t whichif)
  * @brief

--- a/examples/platform/silabs/efr32/rs911x/wfx_rsi_host.c
+++ b/examples/platform/silabs/efr32/rs911x/wfx_rsi_host.c
@@ -30,9 +30,9 @@
 #include "event_groups.h"
 #include "task.h"
 
+#include "rsi_error.h"
 #include "wfx_host_events.h"
 #include "wfx_rsi.h"
-#include "rsi_error.h"
 
 /* wfxRsi Task will use as its stack */
 StackType_t wfxRsiTaskStack[WFX_RSI_TASK_SZ] = { 0 };

--- a/examples/platform/silabs/efr32/rs911x/wfx_rsi_host.c
+++ b/examples/platform/silabs/efr32/rs911x/wfx_rsi_host.c
@@ -32,6 +32,7 @@
 
 #include "wfx_host_events.h"
 #include "wfx_rsi.h"
+#include "rsi_error.h"
 
 /* wfxRsi Task will use as its stack */
 StackType_t wfxRsiTaskStack[WFX_RSI_TASK_SZ] = { 0 };
@@ -206,7 +207,7 @@ sl_status_t wfx_connect_to_ap(void)
  ***********************************************************************/
 sl_status_t wfx_power_save()
 {
-    if (wfx_rsi_power_save() != 0)
+    if (wfx_rsi_power_save() != RSI_ERROR_NONE)
     {
         return SL_STATUS_FAIL;
     }

--- a/examples/platform/silabs/efr32/rs911x/wfx_rsi_host.c
+++ b/examples/platform/silabs/efr32/rs911x/wfx_rsi_host.c
@@ -204,8 +204,10 @@ sl_status_t wfx_connect_to_ap(void)
  * @return  SL_STATUS_OK if successful,
  *          SL_STATUS_FAIL otherwise
  ***********************************************************************/
-sl_status_t wfx_power_save() {
-    if(wfx_rsi_power_save() != 0) {
+sl_status_t wfx_power_save()
+{
+    if (wfx_rsi_power_save() != 0)
+    {
         return SL_STATUS_FAIL;
     }
     return SL_STATUS_OK;

--- a/examples/platform/silabs/efr32/rs911x/wfx_rsi_host.c
+++ b/examples/platform/silabs/efr32/rs911x/wfx_rsi_host.c
@@ -195,9 +195,22 @@ sl_status_t wfx_connect_to_ap(void)
     return SL_STATUS_OK;
 }
 
-void wfx_power_save(){
-    wfx_rsi_power_save();
+#if CHIP_DEVICE_CONFIG_ENABLE_SED
+/*********************************************************************
+ * @fn  sl_status_t wfx_power_save()
+ * @brief
+ *      Implements the power save in sleepy application
+ * @param[in]  None
+ * @return  SL_STATUS_OK if successful,
+ *          SL_STATUS_FAIL otherwise
+ ***********************************************************************/
+sl_status_t wfx_power_save() {
+    if(wfx_rsi_power_save() != 0) {
+        return SL_STATUS_FAIL;
+    }
+    return SL_STATUS_OK;
 }
+#endif /* CHIP_DEVICE_CONFIG_ENABLE_SED */
 
 /*********************************************************************
  * @fn  void wfx_setup_ip6_link_local(sl_wfx_interface_t whichif)

--- a/examples/platform/silabs/efr32/wf200/host_if.cpp
+++ b/examples/platform/silabs/efr32/wf200/host_if.cpp
@@ -602,15 +602,6 @@ static void wfx_events_task(void * p_arg)
             retryJoin     = 0;
             retryInterval = WLAN_MIN_RETRY_TIMER_MS;
             wfx_lwip_set_sta_link_up();
-#ifdef SLEEP_ENABLED
-            if (!(wfx_get_wifi_state() & SL_WFX_AP_INTERFACE_UP))
-            {
-                // Enable the power save
-                SILABS_LOG("WF200 going to DTIM based sleep");
-                sl_wfx_set_power_mode(WFM_PM_MODE_DTIM, WFM_PM_POLL_FAST_PS, BEACON_1);
-                sl_wfx_enable_device_power_save();
-            }
-#endif // SLEEP_ENABLED
         }
 
         if (flags & SL_WFX_DISCONNECT)
@@ -894,6 +885,18 @@ int32_t wfx_reset_counts()
 {
     /* TODO */
     return -1;
+}
+
+/************************************************************************
+ * @brief
+ *    reset the count
+ * @return returns -1
+ **************************************************************************/
+void wfx_power_save() {
+    // Enable the power save
+    SILABS_LOG("WF200 going to DTIM based sleep");
+    sl_wfx_set_power_mode(WFM_PM_MODE_DTIM, WFM_PM_POLL_FAST_PS, BEACON_1);
+    sl_wfx_enable_device_power_save();
 }
 
 /*************************************************************************

--- a/examples/platform/silabs/efr32/wf200/host_if.cpp
+++ b/examples/platform/silabs/efr32/wf200/host_if.cpp
@@ -602,6 +602,15 @@ static void wfx_events_task(void * p_arg)
             retryJoin     = 0;
             retryInterval = WLAN_MIN_RETRY_TIMER_MS;
             wfx_lwip_set_sta_link_up();
+#ifdef SLEEP_ENABLED
+            if (!(wfx_get_wifi_state() & SL_WFX_AP_INTERFACE_UP))
+            {
+                // Enable the power save
+                SILABS_LOG("WF200 going to DTIM based sleep");
+                sl_wfx_set_power_mode(WFM_PM_MODE_DTIM, WFM_PM_POLL_FAST_PS, BEACON_1);
+                sl_wfx_enable_device_power_save();
+            }
+#endif // SLEEP_ENABLED
         }
 
         if (flags & SL_WFX_DISCONNECT)
@@ -885,18 +894,6 @@ int32_t wfx_reset_counts()
 {
     /* TODO */
     return -1;
-}
-
-/************************************************************************
- * @brief
- *    reset the count
- * @return returns -1
- **************************************************************************/
-void wfx_power_save() {
-    // Enable the power save
-    SILABS_LOG("WF200 going to DTIM based sleep");
-    sl_wfx_set_power_mode(WFM_PM_MODE_DTIM, WFM_PM_POLL_FAST_PS, BEACON_1);
-    sl_wfx_enable_device_power_save();
 }
 
 /*************************************************************************

--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -72,7 +72,6 @@ public:
     void HandleTxConfirmationEvent(BLE_CONNECTION_OBJECT conId);
     void HandleTXCharCCCDWrite(rsi_ble_event_write_t * evt);
     void HandleSoftTimerEvent(void);
-    CHIP_ERROR StartAdvertising(void);
 #else
     void HandleConnectEvent(volatile sl_bt_msg_t * evt);
     void HandleConnectionCloseEvent(volatile sl_bt_msg_t * evt);
@@ -81,8 +80,9 @@ public:
     void HandleTxConfirmationEvent(BLE_CONNECTION_OBJECT conId);
     void HandleTXCharCCCDWrite(volatile sl_bt_msg_t * evt);
     void HandleSoftTimerEvent(volatile sl_bt_msg_t * evt);
-    CHIP_ERROR StartAdvertising(void);
 #endif // RSI_BLE_ENABLE
+    CHIP_ERROR StartAdvertising(void);
+    CHIP_ERROR StopAdvertising(void);
 
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
 #ifdef RSI_BLE_ENABLE
@@ -187,7 +187,6 @@ private:
     CHIP_ERROR MapBLEError(int bleErr);
     void DriveBLEState(void);
     CHIP_ERROR ConfigureAdvertisingData(void);
-    CHIP_ERROR StopAdvertising(void);
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
     CHIP_ERROR EncodeAdditionalDataTlv();
 #endif

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -383,9 +383,14 @@ void ConnectivityManagerImpl::OnStationConnected()
     // Setting the rs911x in the power save mode
 #if (CHIP_DEVICE_CONFIG_ENABLE_SED && RS911X_WIFI)
     // TODO : Remove stop advertising after BLEManagerImpl is fixed
+#if RSI_BLE_ENABLE
     chip::DeviceLayer::Internal::BLEManagerImpl().StopAdvertising();
-    wfx_power_save();
-#endif /* CHIP_DEVICE_CONFIG_ENABLE_SED */
+#endif /* RSI_BLE_ENABLE */
+    sl_status_t err = wfx_power_save();
+    if(err != SL_STATUS_OK){
+        ChipLogError(DeviceLayer,"Power save config for Wifi failed");
+    }
+#endif /* CHIP_DEVICE_CONFIG_ENABLE_SED && RS911X_WIFI */
     UpdateInternetConnectivityState();
 }
 

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -380,7 +380,9 @@ void ConnectivityManagerImpl::OnStationConnected()
     event.Type                          = DeviceEventType::kWiFiConnectivityChange;
     event.WiFiConnectivityChange.Result = kConnectivity_Established;
     (void) PlatformMgr().PostEvent(&event);
+    // Setting the rs911x in the power save mode
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
+    chip::DeviceLayer::Internal::BLEManagerImpl().StopAdvertising();
     wfx_power_save();
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_SED */
     UpdateInternetConnectivityState();

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -387,8 +387,9 @@ void ConnectivityManagerImpl::OnStationConnected()
     chip::DeviceLayer::Internal::BLEManagerImpl().StopAdvertising();
 #endif /* RSI_BLE_ENABLE */
     sl_status_t err = wfx_power_save();
-    if(err != SL_STATUS_OK){
-        ChipLogError(DeviceLayer,"Power save config for Wifi failed");
+    if (err != SL_STATUS_OK)
+    {
+        ChipLogError(DeviceLayer, "Power save config for Wifi failed");
     }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_SED && RS911X_WIFI */
     UpdateInternetConnectivityState();

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -380,7 +380,9 @@ void ConnectivityManagerImpl::OnStationConnected()
     event.Type                          = DeviceEventType::kWiFiConnectivityChange;
     event.WiFiConnectivityChange.Result = kConnectivity_Established;
     (void) PlatformMgr().PostEvent(&event);
-
+#if CHIP_DEVICE_CONFIG_ENABLE_SED
+    wfx_power_save();
+#endif /* CHIP_DEVICE_CONFIG_ENABLE_SED */
     UpdateInternetConnectivityState();
 }
 

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -381,7 +381,8 @@ void ConnectivityManagerImpl::OnStationConnected()
     event.WiFiConnectivityChange.Result = kConnectivity_Established;
     (void) PlatformMgr().PostEvent(&event);
     // Setting the rs911x in the power save mode
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
+#if (CHIP_DEVICE_CONFIG_ENABLE_SED && RS911X_WIFI)
+    // TODO : Remove stop advertising after BLEManagerImpl is fixed
     chip::DeviceLayer::Internal::BLEManagerImpl().StopAdvertising();
     wfx_power_save();
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_SED */

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -382,7 +382,7 @@ void ConnectivityManagerImpl::OnStationConnected()
     (void) PlatformMgr().PostEvent(&event);
     // Setting the rs911x in the power save mode
 #if (CHIP_DEVICE_CONFIG_ENABLE_SED && RS911X_WIFI)
-    // TODO : Remove stop advertising after BLEManagerImpl is fixed
+    // TODO: Remove stop advertising after BLEManagerImpl is fixed
 #if RSI_BLE_ENABLE
     chip::DeviceLayer::Internal::BLEManagerImpl().StopAdvertising();
 #endif /* RSI_BLE_ENABLE */

--- a/src/platform/silabs/efr32/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/rs911x/BLEManagerImpl.cpp
@@ -723,24 +723,6 @@ void BLEManagerImpl::HandleConnectionCloseEvent(uint16_t reason)
 
     ChipLogProgress(DeviceLayer, "Disconnect Event for handle : %d", connHandle);
 
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    int32_t status;
-    status = rsi_bt_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
-    if (status != RSI_SUCCESS)
-    {
-        SILABS_LOG("BT Powersave Config Failed, Error Code : 0x%lX", status);
-        return;
-    }
-
-    status = rsi_wlan_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
-    if (status != RSI_SUCCESS)
-    {
-        SILABS_LOG("WLAN Powersave Config Failed, Error Code : 0x%lX", status);
-        return;
-    }
-    SILABS_LOG("Powersave Config Success");
-#endif
-
     if (RemoveConnection(connHandle))
     {
         ChipDeviceEvent event;

--- a/src/platform/silabs/efr32/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/rs911x/BLEManagerImpl.cpp
@@ -665,19 +665,17 @@ CHIP_ERROR BLEManagerImpl::StopAdvertising(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     int32_t status = 0;
-    // TODO: change this condition
-    if (1)
+    // TODO: add the below code in a condition if (mFlags.Has(Flags::kAdvertising))
+    // Since DriveBLEState is not called the device is still advertising advertising
+    mFlags.Clear(Flags::kAdvertising).Clear(Flags::kRestartAdvertising);
+    mFlags.Set(Flags::kFastAdvertisingEnabled, true);
+    status = rsi_ble_stop_advertising();
+    if (status != RSI_SUCCESS)
     {
-        mFlags.Clear(Flags::kAdvertising).Clear(Flags::kRestartAdvertising);
-        mFlags.Set(Flags::kFastAdvertisingEnabled, true);
-        status = rsi_ble_stop_advertising();
-        if (status != RSI_SUCCESS)
-        {
-            ChipLogProgress(DeviceLayer, "advertising failed to stop, with status = 0x%lx", status);
-        }
-        advertising_set_handle = 0xff;
-        CancelBleAdvTimeoutTimer();
+        ChipLogProgress(DeviceLayer, "advertising failed to stop, with status = 0x%lx", status);
     }
+    advertising_set_handle = 0xff;
+    CancelBleAdvTimeoutTimer();
 
     // exit:
     return err;

--- a/src/platform/silabs/efr32/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/rs911x/BLEManagerImpl.cpp
@@ -666,7 +666,7 @@ CHIP_ERROR BLEManagerImpl::StopAdvertising(void)
     CHIP_ERROR err = CHIP_NO_ERROR;
     int32_t status = 0;
     // TODO: add the below code in a condition if (mFlags.Has(Flags::kAdvertising))
-    // Since DriveBLEState is not called the device is still advertising advertising
+    // Since DriveBLEState is not called the device is still advertising
     mFlags.Clear(Flags::kAdvertising).Clear(Flags::kRestartAdvertising);
     mFlags.Set(Flags::kFastAdvertisingEnabled, true);
     status = rsi_ble_stop_advertising();

--- a/src/platform/silabs/efr32/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/rs911x/BLEManagerImpl.cpp
@@ -661,12 +661,12 @@ exit:
     return CHIP_NO_ERROR; // err;
 }
 
-// TODO:: Implementation need to be done.
 CHIP_ERROR BLEManagerImpl::StopAdvertising(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     int32_t status = 0;
-    if (mFlags.Has(Flags::kAdvertising))
+    // TODO: change this condition
+    if (1)
     {
         mFlags.Clear(Flags::kAdvertising).Clear(Flags::kRestartAdvertising);
         mFlags.Set(Flags::kFastAdvertisingEnabled, true);

--- a/src/platform/silabs/efr32/wifi/wfx_host_events.h
+++ b/src/platform/silabs/efr32/wifi/wfx_host_events.h
@@ -316,7 +316,6 @@ bool wfx_is_sta_mode_enabled(void);
 int32_t wfx_get_ap_info(wfx_wifi_scan_result_t * ap);
 int32_t wfx_get_ap_ext(wfx_wifi_scan_ext_t * extra_info);
 int32_t wfx_reset_counts();
-void wfx_power_save();
 
 void wfx_clear_wifi_provision(void);
 sl_status_t wfx_connect_to_ap(void);
@@ -353,6 +352,8 @@ void wfx_ip_changed_notify(int got_ip);
 void wfx_ipv6_notify(int got_ip);
 
 #ifdef RS911X_WIFI
+/* RSI Power Save */
+void wfx_power_save();
 /* RSI for LWIP */
 void * wfx_rsi_alloc_pkt(void);
 void wfx_rsi_pkt_add_data(void * p, uint8_t * buf, uint16_t len, uint16_t off);

--- a/src/platform/silabs/efr32/wifi/wfx_host_events.h
+++ b/src/platform/silabs/efr32/wifi/wfx_host_events.h
@@ -316,6 +316,7 @@ bool wfx_is_sta_mode_enabled(void);
 int32_t wfx_get_ap_info(wfx_wifi_scan_result_t * ap);
 int32_t wfx_get_ap_ext(wfx_wifi_scan_ext_t * extra_info);
 int32_t wfx_reset_counts();
+void wfx_power_save();
 
 void wfx_clear_wifi_provision(void);
 sl_status_t wfx_connect_to_ap(void);

--- a/src/platform/silabs/efr32/wifi/wfx_host_events.h
+++ b/src/platform/silabs/efr32/wifi/wfx_host_events.h
@@ -353,7 +353,9 @@ void wfx_ipv6_notify(int got_ip);
 
 #ifdef RS911X_WIFI
 /* RSI Power Save */
-void wfx_power_save();
+#if CHIP_DEVICE_CONFIG_ENABLE_SED
+sl_status_t wfx_power_save();
+#endif /* CHIP_DEVICE_CONFIG_ENABLE_SED */
 /* RSI for LWIP */
 void * wfx_rsi_alloc_pkt(void);
 void wfx_rsi_pkt_add_data(void * p, uint8_t * buf, uint16_t len, uint16_t off);

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -338,10 +338,14 @@ template("efr32_sdk") {
         "SL_CATALOG_POWER_MANAGER_PRESENT",
         "SL_CATALOG_SLEEPTIMER_PRESENT",
         "SL_SLEEP_TIME_MS=${sleep_time_ms}",
-
-        # Used for wifi devices to get packet details
-        "WIFI_DEBUG_ENABLED=1",
       ]
+
+      if(defined(invoker.chip_enable_wifi) && invoker.chip_enable_wifi){
+        defines += [
+        # Used for wifi devices to get packet details
+          "WIFI_DEBUG_ENABLED=1",
+        ]
+      }
     }
 
     if (chip_build_libshell) {  # matter shell

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -340,9 +340,9 @@ template("efr32_sdk") {
         "SL_SLEEP_TIME_MS=${sleep_time_ms}",
       ]
 
-      if(defined(invoker.chip_enable_wifi) && invoker.chip_enable_wifi){
+      if (defined(invoker.chip_enable_wifi) && invoker.chip_enable_wifi) {
         defines += [
-        # Used for wifi devices to get packet details
+          # Used for wifi devices to get packet details
           "WIFI_DEBUG_ENABLED=1",
         ]
       }

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -343,6 +343,7 @@ template("efr32_sdk") {
       if (defined(invoker.chip_enable_wifi) && invoker.chip_enable_wifi) {
         defines += [
           # Used for wifi devices to get packet details
+          # TODO: Remove this flag, once the communication is fixed
           "WIFI_DEBUG_ENABLED=1",
         ]
       }


### PR DESCRIPTION
RS911x was not going into power save, i.e., sleepy once we are resetting the device. 
Removed the power save call from ble and before connected notify to a single place i.e., upon station connect. 
Added todo of ble of rs9116 since it was still advertising after join was happened. 