### PR TITLE
Inet implementations assume BYTE_ORDER is defined. make sure that it is

### DIFF
--- a/src/inet/arpa-inet-compatibility.h
+++ b/src/inet/arpa-inet-compatibility.h
@@ -23,19 +23,11 @@
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 #include <arpa/inet.h>
 
-#ifndef BYTE_ORDER
-#error Endianness not defined
-#endif
-
 #else // !CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #include <lwip/def.h>
 #include <lwip/opt.h>
-
-#ifndef BYTE_ORDER
-#error Endianness not defined
-#endif
 
 #if defined(LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS)
 #ifndef htons
@@ -56,27 +48,11 @@
 
 #if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 
-#ifndef BYTE_ORDER
-#if defined(__LITTLE_ENDIAN__)
-#define BYTE_ORDER LITTLE_ENDIAN
-#elif defined(__BIG_ENDIAN__)
-#define BYTE_ORDER BIG_ENDIAN
-#elif defined(__BYTE_ORDER__)
-#define BYTE_ORDER __BYTE_ORDER__
-#else
+#ifndef __BYTE_ORDER__
 #error Endianness not defined is not defined
-#endif
 #endif // BYTE_ORDER
 
-#ifndef BIG_ENDIAN
-#define BIG_ENDIAN __ORDER_BIG_ENDIAN__
-#endif
-
-#ifndef LITTLE_ENDIAN
-#define LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
-#endif
-
-#if BYTE_ORDER == BIG_ENDIAN
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #ifndef htons
 #define htons(x) (x)
 #endif
@@ -90,7 +66,7 @@
 #define ntohl(x) (x)
 #endif
 
-#else // BYTE_ORDER != BIG_ENDIAN
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #ifndef htons
 #define htons(x) ((u16_t)((((x) & (u16_t) 0x00ffU) << 8) | (((x) & (u16_t) 0xff00U) >> 8)))
 #endif
@@ -105,7 +81,10 @@
 #ifndef ntohl
 #define ntohl(x) htonl(x)
 #endif
-#endif // BYTE_ORDER == BIG_ENDIAN
+
+#else
+#error Unknown endiannes set to _BYTE_ORDER__
+#endif // _BYTE_ORDER__ ==
 
 #endif // CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 

--- a/src/inet/arpa-inet-compatibility.h
+++ b/src/inet/arpa-inet-compatibility.h
@@ -49,7 +49,7 @@
 #if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 
 #ifndef __BYTE_ORDER__
-#error Endianness not defined is not defined
+#error Endianness is not defined
 #endif // BYTE_ORDER
 
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
@@ -83,8 +83,8 @@
 #endif
 
 #else
-#error Unknown endiannes set to _BYTE_ORDER__
-#endif // _BYTE_ORDER__ ==
+#error __BYTE_ORDER__ value not recognized
+#endif // __BYTE_ORDER__ ==
 
 #endif // CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 

--- a/src/inet/arpa-inet-compatibility.h
+++ b/src/inet/arpa-inet-compatibility.h
@@ -24,7 +24,7 @@
 #include <arpa/inet.h>
 
 #ifndef BYTE_ORDER
-#error Endianess not defined
+#error Endianness not defined
 #endif
 
 #else // !CHIP_SYSTEM_CONFIG_USE_SOCKETS
@@ -34,7 +34,7 @@
 #include <lwip/opt.h>
 
 #ifndef BYTE_ORDER
-#error Endianess not defined
+#error Endianness not defined
 #endif
 
 #if defined(LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS)
@@ -64,7 +64,7 @@
 #elif defined(__BYTE_ORDER__)
 #define BYTE_ORDER __BYTE_ORDER__
 #else
-#error Endianess not defined is not defined
+#error Endianness not defined is not defined
 #endif
 #endif // BYTE_ORDER
 

--- a/src/inet/arpa-inet-compatibility.h
+++ b/src/inet/arpa-inet-compatibility.h
@@ -23,12 +23,19 @@
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 #include <arpa/inet.h>
 
+#ifndef BYTE_ORDER
+#error Endianess not defined
+#endif
+
 #else // !CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-
 #include <lwip/def.h>
 #include <lwip/opt.h>
+
+#ifndef BYTE_ORDER
+#error Endianess not defined
+#endif
 
 #if defined(LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS)
 #ifndef htons
@@ -48,6 +55,26 @@
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
+
+#ifndef BYTE_ORDER
+#if defined(__LITTLE_ENDIAN__)
+#define BYTE_ORDER LITTLE_ENDIAN
+#elif defined(__BIG_ENDIAN__)
+#define BYTE_ORDER BIG_ENDIAN
+#elif defined(__BYTE_ORDER__)
+#define BYTE_ORDER __BYTE_ORDER__
+#else
+#error Endianess not defined is not defined
+#endif
+#endif // BYTE_ORDER
+
+#ifndef BIG_ENDIAN
+#define BIG_ENDIAN __ORDER_BIG_ENDIAN__
+#endif
+
+#ifndef LITTLE_ENDIAN
+#define LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
+#endif
 
 #if BYTE_ORDER == BIG_ENDIAN
 #ifndef htons


### PR DESCRIPTION
BYTE_ORDER was not defined in Silabs Thread apps. But the inet implementation assumes it is for some endianness conversion.

Recent changes to GCC highlighted this missing define as we were now using the big-endian implementation of `hotnl` on the Silabs platform due to `#if BYTE_ORDER == BIG_ENDIAN` evaluating to true when both of the defines didn't exist.
This, ultimately, led to `IPAddress::IPAddress::MakeIPv6Multicast` returning an invalid Multicast address.

Anyhow, this PR adds some checks on the existence of the BYTE_ORDER defined.

for `CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT` inet implementation, Try at least to define BYTE_ORDER to the right endianness of the system if the definition doesn't exist already.

Note: Platforms using `lwip` usually define `BYTE_ORDER`, `BIG_ENDIAN`, `LITTLE_ENDIAN` in `arch/cc.h`


