### PR TITLE
ModeSelect: Gate inclusion of on-off-server.h based on whether an on-off cluster is present in the app

### DIFF
--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -24,11 +24,6 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/clusters/mode-select-server/supported-modes-manager.h>
-
-#ifdef EMBER_AF_PLUGIN_ON_OFF
-#include <app/clusters/on-off-server/on-off-server.h>
-#endif // EMBER_AF_PLUGIN_ON_OFF
-
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
@@ -37,6 +32,10 @@
 #include <app/util/util.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/DiagnosticDataProvider.h>
+
+#ifdef EMBER_AF_PLUGIN_ON_OFF
+#include <app/clusters/on-off-server/on-off-server.h>
+#endif // EMBER_AF_PLUGIN_ON_OFF
 
 using namespace std;
 using namespace chip;

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -24,7 +24,11 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/clusters/mode-select-server/supported-modes-manager.h>
+
+#ifdef EMBER_AF_PLUGIN_ON_OFF
 #include <app/clusters/on-off-server/on-off-server.h>
+#endif // EMBER_AF_PLUGIN_ON_OFF
+
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>


### PR DESCRIPTION
Gate inclusion of on-off-server.h based on whether there is an on-off cluster present in the application. This resolves #26252.

