### PR TITLE
Deprecate MTROnboardingPayloadParser.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.h
+++ b/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.h
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-MTR_DEPRECATED("Please use [MTRSetupPayload setupPayloadWithOnboardingPayload", ios(16.1, 16.4), macos(13.0, 13.3),
+MTR_DEPRECATED("Please use [MTRSetupPayload setupPayloadWithOnboardingPayload:error:]", ios(16.1, 16.4), macos(13.0, 13.3),
     watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRManualSetupPayloadParser : NSObject
 - (instancetype)initWithDecimalStringRepresentation:(NSString *)decimalStringRepresentation;

--- a/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.h
+++ b/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.h
@@ -25,8 +25,9 @@ typedef NS_ENUM(NSUInteger, MTROnboardingPayloadType) {
     MTROnboardingPayloadTypeQRCode = 0,
     MTROnboardingPayloadTypeManualCode,
     MTROnboardingPayloadTypeNFC
-};
+} MTR_NEWLY_DEPRECATED("MTROnboardingPayloadType is unused");
 
+MTR_NEWLY_DEPRECATED("Please use [MTRSetupPayload setupPayloadWithOnboardingPayload:error:]")
 @interface MTROnboardingPayloadParser : NSObject
 
 + (MTRSetupPayload * _Nullable)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload

--- a/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.h
+++ b/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.h
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-MTR_DEPRECATED("Please use [MTRSetupPayload setupPayloadWithOnboardingPayload", ios(16.1, 16.4), macos(13.0, 13.3),
+MTR_DEPRECATED("Please use [MTRSetupPayload setupPayloadWithOnboardingPayload:error:]", ios(16.1, 16.4), macos(13.0, 13.3),
     watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRQRCodeSetupPayloadParser : NSObject
 - (instancetype)initWithBase38Representation:(NSString *)base38Representation;


### PR DESCRIPTION
We forgot to do this when we deprecated the QRCode/Manual parsers.

