### PR TITLE
Fix pigweed RPC logging on ESP32

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -110,11 +110,11 @@ menu "CHIP Core"
 
         config DISPATCH_EVENT_LONG_DISPATCH_TIME_WARNING_THRESHOLD_MS
             int  "Set threshold in ms"
-            default 700
+            default 100
             help
-                 Time threshold for events dispatching. By default set to 0 to
-                 to disable event dispatching time measurement and suppress the
-                 logs for Long dispatch time.
+                 Time threshold for warning that dispatched took too long. You can
+		 set this default set to 0 to to disable event dispatching time
+		 measurement and suppress the logs "Long dispatch time:...".
 
         # TODO: add log level selection
 

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -110,7 +110,7 @@ menu "CHIP Core"
 
         config DISPATCH_EVENT_LONG_DISPATCH_TIME_WARNING_THRESHOLD_MS
             int  "Set threshold in ms"
-            default 100
+            default 700
             help
                  Time threshold for warning that dispatched took too long. You can
 		 set this default set to 0 to to disable event dispatching time

--- a/src/platform/ESP32/Logging.cpp
+++ b/src/platform/ESP32/Logging.cpp
@@ -26,35 +26,20 @@ void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char
     snprintf(tag, sizeof(tag), "chip[%s]", module);
     tag[sizeof(tag) - 1] = 0;
 
+    char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
+    vsnprintf(formattedMsg, sizeof(formattedMsg), msg, v);
+
     switch (category)
     {
     case kLogCategory_Error:
-        if (esp_log_default_level >= ESP_LOG_ERROR)
-        {
-            printf(LOG_COLOR_E "E");                        // set color
-            printf(" (%u) %s: ", esp_log_timestamp(), tag); // add timestamp
-            esp_log_writev(ESP_LOG_ERROR, tag, msg, v);
-            printf(LOG_RESET_COLOR "\n");
-        }
+        ESP_LOGE(tag, "%s", formattedMsg);
         break;
     case kLogCategory_Progress:
     default:
-        if (esp_log_default_level >= ESP_LOG_INFO)
-        {
-            printf(LOG_COLOR_I "I");                        // set color
-            printf(" (%u) %s: ", esp_log_timestamp(), tag); // add timestamp
-            esp_log_writev(ESP_LOG_INFO, tag, msg, v);
-            printf(LOG_RESET_COLOR "\n");
-        }
+        ESP_LOGI(tag, "%s", formattedMsg);
         break;
     case kLogCategory_Detail:
-        if (esp_log_default_level >= ESP_LOG_DEBUG)
-        {
-            printf(LOG_COLOR_D "D");                        // set color
-            printf(" (%u) %s: ", esp_log_timestamp(), tag); // add timestamp
-            esp_log_writev(ESP_LOG_DEBUG, tag, msg, v);
-            printf(LOG_RESET_COLOR "\n");
-        }
+        ESP_LOGD(tag, "%s", formattedMsg);
         break;
     }
 }


### PR DESCRIPTION
Regression introduced in https://github.com/project-chip/connectedhomeip/pull/26227/. After that PR we no longer get matter logs in pigweed RPC. This reverts `src/platform/ESP32/Logging.cpp` to before the regression. Not only is it matter logging broken, but the changes also caused some back to back RPC calls to hang and timeout.

Test:
* Compiled using `./scripts/build/build_examples.py --target esp32-m5stack-all-clusters-rpc build`.
* Flashed onto M5Stack using `./out/esp32-m5stack-all-clusters-rpc/chip-all-clusters-app.flash.py`
* Attached to pigweed rpc console `python3 -m chip_rpc.console --device /dev/ttyUSB0`
* Confirmed
  * That we are getting chip logs again
  * Confirmed that doing multiple back to back`rpcs.chip.rpc.Device.SetPairingState(pairing_enabled=False)` and `rpcs.chip.rpc.Device.SetPairingState(pairing_enabled=True)` does not result in a timeout