### PR TITLE
Ignore root cert expiration in Server.

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -128,7 +128,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     mOperationalKeystore           = initParams.operationalKeystore;
     mOpCertStore                   = initParams.opCertStore;
 
-    mCertificateValidityPolicy = initParams.certificateValidityPolicy;
+    mCertificateValidityPolicy.Init(initParams.certificateValidityPolicy);
 
 #if defined(CHIP_SUPPORT_ENABLE_STORAGE_API_AUDIT)
     VerifyOrDie(chip::audit::ExecutePersistentStorageApiAudit(*mDeviceStorage));
@@ -286,7 +286,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
         .sessionInitParams =  {
             .sessionManager    = &mSessions,
             .sessionResumptionStorage = mSessionResumptionStorage,
-            .certificateValidityPolicy = mCertificateValidityPolicy,
+            .certificateValidityPolicy = &mCertificateValidityPolicy,
             .exchangeMgr       = &mExchangeMgr,
             .fabricTable       = &mFabrics,
             .groupDataProvider = mGroupsProvider,
@@ -300,7 +300,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     SuccessOrExit(err);
 
     err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr, &mSessions, &mFabrics, mSessionResumptionStorage,
-                                                    mCertificateValidityPolicy, mGroupsProvider);
+                                                    &mCertificateValidityPolicy, mGroupsProvider);
     SuccessOrExit(err);
 
     err = chip::app::InteractionModelEngine::GetInstance()->Init(&mExchangeMgr, &GetFabricTable(), &mCASESessionManager,

--- a/src/credentials/CertificateValidityPolicy.h
+++ b/src/credentials/CertificateValidityPolicy.h
@@ -52,6 +52,12 @@ public:
      */
     virtual CHIP_ERROR ApplyCertificateValidityPolicy(const ChipCertificateData * cert, uint8_t depth,
                                                       CertificateValidityResult result) = 0;
+
+    /**
+     * Default policy that will be used if no other policy is defined.  This is
+     * exposed to allow other policies to explicitly delegate to it as needed.
+     */
+    static CHIP_ERROR ApplyDefaultPolicy(const ChipCertificateData * cert, uint8_t depth, CertificateValidityResult result);
 };
 
 } // namespace Credentials


### PR DESCRIPTION
Since there is no real way to rotate the root cert for a fabric, even just to update its validity period, enforcing the validity period for it just means making the fabric not work and runs the risk of making devices completely unreachable.

Switch to not validating expiration time for a root certificate, while keeping existing behavior for the NotBefore and all other certificate types.
