### PR TITLE
[ESP32] Use esp_log_writev() for logging rather than ESP_LOGx macros

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -86,10 +86,29 @@ chip_gn_arg_append("esp32_cpu"             "\"esp32\"")
 chip_gn_arg_bool("is_debug"                ${is_debug})
 
 # Config the chip log level by IDF menuconfig
-chip_gn_arg_bool  ("chip_error_logging"        CONFIG_LOG_DEFAULT_LEVEL GREATER_EQUAL 1)
-chip_gn_arg_bool  ("chip_progress_logging"     CONFIG_LOG_DEFAULT_LEVEL GREATER_EQUAL 3)
-chip_gn_arg_bool  ("chip_detail_logging"       CONFIG_LOG_DEFAULT_LEVEL GREATER_EQUAL 4)
-chip_gn_arg_bool  ("chip_automation_logging"   CONFIG_LOG_DEFAULT_LEVEL GREATER_EQUAL 5)
+if (CONFIG_LOG_DEFAULT_LEVEL GREATER_EQUAL 1)
+    chip_gn_arg_bool  ("chip_error_logging" "true")
+else()
+    chip_gn_arg_bool  ("chip_error_logging" "false")
+endif()
+
+if (CONFIG_LOG_DEFAULT_LEVEL GREATER_EQUAL 3)
+    chip_gn_arg_bool  ("chip_progress_logging" "true")
+else()
+    chip_gn_arg_bool  ("chip_progress_logging" "false")
+endif()
+
+if (CONFIG_LOG_DEFAULT_LEVEL GREATER_EQUAL 4)
+    chip_gn_arg_bool  ("chip_detail_logging" "true")
+else()
+    chip_gn_arg_bool  ("chip_detail_logging" "false")
+endif()
+
+if (CONFIG_LOG_DEFAULT_LEVEL GREATER_EQUAL 5)
+    chip_gn_arg_bool  ("chip_automation_logging" "true")
+else()
+    chip_gn_arg_bool  ("chip_automation_logging" "false")
+endif()
 
 if(CONFIG_ENABLE_CHIPOBLE)
 chip_gn_arg_append("chip_config_network_layer_ble"           "true")

--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -373,8 +373,10 @@ target_link_libraries(${COMPONENT_LIB} INTERFACE -Wl,--start-group
 add_dependencies(${COMPONENT_LIB} chip_gn)
 
 if(CONFIG_ENABLE_PW_RPC)
-    set(WRAP_FUNCTIONS esp_log_write)
-    target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=${WRAP_FUNCTIONS}")
+    set(WRAP_FUNCTIONS esp_log_write esp_log_writev)
+    foreach(func ${WRAP_FUNCTIONS})
+        target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=${func}")
+    endforeach()
 endif()
 
 # Build Matter OTA image

--- a/examples/platform/esp32/PigweedLogger.cpp
+++ b/examples/platform/esp32/PigweedLogger.cpp
@@ -94,11 +94,11 @@ static const char * getLogColorForLevel(esp_log_level_t level)
         return LOG_COLOR_E "E";
 
     case ESP_LOG_INFO:
-        return LOG_COLOR_E "I";
+        return LOG_COLOR_I "I";
 
     default:
         // default is kept as ESP_LOG_DEBUG
-        return LOG_COLOR_E "D";
+        return LOG_COLOR_D "D";
     }
 }
 

--- a/examples/platform/esp32/PigweedLogger.cpp
+++ b/examples/platform/esp32/PigweedLogger.cpp
@@ -102,6 +102,12 @@ static const char * getLogColorForLevel(esp_log_level_t level)
     }
 }
 
+// ESP_LOGx(...) logs are funneled to esp_log_write() and it has the specific format. It contains color codes,
+// log level character, timestamp, tag, and actual log message. Everything here is part of format and variadic argument.
+//
+// ChipLogx(...) logs are funneled to esp_log_writev() will only have actual log message without color codes, log level
+// character, timestamp, and tag. So, to match up __wrap_esp_log_writev() adds those details when sending log to pigweed
+// logger.
 extern "C" void __wrap_esp_log_write(esp_log_level_t level, const char * tag, const char * format, ...)
 {
     va_list v;

--- a/examples/platform/esp32/PigweedLogger.cpp
+++ b/examples/platform/esp32/PigweedLogger.cpp
@@ -86,6 +86,22 @@ SemaphoreHandle_t * getSemaphore()
     return &esp_log_mutex;
 }
 
+static const char * getLogColorForLevel(esp_log_level_t level)
+{
+    switch (level)
+    {
+    case ESP_LOG_ERROR:
+        return LOG_COLOR_E "E";
+
+    case ESP_LOG_INFO:
+        return LOG_COLOR_E "I";
+
+    default:
+        // default is kept as ESP_LOG_DEBUG
+        return LOG_COLOR_E "D";
+    }
+}
+
 extern "C" void __wrap_esp_log_write(esp_log_level_t level, const char * tag, const char * format, ...)
 {
     va_list v;
@@ -105,6 +121,32 @@ extern "C" void __wrap_esp_log_write(esp_log_level_t level, const char * tag, co
 #endif
 
     va_end(v);
+}
+
+extern "C" void __wrap_esp_log_writev(esp_log_level_t level, const char * tag, const char * format, va_list v)
+{
+#ifndef CONFIG_LOG_DEFAULT_LEVEL_NONE
+    if (uartInitialised && level <= CONFIG_LOG_MAXIMUM_LEVEL)
+    {
+        const char * logColor = getLogColorForLevel(level);
+        PigweedLogger::putString(logColor, strlen(logColor));
+
+        char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
+        size_t len = snprintf(formattedMsg, sizeof formattedMsg, " (%u) %s: ", esp_log_timestamp(), tag);
+        PigweedLogger::putString(formattedMsg, len);
+
+        memset(formattedMsg, 0, sizeof formattedMsg);
+        len = vsnprintf(formattedMsg, sizeof formattedMsg, format, v);
+        if (len >= sizeof formattedMsg)
+        {
+            len = sizeof formattedMsg - 1;
+        }
+        PigweedLogger::putString(formattedMsg, len);
+
+        const char * logResetColor = LOG_RESET_COLOR "\n";
+        PigweedLogger::putString(logResetColor, strlen(logResetColor));
+    }
+#endif
 }
 
 } // namespace PigweedLogger

--- a/src/platform/ESP32/Logging.cpp
+++ b/src/platform/ESP32/Logging.cpp
@@ -26,21 +26,38 @@ void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char
     snprintf(tag, sizeof(tag), "chip[%s]", module);
     tag[sizeof(tag) - 1] = 0;
 
-    char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
-    vsnprintf(formattedMsg, sizeof(formattedMsg), msg, v);
-
     switch (category)
     {
-    case kLogCategory_Error:
-        ESP_LOGE(tag, "%s", formattedMsg);
-        break;
+    case kLogCategory_Error: {
+        if (esp_log_default_level >= ESP_LOG_ERROR)
+        {
+            printf(LOG_COLOR_E "E (%u) %s: ", esp_log_timestamp(), tag);
+            esp_log_writev(ESP_LOG_ERROR, tag, msg, v);
+            printf(LOG_RESET_COLOR "\n");
+        }
+    }
+    break;
+
     case kLogCategory_Progress:
-    default:
-        ESP_LOGI(tag, "%s", formattedMsg);
-        break;
-    case kLogCategory_Detail:
-        ESP_LOGD(tag, "%s", formattedMsg);
-        break;
+    default: {
+        if (esp_log_default_level >= ESP_LOG_INFO)
+        {
+            printf(LOG_COLOR_I "I (%u) %s: ", esp_log_timestamp(), tag);
+            esp_log_writev(ESP_LOG_INFO, tag, msg, v);
+            printf(LOG_RESET_COLOR "\n");
+        }
+    }
+    break;
+
+    case kLogCategory_Detail: {
+        if (esp_log_default_level >= ESP_LOG_DEBUG)
+        {
+            printf(LOG_COLOR_D "D (%u) %s: ", esp_log_timestamp(), tag);
+            esp_log_writev(ESP_LOG_DEBUG, tag, msg, v);
+            printf(LOG_RESET_COLOR "\n");
+        }
+    }
+    break;
     }
 }
 

--- a/src/platform/ESP32/Logging.cpp
+++ b/src/platform/ESP32/Logging.cpp
@@ -29,7 +29,6 @@ void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char
     switch (category)
     {
     case kLogCategory_Error: {
-        if (esp_log_default_level >= ESP_LOG_ERROR)
         {
             printf(LOG_COLOR_E "E (%u) %s: ", esp_log_timestamp(), tag);
             esp_log_writev(ESP_LOG_ERROR, tag, msg, v);
@@ -40,7 +39,6 @@ void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char
 
     case kLogCategory_Progress:
     default: {
-        if (esp_log_default_level >= ESP_LOG_INFO)
         {
             printf(LOG_COLOR_I "I (%u) %s: ", esp_log_timestamp(), tag);
             esp_log_writev(ESP_LOG_INFO, tag, msg, v);
@@ -50,7 +48,6 @@ void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char
     break;
 
     case kLogCategory_Detail: {
-        if (esp_log_default_level >= ESP_LOG_DEBUG)
         {
             printf(LOG_COLOR_D "D (%u) %s: ", esp_log_timestamp(), tag);
             esp_log_writev(ESP_LOG_DEBUG, tag, msg, v);


### PR DESCRIPTION
Basically this un-reverts the #26282 with additional changes to fixed the rpc logging problem introduced in #26227.

#### Change Overview
- Earlier a buffer was used to create a log, we won't need that buffer, so getting rid of that buffer.
#26227 tried doing the same thing, but introduced the bug in rpc logging and that PR was reverted with minor changes in #26282.
- Took the changes from #26227 and fixed the RPC logging bug.
- Fix the ESP32 to Chip log level mapping.

#### Tests
- RPC
    - Compiled using ./scripts/build/build_examples.py --target esp32-m5stack-all-clusters-rpc build.
    - Flashed onto ESP32 devkit using ./out/esp32-m5stack-all-clusters-rpc/chip-all-clusters-app.flash.py
    - Attached to pigweed rpc console python3 -m chip_rpc.console --device /dev/cu.usbserial-14340
    - Confirmed that chip and other logs can be seen on rpc console.
    - Tried commissioning using chip-tool
- non-RPC
    - Compiled all-clusters-app/esp32, flashed on ESP32, commissioned the device and verified all `CHIP[..]` and other logs were seen.
- For log level mapping
    - Validated the `build/esp-idf/chip/args.gn`, before change all log levels were set to true in here. After the change, correct values are being set.