### PR TITLE
[Tizen] Add timeout for mDNS resolve operation

### DIFF
--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -103,6 +103,7 @@ struct ResolveContext : public GenericContext
     void * mCbContext;
 
     dnssd_service_h mServiceHandle = 0;
+    GSource * mTimeoutSource       = nullptr;
     bool mIsResolving              = false;
 
     // Resolved service


### PR DESCRIPTION
### Problem

Tizen API `dnssd_resolve_service` does not call callback function in case of resolve timeout (e.g. when a device is off the network). However, we shall notify caller abut such event.

### Changes

- added glib source timer to implement resolve timeout

### Testing

Tested locally with TestDnssd test on Tizen.