### PR TITLE
The skipping of items without a relevant path was failing to pick ite…

### DIFF
--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -283,7 +283,7 @@ class TestDefinition:
                 # happen if the relevant application does not exist.  It's
                 # non-fatal as long as we are not trying to run any tests that
                 # need that application.
-                if len(path) == 1 and path[0] is None:
+                if path[-1] is None:
                     continue
 
                 # For the app indicated by self.target, give it the 'default' key to add to the register


### PR DESCRIPTION
Upon running `./scripts/tests/run_test_suite.py --chip-tool ./examples/chip-tool/out/debug/chip-tool --target 'TestModeSelectCluster' run --all-clusters-app examples/all-clusters-app/linux/out/debug/chip-all-clusters-app` to run the tests against an application, the following error was returned.

```
2023-05-02 14:00:46.638 INFO    Ensuring /run is privately accessible
2023-05-02 14:00:46.834 INFO    Waiting for IPv6 DaD to complete (no tentative addresses)
2023-05-02 14:00:48.864 INFO    No more tentative addresses
2023-05-02 14:00:48.864 INFO    Each test will be executed 1 times
2023-05-02 14:00:48.866 INFO    Starting iteration 1
2023-05-02 14:00:48.866 INFO    TestModeSelectCluster - Starting test
2023-05-02 14:00:48.866 ERROR   !!!!!!!!!!!!!!!!!!!! ERROR !!!!!!!!!!!!!!!!!!!!!!
2023-05-02 14:00:48.866 ERROR   ================ CAPTURED LOG START ==================
2023-05-02 14:00:48.867 ERROR   ================ CAPTURED LOG END ====================
2023-05-02 14:00:48.867 ERROR   TestModeSelectCluster          - FAILED in 0.00 seconds
Traceback (most recent call last):
  File "./scripts/tests/run_test_suite.py", line 342, in cmd_run
    test.Run(
  File "/home/whicklin/Documents/openRepos/connectedhomeip/scripts/tests/chiptest/test_definition.py", line 293, in Run
    key = os.path.basename(path[-1])
  File "/usr/lib/python3.8/posixpath.py", line 142, in basename
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

This is caused by the `test_definition.py` script not skipping invalid application paths because those paths happen to have a length != 1. This PR skips all paths where the last element is `None`, meaning that it is invalid.