### PR TITLE
Make sure DnssdServer does not dereference a dangling fabric table.

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -345,6 +345,9 @@ void DnssdServer::StartServer()
 
 void DnssdServer::StopServer()
 {
+    // Make sure we don't hold on to a dangling fabric table pointer.
+    mFabricTable = nullptr;
+
     DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventWrapper, 0);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY

--- a/src/app/server/Dnssd.h
+++ b/src/app/server/Dnssd.h
@@ -60,8 +60,9 @@ public:
     Inet::InterfaceId GetInterfaceId() { return mInterfaceId; }
 
     //
-    // Override the referenced fabric table from the default that is present
-    // in Server::GetInstance().GetFabricTable() to something else.
+    // Set the fabric table the DnssdServer should use for operational
+    // advertising.  This must be set before StartServer() is called for the
+    // first time.
     //
     void SetFabricTable(FabricTable * table)
     {
@@ -94,7 +95,8 @@ public:
     /// (Re-)starts the Dnssd server, using the provided commissioning mode.
     void StartServer(Dnssd::CommissioningMode mode);
 
-    //// Stop the Dnssd server.
+    //// Stop the Dnssd server.  After this call, SetFabricTable must be called
+    //// again before calling StartServer().
     void StopServer();
 
     CHIP_ERROR GenerateRotatingDeviceId(char rotatingDeviceIdHexBuffer[], size_t rotatingDeviceIdHexBufferSize);

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -185,7 +185,11 @@ public:
     CASESessionManager * CASESessionMgr() const { return mCASESessionManager; }
     Credentials::GroupDataProvider * GetGroupDataProvider() const { return mGroupDataProvider; }
     Crypto::SessionKeystore * GetSessionKeystore() const { return mSessionKeystore; }
-    void SetTempFabricTable(FabricTable * tempFabricTable) { mTempFabricTable = tempFabricTable; }
+    void SetTempFabricTable(FabricTable * tempFabricTable, bool enableServerInteractions)
+    {
+        mTempFabricTable          = tempFabricTable;
+        mEnableServerInteractions = enableServerInteractions;
+    }
 
 private:
     DeviceControllerSystemState() {}
@@ -219,6 +223,8 @@ private:
     std::atomic<uint32_t> mRefCount{ 0 };
 
     bool mHaveShutDown = false;
+
+    bool mEnableServerInteractions = false;
 
     void Shutdown();
 };


### PR DESCRIPTION
We could end up not calling StopServer if the last release of a system state was a direct release on the state itself, not a call to ReleaseSystemState.

To fix this, move the DnssdServer::StopServer bits into the actual system state shutdown, where we know whether we are destroying the fabric table that DnssdServer uses and can clean up appropriately.


