### PR TITLE
lock flask version for cirque

### DIFF
--- a/integrations/docker/images/chip-build-cirque/requirements_nogrpc.txt
+++ b/integrations/docker/images/chip-build-cirque/requirements_nogrpc.txt
@@ -1,6 +1,6 @@
 cmd2
 docker >= 4.1.0
-flask >= 1.1.0
+flask == 2.2.2
 pycodestyle >= 2.5.0
 pylint == 2.4
 pyroute2 >= 0.5.7


### PR DESCRIPTION
lock flask version for cirque since upstream flask in python is broken somehow 

