### PR TITLE
[Tizen] Fix build with non-default toolchain

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -680,7 +680,11 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
       deps = [ "${chip_root}/src/test_driver/tizen:check(${chip_root}/build/toolchain/tizen:tizen_arm)" ]
     }
 
-    extra_check_deps += [ ":check:tizen" ]
+    # Include Tizen check target only if BLE is not enabled, since
+    # currently, QEMU-based Tizen does not support Bluetooth.
+    if (!chip_config_network_layer_ble) {
+      extra_check_deps += [ ":check:tizen" ]
+    }
   }
 
   if (enable_mw320_shell_build) {

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -677,7 +677,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
   if (enable_tizen_builds) {
     group("check:tizen") {
       testonly = true
-      deps = [ "${chip_root}/src/test_driver/tizen/integration-tests:check" ]
+      deps = [ "${chip_root}/src/test_driver/tizen:check(${chip_root}/build/toolchain/tizen:tizen_arm)" ]
     }
 
     extra_check_deps += [ ":check:tizen" ]

--- a/src/test_driver/tizen/integration_tests/lighting-app/BUILD.gn
+++ b/src/test_driver/tizen/integration_tests/lighting-app/BUILD.gn
@@ -28,9 +28,9 @@ tizen_qemu_mkisofs("test-runner") {
 
   # Use artifacts created by the dependencies.
   assets = [
-    rebase_path("${root_build_dir}/chip-tool"),
+    rebase_path("${root_out_dir}/chip-tool"),
     rebase_path(
-        "${root_build_dir}/org.tizen.matter.example.lighting/out/org.tizen.matter.example.lighting-1.0.0.tpk"),
+        "${root_out_dir}/org.tizen.matter.example.lighting/out/org.tizen.matter.example.lighting-1.0.0.tpk"),
   ]
 }
 

--- a/third_party/tizen/tizen_sdk.gni
+++ b/third_party/tizen/tizen_sdk.gni
@@ -82,7 +82,7 @@ template("tizen_sdk_certificate") {
   assert(defined(invoker.sign_security_profile),
          "It is required to specify a `sign_security_profile` which " +
              "should be added to Tizen security profiles.")
-  stamp_file = "${root_build_dir}/.tizen_sdk_dev_certificate_stamp"
+  stamp_file = "${root_out_dir}/.tizen_sdk_dev_certificate_stamp"
   action(target_name) {
     forward_variables_from(invoker, [ "deps" ])
     script = tizen_dev_certificate
@@ -91,7 +91,7 @@ template("tizen_sdk_certificate") {
       "--author-certificate-email=" + invoker.author_certificate_email,
       "--author-certificate-password=" + invoker.author_certificate_password,
       "--sign-security-profile=" + invoker.sign_security_profile,
-      "--stamp-file=" + stamp_file,
+      "--stamp-file=" + rebase_path(stamp_file),
     ]
     outputs = [ stamp_file ]
   }
@@ -112,7 +112,7 @@ template("tizen_sdk_package") {
 
   # Extract data from Tizen XML manifest.
   manifest = exec_script(tizen_manifest_parser,
-                         [ rebase_path(invoker.manifest, root_build_dir) ],
+                         [ rebase_path(invoker.manifest) ],
                          "json")
   manifest_package = manifest["package"]
   manifest_package_name = manifest_package["name"]
@@ -123,7 +123,7 @@ template("tizen_sdk_package") {
   # for this, because Tizen Studio CLI scans "res" (resources), "shared" and
   # "lib" directories for items to pack. In our case it could include in the
   # TPK package libraries available in ${root_out_dir}/lib directory.
-  tizen_package_dir = "${root_build_dir}/${manifest_package_name}"
+  tizen_package_dir = "${root_out_dir}/${manifest_package_name}"
   tizen_package_out_dir = "${tizen_package_dir}/out"
 
   # Copy Tizen manifest from the source directory.
@@ -160,7 +160,7 @@ template("tizen_sdk_package") {
       "--sign",
       invoker.sign_security_profile,
       "--",
-      tizen_package_out_dir,
+      rebase_path(tizen_package_out_dir),
     ]
   }
 }
@@ -192,7 +192,7 @@ template("tizen_qemu_mkisofs") {
       "-JRU",  # Joliet + Rock Ridge with untranslated filenames
       "-o",
       rebase_path(image_file),
-      rebase_path(invoker.runner, root_build_dir),
+      rebase_path(invoker.runner),
     ]
     if (defined(invoker.assets)) {
       args += invoker.assets
@@ -216,7 +216,7 @@ template("tizen_qemu_run") {
          "It is required to specify ISO runner image.")
 
   # Store QEMU output in a dedicated log file.
-  output_log_file = "${root_build_dir}/tizen-qemu-" + target_name + ".log"
+  output_log_file = "${root_out_dir}/tizen-qemu-" + target_name + ".log"
 
   action(target_name) {
     forward_variables_from(invoker, [ "deps" ])


### PR DESCRIPTION
### Problem

Tizen GN SDK does not work properly in case when non-default GN toolchain is used.

### Changes

- fix GN SDK for Tizen
- do not add `tizen:check` to the default `check` target in case when BLE is enabled. Currently, Tizen QEMU-based tests do not support Bluetooth.

### Testing

Tested locally with:
```sh
gn gen out/check --args="target_os=\"all\" tizen_sdk_root=\"$TIZEN_SDK_ROOT\" tizen_sdk_sysroot=\"$TIZEN_SDK_SYSROOT\" enable_tizen_builds=true"
ninja -C out/check check

gn gen out/check --args="target_os=\"all\" tizen_sdk_root=\"$TIZEN_SDK_ROOT\" tizen_sdk_sysroot=\"$TIZEN_SDK_SYSROOT\" enable_tizen_builds=true chip_config_network_layer_ble=false"
ninja -C out/check check
```

CI will check the rest.