### PR TITLE
[Silabs] Move NVM semaphore creation to nvm3_lockBegin() 

### DIFF
--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -43,6 +43,12 @@ static StaticSemaphore_t nvm3_SemStruct;
 
 void nvm3_lockBegin(void)
 {
+    if (nvm3_Sem == NULL)
+    {
+        nvm3_Sem = xSemaphoreCreateBinaryStatic(&nvm3_SemStruct);
+        xSemaphoreGive(nvm3_Sem);
+    }
+
     VerifyOrDie(nvm3_Sem != NULL);
     xSemaphoreTake(nvm3_Sem, portMAX_DELAY);
 }
@@ -65,16 +71,9 @@ namespace Internal {
 
 CHIP_ERROR SilabsConfig::Init()
 {
-#ifndef BRD4325A // TODO: fix semaphore usage in nvm3_lock for siwx917. use weak implementation for that board instead
-    nvm3_Sem = xSemaphoreCreateBinaryStatic(&nvm3_SemStruct);
-
-    if (nvm3_Sem == NULL)
-    {
-        return CHIP_ERROR_NO_MEMORY;
-    }
-    xSemaphoreGive(nvm3_Sem);
-#endif // not BRD4325A
-    return MapNvm3Error(nvm3_open(nvm3_defaultHandle, nvm3_defaultInit));
+    // nvm3_Sem is created in nvm3_lockBegin()
+    // nvm3_open() is  called by nvm3_initDefault() in sl_platform_init() in SLC-generated sl_event_handler.c
+    return CHIP_NO_ERROR;
 }
 
 void SilabsConfig::DeInit()

--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -72,8 +72,8 @@ namespace Internal {
 CHIP_ERROR SilabsConfig::Init()
 {
     // nvm3_Sem is created in nvm3_lockBegin()
-    // nvm3_open() is  called by nvm3_initDefault() in sl_platform_init() in SLC-generated sl_event_handler.c
-    return CHIP_NO_ERROR;
+
+    return MapNvm3Error(nvm3_open(nvm3_defaultHandle, nvm3_defaultInit));
 }
 
 void SilabsConfig::DeInit()


### PR DESCRIPTION
Move nvm3_Sem semaphore creation to nvm3_lockBegin() where it is guaranteed to be initialized on the first use.
Also update matter_support submodule to include NVM initialization from sl_platform_init, nvm3_open() is safe to be called  multiple times.

Testing: Verified that a lighting app on BRD4161A successfully boots