### PR TITLE
Use stack buffer when tokenizing smaller buffers

### DIFF
--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -74,7 +74,7 @@ void HandleTokenizedLog(uint32_t levels, pw_tokenizer_Token token, pw_tokenizer_
 
     if (required_buffer_size > sizeof(stack_buffer))
     {
-        allocated_buffer = (char *) chip::Platform::MemoryAlloc();
+        allocated_buffer = (char *) chip::Platform::MemoryAlloc(required_buffer_size);
         if (allocated_buffer)
         {
             logging_buffer = allocated_buffer;
@@ -96,7 +96,7 @@ void HandleTokenizedLog(uint32_t levels, pw_tokenizer_Token token, pw_tokenizer_
     }
     if (allocated_buffer)
     {
-        chip::Platform::MemoryFree(buffer);
+        chip::Platform::MemoryFree(allocated_buffer);
     }
 }
 

--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -87,7 +87,7 @@ void HandleTokenizedLog(uint32_t levels, pw_tokenizer_Token token, pw_tokenizer_
 
     if (logging_buffer)
     {
-        for (int i = 0; i < encoded_size; i++)
+        for (size_t i = 0; i < encoded_size; i++)
         {
             sprintf(logging_buffer + 2 * i, "%02x", encoded_message[i]);
         }


### PR DESCRIPTION
This reduces the number of alloc/free calls that happen when tokenizing logs and the buffer is small enough to just use the stack.