### PR TITLE
Remove the kDNSServiceInterfaceIndexLocalOnly special-case on Darwin.

### DIFF
--- a/src/platform/Darwin/DnssdHostNameRegistrar.h
+++ b/src/platform/Darwin/DnssdHostNameRegistrar.h
@@ -50,12 +50,16 @@ namespace Dnssd {
         {
             for (auto & interface : interfaces) {
                 auto interfaceId = interface.first;
-                auto interfaceAddress = static_cast<const void *>(&interface.second);
-                auto interfaceAddressLen = sizeof(interface.second);
 
-                LogErrorOnFailure(
-                    RegisterInterface(interfaceId, type, interfaceAddress, static_cast<uint16_t>(interfaceAddressLen)));
+                LogErrorOnFailure(RegisterInterface(interfaceId, interface.second, type));
             }
+        }
+
+        template <typename T> CHIP_ERROR RegisterInterface(uint32_t interfaceId, const T & interfaceAddress, uint16_t type)
+        {
+            auto interfaceAddressLen = sizeof(interfaceAddress);
+
+            return RegisterInterface(interfaceId, type, &interfaceAddress, static_cast<uint16_t>(interfaceAddressLen));
         }
 
         CHIP_ERROR RegisterInterface(uint32_t interfaceId, uint16_t rtype, const void * rdata, uint16_t rdlen);

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -328,12 +328,6 @@ static void OnResolve(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t inter
     if (kDNSServiceErr_NoError == err)
     {
         sdCtx->OnNewInterface(interfaceId, fullname, hostname, port, txtLen, txtRecord);
-        if (kDNSServiceInterfaceIndexLocalOnly == interfaceId)
-        {
-            sdCtx->OnNewLocalOnlyAddress();
-            sdCtx->Finalize();
-            return;
-        }
     }
 
     if (!(flags & kDNSServiceFlagsMoreComing))

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -204,7 +204,6 @@ struct ResolveContext : public GenericContext
     void DispatchSuccess() override;
 
     CHIP_ERROR OnNewAddress(uint32_t interfaceId, const struct sockaddr * address);
-    CHIP_ERROR OnNewLocalOnlyAddress();
     bool HasAddress();
 
     void OnNewInterface(uint32_t interfaceId, const char * fullname, const char * hostname, uint16_t port, uint16_t txtLen,


### PR DESCRIPTION
Interface kDNSServiceInterfaceIndexLocalOnly means the _registration_ is local-only, not that the registered host is localhost and has a loopback address.  There can be local-only registrations for other hosts, and we need to do actual address resolution.

To make this work right in our unit test setup, fix our registration code for the local-only case (which tests use) to register hostname -> IP mappings, which it was not doing before.