### PR TITLE
Fix pigweed tokenizer port

### DIFF
--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -53,10 +53,13 @@ void HandleTokenizedLog(uint32_t levels, pw_tokenizer_Token token, pw_tokenizer_
 {
     uint8_t encoded_message[PW_TOKENIZER_CFG_ENCODING_BUFFER_SIZE_BYTES];
 
+    memcpy(encoded_message, &token, sizeof(token));
+
     va_list args;
     va_start(args, types);
     // Use the C argument encoding API, since the C++ API requires C++17.
-    const size_t encoded_size = pw_tokenizer_EncodeArgs(types, args, encoded_message, sizeof(encoded_message));
+    const size_t encoded_size = sizeof(token) +
+        pw_tokenizer_EncodeArgs(types, args, encoded_message + sizeof(token), sizeof(encoded_message) - sizeof(token));
     va_end(args);
 
     uint8_t log_category = levels >> 8 & 0xFF;


### PR DESCRIPTION
Issue introduced in: https://github.com/project-chip/connectedhomeip/pull/25351

`token` was not used at all in `HandleTokenizedLog`. Encoded message should also contain the token.
The old implementation was using `PW_TOKENIZE_TO_GLOBAL_HANDLER_WITH_PAYLOAD`, which did the token copying behind the scenes.

