### PR TITLE
Fix linux BLE deadlock

### DIFF
--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -132,7 +132,7 @@ extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, 
 
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-    err =scanner->StartScan(chip::System::Clock::Milliseconds32(timeoutMs));
+    err = scanner->StartScan(chip::System::Clock::Milliseconds32(timeoutMs));
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
     if (err != CHIP_NO_ERROR)
     {

--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -130,7 +130,11 @@ extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, 
         return nullptr;
     }
 
-    if (scanner->StartScan(chip::System::Clock::Milliseconds32(timeoutMs)) != CHIP_NO_ERROR)
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
+    err =scanner->StartScan(chip::System::Clock::Milliseconds32(timeoutMs));
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+    if (err != CHIP_NO_ERROR)
     {
         return nullptr;
     }

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -128,6 +128,7 @@ std::unique_ptr<ChipDeviceScanner> ChipDeviceScanner::Create(BluezAdapter1 * ada
 
 CHIP_ERROR ChipDeviceScanner::StartScan(System::Clock::Timeout timeout)
 {
+    assertChipStackLockedByCurrentThread();
     ReturnErrorCodeIf(mIsScanning, CHIP_ERROR_INCORRECT_STATE);
 
     mIsScanning = true; // optimistic, to allow all callbacks to check this

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -78,6 +78,10 @@ ChipDeviceScanner::~ChipDeviceScanner()
 {
     StopScan();
 
+    // The `#if CHIP_STACK_LOCK_TRACKING_ENABLED` code block below should be considered an anti-pattern,
+    // as such this should not be used in most cases, so do not use this as precedent.
+    //
+    // TODO, Provide a rational as to why we are doing this here
 #if CHIP_STACK_LOCK_TRACKING_ENABLED
     if (!DeviceLayer::PlatformMgr().IsChipStackLockedByCurrentThread())
         // In case the timeout timer is still active
@@ -145,14 +149,19 @@ CHIP_ERROR ChipDeviceScanner::StartScan(System::Clock::Timeout timeout)
         return CHIP_ERROR_INTERNAL;
     }
 
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    // The `#if CHIP_STACK_LOCK_TRACKING_ENABLED` code block below should be considered an anti-pattern,
+    // as such this should not be used in most cases, so do not use this as precedent.
+    //
+    // TODO, Provide a rational as to why we are doing this here
 #if CHIP_STACK_LOCK_TRACKING_ENABLED
     if (!DeviceLayer::PlatformMgr().IsChipStackLockedByCurrentThread())
         DeviceLayer::PlatformMgr().LockChipStack();
-        CHIP_ERROR err = chip::DeviceLayer::SystemLayer().StartTimer(timeout, TimerExpiredCallback, static_cast<void *>(this));
+        err = chip::DeviceLayer::SystemLayer().StartTimer(timeout, TimerExpiredCallback, static_cast<void *>(this));
         DeviceLayer::PlatformMgr().UnlockChipStack();
     }
 #else //CHIP_STACK_LOCK_TRACKING_ENABLED
-    CHIP_ERROR err = chip::DeviceLayer::SystemLayer().StartTimer(timeout, TimerExpiredCallback, static_cast<void *>(this));
+    err = chip::DeviceLayer::SystemLayer().StartTimer(timeout, TimerExpiredCallback, static_cast<void *>(this));
 #endif //CHIP_STACK_LOCK_TRACKING_ENABLED
 
     if (err != CHIP_NO_ERROR)

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -83,7 +83,7 @@ ChipDeviceScanner::~ChipDeviceScanner()
     //
     // TODO, Provide a rational as to why we are doing this here
 #if CHIP_STACK_LOCK_TRACKING_ENABLED
-    if (!DeviceLayer::PlatformMgr().IsChipStackLockedByCurrentThread())
+    if (!DeviceLayer::PlatformMgr().IsChipStackLockedByCurrentThread()) {
         // In case the timeout timer is still active
         DeviceLayer::PlatformMgr().LockChipStack();
         chip::DeviceLayer::SystemLayer().CancelTimer(TimerExpiredCallback, this);
@@ -155,7 +155,7 @@ CHIP_ERROR ChipDeviceScanner::StartScan(System::Clock::Timeout timeout)
     //
     // TODO, Provide a rational as to why we are doing this here
 #if CHIP_STACK_LOCK_TRACKING_ENABLED
-    if (!DeviceLayer::PlatformMgr().IsChipStackLockedByCurrentThread())
+    if (!DeviceLayer::PlatformMgr().IsChipStackLockedByCurrentThread()) {
         DeviceLayer::PlatformMgr().LockChipStack();
         err = chip::DeviceLayer::SystemLayer().StartTimer(timeout, TimerExpiredCallback, static_cast<void *>(this));
         DeviceLayer::PlatformMgr().UnlockChipStack();

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -71,6 +71,9 @@ public:
     /// Stop any currently running scan
     CHIP_ERROR StopScan();
 
+    /// Should only be called by TimerExpiredCallback.
+    void MarkTimerExpired() { mTimerExpired = true; }
+
     /// Create a new device scanner
     ///
     /// Convenience method to allocate any required variables.
@@ -101,6 +104,8 @@ private:
     gulong mInterfaceChangedSignal        = 0;
     bool mIsScanning                      = false;
     bool mIsStopping                      = false;
+    /// Used to track if timer has alread expired and doesn't need to be canceled.
+    bool mTimerExpired = false;
 };
 
 } // namespace Internal

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -66,6 +66,9 @@ public:
     ~ChipDeviceScanner();
 
     /// Initiate a scan for devices, with the given timeout
+    ///
+    /// This method must be called while in the Matter context (from the Matter event
+    /// loop, or while holding the Matter stack lock).
     CHIP_ERROR StartScan(System::Clock::Timeout timeout);
 
     /// Stop any currently running scan

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -71,9 +71,6 @@ public:
     /// Stop any currently running scan
     CHIP_ERROR StopScan();
 
-    /// Should only be called by TimerExpiredCallback.
-    void MarkTimerExpired() { mTimerExpired = true; }
-
     /// Create a new device scanner
     ///
     /// Convenience method to allocate any required variables.
@@ -104,8 +101,6 @@ private:
     gulong mInterfaceChangedSignal        = 0;
     bool mIsScanning                      = false;
     bool mIsStopping                      = false;
-    /// Used to track if timer has alread expired and doesn't need to be canceled.
-    bool mTimerExpired = false;
 };
 
 } // namespace Internal


### PR DESCRIPTION
Problem:
* After https://github.com/project-chip/connectedhomeip/pull/26180 calling `pychip_ble_start_scanning` resulted in assert while calling `StartTimer` while in `ChipDeviceScanner::StartScan`. This resulted in https://github.com/project-chip/connectedhomeip/pull/26338 PR being created
* Unfortunately https://github.com/project-chip/connectedhomeip/pull/26338 introduced a deadlock for other callers of `ChipDeviceScanner::StartScan`. Those other callers call `ChipDeviceScanner::StartScan` from a method that was scheduled to run on the ChipStack with `ScheduleWork`.

Solution:
* The requirement can be that `ChipDeviceScanner::StartScan` is called with the `ChipStackLock`. These seems to allow both cases to coexist.
* The destructor calling `CancelTimer` still does seem to be dependent on if it was called in scheduled work that does call `TimerExpiredCallback`, or some other thread. For the time being acquiring the ChipStackLock logic over there still makes sense.

Test:
* `chip-tool pairing ble-wifi 1 asdf asdf 20202021 3840`, no longer deadlocks
* In `chip-repl` issuing `asdf = chip.ble.DiscoverSync(timeoutMs=2000)` followed by `for x in asdf: print(f"TMsg {x}")` works.
* In `chip-repl`, issuing `devCtrl.CommissionWiFi(3840, 20202021, 1, "asdf", "asdf")` no longer deadlocks.

