### PR TITLE
Make clang thread safety analysis configurable.

### DIFF
--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -125,8 +125,8 @@ buildconfig_header("system_buildconfig") {
     ]
   }
   if (chip_enable_thread_safety_checks) {
-    defines += ["SYSTEM_ENABLE_CLANG_THREAD_SAFETY_ANALYSIS=1"]
-  } 
+    defines += [ "SYSTEM_ENABLE_CLANG_THREAD_SAFETY_ANALYSIS=1" ]
+  }
 
   if (chip_system_layer_impl_config_file != "") {
     defines += [ "CHIP_SYSTEM_LAYER_IMPL_CONFIG_FILE=${chip_system_layer_impl_config_file}" ]

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -17,6 +17,7 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/nlassert.gni")
 import("//build_overrides/nlfaultinjection.gni")
 
+import("${build_root}/config/compiler/compiler.gni")
 import("${chip_root}/build/chip/buildconfig_header.gni")
 import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/src/platform/device.gni")
@@ -32,6 +33,12 @@ declare_args() {
 
   # Extra include dirs for project configs.
   chip_project_config_include_dirs = []
+
+  # enable clang thread safety analysis in SystemMutex.h,
+  # specifically attributes such as capability, guarded_by, acquire, ...
+  #
+  # see https://clang.llvm.org/docs/ThreadSafetyAnalysis.html
+  chip_enable_thread_safety_checks = is_clang
 }
 
 if (chip_project_config_include_dirs == [] &&
@@ -117,6 +124,9 @@ buildconfig_header("system_buildconfig") {
       "SYSTEM_PLATFORM_CONFIG_INCLUDE=${chip_system_platform_config_include}",
     ]
   }
+  if (chip_enable_thread_safety_checks) {
+    defines += ["SYSTEM_ENABLE_CLANG_THREAD_SAFETY_ANALYSIS=1"]
+  } 
 
   if (chip_system_layer_impl_config_file != "") {
     defines += [ "CHIP_SYSTEM_LAYER_IMPL_CONFIG_FILE=${chip_system_layer_impl_config_file}" ]

--- a/src/system/SystemMutex.h
+++ b/src/system/SystemMutex.h
@@ -64,7 +64,7 @@ namespace chip {
 namespace System {
 
 // Enable thread safety attributes only with clang.
-#if defined(__clang__) && (!defined(SWIG))
+#if defined(SYSTEM_ENABLE_CLANG_THREAD_SAFETY_ANALYSIS) && (!defined(SWIG))
 #define CHIP_TSA_ATTRIBUTE__(x) __attribute__((x))
 #else
 #define CHIP_TSA_ATTRIBUTE__(x)


### PR DESCRIPTION
Depending on CLANG version used, thread safety analysis may not be available. Found this when OSS-FUZZ tests were failing.

This CL adds a `chip_enable_thread_safety_checks` flag to turn these checks on/off and defaults them to on when the compiler is clang.


