### PR TITLE
qpg: build libFactoryData instead of using an artifact

### DIFF
--- a/examples/lighting-app/qpg/BUILD.gn
+++ b/examples/lighting-app/qpg/BUILD.gn
@@ -64,7 +64,6 @@ qpg_executable("lighting_app") {
   ]
 
   deps = [
-    ":factorydata_lib",
     ":sdk",
     "${chip_root}/examples/lighting-app/lighting-common:color-format",
     "${chip_root}/examples/lighting-app/qpg/zap/",
@@ -73,6 +72,7 @@ qpg_executable("lighting_app") {
     "${chip_root}/src/setup_payload",
     "${chip_root}/third_party/openthread/platforms:libopenthread-platform",
     "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
+    "${chip_root}/third_party/qpg_sdk:qpg_light_factorydata_lib",
   ]
 
   if (chip_openthread_ftd) {
@@ -155,16 +155,4 @@ group("qpg") {
 
 group("default") {
   deps = [ ":qpg" ]
-}
-
-static_library("factorydata_lib") {
-  libs = [ "${qpg_sdk_root}/Binaries/FactoryData/FactoryData_example/FactoryData_example.a" ]
-  public_configs = [ ":qpg_retain_factorydata" ]
-}
-
-config("qpg_retain_factorydata") {
-  ldflags = [
-    "-Wl,-u_binary_factory_data_bin_start",
-    "-Wl,-u_binary_factory_data_start",
-  ]
 }

--- a/examples/lock-app/qpg/BUILD.gn
+++ b/examples/lock-app/qpg/BUILD.gn
@@ -62,7 +62,6 @@ qpg_executable("lock_app") {
   ]
 
   deps = [
-    ":factorydata_lib",
     ":sdk",
     "${chip_root}/examples/lock-app/qpg/zap/",
     "${chip_root}/examples/providers:device_info_provider",
@@ -70,6 +69,7 @@ qpg_executable("lock_app") {
     "${chip_root}/src/setup_payload",
     "${chip_root}/third_party/openthread/platforms:libopenthread-platform",
     "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
+    "${chip_root}/third_party/qpg_sdk:qpg_lock_factorydata_lib",
   ]
 
   if (chip_openthread_ftd) {
@@ -152,16 +152,4 @@ group("qpg") {
 
 group("default") {
   deps = [ ":qpg" ]
-}
-
-static_library("factorydata_lib") {
-  libs = [ "${qpg_sdk_root}/Binaries/FactoryData/FactoryData_example/FactoryData_example.a" ]
-  public_configs = [ ":qpg_retain_factorydata" ]
-}
-
-config("qpg_retain_factorydata") {
-  ldflags = [
-    "-Wl,-u_binary_factory_data_bin_start",
-    "-Wl,-u_binary_factory_data_start",
-  ]
 }

--- a/third_party/qpg_sdk/BUILD.gn
+++ b/third_party/qpg_sdk/BUILD.gn
@@ -193,3 +193,44 @@ static_library("qpg_openthread_glue_lib") {
   deps = [ "${chip_root}/third_party/qpg_sdk:qpg_openthread_glue" ]
   libs = [ "${target_gen_dir}/${qpg_sdk_lib_dir}/OpenThreadQorvoGlue_qpg6105_ftd/libOpenThreadQorvoGlue_${qpg_target_ic}_ftd.a" ]
 }
+
+qpg_make_build("qpg_light_factorydata") {
+  make_sources = [ "${qpg_sdk_root}/Tools/FactoryData" ]
+  make_output = [ "${target_gen_dir}/${qpg_sdk_lib_dir}/FactoryData_light_static_pake/libFactoryData_light_static_pake.a" ]
+  make_args = [
+    "-f",
+    rebase_path(qpg_sdk_root, root_build_dir) +
+        "/Libraries/Qorvo/FactoryData/Makefile.FactoryData_light_static_pake",
+    "WORKDIR=" + rebase_path(target_gen_dir, root_build_dir) +
+        "/${qpg_sdk_lib_dir}/FactoryData_light_static_pake",
+  ]
+}
+static_library("qpg_light_factorydata_lib") {
+  deps = [ "${chip_root}/third_party/qpg_sdk:qpg_light_factorydata" ]
+  libs = [ "${target_gen_dir}/${qpg_sdk_lib_dir}/FactoryData_light_static_pake/libFactoryData_light_static_pake.a" ]
+  public_configs = [ ":qpg_retain_factorydata" ]
+}
+
+qpg_make_build("qpg_lock_factorydata") {
+  make_sources = [ "${qpg_sdk_root}/Tools/FactoryData" ]
+  make_output = [ "${target_gen_dir}/${qpg_sdk_lib_dir}/FactoryData_lock_static_pake/libFactoryData_lock_static_pake.a" ]
+  make_args = [
+    "-f",
+    rebase_path(qpg_sdk_root, root_build_dir) +
+        "/Libraries/Qorvo/FactoryData/Makefile.FactoryData_lock_static_pake",
+    "WORKDIR=" + rebase_path(target_gen_dir, root_build_dir) +
+        "/${qpg_sdk_lib_dir}/FactoryData_lock_static_pake",
+  ]
+}
+static_library("qpg_lock_factorydata_lib") {
+  deps = [ "${chip_root}/third_party/qpg_sdk:qpg_lock_factorydata" ]
+  libs = [ "${target_gen_dir}/${qpg_sdk_lib_dir}/FactoryData_lock_static_pake/libFactoryData_lock_static_pake.a" ]
+  public_configs = [ ":qpg_retain_factorydata" ]
+}
+
+config("qpg_retain_factorydata") {
+  ldflags = [
+    "-Wl,-u_binary_factory_data_bin_start",
+    "-Wl,-u_binary_factory_data_start",
+  ]
+}


### PR DESCRIPTION
Instead of using a static factory data blob, use a freshly build libfactorydata.a so any changes to .factory_data_config file or its input files are picked up by the GN build.
