### PR TITLE
Add ProductAppearance on Bridged Device Basic Information to the list of forced-attribute-access attributes.

### DIFF
--- a/src/app/zap-templates/zcl/zcl-with-test-extensions.json
+++ b/src/app/zap-templates/zcl/zcl-with-test-extensions.json
@@ -142,6 +142,7 @@
             "CapabilityMinima",
             "ProductAppearance"
         ],
+        "Bridged Device Basic Information": ["ProductAppearance"],
         "Descriptor": ["ClusterRevision"],
         "Ethernet Network Diagnostics": [
             "PHYRate",

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -140,6 +140,7 @@
             "CapabilityMinima",
             "ProductAppearance"
         ],
+        "Bridged Device Basic Information": ["ProductAppearance"],
         "Descriptor": ["ClusterRevision"],
         "Ethernet Network Diagnostics": [
             "PHYRate",


### PR DESCRIPTION
This fixes a merge issue between the ProductAppearance PR and the "don't generate accessors for things where they do not make sense" PR.
