### PR TITLE
Upping timeouts from for bootstrap cache 10 -> 20 for now

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,7 +69,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -186,7 +186,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -348,7 +348,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -407,7 +407,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -507,7 +507,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -46,7 +46,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -82,7 +82,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -118,7 +118,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform nrfconnect
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -62,7 +62,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               if: ${{ !env.ACT }}
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -84,7 +84,7 @@ jobs:
               run: echo "val=$(scripts/tests/cirque_tests.sh cachekeyhash)" >> $GITHUB_OUTPUT
             - name: Cirque Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               if: ${{ !env.ACT }}
               with:
                   key: ${{ runner.os }}-cirque-${{ steps.cirque-bootstrap-cache-key.outputs.val }}

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -68,7 +68,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -48,7 +48,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-ameba.yaml
+++ b/.github/workflows/examples-ameba.yaml
@@ -52,7 +52,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform ameba
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-cc13x2x7_26x2x7.yaml
+++ b/.github/workflows/examples-cc13x2x7_26x2x7.yaml
@@ -60,7 +60,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-cc32xx.yaml
+++ b/.github/workflows/examples-cc32xx.yaml
@@ -57,7 +57,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -59,7 +59,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -178,7 +178,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -59,7 +59,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -61,7 +61,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -59,7 +59,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -51,7 +51,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -59,7 +59,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -75,7 +75,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-mw320.yaml
+++ b/.github/workflows/examples-mw320.yaml
@@ -61,7 +61,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -76,7 +76,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-openiotsdk.yaml
+++ b/.github/workflows/examples-openiotsdk.yaml
@@ -61,7 +61,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -61,7 +61,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -60,7 +60,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -54,7 +54,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -65,7 +65,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -56,7 +56,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -116,7 +116,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,7 +57,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -210,4 +210,3 @@ jobs:
               if: always()
               run: |
                   git grep -n 'SuccessOrExit(CHIP_ERROR' -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
-

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -57,7 +57,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -121,7 +121,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -45,7 +45,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -100,7 +100,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -56,7 +56,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/smoketest-darwin.yaml
+++ b/.github/workflows/smoketest-darwin.yaml
@@ -48,7 +48,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -82,7 +82,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -338,7 +338,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -460,7 +460,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -547,7 +547,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |
@@ -720,7 +720,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/zap_regeneration.yaml
+++ b/.github/workflows/zap_regeneration.yaml
@@ -49,7 +49,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -50,7 +50,7 @@ jobs:
 
             - name: Bootstrap cache
               uses: actions/cache@v3
-              timeout-minutes: 10
+              timeout-minutes: 20
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
                   path: |


### PR DESCRIPTION
Looking at our timeouts of late, the bootstrap cache is getting *huge* and very slow. We likely should bring these down, but in the interim, upping these timeouts to stop the bleeding.