### PR TITLE
Encode as much of a list as possible as a single IB when reading.

### DIFF
--- a/src/app/AttributeAccessInterface.cpp
+++ b/src/app/AttributeAccessInterface.cpp
@@ -55,38 +55,81 @@ CHIP_ERROR AttributeReportBuilder::FinishAttribute(AttributeReportIBs::Builder &
     return aAttributeReportIBsBuilder.GetAttributeReport().EndOfAttributeReportIB().GetError();
 }
 
+namespace {
+
+constexpr uint32_t kEndOfListByteCount = 1;
+// 2 bytes: one to end the AttributeDataIB and one to end the AttributeReportIB.
+constexpr uint32_t kEndOfAttributeReportIBByteCount = 2;
+constexpr TLV::TLVType kAttributeDataIBType         = TLV::kTLVType_Structure;
+
+} // anonymous namespace
+
 CHIP_ERROR AttributeValueEncoder::EnsureListStarted()
 {
-    if (mCurrentEncodingListIndex == kInvalidListIndex)
+    VerifyOrDie(mCurrentEncodingListIndex == kInvalidListIndex);
+
+    mEncodingInitialList = (mEncodeState.mCurrentEncodingListIndex == kInvalidListIndex);
+    if (mEncodingInitialList)
     {
-        if (mEncodeState.mCurrentEncodingListIndex == kInvalidListIndex)
-        {
-            // Clear mAllowPartialData flag here since this encode procedure is not atomic.
-            // The most common error in this function is CHIP_ERROR_NO_MEMORY / CHIP_ERROR_BUFFER_TOO_SMALL, just revert and try
-            // next time is ok.
-            mEncodeState.mAllowPartialData = false;
-            // Spec 10.5.4.3.1, 10.5.4.6 (Replace a list w/ Multiple IBs)
-            // Put an empty array before encoding the first array element for list chunking.
-            AttributeReportBuilder builder;
+        // Clear mAllowPartialData flag here since this encode procedure is not atomic.
+        // The most common error in this function is CHIP_ERROR_NO_MEMORY / CHIP_ERROR_BUFFER_TOO_SMALL, just revert and try
+        // next time is ok.
+        mEncodeState.mAllowPartialData = false;
 
-            mPath.mListOp = ConcreteDataAttributePath::ListOperation::ReplaceAll;
-            ReturnErrorOnFailure(builder.PrepareAttribute(mAttributeReportIBsBuilder, mPath, mDataVersion));
-            ReturnErrorOnFailure(builder.EncodeValue(mAttributeReportIBsBuilder, DataModel::List<uint8_t>()));
+        AttributeReportBuilder builder;
 
-            ReturnErrorOnFailure(builder.FinishAttribute(mAttributeReportIBsBuilder));
-            mEncodeState.mCurrentEncodingListIndex = 0;
-        }
-        mCurrentEncodingListIndex = 0;
+        mPath.mListOp = ConcreteDataAttributePath::ListOperation::ReplaceAll;
+        ReturnErrorOnFailure(builder.PrepareAttribute(mAttributeReportIBsBuilder, mPath, mDataVersion));
+
+        auto * attributeDataWriter = mAttributeReportIBsBuilder.GetAttributeReport().GetAttributeData().GetWriter();
+        TLV::TLVType outerType;
+        ReturnErrorOnFailure(
+            attributeDataWriter->StartContainer(TLV::ContextTag(AttributeDataIB::Tag::kData), TLV::kTLVType_Array, outerType));
+        VerifyOrDie(outerType == kAttributeDataIBType);
+
+        // Instead of reserving hardcoded amounts, we could checkpoint the
+        // writer, encode array end and FinishAttribute, check that this fits,
+        // measure how much the writer advanced, then restore the checkpoint,
+        // reserve the measured value, and save it.  But that's probably more
+        // cycles than just reserving this known constant.
+        ReturnErrorOnFailure(
+            mAttributeReportIBsBuilder.GetWriter()->ReserveBuffer(kEndOfAttributeReportIBByteCount + kEndOfListByteCount));
+
+        mEncodeState.mCurrentEncodingListIndex = 0;
+    }
+    else
+    {
+        // For all elements in the list, a report with append operation will be generated. This will not be changed during encoding
+        // of each report since the users cannot access mPath.
+        mPath.mListOp = ConcreteDataAttributePath::ListOperation::AppendItem;
     }
 
-    // After encoding the empty list, the remaining items are atomically encoded into the buffer. Tell report engine to not
+    mCurrentEncodingListIndex = 0;
+
+    // After encoding the initial list start, the remaining items are atomically encoded into the buffer. Tell report engine to not
     // revert partial data.
     mEncodeState.mAllowPartialData = true;
 
-    // For all elements in the list, a report with append operation will be generated. This will not be changed during encoding
-    // of each report since the users cannot access mPath.
-    mPath.mListOp = ConcreteDataAttributePath::ListOperation::AppendItem;
     return CHIP_NO_ERROR;
+}
+
+void AttributeValueEncoder::EnsureListEnded()
+{
+    if (!mEncodingInitialList)
+    {
+        // Nothing to do.
+        return;
+    }
+
+    // Unreserve the space we reserved just for this.  Crash if anything here
+    // fails, because that would mean that we've corrupted our data, and since
+    // mEncodeState.mAllowPartialData is true nothing will clean up for us here.
+    auto * attributeDataWriter = mAttributeReportIBsBuilder.GetAttributeReport().GetAttributeData().GetWriter();
+    VerifyOrDie(attributeDataWriter->UnreserveBuffer(kEndOfListByteCount + kEndOfAttributeReportIBByteCount) == CHIP_NO_ERROR);
+    VerifyOrDie(attributeDataWriter->EndContainer(kAttributeDataIBType) == CHIP_NO_ERROR);
+
+    AttributeReportBuilder builder;
+    VerifyOrDie(builder.FinishAttribute(mAttributeReportIBsBuilder) == CHIP_NO_ERROR);
 }
 
 } // namespace app

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -173,6 +173,24 @@ public:
             mReceivedAttributePaths.push_back(aPath);
             mNumAttributeResponse++;
             mGotReport = true;
+
+            if (aPath.IsListItemOperation())
+            {
+                mNumArrayItems++;
+            }
+            else if (aPath.IsListOperation())
+            {
+                // This is an entire list of things; count up how many.
+                chip::TLV::TLVType containerType;
+                if (apData->EnterContainer(containerType) == CHIP_NO_ERROR)
+                {
+                    size_t count = 0;
+                    if (chip::TLV::Utilities::Count(*apData, count, /* aRecurse = */ false) == CHIP_NO_ERROR)
+                    {
+                        mNumArrayItems += static_cast<int>(count);
+                    }
+                }
+            }
         }
         mLastStatusReceived = status;
     }
@@ -207,6 +225,7 @@ public:
     bool mGotEventResponse                 = false;
     int mNumReadEventFailureStatusReceived = 0;
     int mNumAttributeResponse              = 0;
+    int mNumArrayItems                     = 0;
     bool mGotReport                        = false;
     bool mReadError                        = false;
     chip::app::ReadHandler * mpReadHandler = nullptr;
@@ -1192,7 +1211,9 @@ void TestReadInteraction::TestReadChunking(nlTestSuite * apSuite, void * apConte
 
         ctx.DrainAndServiceIO();
 
-        NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 7); // One empty string, with 6 array evelemtns.
+        // We get one chunk with 3 array elements, and then one chunk per element.
+        NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 4);
+        NL_TEST_ASSERT(apSuite, delegate.mNumArrayItems == 6);
         NL_TEST_ASSERT(apSuite, delegate.mGotReport);
         NL_TEST_ASSERT(apSuite, !delegate.mReadError);
         // By now we should have closed all exchanges and sent all pending acks, so
@@ -1236,12 +1257,16 @@ void TestReadInteraction::TestSetDirtyBetweenChunks(nlTestSuite * apSuite, void 
 
     {
         int currentAttributeResponsesWhenSetDirty = 0;
+        int currentArrayItemsWhenSetDirty         = 0;
 
         class DirtyingMockDelegate : public MockInteractionModelApp
         {
         public:
-            DirtyingMockDelegate(AttributePathParams (&aReadPaths)[2], int & aNumAttributeResponsesWhenSetDirty) :
-                mReadPaths(aReadPaths), mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty)
+            DirtyingMockDelegate(AttributePathParams (&aReadPaths)[2], int & aNumAttributeResponsesWhenSetDirty,
+                                 int & aNumArrayItemsWhenSetDirty) :
+                mReadPaths(aReadPaths),
+                mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
+                mNumArrayItemsWhenSetDirty(aNumArrayItemsWhenSetDirty)
             {}
 
         private:
@@ -1285,6 +1310,7 @@ void TestReadInteraction::TestSetDirtyBetweenChunks(nlTestSuite * apSuite, void 
                         // We're finishing out the message where we decided to
                         // SetDirty.
                         ++mNumAttributeResponsesWhenSetDirty;
+                        ++mNumArrayItemsWhenSetDirty;
                     }
                 }
 
@@ -1302,6 +1328,7 @@ void TestReadInteraction::TestSetDirtyBetweenChunks(nlTestSuite * apSuite, void 
                     {
                         // At this time, we are in the middle of report for second item.
                         mNumAttributeResponsesWhenSetDirty = mNumAttributeResponse;
+                        mNumArrayItemsWhenSetDirty         = mNumArrayItems;
                         InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(dirtyPath);
                     }
                 }
@@ -1316,9 +1343,10 @@ void TestReadInteraction::TestSetDirtyBetweenChunks(nlTestSuite * apSuite, void 
             bool mDidSetDirty           = false;
             AttributePathParams (&mReadPaths)[2];
             int & mNumAttributeResponsesWhenSetDirty;
+            int & mNumArrayItemsWhenSetDirty;
         };
 
-        DirtyingMockDelegate delegate(attributePathParams, currentAttributeResponsesWhenSetDirty);
+        DirtyingMockDelegate delegate(attributePathParams, currentAttributeResponsesWhenSetDirty, currentArrayItemsWhenSetDirty);
         NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
 
         app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
@@ -1329,11 +1357,13 @@ void TestReadInteraction::TestSetDirtyBetweenChunks(nlTestSuite * apSuite, void 
 
         ctx.DrainAndServiceIO();
 
-        // We should receive another (6 + 1) = 7 attribute reports since the underlying path iterator should be reset to the
-        // beginning of the cluster it is currently iterating.
+        // We should receive another (3 + 1) = 4 attribute reports represeting 6
+        // array items, since the underlying path iterator should be reset to
+        // the beginning of the cluster it is currently iterating.
         ChipLogError(DataManagement, "OLD: %d\n", currentAttributeResponsesWhenSetDirty);
         ChipLogError(DataManagement, "NEW: %d\n", delegate.mNumAttributeResponse);
-        NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == currentAttributeResponsesWhenSetDirty + 7);
+        NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == currentAttributeResponsesWhenSetDirty + 4);
+        NL_TEST_ASSERT(apSuite, delegate.mNumArrayItems == currentArrayItemsWhenSetDirty + 6);
         NL_TEST_ASSERT(apSuite, delegate.mGotReport);
         NL_TEST_ASSERT(apSuite, !delegate.mReadError);
         // By now we should have closed all exchanges and sent all pending acks, so
@@ -1868,9 +1898,14 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
         NL_TEST_ASSERT(apSuite, delegate.mGotReport);
 
         // We have 29 attributes in our mock attribute storage. And we subscribed twice.
-        // And attribute 3/2/4 is a list with 6 elements and list chunking is applied to it, thus we should receive ( 29 + 6 ) * 2 =
-        // 70 attribute data in total.
-        NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 70);
+        // And attribute 3/2/4 is a list with 6 elements and list chunking is
+        // applied to it, but the way the packet boundaries fall we get two of
+        // its items as a single list, followed by 4 more single items for one
+        // of our subscriptions, but every item as a separate IB for the other.
+        //
+        // Thus we should receive 29*2 + 4 + 6 = 68 attribute data in total.
+        NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 68);
+        NL_TEST_ASSERT(apSuite, delegate.mNumArrayItems == 12);
         NL_TEST_ASSERT(apSuite, engine->GetNumActiveReadHandlers(ReadHandler::InteractionType::Subscribe) == 1);
         NL_TEST_ASSERT(apSuite, engine->ActiveHandlerAt(0) != nullptr);
         delegate.mpReadHandler = engine->ActiveHandlerAt(0);
@@ -1901,6 +1936,7 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
             delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
             delegate.mGotReport            = false;
             delegate.mNumAttributeResponse = 0;
+            delegate.mNumArrayItems        = 0;
 
             AttributePathParams dirtyPath;
             dirtyPath.mEndpointId = Test::kMockEndpoint3;
@@ -1921,10 +1957,16 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
 
             NL_TEST_ASSERT(apSuite, delegate.mGotReport);
             // Mock endpoint3 has 13 attributes in total, and we subscribed twice.
-            // And attribute 3/2/4 is a list with 6 elements and list chunking is applied to it, thus we should receive ( 13 + 6 ) *
-            // 2 = 28 attribute data in total.
+            // And attribute 3/2/4 is a list with 6 elements and list chunking
+            // is applied to it, but the way the packet boundaries fall we get two of
+            // its items as a single list, followed by 4 more items for one
+            // of our subscriptions, and 3 items as a single list followed by 3
+            // more items for the other.
+            //
+            // Thus we should receive 13*2 + 4 + 3 = 33 attribute data in total.
             ChipLogError(DataManagement, "RESPO: %d\n", delegate.mNumAttributeResponse);
-            NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 38);
+            NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 33);
+            NL_TEST_ASSERT(apSuite, delegate.mNumArrayItems == 12);
         }
     }
 
@@ -2925,6 +2967,7 @@ void TestReadInteraction::TestPostSubscribeRoundtripChunkReport(nlTestSuite * ap
         err                            = engine->GetReportingEngine().SetDirty(dirtyPath1);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
+        delegate.mNumArrayItems        = 0;
 
         // wait for min interval 2 seconds(in test, we use 1.9second considering the time variation), expect no event is received,
         // then wait for 0.5 seconds, then all chunked dirty reports are sent out, which would not honor minInterval
@@ -2949,8 +2992,10 @@ void TestReadInteraction::TestPostSubscribeRoundtripChunkReport(nlTestSuite * ap
         }
         ctx.DrainAndServiceIO();
     }
-    // Two chunked reports carry 7 attributeDataIB
-    NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 7);
+    // Two chunked reports carry 4 attributeDataIB: 1 with a list of 3 items,
+    // and then one per remaining item.
+    NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 4);
+    NL_TEST_ASSERT(apSuite, delegate.mNumArrayItems == 6);
 
     NL_TEST_ASSERT(apSuite, engine->GetNumActiveReadClients() == 0);
     engine->Shutdown();


### PR DESCRIPTION
Instead of doing one IB to start empty list and one IB per item, switch to doing one IB with as many items as we can fit in our packet (with a REPLACE path), then one IB per item with ADD paths as now.

This reduces the data transferred for a wildcard-everything read from lighting-app from 26 AttributeReport packets to 12.

Fixes https://github.com/project-chip/connectedhomeip/issues/26271
