### PR TITLE
doc: tools: add tools section and pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,9 @@ exclude_patterns = [
     "examples/thermostat/nxp/linux-se05x/README.md",
     "examples/common/m5stack-tft/repo",
     "docs/guides/README.md",
+    "scripts/tools/memory/memdf/README.md",
+    "scripts/tools/memory/platform/README.md",
+    "scripts/tools/memory/README-GitHub-CI.md",
 ]
 
 
@@ -69,6 +72,8 @@ external_content_contents = [
     (MATTER_BASE, "examples/**/*.png"),
     (MATTER_BASE, "examples/**/*.jpg"),
     (MATTER_BASE, "examples/**/*.JPG"),
+    (MATTER_BASE, "src/tools/**/*.md"),
+    (MATTER_BASE, "scripts/tools/**/*.md"),
 ]
 external_content_link_prefixes = [
     "src/",

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -34,6 +34,7 @@ esp32/README
 -   [nRF Connect - Software Update](./nrfconnect_examples_software_update.md)
 -   [NXP - Android Commissioning](./nxp_k32w_android_commissioning.md)
 -   [NXP - Linux Examples](./nxp_imx8m_linux_examples.md)
+-   [NXP - Manufacturing Data](./nxp_manufacturing_flow.md)
 -   [Silicon Labs - Documentation](https://github.com/SiliconLabs/matter#readme)
 -   [Silicon Labs - Building](./silabs_efr32_building.md)
 -   [Silicon Labs - Software Update](./silabs_efr32_software_update.md)

--- a/docs/guides/nxp_manufacturing_flow.md
+++ b/docs/guides/nxp_manufacturing_flow.md
@@ -2,7 +2,7 @@
 orphan: true
 ---
 
-## Manufacturing data
+# NXP manufacturing data guide
 
 By default, the example application is configured to use generic test
 certificates and provisioning data embedded with the application code. It is

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ discussion/index
 guides/index
 style/index
 examples/index
+tools/index
 BUG_REPORT
 code_generation
 ERROR_CODES

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,0 +1,62 @@
+# Tools
+
+The Matter SDK provides tools that allow you to generate and manage different aspects of the Matter development.
+
+## C++ tools
+
+Source files for these tools are located at `src/tools`.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+../src/tools/chip-cert/README
+../src/tools/spake2p/README
+
+```
+
+## Python tools
+
+Source files for these tools are located at `scripts/tools`.
+
+### General tools
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+../scripts/tools/memory/README
+../scripts/tools/spake2p/README
+
+```
+
+### NXP tools
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+../scripts/tools/nxp/factory_data_generator/README
+../scripts/tools/nxp/ota/README
+
+```
+
+### Silabs tools
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+../scripts/tools/silabs/README
+
+```
+
+### Telink tools
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+../scripts/tools/telink/readme
+
+```

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,6 +1,7 @@
 # Tools
 
-The Matter SDK provides tools that allow you to generate and manage different aspects of the Matter development.
+The Matter SDK provides tools that allow you to generate and manage different
+aspects of the Matter development.
 
 ## C++ tools
 

--- a/examples/contact-sensor-app/nxp/k32w/k32w0/README.md
+++ b/examples/contact-sensor-app/nxp/k32w/k32w0/README.md
@@ -241,7 +241,7 @@ The resulting output file can be found in out/debug/chip-k32w0x-contact-example.
 ## Manufacturing data
 
 See
-[Guide for writing manufacturing data on NXP devices](../../../../platform/nxp/doc/manufacturing_flow.md).
+[Guide for writing manufacturing data on NXP devices](../../../../../docs/guides/nxp_manufacturing_flow.md).
 
 There are factory data generated binaries available in
 examples/platform/nxp/k32w/k32w0/scripts/demo_generated_factory_data folder.

--- a/examples/lighting-app/nxp/k32w/k32w0/README.md
+++ b/examples/lighting-app/nxp/k32w/k32w0/README.md
@@ -254,7 +254,7 @@ The resulting output file can be found in out/debug/chip-k32w0x-light-example.
 ## Manufacturing data
 
 See
-[Guide for writing manufacturing data on NXP devices](../../../../platform/nxp/doc/manufacturing_flow.md).
+[Guide for writing manufacturing data on NXP devices](../../../../../docs/guides/nxp_manufacturing_flow.md).
 
 There are factory data generated binaries available in
 examples/platform/nxp/k32w/k32w0/scripts/demo_generated_factory_data folder.

--- a/examples/lock-app/nxp/k32w/k32w0/README.md
+++ b/examples/lock-app/nxp/k32w/k32w0/README.md
@@ -227,7 +227,7 @@ The resulting output file can be found in out/debug/chip-k32w0x-lock-example.
 ## Manufacturing data
 
 See
-[Guide for writing manufacturing data on NXP devices](../../../../platform/nxp/doc/manufacturing_flow.md).
+[Guide for writing manufacturing data on NXP devices](../../../../../docs/guides/nxp_manufacturing_flow.md).
 
 There are factory data generated binaries available in
 examples/platform/nxp/k32w/k32w0/scripts/demo_generated_factory_data folder.

--- a/scripts/tools/nxp/factory_data_generator/README.md
+++ b/scripts/tools/nxp/factory_data_generator/README.md
@@ -1,7 +1,7 @@
 # NXP Factory Data Generator
 
 For usage of the tool, please see
-[Guide for writing manufacturing data on NXP devices](../../../../examples/platform/nxp/doc/manufacturing_flow.md).
+[Guide for writing manufacturing data on NXP devices](../../../../docs/guides/nxp_manufacturing_flow.md).
 
 ## Tool implementation
 

--- a/scripts/tools/nxp/factory_data_generator/README.md
+++ b/scripts/tools/nxp/factory_data_generator/README.md
@@ -1,4 +1,4 @@
-## NXP Factory Data Generator
+# NXP Factory Data Generator
 
 For usage of the tool, please see
 [Guide for writing manufacturing data on NXP devices](../../../../examples/platform/nxp/doc/manufacturing_flow.md).

--- a/scripts/tools/nxp/ota/README.md
+++ b/scripts/tools/nxp/ota/README.md
@@ -116,7 +116,7 @@ private:
 update OTA image. If the `PAA` changes, make sure to generate the new
 certificates using the new `PAA` (which is only used by the controller, e.g.
 `chip-tool`). Please see the
-[manufacturing flow guide](../../../../examples/platform/nxp/doc/manufacturing_flow.md)
+[manufacturing flow guide](../../../../docs/guides/nxp_manufacturing_flow.md)
 for generating new certificates.
 
 Example of OTA image generation with factory data and application update (using

--- a/scripts/tools/silabs/README.md
+++ b/scripts/tools/silabs/README.md
@@ -1,4 +1,4 @@
-#`FactoryDataProvider` for EFR32 Matter device
+# `FactoryDataProvider` for EFR32 Matter device
 
 ## Introduction
 

--- a/src/tools/chip-cert/README.md
+++ b/src/tools/chip-cert/README.md
@@ -809,7 +809,7 @@ HELP OPTIONS
        Print the version and then exit.
 ```
 
-#### gen-cd example
+#### print-cd example
 
 An example of printing a Certificate Declaration (CD), which is provided as a
 command line argument in a hex format:


### PR DESCRIPTION
Added tools section and pages in documentation.
This adds readmies for chip-cert and spake2p to the doc pool.

