### PR TITLE
Do not use getenv() in Tizen GN config

### DIFF
--- a/build/config/tizen/config.gni
+++ b/build/config/tizen/config.gni
@@ -14,8 +14,8 @@
 
 declare_args() {
   # Location of Tizen SDK
-  tizen_sdk_root = getenv("TIZEN_SDK_ROOT")
+  tizen_sdk_root = ""
 
   # Location of Tizen SDK sysroot
-  tizen_sdk_sysroot = getenv("TIZEN_SDK_SYSROOT")
+  tizen_sdk_sysroot = ""
 }

--- a/src/test_driver/tizen/README.md
+++ b/src/test_driver/tizen/README.md
@@ -47,7 +47,10 @@ argument of the `gn gen` command.
 # Generate test target
 gn gen --check --fail-on-unused-args \
     --root="$PWD/src/test_driver/tizen" \
-    --args="target_os=\"tizen\" target_cpu=\"arm\" chip_config_network_layer_ble=false" \
+    --args="target_os=\"tizen\" target_cpu=\"arm\" \
+        tizen_sdk_root=\"$TIZEN_SDK_ROOT\" \
+        tizen_sdk_sysroot=\"$TIZEN_SDK_SYSROOT\"
+        chip_config_network_layer_ble=false" \
     out/tizen-check
 # Run Tizen QEMU-based tests
 ninja -C out/tizen-check check


### PR DESCRIPTION
### Problem

Using `getenv()` is discouraged, because it will get the value from the environment of the build system only on first use. Any environment changes after that will not be reflected in the build.

### Testing

CI will verify.