### PR TITLE
Fix for missing MG24/MGM24 boards in silabs lighting-app EFR32 README

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -1239,6 +1239,7 @@ softwareVersionStr
 SoftwareVersionString
 softwareVersionValid
 sphinxcontrib
+SparkFun
 SPI
 spiflash
 spinel

--- a/examples/lighting-app/silabs/efr32/README.md
+++ b/examples/lighting-app/silabs/efr32/README.md
@@ -96,6 +96,8 @@ Silicon Labs platform.
     -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
     -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
     -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD2703A / MG24 Explorer Kit
+    -   BRD2704A / Sparkfun Thing Plus MGM240P board
 
 *   Build the example application:
 

--- a/examples/lighting-app/silabs/efr32/README.md
+++ b/examples/lighting-app/silabs/efr32/README.md
@@ -97,7 +97,7 @@ Silicon Labs platform.
     -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
     -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
     -   BRD2703A / MG24 Explorer Kit
-    -   BRD2704A / Sparkfun Thing Plus MGM240P board
+    -   BRD2704A / SparkFun Thing Plus MGM240P board
 
 *   Build the example application:
 


### PR DESCRIPTION
Fix for missing MG24/MGM24 boards in silabs lighting-app EFR32 README:
- BRD2703A / MG24 Explorer Kit
- BRD2704A / Sparkfun Thing Plus MGM240P board