### PR TITLE
Add element accessors on Span.

### DIFF
--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -38,7 +38,8 @@ template <class T>
 class Span
 {
 public:
-    using pointer = T *;
+    using pointer   = T *;
+    using reference = T &;
 
     constexpr Span() : mDataBuf(nullptr), mDataLen(0) {}
     constexpr Span(pointer databuf, size_t datalen) : mDataBuf(databuf), mDataLen(datalen) {}
@@ -74,6 +75,15 @@ public:
     constexpr bool empty() const { return size() == 0; }
     constexpr pointer begin() const { return data(); }
     constexpr pointer end() const { return data() + size(); }
+
+    // Element accessors, matching the std::span API.
+    constexpr reference operator[](size_t index) const
+    {
+        VerifyOrDie(index < size());
+        return data()[index];
+    }
+    constexpr reference front() const { return (*this)[0]; }
+    constexpr reference back() const { return (*this)[size() - 1]; }
 
     template <class U, typename = std::enable_if_t<std::is_same<std::remove_const_t<T>, std::remove_const_t<U>>::value>>
     bool data_equal(const Span<U> & other) const
@@ -142,7 +152,8 @@ template <class T, size_t N>
 class FixedSpan
 {
 public:
-    using pointer = T *;
+    using pointer   = T *;
+    using reference = T &;
 
     constexpr FixedSpan() : mDataBuf(nullptr) {}
 
@@ -187,6 +198,15 @@ public:
     constexpr bool empty() const { return data() == nullptr; }
     constexpr pointer begin() const { return mDataBuf; }
     constexpr pointer end() const { return mDataBuf + N; }
+
+    // Element accessors, matching the std::span API.
+    constexpr reference operator[](size_t index) const
+    {
+        VerifyOrDie(index < size());
+        return data()[index];
+    }
+    constexpr reference front() const { return (*this)[0]; }
+    constexpr reference back() const { return (*this)[size() - 1]; }
 
     // Allow data_equal for spans that are over the same type up to const-ness.
     template <class U, typename = std::enable_if_t<std::is_same<std::remove_const_t<T>, std::remove_const_t<U>>::value>>

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -77,13 +77,16 @@ public:
     constexpr pointer end() const { return data() + size(); }
 
     // Element accessors, matching the std::span API.
-    constexpr reference operator[](size_t index) const
+    // VerifyOrDie cannot be used inside a constexpr function, because it uses
+    // "static" on some platforms (e.g. when CHIP_PW_TOKENIZER_LOGGING is true)
+    // and that's not allowed in constexpr functions.
+    reference operator[](size_t index) const
     {
         VerifyOrDie(index < size());
         return data()[index];
     }
-    constexpr reference front() const { return (*this)[0]; }
-    constexpr reference back() const { return (*this)[size() - 1]; }
+    reference front() const { return (*this)[0]; }
+    reference back() const { return (*this)[size() - 1]; }
 
     template <class U, typename = std::enable_if_t<std::is_same<std::remove_const_t<T>, std::remove_const_t<U>>::value>>
     bool data_equal(const Span<U> & other) const
@@ -200,13 +203,16 @@ public:
     constexpr pointer end() const { return mDataBuf + N; }
 
     // Element accessors, matching the std::span API.
-    constexpr reference operator[](size_t index) const
+    // VerifyOrDie cannot be used inside a constexpr function, because it uses
+    // "static" on some platforms (e.g. when CHIP_PW_TOKENIZER_LOGGING is true)
+    // and that's not allowed in constexpr functions.
+    reference operator[](size_t index) const
     {
         VerifyOrDie(index < size());
         return data()[index];
     }
-    constexpr reference front() const { return (*this)[0]; }
-    constexpr reference back() const { return (*this)[size() - 1]; }
+    reference front() const { return (*this)[0]; }
+    reference back() const { return (*this)[size() - 1]; }
 
     // Allow data_equal for spans that are over the same type up to const-ness.
     template <class U, typename = std::enable_if_t<std::is_same<std::remove_const_t<T>, std::remove_const_t<U>>::value>>

--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -62,25 +62,6 @@ static void TestByteSpan(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, s2[1] == 2);
     NL_TEST_ASSERT(inSuite, s2[2] == 3);
 
-    // Test that for a constexpr span we can use its data as compile-time
-    // constants.
-    {
-        static constexpr uint8_t constArr[] = { 2, 3, 4 };
-        constexpr ByteSpan constSpan(constArr);
-
-        static_assert(constSpan.front() == 2, "Unexpected front()");
-        uint8_t t1[constSpan.front()];
-        NL_TEST_ASSERT(inSuite, ArraySize(t1) == 2);
-
-        static_assert(constSpan.back() == 4, "Unexpected back()");
-        uint8_t t2[constSpan.back()];
-        NL_TEST_ASSERT(inSuite, ArraySize(t2) == 4);
-
-        static_assert(constSpan[1] == 3, "Unexpected [1]");
-        uint8_t t3[constSpan[1]];
-        NL_TEST_ASSERT(inSuite, ArraySize(t3) == 3);
-    }
-
     ByteSpan s3 = s2;
     NL_TEST_ASSERT(inSuite, s3.data() == arr);
     NL_TEST_ASSERT(inSuite, s3.size() == 3);
@@ -204,25 +185,6 @@ static void TestFixedByteSpan(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, s2[0] == 1);
     NL_TEST_ASSERT(inSuite, s2[1] == 2);
     NL_TEST_ASSERT(inSuite, s2[2] == 3);
-
-    // Test that for a constexpr span we can use its data as compile-time
-    // constants.
-    {
-        static constexpr uint8_t constArr[] = { 2, 3, 4 };
-        constexpr FixedByteSpan<ArraySize(constArr)> constSpan(constArr);
-
-        static_assert(constSpan.front() == 2, "Unexpected front()");
-        uint8_t t1[constSpan.front()];
-        NL_TEST_ASSERT(inSuite, ArraySize(t1) == 2);
-
-        static_assert(constSpan.back() == 4, "Unexpected back()");
-        uint8_t t2[constSpan.back()];
-        NL_TEST_ASSERT(inSuite, ArraySize(t2) == 4);
-
-        static_assert(constSpan[1] == 3, "Unexpected [1]");
-        uint8_t t3[constSpan[1]];
-        NL_TEST_ASSERT(inSuite, ArraySize(t3) == 3);
-    }
 
     FixedByteSpan<3> s3 = s2;
     NL_TEST_ASSERT(inSuite, s3.data() == arr);

--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -56,6 +56,30 @@ static void TestByteSpan(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, s2.data_equal(s2));
     NL_TEST_ASSERT(inSuite, !s2.data_equal(s1));
     NL_TEST_ASSERT(inSuite, IsSpanUsable(s2) == true);
+    NL_TEST_ASSERT(inSuite, s2.front() == 1);
+    NL_TEST_ASSERT(inSuite, s2.back() == 3);
+    NL_TEST_ASSERT(inSuite, s2[0] == 1);
+    NL_TEST_ASSERT(inSuite, s2[1] == 2);
+    NL_TEST_ASSERT(inSuite, s2[2] == 3);
+
+    // Test that for a constexpr span we can use its data as compile-time
+    // constants.
+    {
+        static constexpr uint8_t constArr[] = { 2, 3, 4 };
+        constexpr ByteSpan constSpan(constArr);
+
+        static_assert(constSpan.front() == 2, "Unexpected front()");
+        uint8_t t1[constSpan.front()];
+        NL_TEST_ASSERT(inSuite, ArraySize(t1) == 2);
+
+        static_assert(constSpan.back() == 4, "Unexpected back()");
+        uint8_t t2[constSpan.back()];
+        NL_TEST_ASSERT(inSuite, ArraySize(t2) == 4);
+
+        static_assert(constSpan[1] == 3, "Unexpected [1]");
+        uint8_t t3[constSpan[1]];
+        NL_TEST_ASSERT(inSuite, ArraySize(t3) == 3);
+    }
 
     ByteSpan s3 = s2;
     NL_TEST_ASSERT(inSuite, s3.data() == arr);
@@ -175,6 +199,30 @@ static void TestFixedByteSpan(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, s2.data()[2] == 3);
     NL_TEST_ASSERT(inSuite, !s2.empty());
     NL_TEST_ASSERT(inSuite, s2.data_equal(s2));
+    NL_TEST_ASSERT(inSuite, s2.front() == 1);
+    NL_TEST_ASSERT(inSuite, s2.back() == 3);
+    NL_TEST_ASSERT(inSuite, s2[0] == 1);
+    NL_TEST_ASSERT(inSuite, s2[1] == 2);
+    NL_TEST_ASSERT(inSuite, s2[2] == 3);
+
+    // Test that for a constexpr span we can use its data as compile-time
+    // constants.
+    {
+        static constexpr uint8_t constArr[] = { 2, 3, 4 };
+        constexpr FixedByteSpan<ArraySize(constArr)> constSpan(constArr);
+
+        static_assert(constSpan.front() == 2, "Unexpected front()");
+        uint8_t t1[constSpan.front()];
+        NL_TEST_ASSERT(inSuite, ArraySize(t1) == 2);
+
+        static_assert(constSpan.back() == 4, "Unexpected back()");
+        uint8_t t2[constSpan.back()];
+        NL_TEST_ASSERT(inSuite, ArraySize(t2) == 4);
+
+        static_assert(constSpan[1] == 3, "Unexpected [1]");
+        uint8_t t3[constSpan[1]];
+        NL_TEST_ASSERT(inSuite, ArraySize(t3) == 3);
+    }
 
     FixedByteSpan<3> s3 = s2;
     NL_TEST_ASSERT(inSuite, s3.data() == arr);


### PR DESCRIPTION
This matches std::span and avoids people having to write span.data()[index] and whatnot.

