### PR TITLE
Initialize memory before running schedule lambda test

### DIFF
--- a/src/system/tests/TestSystemScheduleLambda.cpp
+++ b/src/system/tests/TestSystemScheduleLambda.cpp
@@ -67,9 +67,10 @@ static nlTestSuite kTheSuite =
  */
 static int TestSetup(void * aContext)
 {
+    if (chip::Platform::MemoryInit() != CHIP_NO_ERROR)
+        return FAILURE;
     if (chip::DeviceLayer::PlatformMgr().InitChipStack() != CHIP_NO_ERROR)
         return FAILURE;
-
     return (SUCCESS);
 }
 
@@ -80,6 +81,7 @@ static int TestSetup(void * aContext)
 static int TestTeardown(void * aContext)
 {
     chip::DeviceLayer::PlatformMgr().Shutdown();
+    chip::Platform::MemoryShutdown();
     return (SUCCESS);
 }
 


### PR DESCRIPTION
### Problem

On Tizen we've got an error like this when running the TestSystemScheduleLambda test:
```
D/CHIP    ( 1029): SPT: ABORT: chip::Platform::MemoryAlloc() called before chip::Platform::MemoryInit()
```

### Changes

- initialize memory before running test

### Testing

CI will verify. Tizen tested locally.