### PR TITLE
Try next IP address when sending first session establishment message fails.

### DIFF
--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -217,7 +217,7 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
         return false;
     }
 
-    if (!mDiscoveredParameters.empty())
+    while (!mDiscoveredParameters.empty())
     {
         // Grab the first element from the queue and try connecting to it.
         // Remove it from the queue before we try to connect, in case the
@@ -258,7 +258,7 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
             return true;
         }
 
-        // Failed to start establishing PASE.
+        // Failed to start establishing PASE.  Move on to the next item.
         PASEEstablishmentComplete();
     }
 


### PR DESCRIPTION
If DNS-SD discovery comes back with an IP that is not routable for some reason, or if there os some other synchronous error when trying to kick off session establishment, move on to the next IP (just like we would for an async session establishment error), instead of just aborting the session establishment process altogether.

The change in SetUpCodePairer::ConnectToDiscoveredDevice just moves on to the next element in our list, if any.

The change in OperationalSessionSetup::UpdateDeviceData adds the TryNextResult call, but also restructures things to have early returns instead of deep nesting of ifs.

Fixes https://github.com/project-chip/connectedhomeip/issues/26307
