### PR TITLE
Install Python test runner dependencies in `chip-cert-bins` Docker image

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -304,4 +304,5 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-app1 chip-app1
 # Stage 3.1 Setup the Matter Python environment
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/python_lib python_lib
 COPY --from=chip-build-cert-bins /root/connectedhomeip/src/python_testing python_testing
+RUN pip install click websockets lark diskcache
 RUN pip install --no-cache-dir python_lib/controller/python/chip*.whl


### PR DESCRIPTION
Matter TH will be running python test runner in `chip-cert-bins`, the following python packages was missing:

 - `click`
 - `websockets`
 - `lark`
 - `diskcache`
 
 This PR adds a `RUN` step to install them in the `chip-cert-bins` Docker image.