### PR TITLE
Remove unused "<access modifier>" bits from XML.

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
@@ -76,14 +76,12 @@ limitations under the License.
       <description>ACL</description>
       <access op="read" privilege="administer"/>
       <access op="write" privilege="administer"/>
-      <access modifier="fabric-scoped"/>
     </attribute>
 
     <attribute side="server" code="0x0001" define="EXTENSION" type="ARRAY" entryType="AccessControlExtensionStruct" writable="true" optional="true">
       <description>Extension</description>
       <access op="read" privilege="administer"/>
       <access op="write" privilege="administer"/>
-      <access modifier="fabric-scoped"/>
     </attribute>
 
     <attribute side="server" code="0x0002" define="SUBJECTS_PER_ACCESS_CONTROL_ENTRY" type="int16u" writable="false">


### PR DESCRIPTION
Removing these does not change any codegen, either compile-time or for committed files, so we're not using these for anything.  And they're not consistently applied to the attributes that are fabric scoped, so if we did try to start using them we would need to audit to decide where to do that, and not using them anywhere makes that clear.

Fixes https://github.com/project-chip/connectedhomeip/issues/26316
