### PR TITLE
Replace coloredlogs usage in matter_idl with just basicConfig.

### DIFF
--- a/scripts/py_matter_idl/matter_idl/lint/lint_rules_parser.py
+++ b/scripts/py_matter_idl/matter_idl/lint/lint_rules_parser.py
@@ -285,7 +285,6 @@ if __name__ == '__main__':
     # This Parser is generally not intended to be run as a stand-alone binary.
     # The ability to run is for debug and to print out the parsed AST.
     import click
-    import coloredlogs
 
     # Supported log levels, mapping string values required for argument
     # parsing into logging constants
@@ -304,8 +303,10 @@ if __name__ == '__main__':
         help='Determines the verbosity of script output.')
     @click.argument('filename')
     def main(log_level, filename=None):
-        coloredlogs.install(level=__LOG_LEVELS__[
-                            log_level], fmt='%(asctime)s %(levelname)-7s %(message)s')
+        logging.basicConfig(
+            level=__LOG_LEVELS__[log_level],
+            format='%(asctime)s %(levelname)-7s %(message)s',
+        )
 
         logging.info("Starting to parse ...")
         data = CreateParser(filename).parse()

--- a/scripts/py_matter_idl/matter_idl/matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter_idl/matter_idl_parser.py
@@ -540,7 +540,6 @@ if __name__ == '__main__':
     import pprint
 
     import click
-    import coloredlogs
 
     # Supported log levels, mapping string values required for argument
     # parsing into logging constants
@@ -559,8 +558,10 @@ if __name__ == '__main__':
         help='Determines the verbosity of script output.')
     @click.argument('filename')
     def main(log_level, filename=None):
-        coloredlogs.install(level=__LOG_LEVELS__[
-                            log_level], fmt='%(asctime)s %(levelname)-7s %(message)s')
+        logging.basicConfig(
+            level=__LOG_LEVELS__[log_level],
+            format='%(asctime)s %(levelname)-7s %(message)s',
+        )
 
         logging.info("Starting to parse ...")
         data = CreateParser().parse(open(filename).read(), file_name=filename)

--- a/scripts/py_matter_idl/matter_idl/xml_parser.py
+++ b/scripts/py_matter_idl/matter_idl/xml_parser.py
@@ -33,7 +33,6 @@ if __name__ == '__main__':
     import pprint
 
     import click
-    import coloredlogs
 
     # Supported log levels, mapping string values required for argument
     # parsing into logging constants
@@ -59,8 +58,10 @@ if __name__ == '__main__':
         help='Do not pring output data (parsed data)')
     @ click.argument('filenames', nargs=-1)
     def main(log_level, no_print, filenames):
-        coloredlogs.install(level=__LOG_LEVELS__[
-                            log_level], fmt='%(asctime)s %(levelname)-7s %(message)s')
+        logging.basicConfig(
+            level=__LOG_LEVELS__[log_level],
+            format='%(asctime)s %(levelname)-7s %(message)s',
+        )
 
         logging.info("Starting to parse ...")
 


### PR DESCRIPTION
This makes the dependencies of matter_idl even smaller, generally only lark and click.
