### PR TITLE
[nrfconnect] Fixed using temporary buffer in GetWiFiInfo

### DIFF
--- a/src/platform/nrfconnect/DiagnosticDataProviderImplNrf.cpp
+++ b/src/platform/nrfconnect/DiagnosticDataProviderImplNrf.cpp
@@ -46,8 +46,12 @@ CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiBssId(MutableByteSpan & value)
 {
     WiFiManager::WiFiInfo info;
     ReturnErrorOnFailure(WiFiManager::Instance().GetWiFiInfo(info));
+    ReturnErrorCodeIf(sizeof(info.mBssId) >= value.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    return CopySpanToMutableSpan(info.mBssId, value);
+    memcpy(value.data(), info.mBssId, sizeof(info.mBssId));
+    value.reduce_size(sizeof(info.mBssId));
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -286,16 +286,13 @@ CHIP_ERROR WiFiManager::GetWiFiInfo(WiFiInfo & info) const
 
     if (status.state >= WIFI_STATE_ASSOCIATED)
     {
-        uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
-        net_sprint_ll_addr_buf(reinterpret_cast<const uint8_t *>(status.bssid), WIFI_MAC_ADDR_LEN,
-                               reinterpret_cast<char *>(mac_string_buf), sizeof(mac_string_buf));
-        info.mBssId        = ByteSpan(mac_string_buf, sizeof(mac_string_buf));
         info.mSecurityType = MapToMatterSecurityType(status.security);
         info.mWiFiVersion  = MapToMatterWiFiVersionCode(status.link_mode);
         info.mRssi         = static_cast<int8_t>(status.rssi);
         info.mChannel      = static_cast<uint16_t>(status.channel);
         info.mSsidLen      = status.ssid_len;
         memcpy(info.mSsid, status.ssid, status.ssid_len);
+        memcpy(info.mBssId, status.bssid, sizeof(status.bssid));
 
         return CHIP_NO_ERROR;
     }

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -127,7 +127,7 @@ public:
 
     struct WiFiInfo
     {
-        ByteSpan mBssId{};
+        uint8_t mBssId[DeviceLayer::Internal::kWiFiBSSIDLength];
         app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum mSecurityType{};
         app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum mWiFiVersion{};
         uint16_t mChannel{};


### PR DESCRIPTION
In GetWiFiInfo there is temporary buffer used for ByteSpan initialization, that then may be used out of this call scope.

Moved the buffer declaration to the class object to ensure it has proper lifetime.
