### PR TITLE
[EFR32]Add MGM240P board support

### DIFF
--- a/examples/lighting-app/silabs/efr32/README.md
+++ b/examples/lighting-app/silabs/efr32/README.md
@@ -96,6 +96,7 @@ Silicon Labs platform.
     -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
     -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
     -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   MGM240P                / Wireless Starter Kit / 2.4GHz@20dBm
 
 *   Build the example application:
 

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -64,6 +64,7 @@ assert(silabs_board != "", "silabs_board must be specified")
 # - BRD4180A / SLWSTK6006A / MG21 Module / 2.4GHz@20dBm
 # - BRD4186A / SLWSTK6006A  / MG24 / Wireless Starter Kit / 2.4GHz@10dBm
 # - BRD4187A / SLWSTK6006A  / MG24 / Wireless Starter Kit / 2.4GHz@20dBm
+# - MGM240P                 / MG24 / SparkFun MGM240P Thing Plus Matter / 2.4GHz@20dBm
 
 board_defines = []
 
@@ -157,6 +158,14 @@ if (silabs_board == "BRD4304A") {
   silabs_family = "mgm24"
   silabs_mcu = "MGM240PB32VNA"
 
+  # MGM240L do not have an external flash or LCD
+  use_external_flash = false
+  show_qr_code = false
+  disable_lcd = true
+} else if (silabs_board == "MGM240P") {
+  silabs_family = "mgm24"
+  silabs_mcu = "MGM240PB32VNA"
+  
   # Explorer Kits do not have an external flash, buttons nor a LCD
   use_wstk_buttons = false
   use_external_flash = false
@@ -172,7 +181,7 @@ if (silabs_board == "BRD4304A") {
   disable_lcd = true
 } else {
   print(
-      "Please provide a valid value for SILABS_BOARD env variable (currently supported BRD4304A, BRD4161A, BRD4163A, BRD4164A BRD4166A, BRD4170A, BRD4186C, BRD4187C, BRD2601B, BRD2703A, BRD4317A, BRD2704A)")
+      "Please provide a valid value for SILABS_BOARD env variable (currently supported BRD4304A, BRD4161A, BRD4163A, BRD4164A BRD4166A, BRD4170A, BRD4186C, BRD4187C, BRD2601B, BRD2703A, BRD4317A, BRD2704A? MGM240P)")
   assert(false, "The board ${silabs_board} is unsupported")
 }
 

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -158,7 +158,7 @@ if (silabs_board == "BRD4304A") {
   silabs_family = "mgm24"
   silabs_mcu = "MGM240PB32VNA"
 
-  # MGM240L do not have an external flash or LCD
+  # MGM240P do not have an external flash or LCD
   use_external_flash = false
   show_qr_code = false
   disable_lcd = true

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -181,7 +181,7 @@ if (silabs_board == "BRD4304A") {
   disable_lcd = true
 } else {
   print(
-      "Please provide a valid value for SILABS_BOARD env variable (currently supported BRD4304A, BRD4161A, BRD4163A, BRD4164A BRD4166A, BRD4170A, BRD4186C, BRD4187C, BRD2601B, BRD2703A, BRD4317A, BRD2704A? MGM240P)")
+      "Please provide a valid value for SILABS_BOARD env variable (currently supported BRD4304A, BRD4161A, BRD4163A, BRD4164A BRD4166A, BRD4170A, BRD4186C, BRD4187C, BRD2601B, BRD2703A, BRD4317A, BRD2704A, MGM240P)")
   assert(false, "The board ${silabs_board} is unsupported")
 }
 


### PR DESCRIPTION
Trying to add support for MGM240P board based on the Series 2 EFR32MG24 SoC.
Fixes #26350

_The MGM240P wireless module is built around the EFR32MG24 Wireless SoC with a 32-bit ARM Cortext-M33 core processor running at 39 MHz with 1536 kb Flash memory and 256 kb RAM. The MGM240P works with common 802.15.4 wireless protocols (Matter®, Zigbee®, and OpenThread®) as well as Bluetooth® Low Energy 5.3. The MGM240P supports Silicon Labs' [Secure Vault™](https://www.silabs.com/security/secure-vault) for Thread applications._

@jmartinez-silabs Does this look correct?