### PR TITLE
Improve session-management commands in chip-tool.

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -70,8 +70,6 @@ static_library("chip-tool-utils") {
     "commands/discover/DiscoverCommand.cpp",
     "commands/discover/DiscoverCommissionablesCommand.cpp",
     "commands/discover/DiscoverCommissionersCommand.cpp",
-    "commands/pairing/CloseSessionCommand.cpp",
-    "commands/pairing/CloseSessionCommand.h",
     "commands/pairing/OpenCommissioningWindowCommand.cpp",
     "commands/pairing/OpenCommissioningWindowCommand.h",
     "commands/pairing/PairingCommand.cpp",
@@ -80,6 +78,8 @@ static_library("chip-tool-utils") {
     "commands/payload/SetupPayloadGenerateCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",
     "commands/payload/SetupPayloadVerhoeff.cpp",
+    "commands/session-management/CloseSessionCommand.cpp",
+    "commands/session-management/CloseSessionCommand.h",
     "commands/storage/StorageManagementCommand.cpp",
   ]
 

--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "commands/common/Commands.h"
-#include "commands/pairing/CloseSessionCommand.h"
 #include "commands/pairing/GetCommissionerNodeIdCommand.h"
 #include "commands/pairing/GetCommissionerRootCertificateCommand.h"
 #include "commands/pairing/IssueNOCChainCommand.h"
@@ -241,7 +240,6 @@ void registerCommandsPairing(Commands & commands, CredentialIssuerCommands * cre
         //        make_unique<CommissionedListCommand>(),
         make_unique<StartUdcServerCommand>(credsIssuerConfig),
         make_unique<OpenCommissioningWindowCommand>(credsIssuerConfig),
-        make_unique<CloseSessionCommand>(credsIssuerConfig),
         make_unique<GetCommissionerNodeIdCommand>(credsIssuerConfig),
         make_unique<GetCommissionerRootCertificateCommand>(credsIssuerConfig),
         make_unique<IssueNOCChainCommand>(credsIssuerConfig),

--- a/examples/chip-tool/commands/session-management/CloseSessionCommand.h
+++ b/examples/chip-tool/commands/session-management/CloseSessionCommand.h
@@ -80,7 +80,7 @@ class EvictLocalCASESessionsCommand : public detail::SessionManagementCommand
 {
 public:
     EvictLocalCASESessionsCommand(CredentialIssuerCommands * credIssuerCommands) :
-        detail::SessionManagementCommand("expire-CASE-sessions", credIssuerCommands,
+        detail::SessionManagementCommand("expire-case-sessions", credIssuerCommands,
                                          "Expires (evicts) all local CASE sessions to the given node id.")
     {}
 

--- a/examples/chip-tool/commands/session-management/CloseSessionCommand.h
+++ b/examples/chip-tool/commands/session-management/CloseSessionCommand.h
@@ -23,16 +23,35 @@
 #include <lib/core/CHIPCallback.h>
 #include <lib/core/DataModelTypes.h>
 
-class CloseSessionCommand : public CHIPCommand
+namespace detail {
+
+class SessionManagementCommand : public CHIPCommand
 {
 public:
-    CloseSessionCommand(CredentialIssuerCommands * credIssuerCommands) :
-        CHIPCommand("close-session", credIssuerCommands, "Sends a CloseSession message to the given destination node id."),
+    SessionManagementCommand(const char * commandName, CredentialIssuerCommands * credIssuerCommands, const char * helpText) :
+        CHIPCommand(commandName, credIssuerCommands, helpText)
+    {
+        AddArgument("node-id", 0, UINT64_MAX, &mDestinationNodeId);
+    }
+
+protected:
+    chip::NodeId mDestinationNodeId;
+};
+
+} // namespace detail
+
+class SendCloseSessionCommand : public detail::SessionManagementCommand
+{
+public:
+    SendCloseSessionCommand(CredentialIssuerCommands * credIssuerCommands) :
+        detail::SessionManagementCommand("send-close-session", credIssuerCommands,
+                                         "Sends a CloseSession message to the given node id."),
         mOnDeviceConnectedCallback(OnDeviceConnectedFn, this), mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {
-        AddArgument("destination-id", 0, UINT64_MAX, &mDestinationId);
         AddArgument("timeout", 0, UINT64_MAX, &mTimeoutSecs,
                     "Time, in seconds, before this command is considered to have timed out.");
+        AddArgument("evict-local-session", 0, 1, &mEvictLocalSession,
+                    "If true, evicts the local session after sending the message. If false, leaves it around. Defaults to true.");
     }
 
     /////////// CHIPCommand Interface /////////
@@ -43,16 +62,33 @@ public:
     }
 
 private:
-    chip::NodeId mDestinationId;
     chip::Optional<uint16_t> mTimeoutSecs;
+    chip::Optional<bool> mEvictLocalSession;
 
     static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
                                     const chip::SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureFn(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error);
 
-    // Try to send the action CloseSession status report.
+    // Try to send the CloseSession status report.
     CHIP_ERROR CloseSession(chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle);
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
+};
+
+class EvictLocalCASESessionsCommand : public detail::SessionManagementCommand
+{
+public:
+    EvictLocalCASESessionsCommand(CredentialIssuerCommands * credIssuerCommands) :
+        detail::SessionManagementCommand("expire-CASE-sessions", credIssuerCommands,
+                                         "Expires (evicts) all local CASE sessions to the given node id.")
+    {}
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+    chip::System::Clock::Timeout GetWaitDuration() const override
+    {
+        // This command does all its work synchronously, so it really does not matter too much.
+        return chip::System::Clock::Seconds16(5);
+    }
 };

--- a/examples/chip-tool/commands/session-management/Commands.h
+++ b/examples/chip-tool/commands/session-management/Commands.h
@@ -1,0 +1,34 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "commands/common/Commands.h"
+#include "commands/session-management/CloseSessionCommand.h"
+
+void registerCommandsSessionManagement(Commands & commands, CredentialIssuerCommands * credsIssuerConfig)
+{
+    const char * clusterName = "SessionManagement";
+
+    commands_list clusterCommands = {
+        make_unique<SendCloseSessionCommand>(credsIssuerConfig),
+        make_unique<EvictLocalCASESessionsCommand>(credsIssuerConfig),
+    };
+
+    commands.Register(clusterName, clusterCommands, "Commands for managing CASE and PASE session state");
+}

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -26,6 +26,7 @@
 #include "commands/interactive/Commands.h"
 #include "commands/pairing/Commands.h"
 #include "commands/payload/Commands.h"
+#include "commands/session-management/Commands.h"
 #include "commands/storage/Commands.h"
 
 #include <zap-generated/cluster/Commands.h>
@@ -48,6 +49,7 @@ int main(int argc, char * argv[])
     registerClusters(commands, &credIssuerCommands);
     registerCommandsSubscriptions(commands, &credIssuerCommands);
     registerCommandsStorage(commands);
+    registerCommandsSessionManagement(commands, &credIssuerCommands);
 
     return commands.Run(argc, argv);
 }


### PR DESCRIPTION
* Move them into a separate "sessionmanagement" bit, to make them more discoverable.
* Add a command to expire the local CASE sessions for a given node id.
* Rename close-session to send-close-session.
* Add an option to control whether send-close-session also expires the local session (defaulting to true).
