### PR TITLE
avoid compiler error due to undefined 'errno' on Catalina with xcode …

### DIFF
--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -24,6 +24,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <errno.h>
 
 static constexpr const size_t kChipEventCmdBufSize = 256;
 

--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -18,13 +18,13 @@
 
 #include "NamedPipeCommands.h"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <lib/support/CodeUtils.h>
 #include <pthread.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <errno.h>
 
 static constexpr const size_t kChipEventCmdBufSize = 256;
 

--- a/src/tools/chip-cert/GeneralUtils.cpp
+++ b/src/tools/chip-cert/GeneralUtils.cpp
@@ -30,6 +30,7 @@
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/BytesToHex.h>
 #include <lib/support/SafeInt.h>
+#include <errno.h>
 
 using namespace chip;
 using namespace chip::Credentials;

--- a/src/tools/chip-cert/GeneralUtils.cpp
+++ b/src/tools/chip-cert/GeneralUtils.cpp
@@ -27,10 +27,10 @@
 
 #include "chip-cert.h"
 
+#include <errno.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/BytesToHex.h>
 #include <lib/support/SafeInt.h>
-#include <errno.h>
 
 using namespace chip;
 using namespace chip::Credentials;


### PR DESCRIPTION
…12.00.

When compiling the tree on macOS 10.15.7 using Xcode:

mmpmbp01:connectedhomeip michaelp$ clang --version
Apple clang version 12.0.0 (clang-1200.0.32.29)
Target: x86_64-apple-darwin19.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin

The Xcode command line tools had just been freshly installed after removing an older version.

two .cpp files cause the build to fail. In each, simply including <errno.h> fixed the issue.

Here are the two errors:

--------------------
```
[3134/7468] c++ mac_x64_gcc/obj/src/tools/chip-cert/chip-cert.GeneralUtils.cpp.o
FAILED: mac_x64_gcc/obj/src/tools/chip-cert/chip-cert.GeneralUtils.cpp.o 
g++ -MMD -MF mac_x64_gcc/obj/src/tools/chip-cert/chip-cert.GeneralUtils.cpp.o.d -Wconversion -target x86_64-apple-macos11.0 -O0 -g2 -fno-common -ffunction-sections -fdata-sections -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -Wall -Werror -Wextra -Wshadow -Wunreachable-code -Wvla -Wformat -Wformat-nonliteral -Wformat-security -Wconversion -Wno-deprecated-declarations -Wno-missing-field-initializers -Wno-unknown-warning-option -Wno-unused-parameter -Wno-cast-function-type -Wno-psabi -Wno-maybe-uninitialized -fdiagnostics-color -fno-strict-aliasing -fmacro-prefix-map=../../= -fobjc-arc -Wconversion -std=gnu++14 -frtti -Wnon-virtual-dtor -DCHIP_HAVE_CONFIG_H=1 -DOPENSSL_NO_ASM=1 -I../../src/include -I../../src -Imac_x64_gcc/gen/include -I../../zzz_generated/app-common -I../../config/standalone -I../../third_party/nlassert/repo/include -I../../third_party/nlio/repo/include -I../../third_party/nlfaultinjection/repo/include -I../../third_party/boringssl/repo/src/include -c ../../src/tools/chip-cert/GeneralUtils.cpp -o mac_x64_gcc/obj/src/tools/chip-cert/chip-cert.GeneralUtils.cpp.o
../../src/tools/chip-cert/GeneralUtils.cpp:237:75: error: use of undeclared identifier 'errno'
            fprintf(stderr, "Unable to open %s: %s\n", fileName, strerror(errno));
                                                                          ^
../../src/tools/chip-cert/GeneralUtils.cpp:273:70: error: use of undeclared identifier 'errno'
        fprintf(stderr, "Error reading %s: %s\n", fileName, strerror(errno));
                                                                     ^
../../src/tools/chip-cert/GeneralUtils.cpp:286:74: error: use of undeclared identifier 'errno'
            fprintf(stderr, "Error reading %s: %s\n", fileName, strerror(errno));
                                                                         ^
../../src/tools/chip-cert/GeneralUtils.cpp:338:90: error: use of undeclared identifier 'errno'
        fprintf(stderr, "Unable to write to %s: %s\n", fileName, strerror(ferror(file) ? errno : ENOSPC));
                                                                                         ^
../../src/tools/chip-cert/GeneralUtils.cpp:338:98: error: use of undeclared identifier 'ENOSPC'
        fprintf(stderr, "Unable to write to %s: %s\n", fileName, strerror(ferror(file) ? errno : ENOSPC));
                                                                                                 ^
../../src/tools/chip-cert/GeneralUtils.cpp:345:90: error: use of undeclared identifier 'errno'
        fprintf(stderr, "Unable to write to %s: %s\n", fileName, strerror(ferror(file) ? errno : ENOSPC));
                                                                                         ^
../../src/tools/chip-cert/GeneralUtils.cpp:345:98: error: use of undeclared identifier 'ENOSPC'
        fprintf(stderr, "Unable to write to %s: %s\n", fileName, strerror(ferror(file) ? errno : ENOSPC));
                                                                                                 ^
7 errors generated.

[1963/4322] c++ standalone/obj/examples/platform/linux/app-main.NamedPipeCommands.cpp.o
FAILED: standalone/obj/examples/platform/linux/app-main.NamedPipeCommands.cpp.o 
g++ -MMD -MF standalone/obj/examples/platform/linux/app-main.NamedPipeCommands.cpp.o.d -target x86_64-apple-macos11.0 -O0 -g2 -fno-common -ffunction-sections -fdata-sections -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -Wall -Werror -Wextra -Wshadow -Wunreachable-code -Wvla -Wformat -Wformat-nonliteral -Wformat-security -Wconversion -Wno-deprecated-declarations -Wno-missing-field-initializers -Wno-unknown-warning-option -Wno-unused-parameter -Wno-cast-function-type -Wno-psabi -Wno-maybe-uninitialized -fdiagnostics-color -fno-strict-aliasing -fmacro-prefix-map=../../= -fobjc-arc -Wconversion -std=gnu++14 -frtti -Wnon-virtual-dtor -DCHIP_HAVE_CONFIG_H=1 -DOPENSSL_NO_ASM=1 -DCHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=\<lib/address_resolve/AddressResolve_DefaultImpl.h\> -I../../examples/platform/linux -I../../examples/providers -I../../src/include -I../../src -Istandalone/gen/include -I../../zzz_generated/app-common -I../../config/standalone -I../../third_party/nlassert/repo/include -I../../third_party/nlio/repo/include -I../../third_party/boringssl/repo/src/include -I../../examples/common/tracing -I../../third_party/jsoncpp/repo/include -c ../../examples/platform/linux/NamedPipeCommands.cpp -o standalone/obj/examples/platform/linux/app-main.NamedPipeCommands.cpp.o
../../examples/platform/linux/NamedPipeCommands.cpp:40:63: error: use of undeclared identifier 'errno'
    VerifyOrReturnError((mkfifo(path.c_str(), 0666) == 0) || (errno == EEXIST), CHIP_ERROR_OPEN_FAILED);
                                                              ^
../../examples/platform/linux/NamedPipeCommands.cpp:40:72: error: use of undeclared identifier 'EEXIST'
    VerifyOrReturnError((mkfifo(path.c_str(), 0666) == 0) || (errno == EEXIST), CHIP_ERROR_OPEN_FAILED);
                                                                       ^
--------------------

Robert Szewczyk added the following detail for the first error from a system that did not exhibit the problem:

"
This is the chain of includes that makes it work on the system without embedding your patch: 

. ../../src/tools/chip-cert/chip-cert.h
.. /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/memory
... /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/shared_ptr.h
.... /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/atomic
..... /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__threading_support
...... /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/errno.h
....... /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/errno.h
........ /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/errno.h
```
The above was generated with 
```
g++ -H -MMD -MF mac_x64_gcc/obj/src/tools/chip-cert/chip-cert.GeneralUtils.cpp.o.d -Wconversion -target x86_64-apple-macos11.0 -O0 -g2 -fno-common -ffunction-sections -fdata-sections -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -Wall -Werror -Wextra -Wshadow -Wunreachable-code -Wvla -Wformat -Wformat-nonliteral -Wformat-security -Wconversion -Wno-deprecated-declarations -Wno-missing-field-initializers -Wno-unknown-warning-option -Wno-unused-parameter -Wno-cast-function-type -Wno-psabi -Wno-maybe-uninitialized -fdiagnostics-color -fno-strict-aliasing -fmacro-prefix-map=../../= -fobjc-arc -Wconversion -std=gnu++14 -frtti -Wnon-virtual-dtor -DCHIP_HAVE_CONFIG_H=1 -DOPENSSL_NO_ASM=1 -I../../src/include -I../../src -Imac_x64_gcc/gen/include -I../../zzz_generated/app-common -I../../config/standalone -I../../third_party/nlassert/repo/include -I../../third_party/nlio/repo/include -I../../third_party/nlfaultinjection/repo/include -I../../third_party/boringssl/repo/src/include -E ../../src/tools/chip-cert/GeneralUtils.cpp -o mac_x64_gcc/obj/src/tools/chip-cert/chip-cert.GeneralUtils.cpp.E
```
I had also generated a pre-processed GeneralUtils.cpp.E which I am attaching below.

