### PR TITLE
updated board references from BRD4161A to BRD4187C in example commands

### DIFF
--- a/examples/light-switch-app/silabs/efr32/README.md
+++ b/examples/light-switch-app/silabs/efr32/README.md
@@ -106,7 +106,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/light-switch-app/silabs/efr32/ ./out/light-switch-app BRD4161A
+          ./scripts/examples/gn_efr32_example.sh ./examples/light-switch-app/silabs/efr32/ ./out/light-switch-app BRD4187C
 
 -   To delete generated executable, libraries and object files use:
 
@@ -118,7 +118,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/light-switch-app/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4161A
+          $ export EFR32_BOARD=BRD4187C
           $ gn gen out/debug
           $ ninja -C out/debug
 
@@ -129,26 +129,26 @@ Silicon Labs platform.
 
 *   Build the example with Matter shell
 
-          ./scripts/examples/gn_efr32_example.sh examples/light-switch-app/silabs/efr32/ out/light-switch-app BRD4161A chip_build_libshell=true
+          ./scripts/examples/gn_efr32_example.sh examples/light-switch-app/silabs/efr32/ out/light-switch-app BRD4187C chip_build_libshell=true
 
 *   Build the example as Sleepy End Device (SED)
 
-          $ ./scripts/examples/gn_efr32_example.sh ./examples/light-switch-app/silabs/efr32/ ./out/light-switch-app_SED BRD4161A --sed
+          $ ./scripts/examples/gn_efr32_example.sh ./examples/light-switch-app/silabs/efr32/ ./out/light-switch-app_SED BRD4187C --sed
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=silabs_board="BRD4161A" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
+          $ gn gen out/debug '--args=silabs_board="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
 
 *   Build the example with pigweed RCP
 
-          $ ./scripts/examples/gn_efr32_example.sh examples/light-switch-app/silabs/efr32/ out/light-switch-app_rpc BRD4161A 'import("//with_pw_rpc.gni")'
+          $ ./scripts/examples/gn_efr32_example.sh examples/light-switch-app/silabs/efr32/ out/light-switch-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
           $ cd ~/connectedhomeip/examples/light-switch-app/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4161A
+          $ export EFR32_BOARD=BRD4187C
           $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
           $ ninja -C out/debug
 

--- a/examples/light-switch-app/silabs/efr32/README.md
+++ b/examples/light-switch-app/silabs/efr32/README.md
@@ -137,7 +137,7 @@ Silicon Labs platform.
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=silabs_board="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
+          $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
 
 *   Build the example with pigweed RCP
 

--- a/examples/light-switch-app/silabs/efr32/README.md
+++ b/examples/light-switch-app/silabs/efr32/README.md
@@ -118,7 +118,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/light-switch-app/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4187C
+          $ export SILABS_BOARD=BRD4187C
           $ gn gen out/debug
           $ ninja -C out/debug
 
@@ -148,7 +148,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/light-switch-app/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4187C
+          $ export SILABS_BOARD=BRD4187C
           $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
           $ ninja -C out/debug
 

--- a/examples/lighting-app/silabs/efr32/README.md
+++ b/examples/lighting-app/silabs/efr32/README.md
@@ -112,7 +112,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/lighting-app/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export silabs_board=BRD4187C
+          $ export SILABS_BOARD=BRD4187C
           $ gn gen out/debug
           $ ninja -C out/debug
 
@@ -127,7 +127,7 @@ Silicon Labs platform.
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=silabs_board="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
+          $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
 
 *   Build the example with pigweed RPC
 
@@ -138,7 +138,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/lighting-app/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export silabs_board=BRD4187C
+          $ export SILABS_BOARD=BRD4187C
           $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
           $ ninja -C out/debug
 

--- a/examples/lighting-app/silabs/efr32/README.md
+++ b/examples/lighting-app/silabs/efr32/README.md
@@ -100,7 +100,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/silabs/efr32/ ./out/lighting-app BRD4161A
+          ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/silabs/efr32/ ./out/lighting-app BRD4187C
 
 -   To delete generated executable, libraries and object files use:
 
@@ -112,7 +112,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/lighting-app/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export silabs_board=BRD4161A
+          $ export silabs_board=BRD4187C
           $ gn gen out/debug
           $ ninja -C out/debug
 
@@ -123,22 +123,22 @@ Silicon Labs platform.
 
 *   Build the example as Sleepy End Device (SED)
 
-          $ ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/silabs/efr32/ ./out/lighting-app_SED BRD4161A --sed
+          $ ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/silabs/efr32/ ./out/lighting-app_SED BRD4187C --sed
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=silabs_board="BRD4161A" enable_sleepy_device=true chip_openthread_ftd=false'
+          $ gn gen out/debug '--args=silabs_board="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
 
 *   Build the example with pigweed RPC
 
-          $ ./scripts/examples/gn_efr32_example.sh examples/lighting-app/silabs/efr32/ out/lighting_app_rpc BRD4161A 'import("//with_pw_rpc.gni")'
+          $ ./scripts/examples/gn_efr32_example.sh examples/lighting-app/silabs/efr32/ out/lighting_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
           $ cd ~/connectedhomeip/examples/lighting-app/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export silabs_board=BRD4161A
+          $ export silabs_board=BRD4187C
           $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
           $ ninja -C out/debug
 

--- a/examples/lock-app/silabs/efr32/README.md
+++ b/examples/lock-app/silabs/efr32/README.md
@@ -102,7 +102,7 @@ Mac OS X
 
           ```
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/lock-app/silabs/efr32/ ./out/lock_app BRD4161A
+          ./scripts/examples/gn_efr32_example.sh ./examples/lock-app/silabs/efr32/ ./out/lock_app BRD4187C
           ```
 
 -   To delete generated executable, libraries and object files use:
@@ -118,7 +118,7 @@ Mac OS X
           $ cd ~/connectedhomeip/examples/silabs/lock-app/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4161A
+          $ export EFR32_BOARD=BRD4187C
           $ gn gen out/debug --args="efr32_sdk_root=\"${EFR32_SDK_ROOT}\" silabs_board=\"${EFR32_BOARD}\""
           $ ninja -C out/debug
           ```
@@ -133,19 +133,19 @@ Mac OS X
 *   Build the example as Sleepy End Device (SED)
 
           ```
-          $ ./scripts/examples/gn_efr32_example.sh ./examples/lock-app/silabs/efr32/ ./out/lock-app_SED BRD4161A --sed
+          $ ./scripts/examples/gn_efr32_example.sh ./examples/lock-app/silabs/efr32/ ./out/lock-app_SED BRD4187C --sed
           ```
 
     or use gn as previously mentioned but adding the following arguments:
 
           ```
-          $ gn gen out/debug '--args=silabs_board="BRD4161A" enable_sleepy_device=true chip_openthread_ftd=false'
+          $ gn gen out/debug '--args=silabs_board="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
           ```
 
 *   Build the example with pigweed RCP
 
           ```
-          $ ./scripts/examples/gn_efr32_example.sh examples/lock-app/silabs/efr32/ out/lock_app_rpc BRD4161A 'import("//with_pw_rpc.gni")'
+          $ ./scripts/examples/gn_efr32_example.sh examples/lock-app/silabs/efr32/ out/lock_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
           ```
 
     or use GN/Ninja Directly
@@ -154,7 +154,7 @@ Mac OS X
           $ cd ~/connectedhomeip/examples/lock-app/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4161A
+          $ export EFR32_BOARD=BRD4187C
           $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
           $ ninja -C out/debug
           ```

--- a/examples/lock-app/silabs/efr32/README.md
+++ b/examples/lock-app/silabs/efr32/README.md
@@ -118,8 +118,8 @@ Mac OS X
           $ cd ~/connectedhomeip/examples/silabs/lock-app/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4187C
-          $ gn gen out/debug --args="efr32_sdk_root=\"${EFR32_SDK_ROOT}\" silabs_board=\"${EFR32_BOARD}\""
+          $ export SILABS_BOARD=BRD4187C
+          $ gn gen out/debug --args="efr32_sdk_root=\"${EFR32_SDK_ROOT}\" silabs_board=\"${SILABS_BOARD}\""
           $ ninja -C out/debug
           ```
 
@@ -154,7 +154,7 @@ Mac OS X
           $ cd ~/connectedhomeip/examples/lock-app/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4187C
+          $ export SILABS_BOARD=BRD4187C
           $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
           $ ninja -C out/debug
           ```

--- a/examples/lock-app/silabs/efr32/README.md
+++ b/examples/lock-app/silabs/efr32/README.md
@@ -119,7 +119,7 @@ Mac OS X
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug --args="efr32_sdk_root=\"${EFR32_SDK_ROOT}\" silabs_board=\"${SILABS_BOARD}\""
+          $ gn gen out/debug --args="efr32_sdk_root=\"${EFR32_SDK_ROOT}\" SILABS_BOARD=\"${SILABS_BOARD}\""
           $ ninja -C out/debug
           ```
 
@@ -139,7 +139,7 @@ Mac OS X
     or use gn as previously mentioned but adding the following arguments:
 
           ```
-          $ gn gen out/debug '--args=silabs_board="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
+          $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
           ```
 
 *   Build the example with pigweed RCP

--- a/examples/thermostat/silabs/efr32/README.md
+++ b/examples/thermostat/silabs/efr32/README.md
@@ -137,7 +137,7 @@ Silicon Labs platform.
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=silabs_board="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
+          $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
 
 *   Build the example with pigweed RCP
 

--- a/examples/thermostat/silabs/efr32/README.md
+++ b/examples/thermostat/silabs/efr32/README.md
@@ -106,7 +106,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/thermostat/silabs/efr32/ ./out/thermostat-app BRD4161A
+          ./scripts/examples/gn_efr32_example.sh ./examples/thermostat/silabs/efr32/ ./out/thermostat-app BRD4187C
 
 -   To delete generated executable, libraries and object files use:
 
@@ -118,7 +118,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/thermostat/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4161A
+          $ export EFR32_BOARD=BRD4187C
           $ gn gen out/debug
           $ ninja -C out/debug
 
@@ -129,26 +129,26 @@ Silicon Labs platform.
 
 *   Build the example with Matter shell
 
-          ./scripts/examples/gn_efr32_example.sh examples/thermostat/silabs/efr32/ out/thermostat-app BRD4161A chip_build_libshell=true
+          ./scripts/examples/gn_efr32_example.sh examples/thermostat/silabs/efr32/ out/thermostat-app BRD4187C chip_build_libshell=true
 
 *   Build the example as Sleepy End Device (SED)
 
-          $ ./scripts/examples/gn_efr32_example.sh ./examples/thermostat/silabs/efr32/ ./out/thermostat-app_SED BRD4161A --sed
+          $ ./scripts/examples/gn_efr32_example.sh ./examples/thermostat/silabs/efr32/ ./out/thermostat-app_SED BRD4187C --sed
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=silabs_board="BRD4161A" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
+          $ gn gen out/debug '--args=silabs_board="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
 
 *   Build the example with pigweed RCP
 
-          $ ./scripts/examples/gn_efr32_example.sh examples/thermostat/silabs/efr32/ out/thermostat-app_rpc BRD4161A 'import("//with_pw_rpc.gni")'
+          $ ./scripts/examples/gn_efr32_example.sh examples/thermostat/silabs/efr32/ out/thermostat-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
           $ cd ~/connectedhomeip/examples/thermostat/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4161A
+          $ export EFR32_BOARD=BRD4187C
           $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
           $ ninja -C out/debug
 

--- a/examples/thermostat/silabs/efr32/README.md
+++ b/examples/thermostat/silabs/efr32/README.md
@@ -118,7 +118,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/thermostat/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4187C
+          $ export SILABS_BOARD=BRD4187C
           $ gn gen out/debug
           $ ninja -C out/debug
 
@@ -148,7 +148,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/thermostat/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4187C
+          $ export SILABS_BOARD=BRD4187C
           $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
           $ ninja -C out/debug
 

--- a/examples/window-app/silabs/efr32/README.md
+++ b/examples/window-app/silabs/efr32/README.md
@@ -111,7 +111,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/window-app/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4187C
+          $ export SILABS_BOARD=BRD4187C
           $ gn gen out/debug
           $ ninja -C out/debug
 
@@ -137,7 +137,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/window-app/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4187C
+          $ export SILABS_BOARD=BRD4187C
           $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
           $ ninja -C out/debug
 

--- a/examples/window-app/silabs/efr32/README.md
+++ b/examples/window-app/silabs/efr32/README.md
@@ -126,7 +126,7 @@ Silicon Labs platform.
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=silabs_board="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
+          $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
 
 *   Build the example with pigweed RCP
 

--- a/examples/window-app/silabs/efr32/README.md
+++ b/examples/window-app/silabs/efr32/README.md
@@ -99,7 +99,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_efr32_example.sh ./examples/window-app/silabs/efr32/ ./out/window-app BRD4161A
+          ./scripts/examples/gn_efr32_example.sh ./examples/window-app/silabs/efr32/ ./out/window-app BRD4187C
 
 -   To delete generated executable, libraries and object files use:
 
@@ -111,7 +111,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/window-app/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4161A
+          $ export EFR32_BOARD=BRD4187C
           $ gn gen out/debug
           $ ninja -C out/debug
 
@@ -122,22 +122,22 @@ Silicon Labs platform.
 
 *   Build the example as Sleepy End Device (SED)
 
-          $ ./scripts/examples/gn_efr32_example.sh ./examples/window-app/silabs/efr32/ ./out/window-app_SED BRD4161A --sed
+          $ ./scripts/examples/gn_efr32_example.sh ./examples/window-app/silabs/efr32/ ./out/window-app_SED BRD4187C --sed
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=silabs_board="BRD4161A" enable_sleepy_device=true chip_openthread_ftd=false'
+          $ gn gen out/debug '--args=silabs_board="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
 
 *   Build the example with pigweed RCP
 
-          $ ./scripts/examples/gn_efr32_example.sh examples/window-app/silabs/efr32/ out/window_app_rpc BRD4161A 'import("//with_pw_rpc.gni")'
+          $ ./scripts/examples/gn_efr32_example.sh examples/window-app/silabs/efr32/ out/window_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
           $ cd ~/connectedhomeip/examples/window-app/silabs/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_BOARD=BRD4161A
+          $ export EFR32_BOARD=BRD4187C
           $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
           $ ninja -C out/debug
 


### PR DESCRIPTION
Silicon Labs is recommending the use of the EFR32MG24, as such I am updating our board references in our example documentation to use the BRD4187C as a default instead of BRD4161A.

