### PR TITLE
Add LightSensorType to IlluminanceMeasurement for chef lighting example

### DIFF
--- a/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
+++ b/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
@@ -1229,6 +1229,7 @@ server cluster IlluminanceMeasurement = 1024 {
   readonly attribute nullable int16u measuredValue = 0;
   readonly attribute nullable int16u minMeasuredValue = 1;
   readonly attribute nullable int16u maxMeasuredValue = 2;
+  readonly attribute nullable enum8 lightSensorType = 4;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
   readonly attribute event_id eventList[] = 65530;
@@ -1440,6 +1441,7 @@ endpoint 1 {
     ram      attribute measuredValue default = 0xC351;
     ram      attribute minMeasuredValue default = 1;
     ram      attribute maxMeasuredValue default = 0xfffe;
+    ram      attribute lightSensorType default = 1;
     callback attribute generatedCommandList default = 0;
     callback attribute acceptedCommandList default = 0;
     callback attribute attributeList default = 0;

--- a/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.zap
+++ b/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 92,
+  "featureLevel": 96,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -6141,11 +6141,11 @@
               "mfgCode": null,
               "side": "server",
               "type": "enum8",
-              "included": 0,
+              "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0xFF",
+              "defaultValue": "1",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -6255,5 +6255,6 @@
       "endpointVersion": 1,
       "deviceIdentifier": 262
     }
-  ]
+  ],
+  "log": []
 }


### PR DESCRIPTION
We want to test reading `LightSensorType` from a `IlluminanceMeasurement` cluster in the chef example app