### PR TITLE
[Ameba] fix wrong wifi_station_state

### DIFF
--- a/src/platform/Ameba/AmebaUtils.cpp
+++ b/src/platform/Ameba/AmebaUtils.cpp
@@ -133,6 +133,11 @@ CHIP_ERROR AmebaUtils::WiFiDisconnect(void)
     CHIP_ERROR err = CHIP_NO_ERROR;
     ChipLogProgress(DeviceLayer, "matter_wifi_disconnect");
     err = (matter_wifi_disconnect() == RTW_SUCCESS) ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
+    if (err == CHIP_NO_ERROR)
+    {
+        ChipLogProgress(DeviceLayer, "matter_lwip_releaseip");
+        matter_lwip_releaseip();
+    }
     return err;
 }
 

--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -524,7 +524,7 @@ void ConnectivityManagerImpl::DriveStationState()
         {
             WiFiStationState prevState = mWiFiStationState;
             ChangeWiFiStationState(kWiFiStationState_NotConnected);
-            if (prevState != kWiFiStationState_Connecting_Failed)
+            if (prevState == kWiFiStationState_Connecting_Failed)
             {
                 ChipLogProgress(DeviceLayer, "WiFi station failed to connect");
                 // TODO: check retry count if exceeded, then clearwificonfig
@@ -858,13 +858,13 @@ void ConnectivityManagerImpl::RtkWiFiScanCompletedHandler(void)
 
 void ConnectivityManagerImpl::DHCPProcessThread(void * param)
 {
-    matter_lwip_dhcp(0, DHCP_START);
+    matter_lwip_dhcp();
     PlatformMgr().LockChipStack();
     sInstance.OnStationIPv4AddressAvailable();
     PlatformMgr().UnlockChipStack();
 #if LWIP_VERSION_MAJOR > 2 || LWIP_VERSION_MINOR > 0
 #if LWIP_IPV6
-    matter_lwip_dhcp(0, DHCP6_START);
+    matter_lwip_dhcp6();
     PlatformMgr().LockChipStack();
     sInstance.OnIPv6AddressAvailable();
     PlatformMgr().UnlockChipStack();

--- a/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
@@ -127,10 +127,13 @@ Status AmebaWiFiDriver::ReorderNetwork(ByteSpan networkId, uint8_t index, Mutabl
 CHIP_ERROR AmebaWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, const char * key, uint8_t keyLen)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    bool connected;
+
     // If device is already connected to WiFi, then disconnect the WiFi,
-    // clear the WiFi configurations and add the newly provided WiFi configurations.
-    if (chip::DeviceLayer::Internal::AmebaUtils::IsStationProvisioned())
+    chip::DeviceLayer::Internal::AmebaUtils::IsStationConnected(connected);
+    if (connected)
     {
+        ConnectivityMgrImpl().ChangeWiFiStationState(ConnectivityManager::kWiFiStationState_Disconnecting);
         ChipLogProgress(DeviceLayer, "Disconnecting WiFi station interface");
         err = chip::DeviceLayer::Internal::AmebaUtils::WiFiDisconnect();
         if (err != CHIP_NO_ERROR)
@@ -138,6 +141,11 @@ CHIP_ERROR AmebaWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLe
             ChipLogError(DeviceLayer, "WiFiDisconnect() failed");
             return err;
         }
+    }
+
+    // clear the WiFi configurations and add the newly provided WiFi configurations.
+    if (chip::DeviceLayer::Internal::AmebaUtils::IsStationProvisioned())
+    {
         err = chip::DeviceLayer::Internal::AmebaUtils::ClearWiFiConfig();
         if (err != CHIP_NO_ERROR)
         {
@@ -146,9 +154,12 @@ CHIP_ERROR AmebaWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLe
         }
     }
 
-    ConnectivityMgrImpl().ChangeWiFiStationState(ConnectivityManager::kWiFiStationState_Connecting);
+    DeviceLayer::ConnectivityManager::WiFiStationState state = DeviceLayer::ConnectivityManager::kWiFiStationState_Connecting;
+    DeviceLayer::SystemLayer().ScheduleLambda([state, ssid, key]() {
+        ConnectivityMgrImpl().ChangeWiFiStationState(state);
+        chip::DeviceLayer::Internal::AmebaUtils::WiFiConnect(ssid, key);
+    });
 
-    err = chip::DeviceLayer::Internal::AmebaUtils::WiFiConnect(ssid, key);
     return err;
 }
 


### PR DESCRIPTION
- after disconnecting and reconnecting to new wifi, wifi_station_state is wrong
- due wrong order of state changes
- use schedulelambda to queue the ChangeWiFiStationState
- split dhcp into ipv4 and ipv6
- release ip after disconnection

