### PR TITLE
Increase timeout for BuildMatterTVCastingBridge build.

### DIFF
--- a/.github/workflows/smoketest-darwin.yaml
+++ b/.github/workflows/smoketest-darwin.yaml
@@ -66,7 +66,7 @@ jobs:
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
             - name: Build Matter TV Casting Bridge
-              timeout-minutes: 20
+              timeout-minutes: 45
               run: |
                   xcodebuild -target "MatterTvCastingBridge" -sdk iphoneos
               working-directory: examples/tv-casting-app/darwin/MatterTvCastingBridge


### PR DESCRIPTION
This seems to consistently timeout, like
https://github.com/project-chip/connectedhomeip/actions/runs/4917361315/jobs/8785039570?pr=26419

