### PR TITLE
Support multiple cluster codes for enums in xmls

### DIFF
--- a/scripts/py_matter_idl/matter_idl/test_xml_parser.py
+++ b/scripts/py_matter_idl/matter_idl/test_xml_parser.py
@@ -223,7 +223,7 @@ class TestXmlParser(unittest.TestCase):
     def testEnum(self):
         idl = XmlToIdl('''<?xml version="1.0"?>
             <configurator>
-              <cluster><name>Test1</name><code>0x000A</code></cluster>
+              <cluster><name>Test1</name><code>10</code></cluster>
               <cluster><name>Test2</name><code>20</code></cluster>
 
               <enum name="GlobalEnum" type="ENUM8">

--- a/scripts/py_matter_idl/matter_idl/test_xml_parser.py
+++ b/scripts/py_matter_idl/matter_idl/test_xml_parser.py
@@ -18,9 +18,6 @@ import unittest
 from typing import List, Union
 
 try:
-    from matter_idl.matter_idl_types import (AccessPrivilege, Attribute, AttributeQuality, Bitmap, Cluster, ClusterSide, Command,
-                                             ConstantEntry, DataType, Event, EventPriority, EventQuality, Field, FieldQuality, Idl,
-                                             Struct, StructQuality, StructTag)
     from matter_idl.zapxml import ParseSource, ParseXmls
 except ImportError:
     import os
@@ -28,11 +25,11 @@ except ImportError:
 
     sys.path.append(os.path.abspath(
         os.path.join(os.path.dirname(__file__), '..')))
-
-    from matter_idl.matter_idl_types import (AccessPrivilege, Attribute, AttributeQuality, Bitmap, Cluster, ClusterSide, Command,
-                                             ConstantEntry, DataType, Event, EventPriority, EventQuality, Field, FieldQuality, Idl,
-                                             Struct, StructQuality, StructTag)
     from matter_idl.zapxml import ParseSource, ParseXmls
+
+from matter_idl.matter_idl_types import (AccessPrivilege, Attribute, AttributeQuality, Bitmap, Cluster, ClusterSide, Command,
+                                         ConstantEntry, DataType, Enum, Event, EventPriority, EventQuality, Field, FieldQuality,
+                                         Idl, Struct, StructQuality, StructTag)
 
 
 def XmlToIdl(what: Union[str, List[str]]) -> Idl:
@@ -222,6 +219,62 @@ class TestXmlParser(unittest.TestCase):
                                                     name='Field10')],
                                       qualities=StructQuality.FABRIC_SCOPED)],
                          )]))
+
+    def testEnum(self):
+        idl = XmlToIdl('''<?xml version="1.0"?>
+            <configurator>
+              <cluster><name>Test1</name><code>0x000A</code></cluster>
+              <cluster><name>Test2</name><code>20</code></cluster>
+
+              <enum name="GlobalEnum" type="ENUM8">
+                <item value="0" name="First" />
+                <item value="1" name="Second" />
+              </enum>
+
+              <enum name="OneCluster" type="ENUM8">
+                <cluster code="10" />
+                <item value="3" name="Three" />
+              </enum>
+
+              <enum name="TwoClusters" type="ENUM8">
+                <cluster code="10" />
+                <cluster code="20" />
+                <item value="100" name="Big" />
+                <item value="2000" name="Bigger" />
+              </enum>
+            </configurator>
+        ''')
+        e1 = Enum(
+            name='GlobalEnum',
+            base_type="ENUM8",
+            entries=[
+                ConstantEntry(name="First", code=0),
+                ConstantEntry(name="Second", code=1),
+            ]
+        )
+        e2 = Enum(
+            name='OneCluster',
+            base_type="ENUM8",
+            entries=[
+                ConstantEntry(name="Three", code=3),
+            ]
+        )
+        e3 = Enum(
+            name='TwoClusters',
+            base_type="ENUM8",
+            entries=[
+                ConstantEntry(name="Big", code=100),
+                ConstantEntry(name="Bigger", code=2000),
+            ]
+        )
+        self.assertEqual(idl,
+                         Idl(clusters=[
+                             Cluster(side=ClusterSide.CLIENT,
+                                     name='Test1', code=10, enums=[e2, e3]),
+                             Cluster(side=ClusterSide.CLIENT,
+                                     name='Test2', code=20, enums=[e3])],
+                             enums=[e1],
+                             ))
 
     def testStruct(self):
         idl = XmlToIdl('''<?xml version="1.0"?>


### PR DESCRIPTION
#26431 was trying to use the same enum across multiple clusters and it turns out our linter does not support this.

Make the xml parser support this and add unit tests for the support.