### PR TITLE
Fix matter_yamltests with Python 11 again.

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/runner.py
@@ -16,7 +16,7 @@
 import asyncio
 import time
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from .adapter import TestAdapter
 from .hooks import TestRunnerHooks
@@ -72,7 +72,7 @@ class TestRunnerConfig:
     """
     adapter: TestAdapter = None
     pseudo_clusters: PseudoClusters = PseudoClusters([])
-    options: TestRunnerOptions = TestRunnerOptions()
+    options: TestRunnerOptions = field(default_factory=TestRunnerOptions)
     hooks: TestRunnerHooks = TestRunnerHooks()
 
 


### PR DESCRIPTION
Due to https://docs.python.org/3.11/whatsnew/3.11.html#dataclasses, the previous code fails: it's using a mutable class instance as a default values of a dataclass field.
